### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Aries AI is a Next.js 15 marketing automation platform. The main service is a Next.js app on port 3000 that proxies business logic to an external n8n workflow engine. See `SETUP.md` and `README-runtime.md` for full setup docs.
+
+### Critical: NODE_ENV override
+
+The Cloud Agent VM sets `NODE_ENV=production` at the system level. You **must** override it when running the dev server:
+
+```bash
+NODE_ENV=development CODE_ROOT=/workspace DATA_ROOT=/workspace/data npx next dev -p 3000
+```
+
+Without `NODE_ENV=development`, PostCSS/Tailwind CSS v4 processing fails and all pages return 500.
+
+### Dev server
+
+- **Start**: `NODE_ENV=development CODE_ROOT=/workspace DATA_ROOT=/workspace/data npx next dev -p 3000`
+- **Build**: `NODE_ENV=production CODE_ROOT=/workspace DATA_ROOT=/workspace/data npx next build`
+- Pages compile on-demand in dev mode; first hit to each route takes 200-800ms.
+- `CODE_ROOT` and `DATA_ROOT` default to `/app` and `/data` (container paths). Override to `/workspace` and `/workspace/data` for local dev.
+
+### Environment variables
+
+All required env vars are injected as Cloud Agent secrets (see `CLOUD_AGENT_ALL_SECRET_NAMES`). The `.env` file is only needed if secrets are missing. Key required vars: `N8N_BASE_URL`, `N8N_API_KEY`. See `.env.example` for the full list.
+
+### No ESLint config
+
+This repo has no ESLint configuration. TypeScript checking can be done with `npx tsc --noEmit`, but expect pre-existing type errors in the codebase (especially in `.next/types/` generated files and JSX resolution). The `next build` command performs its own type-checking and linting pass.
+
+### Tests
+
+Test suites in `tests/` are custom TypeScript scripts (not jest/vitest). They require a running n8n instance and data directories. Run with `npx tsx tests/<suite>.ts`. These are integration tests that depend on external services.
+
+### Package manager
+
+Uses **npm** with `package-lock.json`. Always use `npm install` (not pnpm/yarn).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions to help future agents set up and run the Aries AI development environment correctly.

## Key Instructions Documented

- **NODE_ENV override**: The Cloud Agent VM sets `NODE_ENV=production` at the system level, which breaks PostCSS/Tailwind CSS v4 processing. The dev server must be started with `NODE_ENV=development` explicitly.
- **Dev server startup**: Correct command with required env var overrides for `CODE_ROOT` and `DATA_ROOT`.
- **Build commands**: Production build command with appropriate env vars.
- **Package manager**: Confirms npm with `package-lock.json`.
- **Test suites**: Documents that tests are custom TypeScript scripts requiring external services.
- **No ESLint config**: Notes the absence of ESLint configuration and pre-existing TypeScript errors.

## Environment Setup Validated

- All npm dependencies installed successfully (89 packages)
- Dev server starts and serves all 11+ routes with HTTP 200
- Production build completes successfully (34 pages)
- Contact form submission works end-to-end (returns success message)
- All marketing/onboarding/dashboard pages render correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8aa33856-420c-40fb-be67-172a9d650504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aa33856-420c-40fb-be67-172a9d650504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

