### PR TITLE
Hide tenant identity in the marketing flow

### DIFF
--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -49,7 +49,7 @@ const ENDPOINTS = [
     desc: 'Read current marketing job state from the local runtime read model.',
     body: '—',
     response:
-      '{ "jobId": "...", "marketing_job_state": "...", "marketing_job_status": "...", "marketing_stage": "...", "marketing_stage_status": {...}, "updatedAt": "...", "needs_attention": false, "approvalRequired": true }',
+      '{ "jobId": "...", "marketing_job_state": "...", "marketing_job_status": "...", "marketing_stage": "...", "marketing_stage_status": {...}, "updatedAt": "...", "needs_attention": false, "approvalRequired": true, "summary": { "headline": "...", "subheadline": "..." }, "stageCards": [...], "artifacts": [...], "timeline": [...], "approval": { "required": true, "title": "...", "message": "..." }, "nextStep": "submit_approval", "repairStatus": "not_required" }',
   },
   {
     method: 'POST',
@@ -58,7 +58,7 @@ const ENDPOINTS = [
     body:
       '{ "approvedBy", "approvedStages"?: ["research"|"strategy"|"production"|"publish"], "resumePublishIfNeeded"?: true }',
     response:
-      '{ "approval_status": "resumed|error", "jobId": "...", "resumedStage": "...", "completed": false, "reason"?: "workflow_missing_for_route", "jobStatusUrl": "/marketing/job-status?jobId=..." }',
+      '{ "approval_status": "resumed|error", "jobId": "...", "resumedStage": "publish", "completed": true, "reason"?: "approval_not_available", "jobStatusUrl": "/marketing/job-status?jobId=..." }',
   },
   {
     method: 'POST',

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -39,9 +39,9 @@ const ENDPOINTS = [
     path: '/api/marketing/jobs',
     desc: 'Create the canonical brand campaign marketing job.',
     body:
-      '{ "tenantId", "jobType": "brand_campaign", "payload": { "brandUrl", "competitorUrl" } }',
+      '{ "jobType": "brand_campaign", "payload": { "brandUrl", "competitorUrl" } }',
     response:
-      '{ "marketing_job_status": "accepted", "jobId": "...", "tenantId": "...", "jobType": "brand_campaign", "wiring": "openclaw_gateway" }',
+      '{ "marketing_job_status": "accepted", "jobId": "...", "jobType": "brand_campaign", "approvalRequired": true, "jobStatusUrl": "/marketing/job-status?jobId=..." }',
   },
   {
     method: 'GET',
@@ -49,16 +49,16 @@ const ENDPOINTS = [
     desc: 'Read current marketing job state from the local runtime read model.',
     body: '—',
     response:
-      '{ "jobId": "...", "tenantId": "...", "marketing_job_state": "...", "marketing_job_status": "...", "marketing_stage": "...", "marketing_stage_status": {...}, "updatedAt": "...", "needs_attention": false }',
+      '{ "jobId": "...", "marketing_job_state": "...", "marketing_job_status": "...", "marketing_stage": "...", "marketing_stage_status": {...}, "updatedAt": "...", "needs_attention": false, "approvalRequired": true }',
   },
   {
     method: 'POST',
     path: '/api/marketing/jobs/:jobId/approve',
     desc: 'Approve a marketing job through the OpenClaw boundary.',
     body:
-      '{ "tenantId", "approvedBy", "approvedStages"?: ["research"|"strategy"|"production"|"publish"], "resumePublishIfNeeded"?: true }',
+      '{ "approvedBy", "approvedStages"?: ["research"|"strategy"|"production"|"publish"], "resumePublishIfNeeded"?: true }',
     response:
-      '{ "approval_status": "resumed|error", "jobId": "...", "tenantId": "...", "resumedStage": "...", "completed": false, "wiring": "openclaw_gateway", "reason"?: "workflow_missing_for_route" }',
+      '{ "approval_status": "resumed|error", "jobId": "...", "resumedStage": "...", "completed": false, "reason"?: "workflow_missing_for_route", "jobStatusUrl": "/marketing/job-status?jobId=..." }',
   },
   {
     method: 'POST',

--- a/app/api/marketing/jobs/[jobId]/approve/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/approve/handler.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server';
+
+import { approveMarketingJob } from '@/backend/marketing/jobs-approve';
+import { OpenClawGatewayError } from '@/backend/openclaw/gateway-client';
+import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
+
+const MARKETING_ONBOARDING_REQUIRED = {
+  status: 409,
+  reason: 'onboarding_required',
+  message: 'Complete tenant onboarding before approving brand campaigns.',
+} as const;
+
+export async function handleApproveMarketingJob(
+  jobId: string,
+  req: Request,
+  tenantContextLoader?: TenantContextLoader
+) {
+  const tenantResult = await loadTenantContextOrResponse(tenantContextLoader, {
+    missingMembershipResponse: MARKETING_ONBOARDING_REQUIRED,
+  });
+  if ('response' in tenantResult) {
+    return tenantResult.response;
+  }
+
+  let payload: {
+    approvedBy?: unknown;
+    approvedStages?: Array<'research' | 'strategy' | 'production' | 'publish'>;
+    resumePublishIfNeeded?: boolean;
+  } = {};
+  try {
+    payload = await req.json();
+  } catch {
+    payload = {};
+  }
+
+  try {
+    const result = await approveMarketingJob({
+      jobId,
+      tenantId: tenantResult.tenantContext.tenantId,
+      approvedBy: typeof payload.approvedBy === 'string' ? payload.approvedBy : '',
+      approvedStages: payload.approvedStages,
+      resumePublishIfNeeded: payload.resumePublishIfNeeded,
+    });
+
+    if (result.reason === 'tenant_mismatch' || result.reason === 'job_not_found') {
+      return NextResponse.json(
+        {
+          error: 'Marketing job not found.',
+          reason: 'marketing_job_not_found',
+        },
+        { status: 404 }
+      );
+    }
+
+    if (result.reason === 'missing_approved_by') {
+      return NextResponse.json(
+        {
+          error: 'approvedBy is required.',
+          reason: result.reason,
+        },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        approval_status: result.status,
+        jobId: result.jobId,
+        resumedStage: result.resumedStage,
+        completed: result.completed,
+        reason: result.reason,
+        jobStatusUrl: `/marketing/job-status?jobId=${encodeURIComponent(result.jobId)}`,
+      },
+      {
+        status:
+          result.reason === 'workflow_missing_for_route'
+            ? 501
+            : result.status === 'resumed'
+              ? 200
+              : 400,
+      }
+    );
+  } catch (error) {
+    if (error instanceof OpenClawGatewayError) {
+      const status =
+        error.code === 'openclaw_gateway_unauthorized'
+          ? 401
+          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
+            ? 503
+            : error.status || 500;
+      return NextResponse.json(
+        {
+          error: error.message,
+          reason: error.code,
+        },
+        { status }
+      );
+    }
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/marketing/jobs/[jobId]/approve/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/approve/handler.ts
@@ -62,6 +62,16 @@ export async function handleApproveMarketingJob(
       );
     }
 
+    if (result.reason === 'approval_not_available') {
+      return NextResponse.json(
+        {
+          error: 'This campaign is not waiting on a live launch approval token.',
+          reason: result.reason,
+        },
+        { status: 409 }
+      );
+    }
+
     return NextResponse.json(
       {
         approval_status: result.status,

--- a/app/api/marketing/jobs/[jobId]/approve/route.ts
+++ b/app/api/marketing/jobs/[jobId]/approve/route.ts
@@ -1,68 +1,9 @@
-import { NextResponse } from 'next/server';
-import { approveMarketingJob } from '../../../../../../backend/marketing/jobs-approve';
-import { OpenClawGatewayError } from '../../../../../../backend/openclaw/gateway-client';
+import { handleApproveMarketingJob } from './handler';
 
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ jobId: string }> }
 ) {
   const { jobId } = await params;
-  let payload: any = {};
-  try {
-    payload = await req.json();
-  } catch {
-    payload = {};
-  }
-
-  try {
-    const result = await approveMarketingJob({
-      jobId,
-      tenantId: payload.tenantId,
-      approvedBy: payload.approvedBy,
-      approvedStages: payload.approvedStages,
-      resumePublishIfNeeded: payload.resumePublishIfNeeded
-    });
-
-    return NextResponse.json(
-      {
-        approval_status: result.status,
-        jobId: result.jobId,
-        tenantId: result.tenantId,
-        resumedStage: result.resumedStage,
-        completed: result.completed,
-        wiring: result.wiring,
-        reason: result.reason
-      },
-      {
-        status:
-          result.reason === 'workflow_missing_for_route'
-            ? 501
-            : result.status === 'resumed'
-              ? 200
-              : 400
-      }
-    );
-  } catch (error) {
-    if (error instanceof OpenClawGatewayError) {
-      const status =
-        error.code === 'openclaw_gateway_unauthorized'
-          ? 401
-          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
-            ? 503
-            : error.status || 500;
-      return NextResponse.json(
-        {
-          error: error.message,
-          reason: error.code
-        },
-        { status }
-      );
-    }
-    return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : String(error)
-      },
-      { status: 500 }
-    );
-  }
+  return handleApproveMarketingJob(jobId, req);
 }

--- a/app/api/marketing/jobs/[jobId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/handler.ts
@@ -9,17 +9,6 @@ const MARKETING_ONBOARDING_REQUIRED = {
   message: 'Complete tenant onboarding before viewing brand campaign status.',
 } as const;
 
-function needsAttention(status: string) {
-  return [
-    'error',
-    'failed',
-    'blocked',
-    'needs_repair',
-    'hard_failure',
-    'rejected',
-  ].includes(status);
-}
-
 export async function handleGetMarketingJobStatus(
   jobId: string,
   tenantContextLoader?: TenantContextLoader
@@ -51,8 +40,15 @@ export async function handleGetMarketingJobStatus(
         marketing_stage: result.currentStage,
         marketing_stage_status: result.stageStatus,
         updatedAt: result.updatedAt,
-        needs_attention: needsAttention(result.status),
+        needs_attention: result.needsAttention,
         approvalRequired: result.approvalRequired,
+        summary: result.summary,
+        stageCards: result.stageCards,
+        artifacts: result.artifacts,
+        timeline: result.timeline,
+        approval: result.approval,
+        nextStep: result.nextStep,
+        repairStatus: result.repairStatus,
       },
       { status: 200 }
     );

--- a/app/api/marketing/jobs/[jobId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/handler.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+
+import { getMarketingJobStatus } from '@/backend/marketing/jobs-status';
+import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
+
+const MARKETING_ONBOARDING_REQUIRED = {
+  status: 409,
+  reason: 'onboarding_required',
+  message: 'Complete tenant onboarding before viewing brand campaign status.',
+} as const;
+
+function needsAttention(status: string) {
+  return [
+    'error',
+    'failed',
+    'blocked',
+    'needs_repair',
+    'hard_failure',
+    'rejected',
+  ].includes(status);
+}
+
+export async function handleGetMarketingJobStatus(
+  jobId: string,
+  tenantContextLoader?: TenantContextLoader
+) {
+  const tenantResult = await loadTenantContextOrResponse(tenantContextLoader, {
+    missingMembershipResponse: MARKETING_ONBOARDING_REQUIRED,
+  });
+  if ('response' in tenantResult) {
+    return tenantResult.response;
+  }
+
+  try {
+    const result = getMarketingJobStatus(jobId);
+    if (result.tenantId && result.tenantId !== tenantResult.tenantContext.tenantId) {
+      return NextResponse.json(
+        {
+          error: 'Marketing job not found.',
+          reason: 'marketing_job_not_found',
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        jobId: result.jobId,
+        marketing_job_state: result.state,
+        marketing_job_status: result.status,
+        marketing_stage: result.currentStage,
+        marketing_stage_status: result.stageStatus,
+        updatedAt: result.updatedAt,
+        needs_attention: needsAttention(result.status),
+        approvalRequired: result.approvalRequired,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/marketing/jobs/[jobId]/route.ts
+++ b/app/api/marketing/jobs/[jobId]/route.ts
@@ -1,43 +1,9 @@
-import { NextResponse } from 'next/server';
-import { getMarketingJobStatus } from '../../../../../backend/marketing/jobs-status';
-
-function needsAttention(status: string) {
-  return [
-    'error',
-    'failed',
-    'blocked',
-    'needs_repair',
-    'hard_failure',
-    'rejected',
-  ].includes(status);
-}
+import { handleGetMarketingJobStatus } from './handler';
 
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ jobId: string }> }
 ) {
   const { jobId } = await params;
-  try {
-    const result = getMarketingJobStatus(jobId);
-    return NextResponse.json(
-      {
-        jobId: result.jobId,
-        tenantId: result.tenantId,
-        marketing_job_state: result.state,
-        marketing_job_status: result.status,
-        marketing_stage: result.currentStage,
-        marketing_stage_status: result.stageStatus,
-        updatedAt: result.updatedAt,
-        needs_attention: needsAttention(result.status)
-      },
-      { status: 200 }
-    );
-  } catch (error) {
-    return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : String(error)
-      },
-      { status: 500 }
-    );
-  }
+  return handleGetMarketingJobStatus(jobId);
 }

--- a/app/api/marketing/jobs/handler.ts
+++ b/app/api/marketing/jobs/handler.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+
+import { startMarketingJob } from '@/backend/marketing/jobs-start';
+import { OpenClawGatewayError } from '@/backend/openclaw/gateway-client';
+import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
+
+const MARKETING_ONBOARDING_REQUIRED = {
+  status: 409,
+  reason: 'onboarding_required',
+  message: 'Complete tenant onboarding before starting a brand campaign.',
+} as const;
+
+export async function handlePostMarketingJobs(
+  req: Request,
+  tenantContextLoader?: TenantContextLoader
+) {
+  const tenantResult = await loadTenantContextOrResponse(tenantContextLoader, {
+    missingMembershipResponse: MARKETING_ONBOARDING_REQUIRED,
+  });
+  if ('response' in tenantResult) {
+    return tenantResult.response;
+  }
+
+  let payload: { jobType?: unknown; payload?: Record<string, unknown> } = {};
+  try {
+    payload = await req.json();
+  } catch {
+    payload = {};
+  }
+
+  try {
+    const result = await startMarketingJob({
+      tenantId: tenantResult.tenantContext.tenantId,
+      jobType: payload.jobType as 'brand_campaign',
+      payload: payload.payload ?? {},
+    });
+
+    return NextResponse.json(
+      {
+        marketing_job_status: result.status,
+        jobId: result.jobId,
+        jobType: result.jobType,
+        approvalRequired: result.approvalRequired,
+        jobStatusUrl: `/marketing/job-status?jobId=${encodeURIComponent(result.jobId)}`,
+      },
+      { status: 202 }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (error instanceof OpenClawGatewayError) {
+      const status =
+        error.code === 'openclaw_gateway_unauthorized'
+          ? 401
+          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
+            ? 503
+            : error.status || 500;
+      return NextResponse.json({ error: message, reason: error.code }, { status });
+    }
+    if (message.startsWith('workflow_missing_for_route:')) {
+      return NextResponse.json({ error: message, reason: 'workflow_missing_for_route' }, { status: 501 });
+    }
+    if (message.startsWith('missing_required_fields:') || message.startsWith('unsupported_job_type:')) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    return NextResponse.json(
+      {
+        error: message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/marketing/jobs/route.ts
+++ b/app/api/marketing/jobs/route.ts
@@ -1,50 +1,5 @@
-import { NextResponse } from 'next/server';
-import { startMarketingJob } from '../../../../backend/marketing/jobs-start';
-import { OpenClawGatewayError, type LobsterEnvelope } from '../../../../backend/openclaw/gateway-client';
+import { handlePostMarketingJobs } from './handler';
 
 export async function POST(req: Request) {
-  let payload: any = {};
-  try {
-    payload = await req.json();
-  } catch {
-    payload = {};
-  }
-
-  try {
-    const result = await startMarketingJob(payload);
-    return NextResponse.json(
-      {
-        marketing_job_status: result.status,
-        jobId: result.jobId,
-        tenantId: result.tenantId,
-        jobType: result.jobType,
-        wiring: result.wiring
-      },
-      { status: 202 }
-    );
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof OpenClawGatewayError) {
-      const status =
-        error.code === 'openclaw_gateway_unauthorized'
-          ? 401
-          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
-            ? 503
-            : error.status || 500;
-      return NextResponse.json({ error: message, reason: error.code }, { status });
-    }
-    if (message.startsWith('workflow_missing_for_route:')) {
-      return NextResponse.json({ error: message, reason: 'workflow_missing_for_route' }, { status: 501 });
-    }
-    if (message.startsWith('missing_required_fields:') || message.startsWith('unsupported_job_type:')) {
-      return NextResponse.json({ error: message }, { status: 400 });
-    }
-
-    return NextResponse.json(
-      {
-        error: message
-      },
-      { status: 500 }
-    );
-  }
+  return handlePostMarketingJobs(req);
 }

--- a/app/marketing/job-approve/page.tsx
+++ b/app/marketing/job-approve/page.tsx
@@ -4,10 +4,9 @@ import MarketingJobApproveScreen from '../../../frontend/marketing/job-approve';
 export default async function MarketingJobApprovePage({
   searchParams
 }: {
-  searchParams?: Promise<{ jobId?: string; tenantId?: string }>;
+  searchParams?: Promise<{ jobId?: string }>;
 }) {
   const resolved = await searchParams;
   const jobId = resolved?.jobId || '';
-  const tenantId = resolved?.tenantId || '';
-  return <MarketingJobApproveScreen defaultJobId={jobId} defaultTenantId={tenantId} />;
+  return <MarketingJobApproveScreen defaultJobId={jobId} />;
 }

--- a/backend/marketing/jobs-approve.ts
+++ b/backend/marketing/jobs-approve.ts
@@ -1,70 +1,17 @@
-declare const require: (name: string) => any;
-import { resolveDataPath, resolveSpecPath } from "../../lib/runtime-paths";
-import { runAriesOpenClawWorkflow } from "../openclaw/aries-execution";
-
-const fs = require("fs");
-const path = require("path");
-
-const REQUIRED_SCHEMA_PATHS = [
-  resolveSpecPath("tenant_runtime_state_schema.v1.json"),
-  resolveSpecPath("job_runtime_state_schema.v1.json")
-] as const;
-
-function nowIso(): string { return new Date().toISOString(); }
-
-function assertRequiredSchemas(): void {
-  for (const schemaPath of REQUIRED_SCHEMA_PATHS) {
-    if (!fs.existsSync(schemaPath)) {
-      throw new Error(`HARD_FAILURE: missing required schema input: ${schemaPath}`);
-    }
-    const parsed = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
-    if (!parsed || typeof parsed !== "object") {
-      throw new Error(`HARD_FAILURE: invalid required schema input: ${schemaPath}`);
-    }
-  }
-}
-
-function runtimePath(jobId: string): string {
-  return resolveDataPath("generated", "draft", "marketing-jobs", `${jobId}.json`);
-}
-
-function localApproveProgress(job: any): { resumedStage: string | null; completed: boolean } {
-  if (!job.outputs) job.outputs = {};
-  if (!job.outputs.stage_status) {
-    job.outputs.stage_status = { research: "queued", strategy: "paused", production: "paused", publish: "paused" };
-  }
-
-  const s = job.outputs.stage_status;
-  const updates = Array.isArray(job.outputs.structured_status_updates) ? job.outputs.structured_status_updates : [];
-  const ts = nowIso();
-
-  const completeStage = (stage: string, next: string | null) => {
-    s[stage] = "completed";
-    if (next) s[next] = "queued";
-    updates.push({ at: ts, state: "running", status: "running", step: stage, details: { transition: next ? `${stage}->${next}` : `${stage}->complete` } });
-    job.outputs.current_stage = next || "done";
-    return stage;
-  };
-
-  let resumed: string | null = null;
-
-  if (s.research === "queued" || s.research === "running" || s.research === "paused") resumed = completeStage("research", "strategy");
-  else if (s.strategy === "queued" || s.strategy === "running" || s.strategy === "paused") resumed = completeStage("strategy", "production");
-  else if (s.production === "queued" || s.production === "running" || s.production === "paused") resumed = completeStage("production", "publish");
-  else if (s.publish === "queued" || s.publish === "running" || s.publish === "paused") {
-    resumed = completeStage("publish", null);
-    job.state = "completed";
-    job.status = "pass";
-  }
-
-  job.outputs.structured_status_updates = updates;
-  job.updated_at = ts;
-  const history = Array.isArray(job.history) ? job.history : [];
-  history.push({ at: ts, state: job.state || "running", status: job.status || "running", note: `approval_resume ${resumed || 'none'}` });
-  job.history = history;
-
-  return { resumedStage: resumed, completed: job.state === "completed" || (s.publish === "completed") };
-}
+import { resumeOpenClawLobsterWorkflow, type LobsterEnvelope } from '../openclaw/gateway-client';
+import {
+  asRecord,
+  asString,
+  assertMarketingRuntimeSchemas,
+  ensureRuntimeHistory,
+  ensureRuntimeOpenClaw,
+  ensureRuntimeOutputs,
+  ensureRuntimeStageStatus,
+  ensureStructuredStatusUpdates,
+  loadMarketingJobRuntime,
+  nowIso,
+  saveMarketingJobRuntime,
+} from './runtime-state';
 
 export type ApproveMarketingJobRequest = {
   jobId: string;
@@ -84,8 +31,22 @@ export type ApproveMarketingJobResponse = {
   reason?: string;
 };
 
+function primaryOutputRecord(envelope: LobsterEnvelope): Record<string, unknown> | null {
+  if (!Array.isArray(envelope.output) || envelope.output.length === 0) {
+    return null;
+  }
+  const first = envelope.output[0];
+  return first && typeof first === 'object' && !Array.isArray(first)
+    ? (first as Record<string, unknown>)
+    : null;
+}
+
+function markStageCompleted(stageStatus: Record<string, string>, stage: string): void {
+  stageStatus[stage] = 'completed';
+}
+
 export async function approveMarketingJob(input: ApproveMarketingJobRequest): Promise<ApproveMarketingJobResponse> {
-  assertRequiredSchemas();
+  assertMarketingRuntimeSchemas();
 
   if (!input.approvedBy?.trim()) {
     return {
@@ -99,8 +60,8 @@ export async function approveMarketingJob(input: ApproveMarketingJobRequest): Pr
     };
   }
 
-  const filePath = runtimePath(input.jobId);
-  if (!fs.existsSync(filePath)) {
+  const job = loadMarketingJobRuntime(input.jobId);
+  if (!job) {
     return {
       status: "error",
       jobId: input.jobId,
@@ -111,8 +72,6 @@ export async function approveMarketingJob(input: ApproveMarketingJobRequest): Pr
       reason: 'job_not_found',
     };
   }
-
-  const job = JSON.parse(fs.readFileSync(filePath, "utf8"));
   if (typeof job.tenant_id !== 'string' || job.tenant_id !== input.tenantId) {
     return {
       status: "error",
@@ -125,17 +84,9 @@ export async function approveMarketingJob(input: ApproveMarketingJobRequest): Pr
     };
   }
 
-  const executed = await runAriesOpenClawWorkflow('marketing_approve', {
-    job_id: input.jobId,
-    tenant_id: input.tenantId,
-    approved_by: input.approvedBy.trim(),
-    approved_stages: input.approvedStages || [],
-    resume_publish_if_needed: input.resumePublishIfNeeded ?? true,
-  });
-  if (executed.kind === 'gateway_error') {
-    throw executed.error;
-  }
-  if (executed.kind === 'not_implemented') {
+  const openclaw = ensureRuntimeOpenClaw(job);
+  const resumeToken = asString(openclaw.resume_token);
+  if (!resumeToken) {
     return {
       status: "error",
       jobId: input.jobId,
@@ -143,16 +94,72 @@ export async function approveMarketingJob(input: ApproveMarketingJobRequest): Pr
       resumedStage: null,
       completed: false,
       wiring: "openclaw_gateway",
-      reason: executed.payload.code,
+      reason: 'approval_not_available',
     };
   }
 
+  const envelope = await resumeOpenClawLobsterWorkflow({
+    token: resumeToken,
+    approve: input.resumePublishIfNeeded ?? true,
+  });
+  const primaryOutput = primaryOutputRecord(envelope);
+  const outputs = ensureRuntimeOutputs(job);
+  const stageStatus = ensureRuntimeStageStatus(job);
+  const statusUpdates = ensureStructuredStatusUpdates(job);
+  const history = ensureRuntimeHistory(job);
+  const ts = nowIso();
+
+  markStageCompleted(stageStatus, 'research');
+  markStageCompleted(stageStatus, 'strategy');
+  markStageCompleted(stageStatus, 'production');
+  stageStatus.publish = envelope.requiresApproval?.resumeToken ? 'awaiting_approval' : 'completed';
+
+  outputs.current_stage = 'publish';
+  openclaw.envelope_status = envelope.status;
+  openclaw.resume_token = envelope.requiresApproval?.resumeToken ?? null;
+  if (!openclaw.run_id && typeof primaryOutput?.run_id === 'string') {
+    openclaw.run_id = primaryOutput.run_id;
+  }
+  if (!openclaw.initial_primary_output && openclaw.primary_output) {
+    openclaw.initial_primary_output = openclaw.primary_output;
+  }
+  openclaw.primary_output = primaryOutput;
+  openclaw.last_resume_output = primaryOutput;
+  openclaw.resumed_by = input.approvedBy.trim();
+  openclaw.resumed_at = ts;
+
+  job.state = envelope.requiresApproval?.resumeToken ? 'approval_required' : 'completed';
+  job.status = envelope.requiresApproval?.resumeToken ? 'awaiting_approval' : 'completed';
+  job.updated_at = ts;
+
+  statusUpdates.push({
+    at: ts,
+    state: job.state,
+    status: job.status,
+    step: 'publish',
+    details: {
+      source: 'openclaw_gateway_resume',
+      envelope_status: envelope.status,
+      approved_by: input.approvedBy.trim(),
+      approved_stages: input.approvedStages || [],
+    },
+  });
+  history.push({
+    at: ts,
+    state: job.state,
+    status: job.status,
+    note: envelope.requiresApproval?.resumeToken
+      ? 'marketing job resumed but is still awaiting approval'
+      : 'marketing job completed after launch approval',
+  });
+
+  saveMarketingJobRuntime(input.jobId, job);
   return {
     status: "resumed",
     jobId: input.jobId,
     tenantId: input.tenantId,
-    resumedStage: null,
-    completed: false,
+    resumedStage: "publish",
+    completed: !envelope.requiresApproval?.resumeToken,
     wiring: "openclaw_gateway"
   };
 }

--- a/backend/marketing/jobs-start.ts
+++ b/backend/marketing/jobs-start.ts
@@ -260,6 +260,7 @@ function createOpenClawBackedJobRuntime(
   const outPath = runtimePath(jobId);
   ensureParent(outPath);
   const ts = nowIso();
+  const approvalRequired = approvalRequiredFromOpenClaw(primaryOutput, envelope);
   const approvalPreview =
     primaryOutput &&
     typeof primaryOutput.approval_preview === 'object' &&
@@ -267,15 +268,15 @@ function createOpenClawBackedJobRuntime(
       ? (primaryOutput.approval_preview as Record<string, unknown>)
       : null;
   const stageStatus: Record<string, string> = {
-    research: 'submitted',
-    strategy: 'submitted',
-    production: 'submitted',
+    research: 'completed',
+    strategy: 'completed',
+    production: 'completed',
     publish:
       typeof approvalPreview?.status === 'string'
         ? String(approvalPreview.status)
         : envelope.requiresApproval?.resumeToken
           ? 'awaiting_approval'
-          : 'submitted',
+          : 'completed',
   };
 
   const doc: Dict = {
@@ -284,8 +285,8 @@ function createOpenClawBackedJobRuntime(
     job_id: jobId,
     job_type: input.jobType,
     tenant_id: input.tenantId,
-    state: envelope.requiresApproval?.resumeToken ? "waiting_repair" : "running",
-    status: "pending",
+    state: approvalRequired ? "approval_required" : "completed",
+    status: approvalRequired ? "awaiting_approval" : "completed",
     attempt: 1,
     max_attempts: 3,
     inputs: {
@@ -300,8 +301,29 @@ function createOpenClawBackedJobRuntime(
       structured_status_updates: [
         {
           at: ts,
-          state: "running",
-          status: "pending",
+          state: "completed",
+          status: "completed",
+          step: "research",
+          details: { source: "openclaw_gateway" }
+        },
+        {
+          at: ts,
+          state: "completed",
+          status: "completed",
+          step: "strategy",
+          details: { source: "openclaw_gateway" }
+        },
+        {
+          at: ts,
+          state: "completed",
+          status: "completed",
+          step: "production",
+          details: { source: "openclaw_gateway" }
+        },
+        {
+          at: ts,
+          state: approvalRequired ? "approval_required" : "completed",
+          status: approvalRequired ? "awaiting_approval" : "completed",
           step: "publish",
           details: { source: "openclaw_gateway", envelope_status: envelope.status }
         }
@@ -309,15 +331,18 @@ function createOpenClawBackedJobRuntime(
       openclaw: {
         envelope_status: envelope.status,
         resume_token: envelope.requiresApproval?.resumeToken || null,
+        run_id: typeof primaryOutput?.run_id === 'string' ? primaryOutput.run_id : null,
         primary_output: primaryOutput,
       },
     },
     history: [
       {
         at: ts,
-        state: envelope.requiresApproval?.resumeToken ? "waiting_repair" : "running",
-        status: "pending",
-        note: "marketing job accepted via OpenClaw gateway"
+        state: approvalRequired ? "approval_required" : "completed",
+        status: approvalRequired ? "awaiting_approval" : "completed",
+        note: approvalRequired
+          ? "marketing job reached launch approval via OpenClaw gateway"
+          : "marketing job completed via OpenClaw gateway"
       }
     ],
     created_at: ts,

--- a/backend/marketing/jobs-start.ts
+++ b/backend/marketing/jobs-start.ts
@@ -1,6 +1,7 @@
 declare const require: (name: string) => any;
 import { resolveDataPath, resolveSpecPath } from "../../lib/runtime-paths";
 import { runAriesOpenClawWorkflow } from "../openclaw/aries-execution";
+import { randomUUID } from "node:crypto";
 
 type Dict = Record<string, unknown>;
 const fs = require("fs");
@@ -13,6 +14,10 @@ const REQUIRED_SCHEMA_PATHS = [
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function makeMarketingJobId(): string {
+  return `mkt_${randomUUID()}`;
 }
 
 function assertRequiredSchemas(): void {
@@ -120,10 +125,33 @@ export type StartMarketingJobResponse = {
   jobType: StartMarketingJobRequest["jobType"];
   wiring: "openclaw_gateway";
   runtimeArtifactPath: string;
+  approvalRequired: boolean;
 };
 
 function runtimeArtifactPath(jobId: string): string {
   return `generated/draft/marketing-jobs/${jobId}.json`;
+}
+
+function approvalRequiredFromOpenClaw(
+  primaryOutput: Record<string, unknown> | null,
+  envelope: { requiresApproval?: { resumeToken?: string } | null }
+): boolean {
+  if (envelope.requiresApproval?.resumeToken) {
+    return true;
+  }
+
+  const approvalPreview =
+    primaryOutput &&
+    typeof primaryOutput.approval_preview === "object" &&
+    primaryOutput.approval_preview !== null
+      ? (primaryOutput.approval_preview as Record<string, unknown>)
+      : null;
+  const approvalStatus =
+    approvalPreview && typeof approvalPreview.status === "string"
+      ? approvalPreview.status.trim().toLowerCase()
+      : "";
+
+  return approvalStatus.includes("approval") || approvalStatus.includes("review");
 }
 
 export type CreateMarketingJobRuntimePayload = {
@@ -162,7 +190,7 @@ export function createMarketingJobRuntime(payload: CreateMarketingJobRuntimePayl
   const jobId =
     typeof req.job_id === "string" && req.job_id.trim()
       ? req.job_id.trim()
-      : `mkt_${tenantId}_${Date.now()}`;
+      : makeMarketingJobId();
   const outPath = runtimePath(jobId);
   ensureParent(outPath);
   const ts = nowIso();
@@ -331,7 +359,7 @@ export async function startMarketingJob(
   }
 
   const tenantId = input.tenantId.trim();
-  const jobId = `mkt_${tenantId}_${Date.now()}`;
+  const jobId = makeMarketingJobId();
   const executed = await runAriesOpenClawWorkflow('marketing_start', {
     competitor: '',
     competitor_facebook_url: competitorUrl,
@@ -347,6 +375,7 @@ export async function startMarketingJob(
     throw new Error(`${executed.payload.code}:${executed.payload.route}`);
   }
 
+  const approvalRequired = approvalRequiredFromOpenClaw(executed.primaryOutput, executed.envelope);
   createOpenClawBackedJobRuntime(input, jobId, executed.primaryOutput, executed.envelope);
   return {
     status: "accepted",
@@ -354,6 +383,7 @@ export async function startMarketingJob(
     tenantId,
     jobType: input.jobType,
     wiring: "openclaw_gateway",
-    runtimeArtifactPath: runtimeArtifactPath(jobId)
+    runtimeArtifactPath: runtimeArtifactPath(jobId),
+    approvalRequired,
   };
 }

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -41,10 +41,39 @@ export type MarketingJobStatusResponse = {
   stageStatus: Record<string, string>;
   updatedAt: string | null;
   runtimeArtifactPath: string;
+  approvalRequired: boolean;
 };
 
 function runtimeArtifactPath(jobId: string): string {
   return `generated/draft/marketing-jobs/${jobId}.json`;
+}
+
+function getJobOutputs(job: Record<string, unknown>): Record<string, unknown> {
+  return job.outputs && typeof job.outputs === "object" ? (job.outputs as Record<string, unknown>) : {};
+}
+
+function approvalRequiredFromJob(job: Record<string, unknown>): boolean {
+  const outputs = getJobOutputs(job);
+  const resumeToken =
+    typeof outputs.openclaw === "object" && outputs.openclaw !== null
+      ? (outputs.openclaw as Record<string, unknown>)
+      : null;
+  const openClawResumeToken =
+    resumeToken && typeof resumeToken.resume_token === "string"
+      ? resumeToken.resume_token.trim()
+      : "";
+  if (openClawResumeToken) {
+    return true;
+  }
+
+  const stageStatus =
+    typeof outputs.stage_status === "object" && outputs.stage_status !== null
+      ? (outputs.stage_status as Record<string, unknown>)
+      : {};
+
+  return Object.values(stageStatus).some(
+    (value) => typeof value === "string" && /(approval|review)/i.test(value)
+  );
 }
 
 export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
@@ -60,20 +89,27 @@ export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse
       currentStage: null,
       stageStatus: {},
       updatedAt: null,
-      runtimeArtifactPath: runtimeArtifactPath(jobId)
+      runtimeArtifactPath: runtimeArtifactPath(jobId),
+      approvalRequired: false,
     };
   }
 
   const raw = fs.readFileSync(filePath, "utf8");
-  const job = JSON.parse(raw);
+  const job = JSON.parse(raw) as Record<string, unknown>;
+  const outputs = getJobOutputs(job);
+  const stageStatus =
+    typeof outputs.stage_status === "object" && outputs.stage_status !== null
+      ? (outputs.stage_status as Record<string, string>)
+      : {};
   return {
     jobId,
     tenantId: typeof job.tenant_id === "string" ? job.tenant_id : null,
     state: typeof job.state === "string" ? job.state : "unknown",
     status: typeof job.status === "string" ? job.status : "unknown",
-    currentStage: typeof job?.outputs?.current_stage === "string" ? job.outputs.current_stage : null,
-    stageStatus: (job?.outputs?.stage_status && typeof job.outputs.stage_status === "object") ? job.outputs.stage_status : {},
+    currentStage: typeof outputs.current_stage === "string" ? outputs.current_stage : null,
+    stageStatus,
     updatedAt: typeof job.updated_at === "string" ? job.updated_at : null,
-    runtimeArtifactPath: runtimeArtifactPath(jobId)
+    runtimeArtifactPath: runtimeArtifactPath(jobId),
+    approvalRequired: approvalRequiredFromJob(job),
   };
 }

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -1,36 +1,80 @@
-declare const require: (name: string) => any;
-import { resolveDataPath, resolveSpecPath } from "../../lib/runtime-paths";
+import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
-const fs = require("fs");
-const path = require("path");
+import {
+  asRecord,
+  asString,
+  asStringArray,
+  assertMarketingRuntimeSchemas,
+  ensureRuntimeOpenClaw,
+  loadMarketingJobRuntime,
+  marketingRunIdFromRuntime,
+} from './runtime-state';
 
-const REQUIRED_SCHEMA_PATHS = [
-  resolveSpecPath("tenant_runtime_state_schema.v1.json"),
-  resolveSpecPath("job_runtime_state_schema.v1.json")
-] as const;
+type MarketingStage = 'research' | 'strategy' | 'production' | 'publish';
+type TimelineTone = 'info' | 'success' | 'warning' | 'danger';
 
-function assertRequiredSchemas(): void {
-  for (const schemaPath of REQUIRED_SCHEMA_PATHS) {
-    if (!fs.existsSync(schemaPath)) {
-      throw new Error(`HARD_FAILURE: missing required schema input: ${schemaPath}`);
-    }
+type MarketingRuntimeData = {
+  runId: string | null;
+  researchCompile: Record<string, unknown> | null;
+  researchExtract: Record<string, unknown> | null;
+  websiteBrandAnalysis: Record<string, unknown> | null;
+  campaignPlanner: Record<string, unknown> | null;
+  headOfMarketing: Record<string, unknown> | null;
+  productionReview: Record<string, unknown> | null;
+  creativeDirectorFinalize: Record<string, unknown> | null;
+  videoGenerator: Record<string, unknown> | null;
+  performancePreflight: Record<string, unknown> | null;
+  launchReview: Record<string, unknown> | null;
+  performanceSummary: Record<string, unknown> | null;
+  publisherPayloads: Array<Record<string, unknown>>;
+  launchPreviewText: string | null;
+  productionPreviewText: string | null;
+};
 
-    try {
-      const raw = fs.readFileSync(schemaPath, "utf8");
-      const parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== "object") {
-        throw new Error("schema root must be an object");
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`HARD_FAILURE: invalid required schema input ${schemaPath}: ${message}`);
-    }
-  }
-}
+export type MarketingStageCard = {
+  stage: MarketingStage;
+  label: string;
+  status: string;
+  summary: string;
+  highlight?: string;
+};
 
-function runtimePath(jobId: string): string {
-  return resolveDataPath("generated", "draft", "marketing-jobs", `${jobId}.json`);
-}
+export type MarketingArtifactCard = {
+  id: string;
+  stage: MarketingStage;
+  title: string;
+  category: string;
+  status: string;
+  summary: string;
+  details: string[];
+  preview?: string;
+  actionLabel?: string;
+  actionHref?: string;
+};
+
+export type MarketingTimelineEntry = {
+  id: string;
+  at: string | null;
+  tone: TimelineTone;
+  label: string;
+  description: string;
+};
+
+export type MarketingApprovalSummary = {
+  required: boolean;
+  status: string;
+  title: string;
+  message: string;
+  actionLabel?: string;
+  actionHref?: string;
+};
+
+export type MarketingSummary = {
+  headline: string;
+  subheadline: string;
+};
 
 export type MarketingJobStatusResponse = {
   jobId: string;
@@ -40,76 +84,653 @@ export type MarketingJobStatusResponse = {
   currentStage: string | null;
   stageStatus: Record<string, string>;
   updatedAt: string | null;
-  runtimeArtifactPath: string;
   approvalRequired: boolean;
+  needsAttention: boolean;
+  summary: MarketingSummary;
+  stageCards: MarketingStageCard[];
+  artifacts: MarketingArtifactCard[];
+  timeline: MarketingTimelineEntry[];
+  approval: MarketingApprovalSummary | null;
+  nextStep: string;
+  repairStatus: string;
 };
 
-function runtimeArtifactPath(jobId: string): string {
-  return `generated/draft/marketing-jobs/${jobId}.json`;
+const STAGE_LABELS: Record<MarketingStage, string> = {
+  research: 'Research',
+  strategy: 'Strategy',
+  production: 'Production',
+  publish: 'Publish',
+};
+
+const PUBLISHER_STEPS = [
+  'meta_ads_publisher',
+  'instagram_publisher',
+  'x_publisher',
+  'tiktok_publisher',
+  'youtube_publisher',
+  'linkedin_publisher',
+  'reddit_publisher',
+] as const;
+
+function cacheRoot(envKey: string, fallbackFolder: string): string {
+  return process.env[envKey]?.trim() || path.join(tmpdir(), fallbackFolder);
 }
 
-function getJobOutputs(job: Record<string, unknown>): Record<string, unknown> {
-  return job.outputs && typeof job.outputs === "object" ? (job.outputs as Record<string, unknown>) : {};
+function stepPayloadPath(stage: 1 | 2 | 3 | 4, runId: string, stepName: string): string {
+  const root =
+    stage === 1
+      ? cacheRoot('LOBSTER_STAGE1_CACHE_DIR', 'lobster-stage1-cache')
+      : stage === 2
+        ? cacheRoot('LOBSTER_STAGE2_CACHE_DIR', 'lobster-stage2-cache')
+        : stage === 3
+          ? cacheRoot('LOBSTER_STAGE3_CACHE_DIR', 'lobster-stage3-cache')
+          : cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache');
+  return path.join(root, runId, `${stepName}.json`);
 }
 
-function approvalRequiredFromJob(job: Record<string, unknown>): boolean {
-  const outputs = getJobOutputs(job);
-  const resumeToken =
-    typeof outputs.openclaw === "object" && outputs.openclaw !== null
-      ? (outputs.openclaw as Record<string, unknown>)
+function readJsonIfExists(filePath: string): Record<string, unknown> | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
       : null;
-  const openClawResumeToken =
-    resumeToken && typeof resumeToken.resume_token === "string"
-      ? resumeToken.resume_token.trim()
-      : "";
-  if (openClawResumeToken) {
+  } catch {
+    return null;
+  }
+}
+
+function readTextPreview(filePath: string | null, maxChars = 420): string | null {
+  if (!filePath || !existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const text = readFileSync(filePath, 'utf8').trim();
+    if (!text) {
+      return null;
+    }
+    return text.length > maxChars ? `${text.slice(0, maxChars).trimEnd()}...` : text;
+  } catch {
+    return null;
+  }
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return fallback;
+}
+
+function generatedAt(payload: Record<string, unknown> | null): string | null {
+  return asString(payload?.generated_at);
+}
+
+function approvalRequiredFromRuntime(
+  runtimeDoc: Record<string, unknown>,
+  launchReview: Record<string, unknown> | null
+): boolean {
+  const openclaw = ensureRuntimeOpenClaw(runtimeDoc);
+  if (asString(openclaw.resume_token)) {
     return true;
   }
 
-  const stageStatus =
-    typeof outputs.stage_status === "object" && outputs.stage_status !== null
-      ? (outputs.stage_status as Record<string, unknown>)
-      : {};
-
-  return Object.values(stageStatus).some(
-    (value) => typeof value === "string" && /(approval|review)/i.test(value)
-  );
+  const approvalPreview = asRecord(launchReview?.approval_preview) ?? asRecord(asRecord(openclaw.primary_output)?.approval_preview);
+  return /pending|approval|review/i.test(stringValue(approvalPreview?.status));
 }
 
-export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
-  assertRequiredSchemas();
-  const filePath = runtimePath(jobId);
+function normalizeFallbackStageStatus(stage: MarketingStage, value: string | null): string | null {
+  if (!value) return null;
+  if (value === 'submitted' && stage !== 'publish') return 'completed';
+  if (value === 'pending_human_review') return 'awaiting_approval';
+  if (value === 'pass') return 'completed';
+  if (value === 'fail') return 'failed';
+  return value;
+}
 
-  if (!fs.existsSync(filePath)) {
+function deriveStageStatus(
+  stage: MarketingStage,
+  runtimeDoc: Record<string, unknown>,
+  runtimeData: MarketingRuntimeData
+): string {
+  const outputs = asRecord(runtimeDoc.outputs);
+  const fallback = normalizeFallbackStageStatus(
+    stage,
+    stringValue(asRecord(outputs?.stage_status)?.[stage], '')
+  );
+
+  switch (stage) {
+    case 'research':
+      return runtimeData.researchCompile ? 'completed' : runtimeData.researchExtract ? 'in_progress' : (fallback || 'accepted');
+    case 'strategy':
+      return runtimeData.headOfMarketing
+        ? 'completed'
+        : runtimeData.campaignPlanner || runtimeData.websiteBrandAnalysis
+          ? 'in_progress'
+          : (fallback || 'ready');
+    case 'production':
+      return runtimeData.creativeDirectorFinalize
+        ? 'completed'
+        : runtimeData.productionReview || runtimeData.videoGenerator
+          ? 'in_progress'
+          : (fallback || 'ready');
+    case 'publish':
+      if (runtimeData.performanceSummary || runtimeData.publisherPayloads.length > 0) {
+        return 'completed';
+      }
+      if (approvalRequiredFromRuntime(runtimeDoc, runtimeData.launchReview)) {
+        return 'awaiting_approval';
+      }
+      if (runtimeData.performancePreflight || runtimeData.launchReview) {
+        return 'in_progress';
+      }
+      return fallback || 'ready';
+    default:
+      return fallback || 'accepted';
+  }
+}
+
+function deriveState(
+  runtimeDoc: Record<string, unknown>,
+  stageStatus: Record<string, string>,
+  approvalRequired: boolean
+): { state: string; status: string; currentStage: string | null; nextStep: string; repairStatus: string; needsAttention: boolean } {
+  const runtimeStatus = stringValue(runtimeDoc.status);
+  const runtimeState = stringValue(runtimeDoc.state);
+  const publishStatus = stageStatus.publish;
+
+  if (runtimeState === 'not_found') {
     return {
-      jobId,
-      tenantId: null,
-      state: "not_found",
-      status: "error",
+      state: 'not_found',
+      status: 'error',
       currentStage: null,
-      stageStatus: {},
-      updatedAt: null,
-      runtimeArtifactPath: runtimeArtifactPath(jobId),
-      approvalRequired: false,
+      nextStep: 'none',
+      repairStatus: 'not_required',
+      needsAttention: false,
     };
   }
 
-  const raw = fs.readFileSync(filePath, "utf8");
-  const job = JSON.parse(raw) as Record<string, unknown>;
-  const outputs = getJobOutputs(job);
-  const stageStatus =
-    typeof outputs.stage_status === "object" && outputs.stage_status !== null
-      ? (outputs.stage_status as Record<string, string>)
-      : {};
+  if (publishStatus === 'completed' || runtimeStatus === 'completed') {
+    return {
+      state: 'completed',
+      status: 'completed',
+      currentStage: 'publish',
+      nextStep: 'none',
+      repairStatus: 'not_required',
+      needsAttention: false,
+    };
+  }
+
+  if (approvalRequired) {
+    return {
+      state: 'approval_required',
+      status: 'awaiting_approval',
+      currentStage: 'publish',
+      nextStep: 'submit_approval',
+      repairStatus: 'not_required',
+      needsAttention: true,
+    };
+  }
+
+  if (
+    ['error', 'failed', 'needs_repair', 'blocked', 'hard_failure', 'rejected'].includes(runtimeStatus) ||
+    ['error', 'failed', 'needs_repair', 'blocked'].includes(runtimeState)
+  ) {
+    return {
+      state: runtimeState || 'failed',
+      status: runtimeStatus || 'failed',
+      currentStage: stageStatus.production === 'completed' ? 'publish' : stageStatus.strategy === 'completed' ? 'production' : 'strategy',
+      nextStep: 'invoke_marketing_repair',
+      repairStatus: 'required',
+      needsAttention: true,
+    };
+  }
+
+  return {
+    state: runtimeState || 'running',
+    status: runtimeStatus || 'in_progress',
+    currentStage: stageStatus.production === 'completed' ? 'publish' : stageStatus.strategy === 'completed' ? 'production' : stageStatus.research === 'completed' ? 'strategy' : 'research',
+    nextStep: 'wait_for_completion',
+    repairStatus: 'not_required',
+    needsAttention: false,
+  };
+}
+
+function buildSummary(
+  state: ReturnType<typeof deriveState>
+): MarketingSummary {
+  if (state.status === 'completed') {
+    return {
+      headline: 'Campaign outputs are ready',
+      subheadline: 'Launch packages, review artifacts, and delivery summaries are available for the current campaign.',
+    };
+  }
+
+  if (state.status === 'awaiting_approval') {
+    return {
+      headline: 'Campaign is ready for launch approval',
+      subheadline: 'Research, strategy, and production completed successfully. Review the launch package to continue.',
+    };
+  }
+
+  if (state.needsAttention) {
+    return {
+      headline: 'Campaign needs operator attention',
+      subheadline: 'The pipeline reported a failure or blocked state. Review the latest artifacts and next action before retrying.',
+    };
+  }
+
+  return {
+    headline: 'Campaign is in progress',
+    subheadline: 'Aries is still collecting workflow signals from the marketing pipeline. Refresh to see the latest stage progress.',
+  };
+}
+
+function buildStageCards(
+  runtimeData: MarketingRuntimeData,
+  stageStatus: Record<string, string>
+): MarketingStageCard[] {
+  const researchSummary = asRecord(runtimeData.researchCompile?.executive_summary);
+  const strategyPlan = asRecord(runtimeData.campaignPlanner?.campaign_plan);
+  const productionReviewPacket = asRecord(runtimeData.productionReview?.review_packet);
+  const publishPlan = asRecord(runtimeData.performancePreflight?.publish_plan);
+
+  return (['research', 'strategy', 'production', 'publish'] as MarketingStage[]).map((stage) => {
+    switch (stage) {
+      case 'research':
+        return {
+          stage,
+          label: STAGE_LABELS[stage],
+          status: stageStatus[stage],
+          summary:
+            stringValue(researchSummary?.creative_takeaway) ||
+            'Competitive research completed and ad-angle insights were compiled.',
+          highlight: stringValue(researchSummary?.campaign_takeaway),
+        };
+      case 'strategy':
+        return {
+          stage,
+          label: STAGE_LABELS[stage],
+          status: stageStatus[stage],
+          summary:
+            stringValue(strategyPlan?.core_message) ||
+            'Campaign strategy and channel plans were assembled from the brand profile.',
+          highlight: stringValue(strategyPlan?.primary_cta),
+        };
+      case 'production':
+        return {
+          stage,
+          label: STAGE_LABELS[stage],
+          status: stageStatus[stage],
+          summary:
+            stringValue(asRecord(productionReviewPacket?.summary)?.core_message) ||
+            'Production assets and review packet were prepared for launch.',
+          highlight: stringValue(asRecord(productionReviewPacket?.asset_previews)?.landing_page_headline),
+        };
+      case 'publish':
+        return {
+          stage,
+          label: STAGE_LABELS[stage],
+          status: stageStatus[stage],
+          summary:
+            stringValue(asRecord(runtimeData.launchReview?.approval_preview)?.message) ||
+            stringValue(asRecord(runtimeData.performanceSummary?.summary)?.message) ||
+            'Launch review and publish package generation are handled in the final stage.',
+          highlight:
+            runtimeData.performanceSummary || runtimeData.publisherPayloads.length > 0
+              ? `${runtimeData.publisherPayloads.length || 1} publish package(s) generated`
+              : `Static contracts: ${stringValue(publishPlan?.static_contract_count, '0')}, Video contracts: ${stringValue(publishPlan?.video_contract_count, '0')}`,
+        };
+    }
+  });
+}
+
+function buildApproval(
+  jobId: string,
+  approvalRequired: boolean,
+  runtimeData: MarketingRuntimeData
+): MarketingApprovalSummary | null {
+  if (!approvalRequired) {
+    return null;
+  }
+
+  const approvalPreview = asRecord(runtimeData.launchReview?.approval_preview);
+  return {
+    required: true,
+    status: stringValue(approvalPreview?.status, 'pending_human_review'),
+    title: 'Launch approval required',
+    message:
+      stringValue(approvalPreview?.message) ||
+      'The real Lobster pipeline paused at launch review. Approve to generate publish-ready assets.',
+    actionLabel: 'Open approval dashboard',
+    actionHref: `/marketing/job-approve?jobId=${encodeURIComponent(jobId)}`,
+  };
+}
+
+function withDetails(...details: Array<string | null | undefined>): string[] {
+  return details.filter((detail): detail is string => typeof detail === 'string' && detail.trim().length > 0);
+}
+
+function buildArtifacts(
+  jobId: string,
+  runtimeData: MarketingRuntimeData,
+  approval: MarketingApprovalSummary | null
+): MarketingArtifactCard[] {
+  const cards: MarketingArtifactCard[] = [];
+  const researchSummary = asRecord(runtimeData.researchCompile?.executive_summary);
+  const researchInputs = asRecord(runtimeData.researchCompile?.inputs);
+  const brandAnalysis = asRecord(runtimeData.websiteBrandAnalysis?.brand_analysis);
+  const campaignPlan = asRecord(runtimeData.campaignPlanner?.campaign_plan);
+  const reviewPacket = asRecord(runtimeData.productionReview?.review_packet);
+  const videoAssets = asRecord(runtimeData.videoGenerator?.video_assets);
+  const publishPlan = asRecord(runtimeData.performancePreflight?.publish_plan);
+
+  if (runtimeData.researchCompile || runtimeData.researchExtract) {
+    cards.push({
+      id: 'research-summary',
+      stage: 'research',
+      title: 'Competitor research summary',
+      category: 'analysis',
+      status: 'completed',
+      summary:
+        stringValue(researchSummary?.market_positioning) ||
+        'The pipeline compiled competitor positioning, creative takeaways, and recommended actions.',
+      details: withDetails(
+        `Competitor: ${stringValue(runtimeData.researchCompile?.competitor || runtimeData.researchExtract?.competitor, 'Unknown')}`,
+        `Ads reviewed: ${stringValue(researchInputs?.ads_seen, '0')}`,
+        stringValue(researchSummary?.campaign_takeaway),
+      ),
+      preview: asStringArray(runtimeData.researchExtract?.competitor_research_summary).join('\n') || undefined,
+    });
+  }
+
+  if (runtimeData.websiteBrandAnalysis || runtimeData.campaignPlanner) {
+    cards.push({
+      id: 'strategy-plan',
+      stage: 'strategy',
+      title: 'Campaign strategy',
+      category: 'brief',
+      status: 'completed',
+      summary:
+        stringValue(brandAnalysis?.brand_promise) ||
+        stringValue(campaignPlan?.core_message) ||
+        'Brand analysis and cross-channel campaign planning are ready.',
+      details: withDetails(
+        stringValue(brandAnalysis?.audience_summary),
+        `Offer: ${stringValue(brandAnalysis?.offer_summary || campaignPlan?.offer, 'n/a')}`,
+        `Primary CTA: ${stringValue(campaignPlan?.primary_cta, 'Learn More')}`,
+      ),
+      preview: asStringArray(brandAnalysis?.proof_points).join('\n') || undefined,
+    });
+  }
+
+  if (runtimeData.productionReview || runtimeData.creativeDirectorFinalize) {
+    cards.push({
+      id: 'production-review',
+      stage: 'production',
+      title: 'Production review packet',
+      category: 'review',
+      status: 'completed',
+      summary:
+        stringValue(asRecord(reviewPacket?.summary)?.core_message) ||
+        'Landing page, ad, script, and video deliverables were prepared for launch.',
+      details: withDetails(
+        `Landing page headline: ${stringValue(asRecord(reviewPacket?.asset_previews)?.landing_page_headline, 'n/a')}`,
+        `Ad hook: ${stringValue(asRecord(reviewPacket?.asset_previews)?.meta_ad_hook, 'n/a')}`,
+        `Video opening line: ${stringValue(asRecord(reviewPacket?.asset_previews)?.video_opening_line, 'n/a')}`,
+      ),
+      preview: runtimeData.productionPreviewText || undefined,
+    });
+  }
+
+  if (runtimeData.videoGenerator) {
+    const platformContracts = Array.isArray(videoAssets?.platform_contracts)
+      ? videoAssets.platform_contracts as Array<Record<string, unknown>>
+      : [];
+    cards.push({
+      id: 'video-contracts',
+      stage: 'production',
+      title: 'Video contract handoff',
+      category: 'contracts',
+      status: 'completed',
+      summary: `${platformContracts.length} video platform contract(s) were prepared for downstream rendering.`,
+      details: platformContracts.slice(0, 4).map((contract) => {
+        const platform = stringValue(contract.platform, 'Platform');
+        const platformSlug = stringValue(contract.platform_slug);
+        return platformSlug ? `${platform} (${platformSlug})` : platform;
+      }),
+    });
+  }
+
+  if (runtimeData.launchReview) {
+    cards.push({
+      id: 'launch-review',
+      stage: 'publish',
+      title: 'Launch review package',
+      category: 'approval',
+      status: approval?.required ? 'awaiting_approval' : 'completed',
+      summary:
+        stringValue(asRecord(runtimeData.launchReview.approval_preview)?.message) ||
+        'The final publish step prepared a launch review package for operator approval.',
+      details: withDetails(
+        `Static contracts: ${stringValue(publishPlan?.static_contract_count, '0')}`,
+        `Video contracts: ${stringValue(publishPlan?.video_contract_count, '0')}`,
+      ),
+      preview: runtimeData.launchPreviewText || undefined,
+      actionLabel: approval?.actionLabel,
+      actionHref: approval?.actionHref,
+    });
+  }
+
+  if (runtimeData.performanceSummary || runtimeData.publisherPayloads.length > 0) {
+    cards.push({
+      id: 'publish-summary',
+      stage: 'publish',
+      title: 'Publish packages',
+      category: 'delivery',
+      status: 'completed',
+      summary:
+        stringValue(asRecord(runtimeData.performanceSummary?.summary)?.message) ||
+        'Publish-ready channel packages were generated for the campaign.',
+      details: runtimeData.publisherPayloads.map((payload) => {
+        const platform = stringValue(payload.platform, 'Platform');
+        const liveDraft = stringValue(asRecord(payload.live_draft_publish)?.status, 'not_configured');
+        const reviewSubmission = stringValue(asRecord(payload.aries_review_submission)?.status, 'not_configured');
+        return `${platform}: draft publish ${liveDraft}, Aries review ${reviewSubmission}`;
+      }),
+    });
+  }
+
+  return cards;
+}
+
+function buildTimeline(
+  runtimeDoc: Record<string, unknown>,
+  runtimeData: MarketingRuntimeData,
+  state: ReturnType<typeof deriveState>
+): MarketingTimelineEntry[] {
+  const timeline: MarketingTimelineEntry[] = [];
+
+  if (asString(runtimeDoc.created_at)) {
+    timeline.push({
+      id: 'accepted',
+      at: asString(runtimeDoc.created_at),
+      tone: 'info',
+      label: 'Campaign accepted',
+      description: 'Aries launched the real Lobster marketing pipeline for this campaign.',
+    });
+  }
+
+  if (runtimeData.researchCompile) {
+    timeline.push({
+      id: 'research',
+      at: generatedAt(runtimeData.researchCompile),
+      tone: 'success',
+      label: 'Research completed',
+      description: 'Competitor ads, positioning, and recommended actions were compiled.',
+    });
+  }
+
+  if (runtimeData.headOfMarketing) {
+    timeline.push({
+      id: 'strategy',
+      at: generatedAt(runtimeData.headOfMarketing),
+      tone: 'success',
+      label: 'Strategy completed',
+      description: 'Campaign messaging, audience, and CTA strategy were finalized.',
+    });
+  }
+
+  if (runtimeData.creativeDirectorFinalize || runtimeData.productionReview) {
+    timeline.push({
+      id: 'production',
+      at: generatedAt(runtimeData.creativeDirectorFinalize) || generatedAt(runtimeData.productionReview),
+      tone: 'success',
+      label: 'Production package ready',
+      description: 'Landing page, ad, script, and video contract deliverables were assembled.',
+    });
+  }
+
+  if (runtimeData.launchReview && state.status === 'awaiting_approval') {
+    timeline.push({
+      id: 'approval',
+      at: generatedAt(runtimeData.launchReview),
+      tone: 'warning',
+      label: 'Launch approval requested',
+      description: 'The pipeline paused for human launch review before publishing assets.',
+    });
+  }
+
+  if (runtimeData.performanceSummary || runtimeData.publisherPayloads.length > 0) {
+    timeline.push({
+      id: 'publish',
+      at: generatedAt(runtimeData.performanceSummary) || generatedAt(runtimeData.publisherPayloads[0] ?? null),
+      tone: 'success',
+      label: 'Publish packages generated',
+      description: 'Channel-ready publish packages and review outputs were generated.',
+    });
+  }
+
+  if (state.needsAttention && state.status !== 'awaiting_approval' && asString(runtimeDoc.updated_at)) {
+    timeline.push({
+      id: 'attention',
+      at: asString(runtimeDoc.updated_at),
+      tone: 'danger',
+      label: 'Operator attention required',
+      description: 'A failure or blocked state was recorded in the local marketing runtime.',
+    });
+  }
+
+  return timeline.sort((left, right) => {
+    if (!left.at && !right.at) return 0;
+    if (!left.at) return 1;
+    if (!right.at) return -1;
+    return left.at.localeCompare(right.at);
+  });
+}
+
+function loadRuntimeData(runtimeDoc: Record<string, unknown>): MarketingRuntimeData {
+  const runId = marketingRunIdFromRuntime(runtimeDoc);
+
+  const researchCompile = runId ? readJsonIfExists(stepPayloadPath(1, runId, 'ads_analyst_compile')) : null;
+  const researchExtract = runId ? readJsonIfExists(stepPayloadPath(1, runId, 'meta_ads_extractor')) : null;
+  const websiteBrandAnalysis = runId ? readJsonIfExists(stepPayloadPath(2, runId, 'website_brand_analysis')) : null;
+  const campaignPlanner = runId ? readJsonIfExists(stepPayloadPath(2, runId, 'campaign_planner')) : null;
+  const headOfMarketing = runId ? readJsonIfExists(stepPayloadPath(2, runId, 'head_of_marketing')) : null;
+  const productionReview = runId ? readJsonIfExists(stepPayloadPath(3, runId, 'production_review_preview')) : null;
+  const creativeDirectorFinalize = runId ? readJsonIfExists(stepPayloadPath(3, runId, 'creative_director_finalize')) : null;
+  const videoGenerator = runId ? readJsonIfExists(stepPayloadPath(3, runId, 'veo_video_generator')) : null;
+  const performancePreflight = runId ? readJsonIfExists(stepPayloadPath(4, runId, 'performance_marketer_preflight')) : null;
+  const launchReview = runId ? readJsonIfExists(stepPayloadPath(4, runId, 'launch_review_preview')) : null;
+  const performanceSummary = runId ? readJsonIfExists(stepPayloadPath(4, runId, 'performance_marketer_summary')) : null;
+  const publisherPayloads = runId
+    ? PUBLISHER_STEPS
+        .map((stepName) => readJsonIfExists(stepPayloadPath(4, runId, stepName)))
+        .filter((payload): payload is Record<string, unknown> => !!payload)
+    : [];
+
+  return {
+    runId,
+    researchCompile,
+    researchExtract,
+    websiteBrandAnalysis,
+    campaignPlanner,
+    headOfMarketing,
+    productionReview,
+    creativeDirectorFinalize,
+    videoGenerator,
+    performancePreflight,
+    launchReview,
+    performanceSummary,
+    publisherPayloads,
+    launchPreviewText: readTextPreview(asString(asRecord(launchReview?.artifacts)?.preview_path)),
+    productionPreviewText: readTextPreview(asString(asRecord(productionReview?.artifacts)?.preview_path)),
+  };
+}
+
+export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
+  assertMarketingRuntimeSchemas();
+
+  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  if (!runtimeDoc) {
+    return {
+      jobId,
+      tenantId: null,
+      state: 'not_found',
+      status: 'error',
+      currentStage: null,
+      stageStatus: {},
+      updatedAt: null,
+      approvalRequired: false,
+      needsAttention: false,
+      summary: {
+        headline: 'Campaign not found',
+        subheadline: 'No local marketing runtime exists for this job yet.',
+      },
+      stageCards: [],
+      artifacts: [],
+      timeline: [],
+      approval: null,
+      nextStep: 'none',
+      repairStatus: 'not_required',
+    };
+  }
+
+  const runtimeData = loadRuntimeData(runtimeDoc);
+  const approvalRequired = approvalRequiredFromRuntime(runtimeDoc, runtimeData.launchReview);
+  const stageStatus: Record<string, string> = {
+    research: deriveStageStatus('research', runtimeDoc, runtimeData),
+    strategy: deriveStageStatus('strategy', runtimeDoc, runtimeData),
+    production: deriveStageStatus('production', runtimeDoc, runtimeData),
+    publish: deriveStageStatus('publish', runtimeDoc, runtimeData),
+  };
+  const state = deriveState(runtimeDoc, stageStatus, approvalRequired);
+  const approval = buildApproval(jobId, approvalRequired, runtimeData);
+
   return {
     jobId,
-    tenantId: typeof job.tenant_id === "string" ? job.tenant_id : null,
-    state: typeof job.state === "string" ? job.state : "unknown",
-    status: typeof job.status === "string" ? job.status : "unknown",
-    currentStage: typeof outputs.current_stage === "string" ? outputs.current_stage : null,
+    tenantId: asString(runtimeDoc.tenant_id),
+    state: state.state,
+    status: state.status,
+    currentStage: state.currentStage,
     stageStatus,
-    updatedAt: typeof job.updated_at === "string" ? job.updated_at : null,
-    runtimeArtifactPath: runtimeArtifactPath(jobId),
-    approvalRequired: approvalRequiredFromJob(job),
+    updatedAt: asString(runtimeDoc.updated_at),
+    approvalRequired,
+    needsAttention: state.needsAttention,
+    summary: buildSummary(state),
+    stageCards: buildStageCards(runtimeData, stageStatus),
+    artifacts: buildArtifacts(jobId, runtimeData, approval),
+    timeline: buildTimeline(runtimeDoc, runtimeData, state),
+    approval,
+    nextStep: state.nextStep,
+    repairStatus: state.repairStatus,
   };
 }

--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -1,0 +1,116 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { resolveDataPath, resolveSpecPath } from '@/lib/runtime-paths';
+
+const REQUIRED_SCHEMA_PATHS = [
+  resolveSpecPath('tenant_runtime_state_schema.v1.json'),
+  resolveSpecPath('job_runtime_state_schema.v1.json'),
+] as const;
+
+export type MarketingJobRuntimeDocument = Record<string, unknown>;
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function assertMarketingRuntimeSchemas(): void {
+  for (const schemaPath of REQUIRED_SCHEMA_PATHS) {
+    if (!existsSync(schemaPath)) {
+      throw new Error(`HARD_FAILURE: missing required schema input: ${schemaPath}`);
+    }
+
+    try {
+      const raw = readFileSync(schemaPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('schema root must be an object');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`HARD_FAILURE: invalid required schema input ${schemaPath}: ${message}`);
+    }
+  }
+}
+
+export function marketingRuntimePath(jobId: string): string {
+  return resolveDataPath('generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+}
+
+export function loadMarketingJobRuntime(jobId: string): MarketingJobRuntimeDocument | null {
+  const filePath = marketingRuntimePath(jobId);
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  const raw = readFileSync(filePath, 'utf8');
+  return JSON.parse(raw) as MarketingJobRuntimeDocument;
+}
+
+export function saveMarketingJobRuntime(jobId: string, doc: MarketingJobRuntimeDocument): string {
+  const filePath = marketingRuntimePath(jobId);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(doc, null, 2));
+  return filePath;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+export function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    : [];
+}
+
+export function ensureRuntimeOutputs(doc: MarketingJobRuntimeDocument): Record<string, unknown> {
+  const outputs = asRecord(doc.outputs) ?? {};
+  doc.outputs = outputs;
+  return outputs;
+}
+
+export function ensureRuntimeOpenClaw(doc: MarketingJobRuntimeDocument): Record<string, unknown> {
+  const outputs = ensureRuntimeOutputs(doc);
+  const openclaw = asRecord(outputs.openclaw) ?? {};
+  outputs.openclaw = openclaw;
+  return openclaw;
+}
+
+export function ensureRuntimeStageStatus(doc: MarketingJobRuntimeDocument): Record<string, string> {
+  const outputs = ensureRuntimeOutputs(doc);
+  const stageStatus = asRecord(outputs.stage_status) ?? {};
+  outputs.stage_status = stageStatus;
+  return stageStatus as Record<string, string>;
+}
+
+export function ensureStructuredStatusUpdates(doc: MarketingJobRuntimeDocument): Array<Record<string, unknown>> {
+  const outputs = ensureRuntimeOutputs(doc);
+  if (!Array.isArray(outputs.structured_status_updates)) {
+    outputs.structured_status_updates = [];
+  }
+  return outputs.structured_status_updates as Array<Record<string, unknown>>;
+}
+
+export function ensureRuntimeHistory(doc: MarketingJobRuntimeDocument): Array<Record<string, unknown>> {
+  if (!Array.isArray(doc.history)) {
+    doc.history = [];
+  }
+  return doc.history as Array<Record<string, unknown>>;
+}
+
+export function marketingRunIdFromRuntime(doc: MarketingJobRuntimeDocument | null): string | null {
+  const openclaw = doc ? ensureRuntimeOpenClaw(doc) : null;
+  const primaryOutput = asRecord(openclaw?.primary_output);
+  return (
+    asString(openclaw?.run_id) ??
+    asString(primaryOutput?.run_id) ??
+    asString(asRecord(openclaw?.last_resume_output)?.run_id)
+  );
+}

--- a/frontend/marketing/job-approve.tsx
+++ b/frontend/marketing/job-approve.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from 'next/link';
 import { useState, type ReactNode } from 'react';
 import type {
   ApproveJobResult,
@@ -28,7 +29,6 @@ const APPROVAL_STAGE_VALUES: MarketingStage[] = ['research', 'strategy', 'produc
 
 export interface MarketingJobApproveScreenProps {
   baseUrl?: string;
-  defaultTenantId?: string;
   defaultJobId?: string;
   defaultApprovedBy?: string;
 }
@@ -60,7 +60,6 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
   const marketingStatus = useMarketingJobStatus({ baseUrl: props.baseUrl, autoLoad: false });
 
   const [jobId, setJobId] = useState(props.defaultJobId ?? '');
-  const [tenantId, setTenantId] = useState(props.defaultTenantId ?? '');
   const [approvedBy, setApprovedBy] = useState(props.defaultApprovedBy ?? '');
   const [resumePublishIfNeeded, setResumePublishIfNeeded] = useState(true);
   const [approvedStages, setApprovedStages] = useState<MarketingStage[]>([]);
@@ -72,7 +71,6 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
 
   const canSubmit =
     jobId.trim().length > 0 &&
-    tenantId.trim().length > 0 &&
     approvedBy.trim().length > 0 &&
     !submitting;
 
@@ -99,7 +97,6 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
     if (!canSubmit) return;
 
     const body: PostMarketingJobApproveRequest = {
-      tenantId: tenantId.trim(),
       approvedBy: approvedBy.trim(),
       approvedStages: approvedStages.length > 0 ? approvedStages : undefined,
       resumePublishIfNeeded
@@ -134,6 +131,7 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
   })();
 
   const statusSuccess = jobStatus && !isErrorResult(jobStatus) ? jobStatus : null;
+  const approveSuccess = approveResult && !isErrorResult(approveResult) ? approveResult : null;
   const statusHints =
     statusSuccess && getMarketingStateHints(statusSuccess.marketing_job_state, statusSuccess.marketing_stage_status);
 
@@ -166,14 +164,6 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
                 value={jobId}
                 onChange={(event) => setJobId(event.target.value)}
                 placeholder="mkt_..."
-              />
-            </Field>
-
-            <Field label="Tenant ID">
-              <TextInput
-                value={tenantId}
-                onChange={(event) => setTenantId(event.target.value)}
-                placeholder="acme-phase5"
               />
             </Field>
 
@@ -241,7 +231,14 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
               <div
                 className={approvalMessage.tone === 'success' ? 'rd-alert rd-alert--success' : 'rd-alert rd-alert--danger'}
               >
-                {approvalMessage.text}
+                <div style={{ display: 'grid', gap: '0.75rem' }}>
+                  <span>{approvalMessage.text}</span>
+                  {approveSuccess?.jobStatusUrl ? (
+                    <Link href={approveSuccess.jobStatusUrl} className="rd-button rd-button--secondary">
+                      Review updated status
+                    </Link>
+                  ) : null}
+                </div>
               </div>
             )}
 

--- a/frontend/marketing/job-approve.tsx
+++ b/frontend/marketing/job-approve.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from 'next/link';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import type {
   ApproveJobResult,
+  MarketingArtifactCard,
+  MarketingStageCard,
   GetMarketingJobStatusResponse,
   MarketingApiError,
   MarketingStage,
@@ -15,12 +17,6 @@ import { Button } from '@/components/redesign/primitives/button';
 import { Card } from '@/components/redesign/primitives/card';
 import { TextInput } from '@/components/redesign/primitives/input';
 import StatusBadge from '../components/status-badge';
-import {
-  marketing_job_status_values,
-  next_step_values,
-  repair_status_values
-} from '../types/runtime';
-import { getMarketingStateHints, nextStepGuidance } from './state-view';
 
 type ApproveResult = ApproveJobResult | MarketingApiError;
 type JobStatusResult = GetMarketingJobStatusResponse | MarketingApiError;
@@ -35,6 +31,38 @@ export interface MarketingJobApproveScreenProps {
 
 function isErrorResult(value: unknown): value is MarketingApiError {
   return !!value && typeof value === 'object' && 'error' in value;
+}
+
+function StageCard({ stage }: { stage: MarketingStageCard }) {
+  return (
+    <div className="rd-glass" style={{ padding: '1rem', borderRadius: '1rem', display: 'grid', gap: '0.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+        <strong>{stage.label}</strong>
+        <StatusBadge status={stage.status as any} />
+      </div>
+      <p className="rd-section-description" style={{ margin: 0 }}>{stage.summary}</p>
+      {stage.highlight ? <span style={{ color: 'var(--rd-text-secondary)' }}>{stage.highlight}</span> : null}
+    </div>
+  );
+}
+
+function ArtifactPreview({ artifact }: { artifact: MarketingArtifactCard }) {
+  return (
+    <div className="rd-glass" style={{ padding: '1rem', borderRadius: '1rem', display: 'grid', gap: '0.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+        <strong>{artifact.title}</strong>
+        <StatusBadge status={artifact.status as any} />
+      </div>
+      <p className="rd-section-description" style={{ margin: 0 }}>{artifact.summary}</p>
+      {artifact.details.length > 0 ? (
+        <ul style={{ margin: 0, paddingLeft: '1.1rem', color: 'var(--rd-text-secondary)' }}>
+          {artifact.details.slice(0, 3).map((detail) => (
+            <li key={detail}>{detail}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
 }
 
 function Field({
@@ -57,7 +85,11 @@ function Field({
 
 export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps) {
   const marketingApprove = useMarketingJobApprove({ baseUrl: props.baseUrl });
-  const marketingStatus = useMarketingJobStatus({ baseUrl: props.baseUrl, autoLoad: false });
+  const marketingStatus = useMarketingJobStatus({
+    baseUrl: props.baseUrl,
+    jobId: props.defaultJobId,
+    autoLoad: false,
+  });
 
   const [jobId, setJobId] = useState(props.defaultJobId ?? '');
   const [approvedBy, setApprovedBy] = useState(props.defaultApprovedBy ?? '');
@@ -73,6 +105,15 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
     jobId.trim().length > 0 &&
     approvedBy.trim().length > 0 &&
     !submitting;
+
+  useEffect(() => {
+    if (!props.defaultJobId?.trim()) {
+      return;
+    }
+
+    void handleLoadStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.defaultJobId]);
 
   async function handleLoadStatus() {
     if (!jobId.trim()) return;
@@ -125,6 +166,12 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
     if (isErrorResult(approveResult)) {
       return { tone: 'danger', text: `Approval failed: ${approveResult.error}` };
     }
+    if (approveResult.reason === 'approval_not_available') {
+      return {
+        tone: 'danger',
+        text: 'This campaign is not holding an active launch approval token, so there is nothing real to resume yet.',
+      };
+    }
     return approveResult.approval_status === 'resumed'
       ? { tone: 'success', text: 'Approval succeeded and resume was accepted.' }
       : { tone: 'danger', text: `Approval failed: ${approveResult.approval_status}` };
@@ -132,18 +179,6 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
 
   const statusSuccess = jobStatus && !isErrorResult(jobStatus) ? jobStatus : null;
   const approveSuccess = approveResult && !isErrorResult(approveResult) ? approveResult : null;
-  const statusHints =
-    statusSuccess && getMarketingStateHints(statusSuccess.marketing_job_state, statusSuccess.marketing_stage_status);
-
-  const hasKnownJobStatus =
-    !!statusSuccess && marketing_job_status_values.includes(statusSuccess.marketing_job_status as any);
-
-  const knownRepairStatus =
-    statusHints?.repairStatus &&
-    repair_status_values.includes(statusHints.repairStatus as (typeof repair_status_values)[number]);
-
-  const knownNextStep =
-    statusHints?.nextStep && next_step_values.includes(statusHints.nextStep as (typeof next_step_values)[number]);
 
   return (
     <div className="rd-workflow-grid rd-workflow-grid--2">
@@ -226,7 +261,7 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
           <p className="rd-section-label">Outcome</p>
 
             {!approvalMessage ? (
-              <p className="rd-section-description">Run an approval action to see result state.</p>
+              <p className="rd-section-description">Load a campaign to review its launch state before approving.</p>
             ) : (
               <div
                 className={approvalMessage.tone === 'success' ? 'rd-alert rd-alert--success' : 'rd-alert rd-alert--danger'}
@@ -243,83 +278,44 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
             )}
 
             {statusSuccess ? (
-              <div className="rd-summary-list">
-                <div className="rd-summary-row">
-                  <strong>Job status</strong>
-                  {hasKnownJobStatus ? (
-                    <StatusBadge
-                      status={statusSuccess.marketing_job_status as (typeof marketing_job_status_values)[number]}
-                    />
-                  ) : <span>{statusSuccess.marketing_job_status}</span>}
+              <div style={{ display: 'grid', gap: '1rem' }}>
+                <div className="rd-summary-list">
+                  <div className="rd-summary-row"><strong>Headline</strong><span>{statusSuccess.summary.headline}</span></div>
+                  <div className="rd-summary-row">
+                    <strong>Status</strong>
+                    <StatusBadge status={statusSuccess.marketing_job_status as any} />
+                  </div>
+                  <div className="rd-summary-row"><strong>Current stage</strong><span>{statusSuccess.marketing_stage ?? 'none'}</span></div>
+                  <div className="rd-summary-row"><strong>Next step</strong><span>{statusSuccess.nextStep}</span></div>
                 </div>
-                <div className="rd-summary-row"><strong>Current stage</strong><span>{statusSuccess.marketing_stage ?? 'none'}</span></div>
-                <div className="rd-summary-row">
-                  <strong>Repair status</strong>
-                  {knownRepairStatus ? (
-                    <StatusBadge status={statusHints.repairStatus as (typeof repair_status_values)[number]} />
-                  ) : <span>{statusHints?.repairStatus ?? 'n/a'}</span>}
-                </div>
-                <div className="rd-summary-row"><strong>Next step</strong><span>{statusHints?.nextStep ?? 'none'}</span></div>
-                {knownNextStep ? (
-                  <div className="rd-alert rd-alert--info">{nextStepGuidance(statusHints?.nextStep)}</div>
+
+                {statusSuccess.approval ? (
+                  <div className="rd-alert rd-alert--info">
+                    <strong style={{ display: 'block', marginBottom: '0.4rem' }}>{statusSuccess.approval.title}</strong>
+                    <span>{statusSuccess.approval.message}</span>
+                  </div>
                 ) : null}
 
-                {statusHints && statusHints.stageStatuses.length > 0 ? (
+                <div>
+                  <p className="rd-label" style={{ marginBottom: '0.75rem' }}>Stage progress</p>
+                  <div className="rd-card-grid rd-card-grid--4">
+                    {statusSuccess.stageCards.map((stage) => (
+                      <StageCard key={stage.stage} stage={stage} />
+                    ))}
+                  </div>
+                </div>
+
+                {statusSuccess.artifacts.length > 0 ? (
                   <div>
-                    <p className="rd-label" style={{ marginBottom: '0.75rem' }}>Stage status</p>
-                    <ul style={{ margin: 0, paddingLeft: 18 }}>
-                      {statusHints.stageStatuses.map((row) => (
-                        <li key={row.stage}>
-                          {row.stage}: {row.status}{' '}
-                          {marketing_job_status_values.includes(
-                            row.status as (typeof marketing_job_status_values)[number]
-                          ) ? (
-                            <StatusBadge status={row.status as (typeof marketing_job_status_values)[number]} />
-                          ) : null}
-                        </li>
+                    <p className="rd-label" style={{ marginBottom: '0.75rem' }}>Key artifacts</p>
+                    <div style={{ display: 'grid', gap: '0.75rem' }}>
+                      {statusSuccess.artifacts.slice(0, 3).map((artifact) => (
+                        <ArtifactPreview key={artifact.id} artifact={artifact} />
                       ))}
-                    </ul>
+                    </div>
                   </div>
                 ) : null}
               </div>
-            ) : null}
-
-            {approveResult ? (
-              <details open style={{ marginTop: 4 }}>
-                <summary style={{ cursor: 'pointer', fontWeight: 700, color: '#344054' }}>Approve response JSON</summary>
-                <pre
-                  style={{
-                    marginTop: 8,
-                    background: '#0b1020',
-                    color: '#d1e9ff',
-                    borderRadius: 10,
-                    padding: 12,
-                    fontSize: 12,
-                    overflow: 'auto'
-                  }}
-                >
-                  {JSON.stringify(approveResult, null, 2)}
-                </pre>
-              </details>
-            ) : null}
-
-            {jobStatus ? (
-              <details style={{ marginTop: 4 }}>
-                <summary style={{ cursor: 'pointer', fontWeight: 700, color: '#344054' }}>Live job status JSON</summary>
-                <pre
-                  style={{
-                    marginTop: 8,
-                    background: '#101828',
-                    color: '#d1fadf',
-                    borderRadius: 10,
-                    padding: 12,
-                    fontSize: 12,
-                    overflow: 'auto'
-                  }}
-                >
-                  {JSON.stringify(jobStatus, null, 2)}
-                </pre>
-              </details>
             ) : null}
         </div>
       </Card>

--- a/frontend/marketing/job-status.tsx
+++ b/frontend/marketing/job-status.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import type {
@@ -153,6 +154,17 @@ export function MarketingJobStatusScreen(props: MarketingJobStatusScreenProps) {
 
               {knownNextStep ? (
                 <div className="rd-alert rd-alert--info">{nextStepGuidance(hints?.nextStep) ?? 'No extra guidance.'}</div>
+              ) : null}
+
+              {successResult.approvalRequired ? (
+                <div className="rd-inline-actions">
+                  <Link
+                    href={`/marketing/job-approve?jobId=${encodeURIComponent(successResult.jobId)}`}
+                    className="rd-button rd-button--secondary"
+                  >
+                    Open approval dashboard
+                  </Link>
+                </div>
               ) : null}
 
               <div>

--- a/frontend/marketing/job-status.tsx
+++ b/frontend/marketing/job-status.tsx
@@ -4,20 +4,18 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import type {
+  MarketingArtifactCard,
+  MarketingApprovalSummary,
   GetMarketingJobStatusResponse,
   MarketingApiError,
+  MarketingStageCard,
+  MarketingTimelineEntry,
 } from '@/lib/api/marketing';
 import { useMarketingJobStatus } from '@/hooks/use-marketing-job-status';
 import { Button } from '@/components/redesign/primitives/button';
 import { Card } from '@/components/redesign/primitives/card';
 import { TextInput } from '@/components/redesign/primitives/input';
 import StatusBadge from '../components/status-badge';
-import {
-  marketing_job_status_values,
-  next_step_values,
-  repair_status_values
-} from '../types/runtime';
-import { getMarketingStateHints, nextStepGuidance } from './state-view';
 
 type JobStatusResult = GetMarketingJobStatusResponse | MarketingApiError;
 
@@ -34,6 +32,116 @@ function isErrorResult(value: JobStatusResult | null): value is MarketingApiErro
   return !!value && typeof value === 'object' && 'error' in value;
 }
 
+function isActiveStatus(status: string): boolean {
+  return ['accepted', 'running', 'in_progress', 'ready', 'awaiting_approval', 'resumed'].includes(status);
+}
+
+function nextStepGuidance(nextStep: string): string | null {
+  switch (nextStep) {
+    case 'submit_approval':
+      return 'Review the launch package and approve the publish stage when the campaign is ready to continue.';
+    case 'invoke_marketing_repair':
+      return 'A failure or blocked state was recorded. Review the latest artifacts before retrying the run.';
+    case 'wait_for_completion':
+      return 'Aries is still collecting the latest pipeline signals. Keep this page open or refresh manually.';
+    default:
+      return null;
+  }
+}
+
+function ArtifactCard({ artifact }: { artifact: MarketingArtifactCard }) {
+  return (
+    <div className="rd-glass" style={{ padding: '1rem', borderRadius: '1rem', display: 'grid', gap: '0.75rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+        <div>
+          <p className="rd-label" style={{ marginBottom: '0.35rem' }}>{artifact.category}</p>
+          <strong>{artifact.title}</strong>
+        </div>
+        <StatusBadge status={artifact.status as any} />
+      </div>
+      <p className="rd-section-description" style={{ margin: 0 }}>{artifact.summary}</p>
+      {artifact.details.length > 0 ? (
+        <ul style={{ margin: 0, paddingLeft: '1.1rem', color: 'var(--rd-text-secondary)' }}>
+          {artifact.details.map((detail) => (
+            <li key={detail}>{detail}</li>
+          ))}
+        </ul>
+      ) : null}
+      {artifact.preview ? (
+        <div className="rd-json-panel" style={{ whiteSpace: 'pre-wrap' }}>{artifact.preview}</div>
+      ) : null}
+      {artifact.actionHref && artifact.actionLabel ? (
+        <div className="rd-inline-actions">
+          <Link href={artifact.actionHref} className="rd-button rd-button--secondary">
+            {artifact.actionLabel}
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StageCard({ stage }: { stage: MarketingStageCard }) {
+  return (
+    <div className="rd-glass" style={{ padding: '1rem', borderRadius: '1rem', display: 'grid', gap: '0.75rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+        <strong>{stage.label}</strong>
+        <StatusBadge status={stage.status as any} />
+      </div>
+      <p className="rd-section-description" style={{ margin: 0 }}>{stage.summary}</p>
+      {stage.highlight ? (
+        <div className="rd-alert rd-alert--info" style={{ margin: 0 }}>
+          {stage.highlight}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function TimelineCard({ event }: { event: MarketingTimelineEntry }) {
+  const alertClass =
+    event.tone === 'success'
+      ? 'rd-alert rd-alert--success'
+      : event.tone === 'warning'
+        ? 'rd-alert rd-alert--info'
+        : event.tone === 'danger'
+          ? 'rd-alert rd-alert--danger'
+          : 'rd-alert rd-alert--info';
+
+  return (
+    <div className={alertClass} style={{ margin: 0 }}>
+      <div style={{ display: 'grid', gap: '0.35rem' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+          <strong>{event.label}</strong>
+          {event.at ? <span>{new Date(event.at).toLocaleString()}</span> : null}
+        </div>
+        <span>{event.description}</span>
+      </div>
+    </div>
+  );
+}
+
+function ApprovalBanner({ approval }: { approval: MarketingApprovalSummary }) {
+  return (
+    <div className="rd-alert rd-alert--info">
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+          <strong>{approval.title}</strong>
+          <StatusBadge status="awaiting_approval" />
+        </div>
+        <span>{approval.message}</span>
+        {approval.actionHref && approval.actionLabel ? (
+          <div className="rd-inline-actions">
+            <Link href={approval.actionHref} className="rd-button rd-button--secondary">
+              {approval.actionLabel}
+            </Link>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function MarketingJobStatusScreen(props: MarketingJobStatusScreenProps) {
   const marketingStatus = useMarketingJobStatus({
     baseUrl: props.baseUrl,
@@ -43,22 +151,32 @@ export function MarketingJobStatusScreen(props: MarketingJobStatusScreenProps) {
 
   const [jobId, setJobId] = useState(normalizeMarketingJobId(props.defaultJobId));
   const [loading, setLoading] = useState(false);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<string | null>(null);
   const [result, setResult] = useState<JobStatusResult | null>(null);
 
-  async function loadStatus(rawJobId: string) {
+  async function loadStatus(rawJobId: string, quiet = false) {
     const trimmedJobId = normalizeMarketingJobId(rawJobId);
     if (!trimmedJobId) {
       marketingStatus.setError(new Error('jobId is required'));
       return;
     }
 
-    setLoading(true);
+    if (!quiet) {
+      setLoading(true);
+    }
     try {
-      marketingStatus.reset();
-      const response = await marketingStatus.load(trimmedJobId);
+      if (!quiet) {
+        marketingStatus.reset();
+      }
+      const response = await marketingStatus.load(trimmedJobId, { quiet });
       setResult(response);
+      if (response && !isErrorResult(response)) {
+        setLastRefreshedAt(new Date().toISOString());
+      }
     } finally {
-      setLoading(false);
+      if (!quiet) {
+        setLoading(false);
+      }
     }
   }
 
@@ -78,122 +196,164 @@ export function MarketingJobStatusScreen(props: MarketingJobStatusScreenProps) {
   }, [props.defaultJobId]);
 
   const successResult = result && !isErrorResult(result) ? result : null;
-  const hints =
-    successResult &&
-    getMarketingStateHints(successResult.marketing_job_state, successResult.marketing_stage_status);
 
-  const hasKnownJobStatus =
-    !!successResult && marketing_job_status_values.includes(successResult.marketing_job_status as any);
+  useEffect(() => {
+    if (!successResult || !jobId.trim() || !isActiveStatus(successResult.marketing_job_status)) {
+      return;
+    }
 
-  const knownRepairStatus =
-    hints?.repairStatus &&
-    repair_status_values.includes(hints.repairStatus as (typeof repair_status_values)[number]);
+    const timer = window.setInterval(() => {
+      void loadStatus(jobId, true);
+    }, 5000);
 
-  const knownNextStep =
-    hints?.nextStep && next_step_values.includes(hints.nextStep as (typeof next_step_values)[number]);
+    return () => window.clearInterval(timer);
+  }, [jobId, successResult]);
 
   return (
-    <div className="rd-workflow-grid rd-workflow-grid--2">
-      <Card>
-        <div style={{ display: 'grid', gap: '1rem' }}>
-          <div>
-            <p className="rd-section-label">Job status</p>
-            <h2 style={{ margin: '0.8rem 0 0.5rem', fontFamily: 'var(--rd-font-display)', fontSize: '2rem' }}>
-              Inspect current workflow progress
-            </h2>
-            <p className="rd-section-description">
-              Load a job ID to inspect phase progress, repair state, and the next recommended operator action.
-            </p>
+    <div style={{ display: 'grid', gap: '1.5rem' }}>
+      <div className="rd-workflow-grid rd-workflow-grid--2">
+        <Card>
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            <div>
+              <p className="rd-section-label">Campaign status</p>
+              <h1 style={{ margin: '0.8rem 0 0.5rem', fontFamily: 'var(--rd-font-display)', fontSize: '2rem' }}>
+                Operational campaign workspace
+              </h1>
+              <p className="rd-section-description">
+                Monitor the brand campaign, refresh real stage progress, and jump to launch approval when needed.
+              </p>
+            </div>
+
+            <label className="rd-field">
+              <span className="rd-label">Job ID</span>
+              <TextInput value={jobId} onChange={(event) => setJobId(event.target.value)} placeholder="mkt_..." />
+            </label>
+
+            <div className="rd-inline-actions">
+              <Button type="button" onClick={handleLoadStatus} disabled={loading || !jobId.trim()}>
+                {loading ? 'Refreshing…' : 'Refresh status'}
+              </Button>
+              {successResult?.approval?.required ? (
+                <Link href={`/marketing/job-approve?jobId=${encodeURIComponent(successResult.jobId)}`} className="rd-button rd-button--secondary">
+                  Review approval
+                </Link>
+              ) : null}
+            </div>
+
+            {lastRefreshedAt ? (
+              <p className="rd-section-description" style={{ margin: 0 }}>
+                Last synced {new Date(lastRefreshedAt).toLocaleTimeString()}.
+                {successResult && isActiveStatus(successResult.marketing_job_status)
+                  ? ' Auto-refresh is active while the campaign is still changing.'
+                  : ''}
+              </p>
+            ) : null}
+
+            {marketingStatus.error ? <div className="rd-alert rd-alert--danger">{marketingStatus.error.message}</div> : null}
+            {result && isErrorResult(result) ? <div className="rd-alert rd-alert--danger">{result.error}</div> : null}
           </div>
+        </Card>
 
-          <label className="rd-field">
-            <span className="rd-label">Job ID</span>
-            <TextInput value={jobId} onChange={(event) => setJobId(event.target.value)} placeholder="mkt_..." />
-          </label>
-
-          <Button type="button" onClick={handleLoadStatus} disabled={loading || !jobId.trim()}>
-            {loading ? 'Loading…' : 'Load job status'}
-          </Button>
-
-          {marketingStatus.error ? <div className="rd-alert rd-alert--danger">{marketingStatus.error.message}</div> : null}
-          {result && isErrorResult(result) ? <div className="rd-alert rd-alert--danger">{result.error}</div> : null}
-        </div>
-      </Card>
-
-      <Card>
-        <div style={{ display: 'grid', gap: '1rem' }}>
-          <p className="rd-section-label">Workflow state</p>
-
+        <Card>
           {!successResult ? (
-            <div className="rd-empty" style={{ minHeight: '320px' }}>
-              <strong>No job loaded</strong>
-              <p>Enter a job ID to review the current stage, per-stage status, and recommended next step.</p>
+            <div className="rd-empty" style={{ minHeight: '280px' }}>
+              <strong>No campaign loaded</strong>
+              <p>Enter a job ID to open the operational status view for a brand campaign.</p>
             </div>
           ) : (
-            <>
+            <div style={{ display: 'grid', gap: '1rem' }}>
+              <p className="rd-section-label">Current state</p>
+              <h2 style={{ margin: 0, fontFamily: 'var(--rd-font-display)', fontSize: '1.8rem' }}>
+                {successResult.summary.headline}
+              </h2>
+              <p className="rd-section-description" style={{ margin: 0 }}>
+                {successResult.summary.subheadline}
+              </p>
               <div className="rd-summary-list">
+                <div className="rd-summary-row"><strong>Job ID</strong><code>{successResult.jobId}</code></div>
+                <div className="rd-summary-row">
+                  <strong>Status</strong>
+                  <StatusBadge status={successResult.marketing_job_status as any} />
+                </div>
                 <div className="rd-summary-row"><strong>Current stage</strong><span>{successResult.marketing_stage ?? 'none'}</span></div>
-                <div className="rd-summary-row">
-                  <strong>Job status</strong>
-                  {hasKnownJobStatus ? (
-                    <StatusBadge status={successResult.marketing_job_status as (typeof marketing_job_status_values)[number]} />
-                  ) : (
-                    <span>{successResult.marketing_job_status}</span>
-                  )}
-                </div>
-                <div className="rd-summary-row">
-                  <strong>Repair status</strong>
-                  {knownRepairStatus ? (
-                    <StatusBadge status={hints?.repairStatus as (typeof repair_status_values)[number]} />
-                  ) : (
-                    <span>{hints?.repairStatus ?? 'n/a'}</span>
-                  )}
-                </div>
-                <div className="rd-summary-row"><strong>Next step</strong><span>{hints?.nextStep ?? 'none'}</span></div>
+                <div className="rd-summary-row"><strong>Next action</strong><span>{successResult.nextStep}</span></div>
+                <div className="rd-summary-row"><strong>Repair status</strong><span>{successResult.repairStatus}</span></div>
               </div>
-
-              {knownNextStep ? (
-                <div className="rd-alert rd-alert--info">{nextStepGuidance(hints?.nextStep) ?? 'No extra guidance.'}</div>
+              {nextStepGuidance(successResult.nextStep) ? (
+                <div className="rd-alert rd-alert--info">{nextStepGuidance(successResult.nextStep)}</div>
               ) : null}
-
-              {successResult.approvalRequired ? (
-                <div className="rd-inline-actions">
-                  <Link
-                    href={`/marketing/job-approve?jobId=${encodeURIComponent(successResult.jobId)}`}
-                    className="rd-button rd-button--secondary"
-                  >
-                    Open approval dashboard
-                  </Link>
+              {successResult.approval ? <ApprovalBanner approval={successResult.approval} /> : null}
+              {successResult.needs_attention && !successResult.approval ? (
+                <div className="rd-alert rd-alert--danger">
+                  This workflow needs operator attention before it can continue.
                 </div>
               ) : null}
+            </div>
+          )}
+        </Card>
+      </div>
 
+      {successResult ? (
+        <>
+          <Card>
+            <div style={{ display: 'grid', gap: '1rem' }}>
               <div>
-                <p className="rd-label" style={{ marginBottom: '0.75rem' }}>Stage status</p>
-                {!hints || hints.stageStatuses.length === 0 ? (
-                  <p className="rd-section-description">No stage status values returned.</p>
+                <p className="rd-section-label">Stage progress</p>
+                <h2 style={{ margin: '0.5rem 0 0', fontFamily: 'var(--rd-font-display)', fontSize: '1.5rem' }}>
+                  Real pipeline stages
+                </h2>
+              </div>
+              <div className="rd-card-grid rd-card-grid--4">
+                {successResult.stageCards.map((stage) => (
+                  <StageCard key={stage.stage} stage={stage} />
+                ))}
+              </div>
+            </div>
+          </Card>
+
+          <div className="rd-workflow-grid rd-workflow-grid--2">
+            <Card>
+              <div style={{ display: 'grid', gap: '1rem' }}>
+                <div>
+                  <p className="rd-section-label">Outputs and artifacts</p>
+                  <h2 style={{ margin: '0.5rem 0 0', fontFamily: 'var(--rd-font-display)', fontSize: '1.5rem' }}>
+                    Product-safe campaign deliverables
+                  </h2>
+                </div>
+                {successResult.artifacts.length === 0 ? (
+                  <p className="rd-section-description">No artifact summaries are available yet.</p>
                 ) : (
-                  <div className="rd-chip-group">
-                    {hints.stageStatuses.map((row) => (
-                      <span key={row.stage} className="rd-chip" data-active="true">
-                        <strong>{row.stage}</strong>
-                        {marketing_job_status_values.includes(row.status as (typeof marketing_job_status_values)[number]) ? (
-                          <StatusBadge status={row.status as (typeof marketing_job_status_values)[number]} />
-                        ) : (
-                          <span>{row.status}</span>
-                        )}
-                      </span>
+                  <div style={{ display: 'grid', gap: '1rem' }}>
+                    {successResult.artifacts.map((artifact) => (
+                      <ArtifactCard key={artifact.id} artifact={artifact} />
                     ))}
                   </div>
                 )}
               </div>
+            </Card>
 
-              {successResult.needs_attention ? (
-                <div className="rd-alert rd-alert--danger">This workflow needs operator attention before it can continue.</div>
-              ) : null}
-            </>
-          )}
-        </div>
-      </Card>
+            <Card>
+              <div style={{ display: 'grid', gap: '1rem' }}>
+                <div>
+                  <p className="rd-section-label">Timeline</p>
+                  <h2 style={{ margin: '0.5rem 0 0', fontFamily: 'var(--rd-font-display)', fontSize: '1.5rem' }}>
+                    Campaign events
+                  </h2>
+                </div>
+                {successResult.timeline.length === 0 ? (
+                  <p className="rd-section-description">No timeline events are available yet.</p>
+                ) : (
+                  <div style={{ display: 'grid', gap: '0.75rem' }}>
+                    {successResult.timeline.map((event) => (
+                      <TimelineCard key={event.id} event={event} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </Card>
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -27,7 +27,6 @@ export interface MarketingNewJobScreenProps {
 export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
   const marketingCreate = useMarketingJobCreate(props.clientOptions);
 
-  const [tenantId, setTenantId] = useState('');
   const [brandUrl, setBrandUrl] = useState('');
   const [competitorUrl, setCompetitorUrl] = useState('');
 
@@ -40,21 +39,14 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
     setErrorText(null);
     setSuccess(null);
 
-    const trimmedTenantId = tenantId.trim();
-    if (!trimmedTenantId) {
-      setErrorText('tenantId is required');
-      return;
-    }
-
     const trimmedBrandUrl = brandUrl.trim();
     const trimmedCompetitorUrl = competitorUrl.trim();
     if (!trimmedBrandUrl || !trimmedCompetitorUrl) {
-      setErrorText('tenantId, brandUrl, and competitorUrl are required');
+      setErrorText('brandUrl and competitorUrl are required');
       return;
     }
 
     const request: PostMarketingJobsRequest = {
-      tenantId: trimmedTenantId,
       jobType: 'brand_campaign',
       payload: {
         brandUrl: trimmedBrandUrl,
@@ -91,14 +83,9 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
               Launch the canonical marketing job
             </h1>
             <p className="rd-section-description">
-              Provide the tenant ID, primary brand URL, and competitor reference URL to create the workflow-backed campaign job.
+              Start a workflow-backed brand campaign using your current workspace context and the URLs that define the brief.
             </p>
           </div>
-
-          <label className="rd-field">
-            <span className="rd-label">Tenant ID</span>
-            <TextInput value={tenantId} onChange={(event) => setTenantId(event.target.value)} placeholder="tenant_123" required />
-          </label>
 
           <label className="rd-field">
             <span className="rd-label">Brand website URL</span>
@@ -143,14 +130,17 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
                 </div>
                 <code>{success.jobId}</code>
                 <div className="rd-inline-actions">
-                  <Link href={`/marketing/job-status?jobId=${encodeURIComponent(success.jobId)}`} className="rd-button rd-button--secondary">
+                  <Link
+                    href={success.jobStatusUrl ?? `/marketing/job-status?jobId=${encodeURIComponent(success.jobId)}`}
+                    className="rd-button rd-button--secondary"
+                  >
                     Monitor status
                   </Link>
                   <Link
-                    href={`/marketing/job-approve?jobId=${encodeURIComponent(success.jobId)}&tenantId=${encodeURIComponent(success.tenantId)}`}
+                    href={`/marketing/job-approve?jobId=${encodeURIComponent(success.jobId)}`}
                     className="rd-button rd-button--ghost"
                   >
-                    Approval dashboard
+                    {success.approvalRequired ? 'Review approval queue' : 'Approval dashboard'}
                   </Link>
                 </div>
               </div>

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -1,22 +1,16 @@
 "use client";
 
 import React, { useState, type FormEvent } from 'react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
-import type {
-  MarketingApiError,
-  PostMarketingJobsRequest,
-  StartJobAccepted,
-} from '@/lib/api/marketing';
+import type { MarketingApiError, PostMarketingJobsRequest } from '@/lib/api/marketing';
 import { useMarketingJobCreate, type UseMarketingJobCreateOptions } from '@/hooks/use-marketing-job-create';
 import { Button } from '@/components/redesign/primitives/button';
 import { Card } from '@/components/redesign/primitives/card';
 import { TextInput } from '@/components/redesign/primitives/input';
 import StatusBadge from '../components/status-badge';
 
-type CreateJobResult = StartJobAccepted | MarketingApiError;
-
-function isErrorResult(value: CreateJobResult): value is MarketingApiError {
+function isErrorResult(value: unknown): value is MarketingApiError {
   return typeof (value as MarketingApiError)?.error === 'string';
 }
 
@@ -25,6 +19,7 @@ export interface MarketingNewJobScreenProps {
 }
 
 export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
+  const router = useRouter();
   const marketingCreate = useMarketingJobCreate(props.clientOptions);
 
   const [brandUrl, setBrandUrl] = useState('');
@@ -32,12 +27,10 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
 
   const [submitting, setSubmitting] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
-  const [success, setSuccess] = useState<StartJobAccepted | null>(null);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setErrorText(null);
-    setSuccess(null);
 
     const trimmedBrandUrl = brandUrl.trim();
     const trimmedCompetitorUrl = competitorUrl.trim();
@@ -63,11 +56,11 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
       }
 
       if (isErrorResult(response)) {
-        setErrorText(response.error);
+        setErrorText(response.message || response.error);
         return;
       }
 
-      setSuccess(response);
+      router.push(response.jobStatusUrl ?? `/marketing/job-status?jobId=${encodeURIComponent(response.jobId)}`);
     } finally {
       setSubmitting(false);
     }
@@ -114,43 +107,22 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
           <div className="rd-summary-list">
             {[
               'The browser submits only to the Aries internal route.',
-              'Aries starts the campaign through the OpenClaw gateway.',
-              'You can follow state changes from the status and approval screens.',
+              'Aries launches the real OpenClaw-backed Lobster pipeline server-side.',
+              'After launch, you land on the campaign status workspace automatically.',
             ].map((item) => (
               <div key={item} className="rd-glass" style={{ padding: '1rem', borderRadius: '1rem' }}>{item}</div>
             ))}
           </div>
 
-          {success ? (
-            <div className="rd-alert rd-alert--success">
-              <div style={{ display: 'grid', gap: '0.75rem' }}>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
-                  <strong>Brand campaign accepted</strong>
-                  <StatusBadge status="accepted" />
-                </div>
-                <code>{success.jobId}</code>
-                <div className="rd-inline-actions">
-                  <Link
-                    href={success.jobStatusUrl ?? `/marketing/job-status?jobId=${encodeURIComponent(success.jobId)}`}
-                    className="rd-button rd-button--secondary"
-                  >
-                    Monitor status
-                  </Link>
-                  <Link
-                    href={`/marketing/job-approve?jobId=${encodeURIComponent(success.jobId)}`}
-                    className="rd-button rd-button--ghost"
-                  >
-                    {success.approvalRequired ? 'Review approval queue' : 'Approval dashboard'}
-                  </Link>
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="rd-empty" style={{ minHeight: '280px' }}>
-              <strong>No active campaign yet</strong>
-              <p>Submitting the form will create a new job and surface its job ID here.</p>
-            </div>
-          )}
+          <div className="rd-empty" style={{ minHeight: '280px' }}>
+            <strong>{submitting ? 'Launching your campaign...' : 'Ready to launch'}</strong>
+            <p>
+              {submitting
+                ? 'Aries is starting the campaign and will take you straight to the status workspace.'
+                : 'Submit the brief to start the pipeline and move into the operational status view.'}
+            </p>
+            {submitting ? <StatusBadge status="running" /> : null}
+          </div>
         </div>
       </Card>
     </div>

--- a/hooks/use-marketing-job-status.ts
+++ b/hooks/use-marketing-job-status.ts
@@ -15,19 +15,25 @@ export interface UseMarketingJobStatusOptions {
   autoLoad?: boolean;
 }
 
+export interface LoadMarketingJobStatusOptions {
+  quiet?: boolean;
+}
+
 export function useMarketingJobStatus(options: UseMarketingJobStatusOptions = {}) {
   const api = useMemo(() => createMarketingApi(options), [options.baseUrl]);
   const state = useRequestState<MarketingResult<GetMarketingJobStatusResponse>>();
 
   const load = useCallback(
-    async (jobId: string) => {
+    async (jobId: string, loadOptions: LoadMarketingJobStatusOptions = {}) => {
       const normalizedJobId = jobId.trim();
       if (!normalizedJobId) {
         state.setError(new Error('jobId is required'));
         return null;
       }
 
-      state.setLoading();
+      if (!loadOptions.quiet) {
+        state.setLoading();
+      }
       try {
         const response = await api.getJob(normalizedJobId);
         state.setSuccess(response);

--- a/lib/api/marketing.ts
+++ b/lib/api/marketing.ts
@@ -9,7 +9,6 @@ export interface BrandCampaignPayload {
 }
 
 export interface PostMarketingJobsRequest {
-  tenantId: string;
   jobType: MarketingJobType;
   payload: BrandCampaignPayload;
 }
@@ -17,24 +16,23 @@ export interface PostMarketingJobsRequest {
 export interface StartJobAccepted {
   marketing_job_status: 'accepted';
   jobId: string;
-  tenantId: string;
   jobType: MarketingJobType;
-  wiring: 'openclaw_gateway';
+  approvalRequired?: boolean;
+  jobStatusUrl?: string;
 }
 
 export interface GetMarketingJobStatusResponse {
   jobId: string;
-  tenantId: string | null;
   marketing_job_state: string;
   marketing_job_status: string;
   marketing_stage: string | null;
   marketing_stage_status: Record<string, string>;
   updatedAt: string | null;
   needs_attention: boolean;
+  approvalRequired?: boolean;
 }
 
 export interface PostMarketingJobApproveRequest {
-  tenantId: string;
   approvedBy: string;
   approvedStages?: MarketingStage[];
   resumePublishIfNeeded?: boolean;
@@ -43,11 +41,10 @@ export interface PostMarketingJobApproveRequest {
 export interface ApproveJobResult {
   approval_status: 'resumed' | 'error';
   jobId: string;
-  tenantId: string;
   resumedStage: string | null;
   completed: boolean;
-  wiring: 'openclaw_gateway';
   reason?: string;
+  jobStatusUrl?: string;
 }
 
 export interface MarketingApiError {

--- a/lib/api/marketing.ts
+++ b/lib/api/marketing.ts
@@ -21,6 +21,44 @@ export interface StartJobAccepted {
   jobStatusUrl?: string;
 }
 
+export interface MarketingStageCard {
+  stage: MarketingStage;
+  label: string;
+  status: string;
+  summary: string;
+  highlight?: string;
+}
+
+export interface MarketingArtifactCard {
+  id: string;
+  stage: MarketingStage;
+  title: string;
+  category: string;
+  status: string;
+  summary: string;
+  details: string[];
+  preview?: string;
+  actionLabel?: string;
+  actionHref?: string;
+}
+
+export interface MarketingTimelineEntry {
+  id: string;
+  at: string | null;
+  tone: 'info' | 'success' | 'warning' | 'danger';
+  label: string;
+  description: string;
+}
+
+export interface MarketingApprovalSummary {
+  required: boolean;
+  status: string;
+  title: string;
+  message: string;
+  actionLabel?: string;
+  actionHref?: string;
+}
+
 export interface GetMarketingJobStatusResponse {
   jobId: string;
   marketing_job_state: string;
@@ -30,6 +68,16 @@ export interface GetMarketingJobStatusResponse {
   updatedAt: string | null;
   needs_attention: boolean;
   approvalRequired?: boolean;
+  summary: {
+    headline: string;
+    subheadline: string;
+  };
+  stageCards: MarketingStageCard[];
+  artifacts: MarketingArtifactCard[];
+  timeline: MarketingTimelineEntry[];
+  approval: MarketingApprovalSummary | null;
+  nextStep: string;
+  repairStatus: string;
 }
 
 export interface PostMarketingJobApproveRequest {

--- a/lib/tenant-context-http.ts
+++ b/lib/tenant-context-http.ts
@@ -2,20 +2,37 @@ import { getTenantContext, type TenantContext } from '@/lib/tenant-context';
 
 export type TenantContextLoader = () => Promise<TenantContext>;
 
+export interface TenantContextHttpOptions {
+  missingMembershipResponse?: {
+    status: number;
+    reason: string;
+    message: string;
+  };
+}
+
 export async function loadTenantContextOrResponse(
-  tenantContextLoader: TenantContextLoader = getTenantContext
+  tenantContextLoader: TenantContextLoader = getTenantContext,
+  options: TenantContextHttpOptions = {}
 ): Promise<{ tenantContext: TenantContext } | { response: Response }> {
   try {
     return { tenantContext: await tenantContextLoader() };
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Authentication required.';
+    const missingMembership =
+      message === 'No tenant membership found for authenticated user.' &&
+      options.missingMembershipResponse;
+
     return {
       response: new Response(
         JSON.stringify({
           status: 'error',
-          reason: 'tenant_context_required',
-          message: error instanceof Error ? error.message : 'Authentication required.',
+          reason: missingMembership?.reason ?? 'tenant_context_required',
+          message: missingMembership?.message ?? message,
         }),
-        { status: 403, headers: { 'content-type': 'application/json' } }
+        {
+          status: missingMembership?.status ?? 403,
+          headers: { 'content-type': 'application/json' },
+        }
       ),
     };
   }

--- a/lib/tenant-context-http.ts
+++ b/lib/tenant-context-http.ts
@@ -19,8 +19,9 @@ export async function loadTenantContextOrResponse(
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Authentication required.';
     const missingMembership =
-      message === 'No tenant membership found for authenticated user.' &&
-      options.missingMembershipResponse;
+      message === 'No tenant membership found for authenticated user.'
+        ? options.missingMembershipResponse
+        : undefined;
 
     return {
       response: new Response(

--- a/tests/frontend-api-layer.test.ts
+++ b/tests/frontend-api-layer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -92,22 +92,26 @@ test('/api/onboarding/status exposes artifact booleans instead of runtime paths'
   assert.equal('pathsAreRelative' in body, false);
 });
 
-test('/api/marketing/jobs returns a frontend-safe payload without runtime paths', async () => {
+test('/api/marketing/jobs resolves tenant context server-side and returns a frontend-safe payload', async () => {
   await withRuntimeEnv(async () => {
-    const { POST: postMarketingJobs } = await import('../app/api/marketing/jobs/route');
-    setOpenClawTestInvoker(() => ({
-      ok: true,
-      status: 'ok',
-      output: [{ accepted: true }],
-      requiresApproval: null,
-    }));
+    const { handlePostMarketingJobs } = await import('../app/api/marketing/jobs/handler');
+    let captured: Record<string, unknown> | null = null;
+    setOpenClawTestInvoker((payload) => {
+      captured = payload;
+      return {
+        ok: true,
+        status: 'ok',
+        output: [{ accepted: true, approval_preview: { status: 'pending_human_review' } }],
+        requiresApproval: { resumeToken: 'resume_123' },
+      };
+    });
 
-    const response = await postMarketingJobs(
+    const response = await handlePostMarketingJobs(
       new Request('http://localhost/api/marketing/jobs', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          tenantId: 'tenant_123',
+          tenantId: 'forged_tenant',
           jobType: 'brand_campaign',
           payload: {
             brandUrl: 'https://brand.example',
@@ -115,37 +119,240 @@ test('/api/marketing/jobs returns a frontend-safe payload without runtime paths'
           },
         }),
       }),
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      })
     );
     const body = (await response.json()) as Record<string, unknown>;
+    const workflowArgs = JSON.parse(String((captured as any)?.args?.argsJson)) as Record<string, unknown>;
 
     assert.equal(response.status, 202);
     assert.equal(body.marketing_job_status, 'accepted');
-    assert.equal(body.tenantId, 'tenant_123');
     assert.equal(body.jobType, 'brand_campaign');
-    assert.equal(body.wiring, 'openclaw_gateway');
+    assert.equal(body.approvalRequired, true);
+    assert.equal(typeof body.jobStatusUrl, 'string');
+    assert.equal('tenantId' in body, false);
+    assert.equal('wiring' in body, false);
     assert.equal('runtimeArtifactPath' in body, false);
     assert.equal('runtimePath' in body, false);
     assert.equal('runtimePathDeprecated' in body, false);
+    assert.equal(String(body.jobId).includes('tenant_real'), false);
+    assert.equal(workflowArgs.brand_slug, 'tenant_real');
+    assert.equal(workflowArgs.website_url, 'https://brand.example');
+    assert.equal(workflowArgs.competitor_facebook_url, 'https://facebook.com/competitor');
     clearOpenClawTestInvoker();
   });
 });
 
-test('/api/marketing/jobs/:jobId omits runtime path fields and exposes attention state', async () => {
+test('/api/marketing/jobs returns onboarding_required when tenant context has not been established', async () => {
+  const { handlePostMarketingJobs } = await import('../app/api/marketing/jobs/handler');
+  const response = await handlePostMarketingJobs(
+    new Request('http://localhost/api/marketing/jobs', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jobType: 'brand_campaign',
+        payload: {
+          brandUrl: 'https://brand.example',
+          competitorUrl: 'https://facebook.com/competitor',
+        },
+      }),
+    }),
+    async () => {
+      throw new Error('No tenant membership found for authenticated user.');
+    }
+  );
+  const body = (await response.json()) as Record<string, unknown>;
+
+  assert.equal(response.status, 409);
+  assert.equal(body.status, 'error');
+  assert.equal(body.reason, 'onboarding_required');
+  assert.equal(body.message, 'Complete tenant onboarding before starting a brand campaign.');
+});
+
+test('/api/marketing/jobs/:jobId omits runtime path fields and resolves approval state for the current tenant', async () => {
   await withRuntimeEnv(async () => {
-    const { GET: getMarketingJobStatus } = await import('../app/api/marketing/jobs/[jobId]/route');
-    const response = await getMarketingJobStatus(
-      new Request('http://localhost/api/marketing/jobs/mkt_missing', { method: 'GET' }),
-      { params: Promise.resolve({ jobId: 'mkt_missing' }) },
+    const { handleGetMarketingJobStatus } = await import('../app/api/marketing/jobs/[jobId]/handler');
+    const jobId = 'mkt_safe_job';
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'job_runtime_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_real',
+        state: 'running',
+        status: 'pending',
+        attempt: 1,
+        max_attempts: 3,
+        outputs: {
+          current_stage: 'publish',
+          stage_status: {
+            research: 'submitted',
+            strategy: 'submitted',
+            production: 'submitted',
+            publish: 'awaiting_approval',
+          },
+          openclaw: {
+            resume_token: 'resume_123',
+          },
+          structured_status_updates: [],
+        },
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2)
+    );
+
+    const response = await handleGetMarketingJobStatus(
+      jobId,
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      })
     );
     const body = (await response.json()) as Record<string, unknown>;
 
     assert.equal(response.status, 200);
-    assert.equal(body.jobId, 'mkt_missing');
-    assert.equal(body.marketing_job_state, 'not_found');
-    assert.equal(body.marketing_job_status, 'error');
-    assert.equal(body.needs_attention, true);
+    assert.equal(body.jobId, jobId);
+    assert.equal(body.marketing_job_state, 'running');
+    assert.equal(body.marketing_job_status, 'pending');
+    assert.equal(body.needs_attention, false);
+    assert.equal(body.approvalRequired, true);
+    assert.equal('tenantId' in body, false);
     assert.equal('runtimeArtifactPath' in body, false);
     assert.equal('runtimePath' in body, false);
     assert.equal('runtimePathDeprecated' in body, false);
+  });
+});
+
+test('/api/marketing/jobs/:jobId hides jobs owned by a different tenant', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingJobStatus } = await import('../app/api/marketing/jobs/[jobId]/handler');
+    const jobId = 'mkt_hidden_job';
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'job_runtime_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_other',
+        state: 'running',
+        status: 'pending',
+        outputs: {
+          current_stage: 'publish',
+          stage_status: {},
+          structured_status_updates: [],
+        },
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2)
+    );
+
+    const response = await handleGetMarketingJobStatus(
+      jobId,
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      })
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 404);
+    assert.equal(body.error, 'Marketing job not found.');
+    assert.equal(body.reason, 'marketing_job_not_found');
+  });
+});
+
+test('/api/marketing/jobs/:jobId/approve resolves tenant context server-side and returns a product-safe payload', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleApproveMarketingJob } = await import('../app/api/marketing/jobs/[jobId]/approve/handler');
+    const jobId = 'mkt_approve_job';
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'job_runtime_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_real',
+        state: 'waiting_repair',
+        status: 'pending',
+        attempt: 1,
+        max_attempts: 3,
+        outputs: {
+          current_stage: 'publish',
+          stage_status: {
+            research: 'completed',
+            strategy: 'completed',
+            production: 'completed',
+            publish: 'awaiting_approval',
+          },
+          structured_status_updates: [],
+        },
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2)
+    );
+
+    let captured: Record<string, unknown> | null = null;
+    setOpenClawTestInvoker((payload) => {
+      captured = payload;
+      return {
+        ok: true,
+        status: 'ok',
+        output: [{ accepted: true }],
+        requiresApproval: null,
+      };
+    });
+
+    const response = await handleApproveMarketingJob(
+      jobId,
+      new Request(`http://localhost/api/marketing/jobs/${jobId}/approve`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          tenantId: 'forged_tenant',
+          approvedBy: 'operator',
+          approvedStages: ['publish'],
+          resumePublishIfNeeded: true,
+        }),
+      }),
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      })
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    const workflowArgs = JSON.parse(String((captured as any)?.args?.argsJson)) as Record<string, unknown>;
+
+    assert.equal(response.status, 200);
+    assert.equal(body.approval_status, 'resumed');
+    assert.equal(body.jobId, jobId);
+    assert.equal(typeof body.jobStatusUrl, 'string');
+    assert.equal('tenantId' in body, false);
+    assert.equal('wiring' in body, false);
+    assert.equal(workflowArgs.tenant_id, 'tenant_real');
+    assert.equal(workflowArgs.job_id, jobId);
+    clearOpenClawTestInvoker();
   });
 });

--- a/tests/frontend-api-layer.test.ts
+++ b/tests/frontend-api-layer.test.ts
@@ -20,10 +20,18 @@ function clearOpenClawTestInvoker(): void {
 async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
   const previousCodeRoot = process.env.CODE_ROOT;
   const previousDataRoot = process.env.DATA_ROOT;
+  const previousStage1CacheDir = process.env.LOBSTER_STAGE1_CACHE_DIR;
+  const previousStage2CacheDir = process.env.LOBSTER_STAGE2_CACHE_DIR;
+  const previousStage3CacheDir = process.env.LOBSTER_STAGE3_CACHE_DIR;
+  const previousStage4CacheDir = process.env.LOBSTER_STAGE4_CACHE_DIR;
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-frontend-api-'));
 
   process.env.CODE_ROOT = process.cwd();
   process.env.DATA_ROOT = dataRoot;
+  process.env.LOBSTER_STAGE1_CACHE_DIR = path.join(dataRoot, 'lobster-stage1-cache');
+  process.env.LOBSTER_STAGE2_CACHE_DIR = path.join(dataRoot, 'lobster-stage2-cache');
+  process.env.LOBSTER_STAGE3_CACHE_DIR = path.join(dataRoot, 'lobster-stage3-cache');
+  process.env.LOBSTER_STAGE4_CACHE_DIR = path.join(dataRoot, 'lobster-stage4-cache');
 
   try {
     return await run(dataRoot);
@@ -40,8 +48,36 @@ async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise
       process.env.DATA_ROOT = previousDataRoot;
     }
 
+    if (previousStage1CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE1_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE1_CACHE_DIR = previousStage1CacheDir;
+    }
+
+    if (previousStage2CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE2_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE2_CACHE_DIR = previousStage2CacheDir;
+    }
+
+    if (previousStage3CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE3_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE3_CACHE_DIR = previousStage3CacheDir;
+    }
+
+    if (previousStage4CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE4_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE4_CACHE_DIR = previousStage4CacheDir;
+    }
+
     await rm(dataRoot, { recursive: true, force: true });
   }
+}
+
+function stageStepPath(dataRoot: string, stage: 1 | 2 | 3 | 4, runId: string, stepName: string): string {
+  return path.join(dataRoot, `lobster-stage${stage}-cache`, runId, `${stepName}.json`);
 }
 
 test('/api/onboarding/start returns a frontend-safe payload without workflow internals', async () => {
@@ -173,12 +209,16 @@ test('/api/marketing/jobs returns onboarding_required when tenant context has no
   assert.equal(body.message, 'Complete tenant onboarding before starting a brand campaign.');
 });
 
-test('/api/marketing/jobs/:jobId omits runtime path fields and resolves approval state for the current tenant', async () => {
-  await withRuntimeEnv(async () => {
+test('/api/marketing/jobs/:jobId returns stage progress and safe artifact summaries for the current tenant', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
     const { handleGetMarketingJobStatus } = await import('../app/api/marketing/jobs/[jobId]/handler');
     const jobId = 'mkt_safe_job';
+    const runId = 'demo-run-123';
     const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
     await mkdir(path.dirname(runtimeFile), { recursive: true });
+    const launchPreviewPath = path.join(dataRoot, 'launch-review-preview.txt');
+    await writeFile(launchPreviewPath, 'Campaign: Demo launch\nApproval state: pending_human_review\n', 'utf8');
+
     await writeFile(
       runtimeFile,
       JSON.stringify({
@@ -194,19 +234,130 @@ test('/api/marketing/jobs/:jobId omits runtime path fields and resolves approval
         outputs: {
           current_stage: 'publish',
           stage_status: {
-            research: 'submitted',
-            strategy: 'submitted',
-            production: 'submitted',
+            research: 'completed',
+            strategy: 'completed',
+            production: 'completed',
             publish: 'awaiting_approval',
           },
           openclaw: {
+            run_id: runId,
             resume_token: 'resume_123',
+            primary_output: {
+              run_id: runId,
+            },
           },
           structured_status_updates: [],
         },
         history: [],
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
+      }, null, 2)
+    );
+    await mkdir(path.dirname(stageStepPath(dataRoot, 1, runId, 'ads_analyst_compile')), { recursive: true });
+    await writeFile(
+      stageStepPath(dataRoot, 1, runId, 'ads_analyst_compile'),
+      JSON.stringify({
+        generated_at: '2026-03-19T00:00:01.000Z',
+        executive_summary: {
+          market_positioning: 'Competitor leans on practical outcomes.',
+          campaign_takeaway: 'Proof-led hooks are winning.',
+          creative_takeaway: 'Proof-heavy creative is performing best.',
+        },
+        competitor: 'CompetitorCo',
+        inputs: { ads_seen: 6 },
+      }, null, 2)
+    );
+    await writeFile(
+      stageStepPath(dataRoot, 1, runId, 'meta_ads_extractor'),
+      JSON.stringify({
+        competitor: 'CompetitorCo',
+        competitor_research_summary: ['Outcome-first claims', 'Low-friction CTA'],
+      }, null, 2)
+    );
+    await mkdir(path.dirname(stageStepPath(dataRoot, 2, runId, 'head_of_marketing')), { recursive: true });
+    await writeFile(
+      stageStepPath(dataRoot, 2, runId, 'website_brand_analysis'),
+      JSON.stringify({
+        brand_analysis: {
+          brand_promise: 'Aries helps operators launch faster.',
+          audience_summary: 'In-house marketing teams',
+          offer_summary: 'Operational visibility',
+          proof_points: ['Workflow transparency', 'Human approval controls'],
+        },
+      }, null, 2)
+    );
+    await writeFile(
+      stageStepPath(dataRoot, 2, runId, 'campaign_planner'),
+      JSON.stringify({
+        campaign_plan: {
+          core_message: 'Launch campaigns with operator control.',
+          primary_cta: 'Book a walkthrough',
+          offer: 'Operational visibility',
+        },
+      }, null, 2)
+    );
+    await writeFile(
+      stageStepPath(dataRoot, 2, runId, 'head_of_marketing'),
+      JSON.stringify({
+        generated_at: '2026-03-19T00:00:02.000Z',
+      }, null, 2)
+    );
+    await mkdir(path.dirname(stageStepPath(dataRoot, 3, runId, 'production_review_preview')), { recursive: true });
+    await writeFile(
+      stageStepPath(dataRoot, 3, runId, 'production_review_preview'),
+      JSON.stringify({
+        generated_at: '2026-03-19T00:00:03.000Z',
+        review_packet: {
+          summary: { core_message: 'Proof-led launch package' },
+          asset_previews: {
+            landing_page_headline: 'Ship the campaign with confidence',
+            meta_ad_hook: 'The cleanest path from idea to launch',
+            video_opening_line: 'See every stage before you publish',
+          },
+        },
+        artifacts: {
+          preview_path: launchPreviewPath,
+        },
+      }, null, 2)
+    );
+    await writeFile(
+      stageStepPath(dataRoot, 3, runId, 'creative_director_finalize'),
+      JSON.stringify({
+        generated_at: '2026-03-19T00:00:04.000Z',
+      }, null, 2)
+    );
+    await writeFile(
+      stageStepPath(dataRoot, 3, runId, 'veo_video_generator'),
+      JSON.stringify({
+        video_assets: {
+          platform_contracts: [
+            { platform: 'YouTube Shorts', platform_slug: 'youtube-shorts' },
+            { platform: 'TikTok', platform_slug: 'tiktok' },
+          ],
+        },
+      }, null, 2)
+    );
+    await mkdir(path.dirname(stageStepPath(dataRoot, 4, runId, 'launch_review_preview')), { recursive: true });
+    await writeFile(
+      stageStepPath(dataRoot, 4, runId, 'performance_marketer_preflight'),
+      JSON.stringify({
+        publish_plan: {
+          static_contract_count: 7,
+          video_contract_count: 2,
+        },
+      }, null, 2)
+    );
+    await writeFile(
+      stageStepPath(dataRoot, 4, runId, 'launch_review_preview'),
+      JSON.stringify({
+        generated_at: '2026-03-19T00:00:05.000Z',
+        approval_preview: {
+          status: 'pending_human_review',
+          message: 'Approval needed before publish-ready assets are generated.',
+        },
+        artifacts: {
+          preview_path: launchPreviewPath,
+        },
       }, null, 2)
     );
 
@@ -223,10 +374,19 @@ test('/api/marketing/jobs/:jobId omits runtime path fields and resolves approval
 
     assert.equal(response.status, 200);
     assert.equal(body.jobId, jobId);
-    assert.equal(body.marketing_job_state, 'running');
-    assert.equal(body.marketing_job_status, 'pending');
-    assert.equal(body.needs_attention, false);
+    assert.equal(body.marketing_job_state, 'approval_required');
+    assert.equal(body.marketing_job_status, 'awaiting_approval');
+    assert.equal(body.needs_attention, true);
     assert.equal(body.approvalRequired, true);
+    assert.equal((body.summary as any).headline, 'Campaign is ready for launch approval');
+    assert.equal(Array.isArray(body.stageCards), true);
+    assert.equal((body.stageCards as any[]).length, 4);
+    assert.equal(Array.isArray(body.artifacts), true);
+    assert.equal((body.artifacts as any[]).length > 0, true);
+    assert.equal(Array.isArray(body.timeline), true);
+    assert.equal((body.approval as any).required, true);
+    assert.equal(body.nextStep, 'submit_approval');
+    assert.equal(body.repairStatus, 'not_required');
     assert.equal('tenantId' in body, false);
     assert.equal('runtimeArtifactPath' in body, false);
     assert.equal('runtimePath' in body, false);
@@ -304,6 +464,16 @@ test('/api/marketing/jobs/:jobId/approve resolves tenant context server-side and
             production: 'completed',
             publish: 'awaiting_approval',
           },
+          openclaw: {
+            run_id: 'demo-run-approve',
+            resume_token: 'resume_123',
+            primary_output: {
+              run_id: 'demo-run-approve',
+              approval_preview: {
+                status: 'pending_human_review',
+              },
+            },
+          },
           structured_status_updates: [],
         },
         history: [],
@@ -318,7 +488,12 @@ test('/api/marketing/jobs/:jobId/approve resolves tenant context server-side and
       return {
         ok: true,
         status: 'ok',
-        output: [{ accepted: true }],
+        output: [{
+          run_id: 'demo-run-approve',
+          summary: {
+            message: 'Publish packages ready.',
+          },
+        }],
         requiresApproval: null,
       };
     });
@@ -343,7 +518,6 @@ test('/api/marketing/jobs/:jobId/approve resolves tenant context server-side and
       })
     );
     const body = (await response.json()) as Record<string, unknown>;
-    const workflowArgs = JSON.parse(String((captured as any)?.args?.argsJson)) as Record<string, unknown>;
 
     assert.equal(response.status, 200);
     assert.equal(body.approval_status, 'resumed');
@@ -351,8 +525,9 @@ test('/api/marketing/jobs/:jobId/approve resolves tenant context server-side and
     assert.equal(typeof body.jobStatusUrl, 'string');
     assert.equal('tenantId' in body, false);
     assert.equal('wiring' in body, false);
-    assert.equal(workflowArgs.tenant_id, 'tenant_real');
-    assert.equal(workflowArgs.job_id, jobId);
+    assert.equal((captured as any)?.args?.action, 'resume');
+    assert.equal((captured as any)?.args?.token, 'resume_123');
+    assert.equal((captured as any)?.args?.approve, true);
     clearOpenClawTestInvoker();
   });
 });

--- a/tests/marketing-job-flow.test.ts
+++ b/tests/marketing-job-flow.test.ts
@@ -107,6 +107,7 @@ test('startMarketingJob uses repo-managed runtime without requiring N8N env', as
 
     assert.equal(result.jobType, 'brand_campaign');
     assert.equal(result.wiring, 'openclaw_gateway');
+    assert.equal(result.jobId.includes('tenant_123'), false);
 
     const runtimeFile = path.join(dataRoot, 'generated', 'draft', 'marketing-jobs', `${result.jobId}.json`);
     const runtimeDoc = JSON.parse(await readFile(runtimeFile, 'utf8')) as {

--- a/tests/marketing-job-flow.test.ts
+++ b/tests/marketing-job-flow.test.ts
@@ -172,3 +172,85 @@ test('approveMarketingJob rejects tenant mismatches for local runtime jobs', asy
     assert.equal(result.wiring, 'openclaw_gateway');
   });
 });
+
+test('approveMarketingJob resumes the real OpenClaw token and marks publish complete', async () => {
+  await withMarketingRuntimeEnv(async (dataRoot) => {
+    const { approveMarketingJob } = await import('../backend/marketing/jobs-approve');
+    const jobId = 'mkt_resume_real_1';
+    const runtimeFile = path.join(dataRoot, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'job_runtime_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant-a',
+        state: 'approval_required',
+        status: 'awaiting_approval',
+        attempt: 1,
+        max_attempts: 3,
+        outputs: {
+          current_stage: 'publish',
+          stage_status: {
+            research: 'completed',
+            strategy: 'completed',
+            production: 'completed',
+            publish: 'awaiting_approval',
+          },
+          openclaw: {
+            run_id: 'demo-run-approve',
+            resume_token: 'resume_123',
+            primary_output: {
+              run_id: 'demo-run-approve',
+              approval_preview: {
+                status: 'pending_human_review',
+              },
+            },
+          },
+          structured_status_updates: [],
+        },
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2)
+    );
+
+    let captured: Record<string, unknown> | null = null;
+    setOpenClawTestInvoker((payload) => {
+      captured = payload;
+      return {
+        ok: true,
+        status: 'ok',
+        output: [{
+          run_id: 'demo-run-approve',
+          summary: {
+            message: 'Publish packages ready.',
+          },
+        }],
+        requiresApproval: null,
+      };
+    });
+
+    const result = await approveMarketingJob({
+      jobId,
+      tenantId: 'tenant-a',
+      approvedBy: 'operator',
+      approvedStages: ['publish'],
+      resumePublishIfNeeded: true,
+    });
+    const runtimeDoc = JSON.parse(await readFile(runtimeFile, 'utf8')) as Record<string, any>;
+
+    assert.equal(result.status, 'resumed');
+    assert.equal(result.resumedStage, 'publish');
+    assert.equal(result.completed, true);
+    assert.equal((captured as any)?.args?.action, 'resume');
+    assert.equal((captured as any)?.args?.token, 'resume_123');
+    assert.equal(runtimeDoc.state, 'completed');
+    assert.equal(runtimeDoc.status, 'completed');
+    assert.equal(runtimeDoc.outputs?.stage_status?.publish, 'completed');
+    assert.equal(runtimeDoc.outputs?.openclaw?.resume_token, null);
+    clearOpenClawTestInvoker();
+  });
+});

--- a/tests/runtime-pages.test.ts
+++ b/tests/runtime-pages.test.ts
@@ -58,18 +58,16 @@ test('/marketing/job-status preserves jobId from the route boundary', async () =
   assert.equal(element.props.defaultJobId, 'mkt_123');
 });
 
-test('/marketing/job-approve preserves job and tenant ids from the route boundary', async () => {
+test('/marketing/job-approve preserves the job id from the route boundary', async () => {
   const element = await MarketingJobApprovePage({
     searchParams: Promise.resolve({
       jobId: 'mkt_123',
-      tenantId: 'tenant_123',
     }),
   });
 
   assert.equal(isValidElement(element), true);
   assert.equal(element.type, MarketingJobApproveScreen);
   assert.equal(element.props.defaultJobId, 'mkt_123');
-  assert.equal(element.props.defaultTenantId, 'tenant_123');
 });
 
 test('/platforms wraps the integrations screen in the app shell', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep tenant resolution server-side while redirecting brand campaign launches straight into the job-status workspace
- turn the marketing status route into a product-safe operational read model with stage cards, approval state, timeline, and artifact summaries derived from real Lobster outputs
- replace the stubbed approval flow with real OpenClaw resume-token handling so approved campaigns can reach a completed publish state

## Testing
- `./node_modules/.bin/tsx --test tests/marketing-job-flow.test.ts tests/frontend-api-layer.test.ts tests/runtime-pages.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `NODE_ENV=production npm run build`
- manual UI walkthrough on `http://localhost:3002/marketing/new-job`, `/marketing/job-status?jobId=mkt_demo_123`, and `/marketing/job-approve?jobId=mkt_demo_123`

[Slack Thread](https://hid-consulting.slack.com/archives/D0AL48NJA7R/p1773878348933659?thread_ts=1773878348.933659&cid=D0AL48NJA7R)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://hid-consulting.slack.com/archives/D0AL48NJA7R/p1773878348933659?thread_ts=1773878348.933659&cid=D0AL48NJA7R)

<div><a href="https://cursor.com/agents/bc-4ca773cf-10f9-50fd-a5b8-347f04b86049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca773cf-10f9-50fd-a5b8-347f04b86049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

