### PR TITLE
fix(onboarding): address review findings in postgres migration

### DIFF
--- a/backend/onboarding/draft-store.ts
+++ b/backend/onboarding/draft-store.ts
@@ -277,9 +277,14 @@ type DraftRow = {
   provenance: OnboardingDraftProvenance;
   materialized_tenant_id: string | null;
   materialized_job_id: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: string | Date;
+  updated_at: string | Date;
 };
+
+function toIsoString(value: string | Date): string {
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
+}
 
 function rowToDraft(row: DraftRow): OnboardingDraft {
   return emptyDraft({
@@ -297,8 +302,8 @@ function rowToDraft(row: DraftRow): OnboardingDraft {
     provenance: row.provenance,
     materializedTenantId: row.materialized_tenant_id,
     materializedJobId: row.materialized_job_id,
-    createdAt: row.created_at.toISOString(),
-    updatedAt: row.updated_at.toISOString(),
+    createdAt: toIsoString(row.created_at),
+    updatedAt: toIsoString(row.updated_at),
   });
 }
 
@@ -347,7 +352,13 @@ export async function createOnboardingDraft(initial?: Partial<OnboardingDraft>):
 }
 
 export async function getOnboardingDraft(draftId: string): Promise<OnboardingDraft | null> {
-  const normalized = normalizeDraftId(draftId);
+  let normalized: string;
+  try {
+    normalized = normalizeDraftId(draftId);
+  } catch {
+    return null;
+  }
+
   const result = await pool.query<DraftRow>(
     'SELECT * FROM onboarding_drafts WHERE draft_id = $1',
     [normalized],

--- a/backend/tenant/business-profile.ts
+++ b/backend/tenant/business-profile.ts
@@ -311,6 +311,11 @@ function saveBusinessProfileRecordToFile(record: BusinessProfileRecord): void {
 }
 
 function saveBusinessProfileRecordToDb(record: BusinessProfileRecord): void {
+  const numericId = Number(record.tenant_id);
+  if (!Number.isFinite(numericId) || numericId <= 0) {
+    return;
+  }
+
   pool.query(
     `INSERT INTO business_profiles (
       tenant_id, business_name, tenant_slug, website_url, business_type,
@@ -333,7 +338,7 @@ function saveBusinessProfileRecordToDb(record: BusinessProfileRecord): void {
       channels = EXCLUDED.channels,
       updated_at = now()`,
     [
-      Number(record.tenant_id), record.business_name, record.tenant_slug,
+      numericId, record.business_name, record.tenant_slug,
       record.website_url, record.business_type, record.primary_goal,
       record.launch_approver_user_id, record.launch_approver_name, record.offer,
       record.brand_voice, record.style_vibe, record.notes,

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -123,7 +123,7 @@ async function initDb() {
     await client.query(`
       CREATE TABLE IF NOT EXISTS onboarding_drafts (
         draft_id TEXT PRIMARY KEY,
-        status TEXT NOT NULL DEFAULT 'draft',
+        status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','ready_for_auth','materializing','materialized')),
         website_url TEXT NOT NULL DEFAULT '',
         business_name TEXT NOT NULL DEFAULT '',
         business_type TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
## Summary

Fixes four issues flagged by Copilot code review on PR #81:

- **Defensive timestamp conversion**: `rowToDraft` now handles `TIMESTAMPTZ` columns whether `pg` returns them as `Date` objects or strings, preventing a potential `toISOString is not a function` runtime error
- **Restore null-return for bad draft IDs**: `getOnboardingDraft` catches `invalid_draft_token` from `normalizeDraftId` and returns `null` (matching the original filesystem behavior) instead of letting it bubble as a 500
- **Skip DB upsert for non-numeric tenant IDs**: `saveBusinessProfileRecordToDb` now short-circuits when `tenant_id` is not a valid positive integer, preventing `NaN` from reaching the INSERT for public/derived tenant identifiers like `pub_abc123`
- **CHECK constraint on draft status**: `onboarding_drafts.status` now enforces the same enum pattern (`draft`, `ready_for_auth`, `materializing`, `materialized`) used by other status columns in the schema

## Test plan

- [ ] Build passes (`next build`, `tsc --noEmit`)
- [ ] Existing test suite has no new failures
- [ ] Onboarding flow with a valid draft ID works end-to-end
- [ ] Requesting a malformed draft ID (e.g. `?draft=;;;`) returns 404 not 500