### PR TITLE
fix(frontend): restore missing campaign-workspace-state.ts (master build red)

### DIFF
--- a/frontend/aries-v1/campaign-workspace-state.ts
+++ b/frontend/aries-v1/campaign-workspace-state.ts
@@ -1,0 +1,512 @@
+import type {
+  GetMarketingJobStatusResponse,
+  MarketingCreativeAssetReviewPayload,
+  MarketingDashboardAsset,
+  MarketingStageCard,
+} from '@/lib/api/marketing';
+
+export type WorkspaceView = 'brand' | 'strategy' | 'creative' | 'publish';
+
+export interface WorkspaceAction {
+  label: string;
+  href: string;
+}
+
+export interface WorkspaceHeaderState {
+  title: string;
+  sourceDomain: string | null;
+  sourceUrl: string | null;
+}
+
+export interface GateFallbackState {
+  title: string;
+  description: string;
+  detail: string | null;
+  action: WorkspaceAction | null;
+}
+
+export interface PublishSurfaceState {
+  title: string;
+  description: string;
+  action: WorkspaceAction | null;
+  emptyTitle: string;
+  emptyDescription: string;
+}
+
+export interface GenerationProgressState {
+  title: string;
+  currentLabel: string;
+  description: string;
+  completedCount: number;
+  activeCount: number;
+  totalCount: number;
+  percentComplete: number;
+  activePercent: number;
+  imageCount: number | null;
+  videoCount: number | null;
+  completedImageCount: number;
+  completedVideoCount: number;
+  isComplete: boolean;
+}
+
+const VIEW_ORDER: Record<WorkspaceView, number> = {
+  brand: 0,
+  strategy: 1,
+  creative: 2,
+  publish: 3,
+};
+
+const VIEW_LABELS: Record<WorkspaceView, string> = {
+  brand: 'Brand Review',
+  strategy: 'Strategy Review',
+  creative: 'Creative Review',
+  publish: 'Launch Status',
+};
+
+const DEFAULT_WAITING_COPY: Record<WorkspaceView, { title: string; description: string }> = {
+  brand: {
+    title: 'Brand review will open here',
+    description: 'The current-source brand package will appear here as soon as the website review and brand identity are ready.',
+  },
+  strategy: {
+    title: 'Strategy review will open here',
+    description: 'The campaign strategy package will appear here as soon as the current plan is ready for approval.',
+  },
+  creative: {
+    title: 'Creative review will open here',
+    description: 'Reviewable assets will appear here when production outputs are available.',
+  },
+  publish: {
+    title: 'Launch status will open here',
+    description: 'Launch-ready items will appear here after upstream approvals and final preparation finish.',
+  },
+};
+
+function normalizeUrl(value: string | null | undefined): string | null {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    return new URL(trimmed).toString();
+  } catch {
+    return trimmed;
+  }
+}
+
+function normalizedDomain(value: string | null | undefined): string | null {
+  const normalized = normalizeUrl(value);
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    return new URL(normalized).hostname.replace(/^www\./i, '').toLowerCase();
+  } catch {
+    return normalized.replace(/^https?:\/\//i, '').replace(/\/+$/, '') || null;
+  }
+}
+
+function currentStageHref(campaignId: string, view: WorkspaceView): string {
+  return `/dashboard/campaigns/${encodeURIComponent(campaignId)}?view=${view}`;
+}
+
+function stageForView(view: WorkspaceView): MarketingStageCard['stage'] {
+  if (view === 'brand') return 'strategy';
+  if (view === 'strategy') return 'production';
+  return 'publish';
+}
+
+function stageCardForView(
+  stageCards: MarketingStageCard[] | null | undefined,
+  view: WorkspaceView,
+): MarketingStageCard | null {
+  return stageCards?.find((card) => card.stage === stageForView(view)) || null;
+}
+
+function blockerViewFromWorkflowState(
+  workflowState: GetMarketingJobStatusResponse['workflowState'],
+): WorkspaceView | null {
+  if (workflowState === 'brand_review_required') return 'brand';
+  if (workflowState === 'strategy_review_required') return 'strategy';
+  if (workflowState === 'creative_review_required') return 'creative';
+  return null;
+}
+
+function nextStepDetail(nextStep: string): string | null {
+  if (nextStep === 'submit_approval') {
+    return 'The next step is waiting on an approval checkpoint.';
+  }
+  if (nextStep === 'wait_for_completion') {
+    return 'Aries is still preparing the next package.';
+  }
+  return null;
+}
+
+function sameOrDownstream(activeView: WorkspaceView, blockerView: WorkspaceView): boolean {
+  return VIEW_ORDER[activeView] >= VIEW_ORDER[blockerView];
+}
+
+function positiveCount(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function clampCount(value: number, total: number): number {
+  return Math.min(Math.max(Math.floor(value), 0), total);
+}
+
+function parseProductionContractCounts(
+  stageCards: MarketingStageCard[] | null | undefined,
+): { imageCount: number | null; videoCount: number | null } {
+  const highlight = stageCards?.find((card) => card.stage === 'production')?.highlight?.trim() || '';
+  if (!highlight) {
+    return {
+      imageCount: null,
+      videoCount: null,
+    };
+  }
+
+  const imageMatch = highlight.match(/static contracts:\s*(\d+)/i);
+  const videoMatch = highlight.match(/video contracts:\s*(\d+)/i);
+
+  return {
+    imageCount: imageMatch ? Number(imageMatch[1]) : null,
+    videoCount: videoMatch ? Number(videoMatch[1]) : null,
+  };
+}
+
+function videoLike(value: string | null | undefined): boolean {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return /video|reel|short|tiktok|story/.test(normalized);
+}
+
+function isVideoDashboardAsset(asset: MarketingDashboardAsset): boolean {
+  return (asset.contentType || '').toLowerCase().startsWith('video/') || videoLike(`${asset.platform} ${asset.title}`);
+}
+
+function countCompletedCreativeAssets(
+  dashboardAssets: MarketingDashboardAsset[] | null | undefined,
+  creativeReviewAssets: MarketingCreativeAssetReviewPayload[] | null | undefined,
+  dashboardImageAds: number | null | undefined,
+): { imageCount: number; videoCount: number } {
+  const reviewAssets = creativeReviewAssets || [];
+  const reviewVideoCount = reviewAssets.filter(
+    (asset) => (asset.contentType || '').toLowerCase().startsWith('video/') || videoLike(`${asset.platformLabel} ${asset.title}`),
+  ).length;
+  const reviewImageCount = reviewAssets.filter(
+    (asset) => (asset.contentType || '').toLowerCase().startsWith('image/'),
+  ).length;
+
+  const dashboardVideoCount = (dashboardAssets || []).filter((asset) => isVideoDashboardAsset(asset)).length;
+  const dashboardImageCount = Math.max(
+    dashboardImageAds || 0,
+    (dashboardAssets || []).filter(
+      (asset) => asset.type === 'image_ad' && !isVideoDashboardAsset(asset),
+    ).length,
+  );
+
+  return {
+    imageCount: Math.max(reviewImageCount, dashboardImageCount),
+    videoCount: Math.max(reviewVideoCount, dashboardVideoCount),
+  };
+}
+
+function generationCopy(
+  imageCount: number | null,
+  videoCount: number | null,
+  completedCount: number,
+  totalCount: number,
+): { title: string; currentLabel: string; description: string } {
+  const hasImages = !!imageCount;
+  const hasVideos = !!videoCount;
+  const unitSingular = hasVideos && !hasImages ? 'video' : hasImages && !hasVideos ? 'image' : hasImages || hasVideos ? 'asset' : 'item';
+  const unitPlural = unitSingular === 'item' ? 'items' : `${unitSingular}s`;
+  const verb = unitSingular === 'video' ? 'Rendering' : 'Generating';
+  const pendingCount = Math.max(totalCount - completedCount, 0);
+  const activeCount = completedCount < totalCount ? completedCount + 1 : totalCount;
+  const breakdown: string[] = [];
+
+  if (hasImages) {
+    breakdown.push(`${imageCount} static image${imageCount === 1 ? '' : 's'}`);
+  }
+  if (hasVideos) {
+    breakdown.push(`${videoCount} video render${videoCount === 1 ? '' : 's'}`);
+  }
+
+  if (completedCount >= totalCount) {
+    return {
+      title: 'Creative generation is complete',
+      currentLabel: `${totalCount} ${unitPlural} ready`,
+      description:
+        breakdown.length > 0
+          ? `All planned creative outputs are ready. ${breakdown.join(' · ')}.`
+          : 'All planned creative outputs are ready.',
+    };
+  }
+
+  return {
+    title: 'Creative generation is running',
+    currentLabel: `${verb} ${unitSingular} ${activeCount} of ${totalCount}`,
+    description:
+      breakdown.length > 0
+        ? `${completedCount} complete and ${pendingCount} remaining. ${breakdown.join(' · ')}.`
+        : `${completedCount} complete and ${pendingCount} remaining.`,
+  };
+}
+
+export function approvalStepToView(workflowStepId: string | null | undefined): WorkspaceView | null {
+  if (workflowStepId === 'approve_stage_2') return 'brand';
+  if (workflowStepId === 'approve_stage_3') return 'strategy';
+  if (workflowStepId === 'approve_stage_4') return 'creative';
+  if (workflowStepId === 'approve_stage_4_publish') return 'publish';
+  return null;
+}
+
+export function deriveGenerationProgressState(
+  status: Pick<
+    GetMarketingJobStatusResponse,
+    'approval' | 'workflowState' | 'plannedPostCount' | 'createdPostCount' | 'stageCards' | 'publishConfig' | 'dashboard' | 'creativeReview'
+  >,
+): GenerationProgressState | null {
+  const approvalView = approvalStepToView(status.approval?.workflowStepId);
+  const explicitCounts = parseProductionContractCounts(status.stageCards);
+  const plannedImageCount = explicitCounts.imageCount;
+  const plannedVideoCount = explicitCounts.videoCount ?? positiveCount(status.publishConfig.videoRenderPlatforms.length);
+  const explicitTotal =
+    plannedImageCount !== null || plannedVideoCount !== null ? (plannedImageCount || 0) + (plannedVideoCount || 0) : null;
+  const productionActive =
+    approvalView === 'creative' ||
+    approvalView === 'publish' ||
+    status.workflowState === 'creative_review_required' ||
+    status.workflowState === 'ready_to_publish' ||
+    status.workflowState === 'published' ||
+    explicitTotal !== null;
+  const completedCreativeCounts = countCompletedCreativeAssets(
+    status.dashboard.assets,
+    status.creativeReview?.assets,
+    status.dashboard.campaign?.counts.imageAds,
+  );
+  const fallbackTotal = positiveCount(status.plannedPostCount);
+  const totalCount = explicitTotal && explicitTotal > 0 ? explicitTotal : fallbackTotal;
+
+  if (!productionActive || !totalCount) {
+    return null;
+  }
+
+  const explicitCompletedCount = completedCreativeCounts.imageCount + completedCreativeCounts.videoCount;
+  const fallbackCompletedCount = positiveCount(status.createdPostCount);
+  const completedCount = clampCount(
+    explicitTotal && explicitTotal > 0
+      ? explicitCompletedCount > 0
+        ? explicitCompletedCount
+        : fallbackCompletedCount && fallbackCompletedCount <= totalCount
+          ? fallbackCompletedCount
+          : 0
+      : fallbackCompletedCount || explicitCompletedCount,
+    totalCount,
+  );
+  const activeCount = completedCount < totalCount ? completedCount + 1 : totalCount;
+  const copy = generationCopy(plannedImageCount, plannedVideoCount, completedCount, totalCount);
+
+  return {
+    title: copy.title,
+    currentLabel: copy.currentLabel,
+    description: copy.description,
+    completedCount,
+    activeCount,
+    totalCount,
+    percentComplete: completedCount / totalCount,
+    activePercent: activeCount / totalCount,
+    imageCount: plannedImageCount,
+    videoCount: plannedVideoCount,
+    completedImageCount: completedCreativeCounts.imageCount,
+    completedVideoCount: completedCreativeCounts.videoCount,
+    isComplete: completedCount >= totalCount,
+  };
+}
+
+export function deriveWorkspaceHeaderState(
+  status: Pick<GetMarketingJobStatusResponse, 'reviewBundle' | 'brandWebsiteUrl' | 'campaignBrief' | 'dashboard' | 'jobId' | 'tenantName'>,
+): WorkspaceHeaderState {
+  const sourceUrl = normalizeUrl(status.brandWebsiteUrl) || normalizeUrl(status.campaignBrief?.websiteUrl);
+  const sourceDomain = normalizedDomain(sourceUrl);
+
+  return {
+    title:
+      status.reviewBundle?.campaignName?.trim() ||
+      sourceDomain ||
+      status.dashboard.campaign?.name ||
+      status.tenantName ||
+      `Campaign ${status.jobId}`,
+    sourceDomain,
+    sourceUrl,
+  };
+}
+
+export function deriveGateFallbackState(
+  status: Pick<GetMarketingJobStatusResponse, 'approval' | 'workflowState' | 'stageCards' | 'nextStep'>,
+  activeView: WorkspaceView,
+  campaignId: string,
+  publishBlockedReason?: string | null,
+): GateFallbackState {
+  const defaultCopy = DEFAULT_WAITING_COPY[activeView];
+  const approvalView = approvalStepToView(status.approval?.workflowStepId);
+  const blockerView = approvalView || blockerViewFromWorkflowState(status.workflowState);
+  const activeStageCard = stageCardForView(status.stageCards, activeView);
+  const stageSummary = activeStageCard?.summary?.trim() || null;
+  const stageHighlight = activeStageCard?.highlight?.trim() || null;
+
+  if (status.workflowState === 'revisions_requested') {
+    return {
+      title: 'Revisions are blocking this gate',
+      description: publishBlockedReason || 'Requested changes must be resolved before this gate can continue.',
+      detail: stageHighlight || nextStepDetail(status.nextStep),
+      action: {
+        label: 'Open review queue',
+        href: '/review',
+      },
+    };
+  }
+
+  if (
+    approvalView === activeView &&
+    status.approval?.actionHref &&
+    status.approval.actionHref.trim().length > 0
+  ) {
+    return {
+      title: status.approval.title || `${VIEW_LABELS[activeView]} checkpoint`,
+      description: status.approval.message || stageSummary || defaultCopy.description,
+      detail: stageHighlight || nextStepDetail(status.nextStep),
+      action: {
+        label: status.approval.actionLabel || `Open ${VIEW_LABELS[activeView]}`,
+        href: status.approval.actionHref,
+      },
+    };
+  }
+
+  if (
+    blockerView &&
+    blockerView !== activeView &&
+    sameOrDownstream(activeView, blockerView)
+  ) {
+    return {
+      title: `${VIEW_LABELS[blockerView]} is blocking this gate`,
+      description: `${VIEW_LABELS[blockerView]} must be approved before ${VIEW_LABELS[activeView].toLowerCase()} can continue.`,
+      detail: stageSummary || stageHighlight || nextStepDetail(status.nextStep),
+      action: {
+        label: `Open ${VIEW_LABELS[blockerView]}`,
+        href: currentStageHref(campaignId, blockerView),
+      },
+    };
+  }
+
+  return {
+    title: defaultCopy.title,
+    description: stageSummary || defaultCopy.description,
+    detail: stageHighlight || nextStepDetail(status.nextStep),
+    action: null,
+  };
+}
+
+export function derivePublishSurfaceState(
+  status: Pick<GetMarketingJobStatusResponse, 'approval' | 'workflowState' | 'stageCards' | 'nextStep' | 'dashboard'>,
+  campaignId: string,
+  publishBlockedReason?: string | null,
+): PublishSurfaceState {
+  const publishItems = status.dashboard.publishItems || [];
+  const approvalView = approvalStepToView(status.approval?.workflowStepId);
+  const blockerView = approvalView || blockerViewFromWorkflowState(status.workflowState);
+  const publishStageCard = stageCardForView(status.stageCards, 'publish');
+  const stageSummary =
+    publishStageCard?.summary?.trim() ||
+    'Launch items will appear here after upstream approvals and final preparation finish.';
+
+  if (status.workflowState === 'revisions_requested') {
+    return {
+      title: 'Launch is blocked by requested changes',
+      description: publishBlockedReason || 'Requested changes must be resolved before publishing can continue.',
+      action: {
+        label: 'Open review queue',
+        href: '/review',
+      },
+      emptyTitle: 'Launch items are waiting on revisions',
+      emptyDescription: 'Launch packages will appear here after the requested changes are resolved.',
+    };
+  }
+
+  if (publishBlockedReason) {
+    return {
+      title: 'Launch is blocked',
+      description: publishBlockedReason,
+      action:
+        blockerView && blockerView !== 'publish'
+          ? {
+              label: `Open ${VIEW_LABELS[blockerView]}`,
+              href: currentStageHref(campaignId, blockerView),
+            }
+          : null,
+      emptyTitle: 'Launch items are waiting on approvals',
+      emptyDescription: 'Launch packages will appear here after the blocking review is approved and final preparation finishes.',
+    };
+  }
+
+  if (
+    approvalView === 'publish' &&
+    status.approval?.actionHref &&
+    status.approval.actionHref.trim().length > 0
+  ) {
+    return {
+      title: status.approval.title || 'Publish approval is ready',
+      description: status.approval.message || stageSummary,
+      action: {
+        label: status.approval.actionLabel || 'Open publish approval',
+        href: status.approval.actionHref,
+      },
+      emptyTitle: 'Publish queue opens after approval',
+      emptyDescription: 'Launch items will populate here after the publish checkpoint is approved.',
+    };
+  }
+
+  if (
+    blockerView &&
+    blockerView !== 'publish' &&
+    sameOrDownstream('publish', blockerView)
+  ) {
+    return {
+      title: `${VIEW_LABELS[blockerView]} is still blocking launch`,
+      description: `${VIEW_LABELS[blockerView]} must be approved before launch-ready items can move forward.`,
+      action: {
+        label: `Open ${VIEW_LABELS[blockerView]}`,
+        href: currentStageHref(campaignId, blockerView),
+      },
+      emptyTitle: 'Launch queue is still locked',
+      emptyDescription: 'Launch packages will appear here after the blocking review is approved.',
+    };
+  }
+
+  if (
+    publishItems.length > 0 &&
+    (status.workflowState === 'ready_to_publish' || status.workflowState === 'published')
+  ) {
+    return {
+      title: status.workflowState === 'published' ? 'Launch is live' : 'Launch-ready items are available',
+      description:
+        status.workflowState === 'published'
+          ? 'Published items are available below with their current launch status.'
+          : 'All required approvals are complete. Publish-ready items can now move forward.',
+      action: null,
+      emptyTitle: 'No launch items yet',
+      emptyDescription: 'Launch packages will appear here as soon as final preparation finishes.',
+    };
+  }
+
+  return {
+    title: 'Launch preparation is still running',
+    description: stageSummary,
+    action: null,
+    emptyTitle: 'No launch items yet',
+    emptyDescription:
+      nextStepDetail(status.nextStep) || 'Launch packages will appear here as soon as upstream approvals and final preparation are complete.',
+  };
+}

--- a/scripts/check-repo-boundary.mjs
+++ b/scripts/check-repo-boundary.mjs
@@ -1,0 +1,128 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const explicitCodeRoot = process.env.CODE_ROOT?.trim();
+const candidateRoot = explicitCodeRoot ? path.resolve(explicitCodeRoot) : null;
+const root =
+  candidateRoot && fs.existsSync(path.join(candidateRoot, 'package.json'))
+    ? candidateRoot
+    : process.cwd();
+
+const protectedEntries = [
+  'AGENTS.md',
+  'SOUL.md',
+  'IDENTITY.md',
+  'MEMORY.md',
+  'TOOLS.md',
+  'README.md',
+  'README-runtime.md',
+  'SETUP.md',
+  'ROUTE_MANIFEST.md',
+  '.env.example',
+  'package.json',
+  'docker-compose.yml',
+  'docker-compose.local.yml',
+  'app',
+  'backend',
+  'components',
+  'frontend',
+  'lib',
+  'scripts/check-banned-patterns.mjs',
+  'scripts/init-db.js',
+  'scripts/inventory-paperclip-workspaces.mjs',
+  'scripts/runtime-precheck.mjs',
+  'scripts/start-runtime.mjs',
+  'scripts/verify-canonical-workspace.mjs',
+  'scripts/verify-regression-suite.mjs',
+  'tests',
+];
+
+const excludedFiles = new Set([
+  'scripts/check-repo-boundary.mjs',
+  'tests/repo-boundary-guard.test.ts',
+]);
+
+const ariesOsToken = ['aries', 'os'].join('-');
+const missionControlHyphenToken = ['mission', 'control'].join('-');
+const missionControlSpaceToken = ['mission', 'control'].join(' ');
+
+const forbiddenPathSegment = new RegExp(`(^|[\\\\/])(${ariesOsToken}|${missionControlHyphenToken})(?=([\\\\/]|$))`, 'i');
+const forbiddenContentPatterns = [
+  { label: ariesOsToken, regex: new RegExp(`\\b${ariesOsToken}\\b`, 'i') },
+  { label: missionControlHyphenToken, regex: new RegExp(`\\b${missionControlHyphenToken}\\b`, 'i') },
+  { label: missionControlSpaceToken, regex: new RegExp(`\\b${missionControlSpaceToken}\\b`, 'i') },
+];
+
+function listFiles(relPath) {
+  const absPath = path.join(root, relPath);
+  if (!fs.existsSync(absPath)) {
+    return [];
+  }
+
+  const stat = fs.statSync(absPath);
+  if (stat.isFile()) {
+    return [relPath];
+  }
+
+  return fs.readdirSync(absPath, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .flatMap((entry) => {
+      const childRelPath = path.join(relPath, entry.name);
+      if (entry.isDirectory()) {
+        return listFiles(childRelPath);
+      }
+      return [childRelPath];
+    });
+}
+
+function readTextFile(relPath) {
+  const text = fs.readFileSync(path.join(root, relPath), 'utf8');
+  if (text.includes('\u0000')) {
+    return null;
+  }
+  return text;
+}
+
+const files = protectedEntries
+  .flatMap((entry) => listFiles(entry))
+  .filter((relPath) => !excludedFiles.has(relPath.split(path.sep).join('/')));
+const violations = [];
+
+for (const relPath of files) {
+  const normalizedPath = relPath.split(path.sep).join('/');
+
+  if (forbiddenPathSegment.test(normalizedPath)) {
+    violations.push({
+      type: 'path',
+      file: normalizedPath,
+      pattern: 'forbidden project path segment',
+    });
+  }
+
+  const text = readTextFile(relPath);
+  if (text === null) {
+    continue;
+  }
+
+  const lines = text.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    for (const pattern of forbiddenContentPatterns) {
+      if (pattern.regex.test(line)) {
+        violations.push({
+          type: 'content',
+          file: normalizedPath,
+          line: index + 1,
+          pattern: pattern.label,
+          text: line.trim(),
+        });
+      }
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error(JSON.stringify({ ok: false, violations }, null, 2));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ ok: true, filesChecked: files.length }, null, 2));

--- a/tests/campaign-workspace-state.test.ts
+++ b/tests/campaign-workspace-state.test.ts
@@ -1,0 +1,262 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  approvalStepToView,
+  deriveGenerationProgressState,
+  deriveGateFallbackState,
+  derivePublishSurfaceState,
+  deriveWorkspaceHeaderState,
+} from '../frontend/aries-v1/campaign-workspace-state';
+
+function emptyDashboard() {
+  return {
+    campaign: null,
+    posts: [],
+    assets: [],
+    publishItems: [],
+    calendarEvents: [],
+    statuses: {
+      countsByStatus: {
+        draft: 0,
+        in_review: 0,
+        ready: 0,
+        ready_to_publish: 0,
+        published_to_meta_paused: 0,
+        scheduled: 0,
+        live: 0,
+      },
+    },
+  };
+}
+
+function makeStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    jobId: 'mkt_123',
+    tenantName: 'Tenant Name',
+    brandWebsiteUrl: null,
+    campaignBrief: null,
+    reviewBundle: null,
+    dashboard: emptyDashboard(),
+    approval: null,
+    workflowState: 'draft',
+    stageCards: [],
+    nextStep: 'wait_for_completion',
+    plannedPostCount: null,
+    createdPostCount: null,
+    creativeReview: null,
+    publishConfig: {
+      platforms: [],
+      livePublishPlatforms: [],
+      videoRenderPlatforms: [],
+    },
+    ...overrides,
+  };
+}
+
+test('approvalStepToView maps workflow checkpoints to campaign gates', () => {
+  assert.equal(approvalStepToView('approve_stage_2'), 'brand');
+  assert.equal(approvalStepToView('approve_stage_3'), 'strategy');
+  assert.equal(approvalStepToView('approve_stage_4'), 'creative');
+  assert.equal(approvalStepToView('approve_stage_4_publish'), 'publish');
+  assert.equal(approvalStepToView('unknown'), null);
+});
+
+test('deriveGateFallbackState links the active gate to the approval review route when the checkpoint matches', () => {
+  const fallback = deriveGateFallbackState(
+    makeStatus({
+      approval: {
+        workflowStepId: 'approve_stage_2',
+        title: 'Research complete',
+        message: 'Research is complete. Continue to brand analysis.',
+        actionLabel: 'Continue to brand analysis',
+        actionHref: '/review/mkt_123%3A%3Aapproval',
+      },
+      nextStep: 'submit_approval',
+    }) as any,
+    'brand',
+    'mkt_123',
+  );
+
+  assert.equal(fallback.title, 'Research complete');
+  assert.equal(fallback.action?.label, 'Continue to brand analysis');
+  assert.equal(fallback.action?.href, '/review/mkt_123%3A%3Aapproval');
+});
+
+test('deriveGateFallbackState routes downstream gates back to the blocking review gate', () => {
+  const fallback = deriveGateFallbackState(
+    makeStatus({
+      workflowState: 'strategy_review_required',
+    }) as any,
+    'publish',
+    'mkt_123',
+  );
+
+  assert.equal(fallback.title, 'Strategy Review is blocking this gate');
+  assert.equal(fallback.action?.label, 'Open Strategy Review');
+  assert.equal(fallback.action?.href, '/dashboard/campaigns/mkt_123?view=strategy');
+});
+
+test('deriveGateFallbackState sends revisions_requested traffic to the review queue', () => {
+  const fallback = deriveGateFallbackState(
+    makeStatus({
+      workflowState: 'revisions_requested',
+    }) as any,
+    'creative',
+    'mkt_123',
+    'Requested changes must be resolved before this gate can continue.',
+  );
+
+  assert.equal(fallback.action?.href, '/review');
+  assert.equal(fallback.description, 'Requested changes must be resolved before this gate can continue.');
+});
+
+test('derivePublishSurfaceState prefers blocked and approval-pending copy before ready copy', () => {
+  const blocked = derivePublishSurfaceState(
+    makeStatus({
+      workflowState: 'creative_review_required',
+      dashboard: emptyDashboard(),
+    }) as any,
+    'mkt_123',
+    'Every required creative asset must be approved before publish can be unlocked.',
+  );
+  assert.equal(blocked.title, 'Launch is blocked');
+  assert.equal(blocked.description, 'Every required creative asset must be approved before publish can be unlocked.');
+
+  const pendingApproval = derivePublishSurfaceState(
+    makeStatus({
+      approval: {
+        workflowStepId: 'approve_stage_4_publish',
+        title: 'Publish approval is ready',
+        message: 'The final publish checkpoint is ready for review.',
+        actionLabel: 'Open publish approval',
+        actionHref: '/review/mkt_123%3A%3Aapproval',
+      },
+      dashboard: emptyDashboard(),
+    }) as any,
+    'mkt_123',
+  );
+  assert.equal(pendingApproval.action?.href, '/review/mkt_123%3A%3Aapproval');
+  assert.equal(pendingApproval.emptyTitle, 'Publish queue opens after approval');
+});
+
+test('derivePublishSurfaceState only shows publish-ready copy when launch items exist', () => {
+  const ready = derivePublishSurfaceState(
+    makeStatus({
+      workflowState: 'ready_to_publish',
+      dashboard: {
+        ...emptyDashboard(),
+        publishItems: [
+          {
+            id: 'pub_1',
+            title: 'Meta launch package',
+            summary: 'Ready to go',
+            status: 'ready_to_publish',
+            platformLabel: 'Meta Ads',
+            destinationUrl: null,
+          },
+        ],
+      },
+    }) as any,
+    'mkt_123',
+  );
+  assert.equal(ready.title, 'Launch-ready items are available');
+
+  const waiting = derivePublishSurfaceState(
+    makeStatus({
+      workflowState: 'ready_to_publish',
+      dashboard: emptyDashboard(),
+    }) as any,
+    'mkt_123',
+  );
+  assert.equal(waiting.title, 'Launch preparation is still running');
+});
+
+test('deriveGenerationProgressState maps creative asset progress from production contract counts', () => {
+  const progress = deriveGenerationProgressState(
+    makeStatus({
+      workflowState: 'creative_review_required',
+      stageCards: [
+        {
+          stage: 'production',
+          label: 'Production',
+          status: 'running',
+          summary: 'Creative outputs are in production.',
+          highlight: 'Static contracts: 3, Video contracts: 1',
+        },
+      ],
+      dashboard: {
+        ...emptyDashboard(),
+        campaign: {
+          counts: {
+            imageAds: 1,
+          },
+        },
+        assets: [
+          {
+            id: 'asset_1',
+            type: 'image_ad',
+            title: 'Meta image',
+            platform: 'meta-ads',
+            contentType: 'image/png',
+          },
+        ],
+      },
+    }) as any,
+  );
+
+  assert.equal(progress?.totalCount, 4);
+  assert.equal(progress?.completedCount, 1);
+  assert.equal(progress?.activeCount, 2);
+  assert.equal(progress?.currentLabel, 'Generating asset 2 of 4');
+  assert.equal(progress?.imageCount, 3);
+  assert.equal(progress?.videoCount, 1);
+});
+
+test('deriveGenerationProgressState falls back to planned and created counts when contract counts are missing', () => {
+  const progress = deriveGenerationProgressState(
+    makeStatus({
+      workflowState: 'creative_review_required',
+      plannedPostCount: 4,
+      createdPostCount: 1,
+    }) as any,
+  );
+
+  assert.equal(progress?.totalCount, 4);
+  assert.equal(progress?.completedCount, 1);
+  assert.equal(progress?.currentLabel, 'Generating item 2 of 4');
+});
+
+test('deriveGenerationProgressState stays hidden before creative production becomes relevant', () => {
+  const progress = deriveGenerationProgressState(
+    makeStatus({
+      workflowState: 'draft',
+      plannedPostCount: 4,
+      createdPostCount: 1,
+    }) as any,
+  );
+
+  assert.equal(progress, null);
+});
+
+test('deriveWorkspaceHeaderState prefers the source domain over contaminated dashboard campaign names', () => {
+  const header = deriveWorkspaceHeaderState(
+    makeStatus({
+      brandWebsiteUrl: 'https://www.glossier.com/',
+      campaignBrief: {
+        websiteUrl: 'https://www.glossier.com/',
+      },
+      dashboard: {
+        ...emptyDashboard(),
+        campaign: {
+          name: 'frameX',
+        },
+      },
+      tenantName: 'frameX',
+    }) as any,
+  );
+
+  assert.equal(header.title, 'glossier.com');
+  assert.equal(header.sourceDomain, 'glossier.com');
+  assert.equal(header.sourceUrl, 'https://www.glossier.com/');
+});

--- a/tests/repo-boundary-guard.test.ts
+++ b/tests/repo-boundary-guard.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const CHECK_SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'check-repo-boundary.mjs');
+const siblingToken = ['mission', 'control'].join('-');
+
+function runBoundaryCheck(codeRoot: string): string {
+  return execFileSync(process.execPath, [CHECK_SCRIPT], {
+    cwd: codeRoot,
+    env: {
+      ...process.env,
+      CODE_ROOT: codeRoot,
+    },
+    encoding: 'utf8',
+  });
+}
+
+test('repo boundary guard passes against the current repository', () => {
+  const output = runBoundaryCheck(PROJECT_ROOT);
+  assert.match(output, /"ok": true/);
+});
+
+test('repo boundary guard fails when a protected file mentions a sibling project', async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'aries-boundary-guard-'));
+
+  try {
+    await writeFile(path.join(tempRoot, 'package.json'), JSON.stringify({ name: 'tmp', private: true }), 'utf8');
+    await mkdir(path.join(tempRoot, 'app'), { recursive: true });
+    await writeFile(
+      path.join(tempRoot, 'app', 'page.tsx'),
+      `export default function Page() { return <div>${siblingToken}</div>; }\n`,
+      'utf8',
+    );
+
+    assert.throws(() => runBoundaryCheck(tempRoot), new RegExp(siblingToken, 'i'));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Master tsc is currently broken: `frontend/aries-v1/campaign-workspace.tsx` imports 9 symbols from `./campaign-workspace-state` but that file is missing from git. Left untracked during an earlier merge-conflict resolution.
- Adds the missing state-selector module, its test, and two sibling helpers that were sitting untracked (`check-repo-boundary.mjs` + its test).
- Verified `npm run typecheck` exits 0 with these files present.

## Why master is red right now

During the `feat(marketing): per-family diversity across scripts, previews, and videos` work I resolved a stash-pop merge conflict on `campaign-workspace.tsx` in favor of the "Stashed changes" side, which kept imports like `deriveGenerationProgressState` and `GenerationProgressState`. I committed the resolved workspace.tsx via a temp clone, but the sibling `campaign-workspace-state.ts` that those symbols live in was sitting untracked in the main checkout and never made it into the commit. Result: master references a module that doesn't exist.

This PR restores it. The file has been in the main checkout the whole time — just not in git.

## Files

| File | Lines | Purpose |
|---|---|---|
| frontend/aries-v1/campaign-workspace-state.ts | 512 | Pure-function state selectors for the campaign workspace UI. Exports all 9 symbols imported by workspace.tsx. |
| tests/campaign-workspace-state.test.ts | 262 | node:test coverage for the 5 derivation helpers. |
| scripts/check-repo-boundary.mjs | 128 | Orthogonal repo-hygiene script that prevents sibling-project drift. |
| tests/repo-boundary-guard.test.ts | 45 | Exercises the boundary script against a synthetic sibling tree. |

## Test plan

- [x] npm run typecheck exits 0 locally
- [ ] CI typecheck on this branch passes
- [ ] tests/campaign-workspace-state.test.ts runs green
- [ ] tests/repo-boundary-guard.test.ts runs green

## What's NOT in this PR

Intentionally scoped down — calling out deliberately skipped items:

- default/memory/2026-04-14-1110.md — raw session transcript. Project convention (see the sanitized stub at default/memory/2026-04-10-daily-standup.md) is to strip raw session content before committing. Sanitize in a follow-up.
- docs/briefs/2026-04-14-brief.md — orthogonal daily brief content, worth a separate review.
- Pre-session UU merge-conflict files (data/nightly-build-log.json, docs/SYSTEM-REFERENCE.md, scripts/automations/daily-standup.mjs, scripts/automations/verify-automations.mjs) — multi-agent cruft from before my session, not mine to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)