### PR TITLE
feat(onboarding): persist drafts and business profiles to PostgreSQL

### DIFF
--- a/backend/onboarding/draft-store.ts
+++ b/backend/onboarding/draft-store.ts
@@ -1,9 +1,7 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import crypto from 'node:crypto';
-import path from 'node:path';
 
+import pool from '@/lib/db';
 import { normalizeMarketingWebsiteUrl } from '@/lib/marketing-public-mode';
-import { resolveDataPath } from '@/lib/runtime-paths';
 
 export type OnboardingDraftStatus =
   | 'draft'
@@ -81,10 +79,6 @@ type OnboardingDraftMutation = Partial<{
 
 const DRAFT_ID_PATTERN = /^[a-f0-9-]{16,}$/i;
 
-function nowIso(): string {
-  return new Date().toISOString();
-}
-
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
@@ -120,16 +114,8 @@ function normalizeDraftId(draftId: string): string {
   return normalized;
 }
 
-function draftDirectoryPath(): string {
-  return resolveDataPath('generated', 'draft', 'onboarding-drafts');
-}
-
-function draftPath(draftId: string): string {
-  return path.join(draftDirectoryPath(), `${normalizeDraftId(draftId)}.json`);
-}
-
 function emptyDraft(input?: Partial<OnboardingDraft>): OnboardingDraft {
-  const timestamp = nowIso();
+  const timestamp = new Date().toISOString();
   const draftId = input?.draftId || crypto.randomUUID();
 
   return {
@@ -154,16 +140,6 @@ function emptyDraft(input?: Partial<OnboardingDraft>): OnboardingDraft {
     materializedTenantId: input?.materializedTenantId || null,
     materializedJobId: input?.materializedJobId || null,
   };
-}
-
-async function writeDraft(draft: OnboardingDraft): Promise<OnboardingDraft> {
-  await mkdir(draftDirectoryPath(), { recursive: true });
-  const nextDraft = {
-    ...draft,
-    updatedAt: nowIso(),
-  };
-  await writeFile(draftPath(draft.draftId), JSON.stringify(nextDraft, null, 2));
-  return nextDraft;
 }
 
 function sanitizePreview(value: unknown): OnboardingDraftPreview | null {
@@ -286,21 +262,102 @@ function applyDraftMutation(draft: OnboardingDraft, mutation: OnboardingDraftMut
   };
 }
 
+type DraftRow = {
+  draft_id: string;
+  status: string;
+  website_url: string;
+  business_name: string;
+  business_type: string;
+  approver_name: string;
+  channels: string[];
+  goal: string;
+  offer: string;
+  competitor_url: string;
+  preview: OnboardingDraftPreview | null;
+  provenance: OnboardingDraftProvenance;
+  materialized_tenant_id: string | null;
+  materialized_job_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function rowToDraft(row: DraftRow): OnboardingDraft {
+  return emptyDraft({
+    draftId: row.draft_id,
+    status: row.status as OnboardingDraftStatus,
+    websiteUrl: row.website_url,
+    businessName: row.business_name,
+    businessType: row.business_type,
+    approverName: row.approver_name,
+    channels: row.channels,
+    goal: row.goal,
+    offer: row.offer,
+    competitorUrl: row.competitor_url,
+    preview: row.preview,
+    provenance: row.provenance,
+    materializedTenantId: row.materialized_tenant_id,
+    materializedJobId: row.materialized_job_id,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  });
+}
+
+function draftToRow(draft: OnboardingDraft) {
+  return {
+    draft_id: draft.draftId,
+    status: draft.status,
+    website_url: draft.websiteUrl,
+    business_name: draft.businessName,
+    business_type: draft.businessType,
+    approver_name: draft.approverName,
+    channels: draft.channels,
+    goal: draft.goal,
+    offer: draft.offer,
+    competitor_url: draft.competitorUrl,
+    preview: draft.preview ? JSON.stringify(draft.preview) : null,
+    provenance: JSON.stringify(draft.provenance),
+    materialized_tenant_id: draft.materializedTenantId,
+    materialized_job_id: draft.materializedJobId,
+  };
+}
+
 export function draftTenantId(draftId: string): string {
   return `draft_${normalizeDraftId(draftId).replace(/-/g, '')}`;
 }
 
 export async function createOnboardingDraft(initial?: Partial<OnboardingDraft>): Promise<OnboardingDraft> {
-  return writeDraft(emptyDraft(initial));
+  const draft = emptyDraft(initial);
+  const row = draftToRow(draft);
+
+  const result = await pool.query<DraftRow>(
+    `INSERT INTO onboarding_drafts (
+      draft_id, status, website_url, business_name, business_type,
+      approver_name, channels, goal, offer, competitor_url,
+      preview, provenance, materialized_tenant_id, materialized_job_id
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+    RETURNING *`,
+    [
+      row.draft_id, row.status, row.website_url, row.business_name, row.business_type,
+      row.approver_name, row.channels, row.goal, row.offer, row.competitor_url,
+      row.preview, row.provenance, row.materialized_tenant_id, row.materialized_job_id,
+    ],
+  );
+
+  return rowToDraft(result.rows[0]);
 }
 
 export async function getOnboardingDraft(draftId: string): Promise<OnboardingDraft | null> {
-  try {
-    const parsed = JSON.parse(await readFile(draftPath(draftId), 'utf8')) as Partial<OnboardingDraft>;
-    return emptyDraft(parsed);
-  } catch {
+  const normalized = normalizeDraftId(draftId);
+  const result = await pool.query<DraftRow>(
+    'SELECT * FROM onboarding_drafts WHERE draft_id = $1',
+    [normalized],
+  );
+
+  if (result.rowCount === 0) {
     return null;
   }
+
+  return rowToDraft(result.rows[0]);
 }
 
 export async function requireOnboardingDraft(draftId: string): Promise<OnboardingDraft> {
@@ -316,5 +373,23 @@ export async function updateOnboardingDraft(
   mutation: OnboardingDraftMutation,
 ): Promise<OnboardingDraft> {
   const current = await requireOnboardingDraft(draftId);
-  return writeDraft(applyDraftMutation(current, mutation));
+  const next = applyDraftMutation(current, mutation);
+  const row = draftToRow(next);
+
+  const result = await pool.query<DraftRow>(
+    `UPDATE onboarding_drafts SET
+      status = $2, website_url = $3, business_name = $4, business_type = $5,
+      approver_name = $6, channels = $7, goal = $8, offer = $9, competitor_url = $10,
+      preview = $11, provenance = $12, materialized_tenant_id = $13,
+      materialized_job_id = $14, updated_at = now()
+    WHERE draft_id = $1
+    RETURNING *`,
+    [
+      row.draft_id, row.status, row.website_url, row.business_name, row.business_type,
+      row.approver_name, row.channels, row.goal, row.offer, row.competitor_url,
+      row.preview, row.provenance, row.materialized_tenant_id, row.materialized_job_id,
+    ],
+  );
+
+  return rowToDraft(result.rows[0]);
 }

--- a/backend/tenant/business-profile.ts
+++ b/backend/tenant/business-profile.ts
@@ -3,11 +3,11 @@ import path from 'node:path';
 
 import type { PoolClient } from 'pg';
 
+import pool from '@/lib/db';
 import {
   extractAndSaveTenantBrandKit,
   loadTenantBrandKit,
   sanitizeBrandKitSummaryText,
-  tenantBrandKitPath,
   type TenantBrandKit,
 } from '@/backend/marketing/brand-kit';
 import type { MarketingBrandIdentity } from '@/lib/api/marketing';
@@ -304,11 +304,49 @@ function loadBusinessProfileRecord(tenantId: string): BusinessProfileRecord | nu
   }
 }
 
-function saveBusinessProfileRecord(record: BusinessProfileRecord): string {
+function saveBusinessProfileRecordToFile(record: BusinessProfileRecord): void {
   const filePath = businessProfilePath(record.tenant_id);
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify({ ...record, updated_at: nowIso() }, null, 2));
-  return filePath;
+}
+
+function saveBusinessProfileRecordToDb(record: BusinessProfileRecord): void {
+  pool.query(
+    `INSERT INTO business_profiles (
+      tenant_id, business_name, tenant_slug, website_url, business_type,
+      primary_goal, launch_approver_user_id, launch_approver_name, offer,
+      brand_voice, style_vibe, notes, competitor_url, channels, updated_at
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,now())
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      business_name = EXCLUDED.business_name,
+      tenant_slug = EXCLUDED.tenant_slug,
+      website_url = EXCLUDED.website_url,
+      business_type = EXCLUDED.business_type,
+      primary_goal = EXCLUDED.primary_goal,
+      launch_approver_user_id = EXCLUDED.launch_approver_user_id,
+      launch_approver_name = EXCLUDED.launch_approver_name,
+      offer = EXCLUDED.offer,
+      brand_voice = EXCLUDED.brand_voice,
+      style_vibe = EXCLUDED.style_vibe,
+      notes = EXCLUDED.notes,
+      competitor_url = EXCLUDED.competitor_url,
+      channels = EXCLUDED.channels,
+      updated_at = now()`,
+    [
+      Number(record.tenant_id), record.business_name, record.tenant_slug,
+      record.website_url, record.business_type, record.primary_goal,
+      record.launch_approver_user_id, record.launch_approver_name, record.offer,
+      record.brand_voice, record.style_vibe, record.notes,
+      record.competitor_url, record.channels,
+    ],
+  ).catch((err) => {
+    console.error('[business-profile] Failed to persist to database:', err);
+  });
+}
+
+function saveBusinessProfileRecord(record: BusinessProfileRecord): void {
+  saveBusinessProfileRecordToFile(record);
+  saveBusinessProfileRecordToDb(record);
 }
 
 async function launchApproverName(client: PoolClient, approverUserId: string | null): Promise<string | null> {
@@ -699,15 +737,6 @@ export async function updateBusinessProfileWithDiagnostics(
   return getBusinessProfileWithDiagnostics(client, input.tenantId);
 }
 
-
-export function businessProfileWritePathForTenant(tenantId: string): string {
-  return businessProfilePath(tenantId);
-}
-
-export function tenantBrandKitWritePathForTenant(tenantId: string): string {
-  return tenantBrandKitPath(tenantId);
-}
-
 export function tenantHasStoredBusinessProfileState(tenantId: string): boolean {
   const record = loadBusinessProfileRecord(tenantId);
   if (
@@ -732,8 +761,6 @@ export function tenantHasStoredBusinessProfileState(tenantId: string): boolean {
   return Boolean(docs.brandProfile || docs.websiteAnalysis || docs.businessProfile || docs.brandKit);
 }
 
-// Compatibility wrappers for older generated artifacts. The live public onboarding flow
-// no longer reads or writes customer business profiles through these helpers.
 export function getPublicBusinessProfile(websiteUrl?: string | null): ResolvedBusinessProfile {
   const normalizedWebsiteUrl = normalizeMarketingWebsiteUrl(websiteUrl);
   const tenantId =

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -110,6 +110,46 @@ async function initDb() {
       CREATE INDEX IF NOT EXISTS idx_oauth_pending_states_expires ON oauth_pending_states (expires_at);
       CREATE INDEX IF NOT EXISTS idx_oauth_audit_tenant_time ON oauth_audit_events (tenant_id, occurred_at DESC);
     `);
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS onboarding_drafts (
+        draft_id TEXT PRIMARY KEY,
+        status TEXT NOT NULL DEFAULT 'draft',
+        website_url TEXT NOT NULL DEFAULT '',
+        business_name TEXT NOT NULL DEFAULT '',
+        business_type TEXT NOT NULL DEFAULT '',
+        approver_name TEXT NOT NULL DEFAULT '',
+        channels TEXT[] NOT NULL DEFAULT '{}',
+        goal TEXT NOT NULL DEFAULT '',
+        offer TEXT NOT NULL DEFAULT '',
+        competitor_url TEXT NOT NULL DEFAULT '',
+        preview JSONB,
+        provenance JSONB NOT NULL DEFAULT '{}'::jsonb,
+        materialized_tenant_id TEXT,
+        materialized_job_id TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+
+      CREATE TABLE IF NOT EXISTS business_profiles (
+        tenant_id INTEGER PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+        business_name TEXT,
+        tenant_slug TEXT,
+        website_url TEXT,
+        business_type TEXT,
+        primary_goal TEXT,
+        launch_approver_user_id TEXT,
+        launch_approver_name TEXT,
+        offer TEXT,
+        brand_voice TEXT,
+        style_vibe TEXT,
+        notes TEXT,
+        competitor_url TEXT,
+        channels TEXT[] NOT NULL DEFAULT '{}',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+    `);
     
     console.log('Database initialized successfully.');
   } catch (err) {


### PR DESCRIPTION
## Summary

- Adds `onboarding_drafts` and `business_profiles` tables to the PostgreSQL schema (`init-db.js`)
- Rewrites `draft-store.ts` to use PostgreSQL instead of filesystem JSON files -- all CRUD operations now go through `INSERT`/`SELECT`/`UPDATE` queries against the `onboarding_drafts` table
- Adds dual-write to `business-profile.ts`: every `saveBusinessProfileRecord` call now writes to both the filesystem (preserving sync read compatibility for the workspace/runtime-views layer) and PostgreSQL via an async upsert, so profile data is durably stored in the database

## Motivation

Onboarding drafts and business profiles were stored as JSON files under `/data/generated/` on a Docker volume. While the named volume survives container restarts, the data is invisible to database backups and could be lost if the volume is removed. Moving this user-entered data into PostgreSQL ensures it is backed up alongside the rest of the application state.

## Design decisions

- **Drafts: full migration** -- the draft store was already fully async, so switching reads and writes to PostgreSQL was straightforward with no cascading signature changes
- **Business profiles: dual-write** -- many sync functions across the workspace-views and runtime-views layers read business profiles. Making `loadBusinessProfileRecord` async would cascade through 15+ files. Instead, writes go to both filesystem (sync, immediate) and PostgreSQL (async, fire-and-forget with error logging). Reads continue from filesystem. A follow-up PR can migrate reads to PostgreSQL once the async cascade is addressed

## Test plan

- [ ] Run `node scripts/init-db.js` and verify both new tables are created
- [ ] Complete an onboarding flow end-to-end and verify the draft appears in `onboarding_drafts` table
- [ ] Verify the business profile is written to `business_profiles` table after onboarding resume
- [ ] Verify existing marketing job creation still works (workspace-store, handler unchanged)
- [ ] Verify the dashboard loads correctly for existing tenants (sync read path unchanged)