### PR TITLE
Wave 1: campaign review polish (per-family hooks, slug leak, header name)

### DIFF
--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -1002,7 +1002,8 @@ function extractSummaryFromCopyPayload(filePath: string | null | undefined): str
 }
 
 function extractDestinationUrl(runtimeDoc: MarketingJobRuntimeDocument, contractPayload: Record<string, unknown> | null): string | null {
-  const slug = stringValue(recordValue(contractPayload?.landing_page)?.slug)
+  const rawSlug = stringValue(recordValue(contractPayload?.landing_page)?.slug)
+  const slug = rawSlug ? rawSlug.replace(/^\/\d+\/?/, '/') : rawSlug
   const brandUrl = stringValue(runtimeDoc.inputs.brand_url || runtimeDoc.brand_kit?.source_url)
   if (slug && brandUrl) {
     try {

--- a/backend/marketing/workspace-views.ts
+++ b/backend/marketing/workspace-views.ts
@@ -960,17 +960,32 @@ function buildCreativeAssets(
   const fallbackLanding = readLandingPageArtifactDetails({ runtimeDoc });
   const fallbackScripts = readScriptArtifactDetails({ runtimeDoc });
 
-  const scriptwriterPayload = readMarketingStageStepPayload(runtimeDoc, 3, 'scriptwriter').payload;
-  const metaAdScriptsByFamily = recordValue(
-    recordValue(scriptwriterPayload?.script_assets)?.meta_ad_scripts_by_family,
-  );
+  let metaAdScriptsByFamily:
+    | Record<string, unknown>
+    | null
+    | undefined;
+
+  function getMetaAdScriptsByFamily(): Record<string, unknown> | null {
+    if (metaAdScriptsByFamily !== undefined) {
+      return metaAdScriptsByFamily;
+    }
+    const scriptwriterPayload = readMarketingStageStepPayload(runtimeDoc, 3, 'scriptwriter').payload;
+    metaAdScriptsByFamily = recordValue(
+      recordValue(scriptwriterPayload?.script_assets)?.meta_ad_scripts_by_family,
+    );
+    return metaAdScriptsByFamily;
+  }
 
   function perFamilyHook(filePath: string | null): string | null {
     const familyId = familyIdFromImagePath(filePath);
-    if (!familyId || !metaAdScriptsByFamily) {
+    if (!familyId) {
       return null;
     }
-    const entry = recordValue(metaAdScriptsByFamily[familyId]);
+    const scriptsByFamily = getMetaAdScriptsByFamily();
+    if (!scriptsByFamily) {
+      return null;
+    }
+    const entry = recordValue(scriptsByFamily[familyId]);
     return stringValue(entry?.hook) || null;
   }
 

--- a/backend/marketing/workspace-views.ts
+++ b/backend/marketing/workspace-views.ts
@@ -32,6 +32,7 @@ import {
   readLandingPageArtifactDetails,
   readScriptArtifactDetails,
 } from './real-artifacts';
+import { readMarketingStageStepPayload } from './stage-artifact-resolution';
 import {
   ensureCampaignWorkspaceRecord,
   marketingWorkspaceAssetUrl,
@@ -133,6 +134,15 @@ function readTextIfExists(filePath: string | null | undefined): string | null {
   } catch {
     return null;
   }
+}
+
+function familyIdFromImagePath(filePath: string | null): string | null {
+  if (!filePath) {
+    return null;
+  }
+  const basename = path.basename(filePath);
+  const match = /^(meta-[a-z0-9-]+)\.(png|jpe?g|webp)$/i.exec(basename);
+  return match ? match[1] : null;
 }
 
 function currentSourceUrl(runtimeDoc: MarketingJobRuntimeDocument): string | null {
@@ -950,6 +960,20 @@ function buildCreativeAssets(
   const fallbackLanding = readLandingPageArtifactDetails({ runtimeDoc });
   const fallbackScripts = readScriptArtifactDetails({ runtimeDoc });
 
+  const scriptwriterPayload = readMarketingStageStepPayload(runtimeDoc, 3, 'scriptwriter').payload;
+  const metaAdScriptsByFamily = recordValue(
+    recordValue(scriptwriterPayload?.script_assets)?.meta_ad_scripts_by_family,
+  );
+
+  function perFamilyHook(filePath: string | null): string | null {
+    const familyId = familyIdFromImagePath(filePath);
+    if (!familyId || !metaAdScriptsByFamily) {
+      return null;
+    }
+    const entry = recordValue(metaAdScriptsByFamily[familyId]);
+    return stringValue(entry?.hook) || null;
+  }
+
   return creativeAssets.map((asset) => {
     const reviewState = record.creative_asset_reviews[asset.id];
     const resolvedAsset = findMarketingAsset(runtimeDoc.job_id, runtimeDoc, asset.id);
@@ -968,7 +992,8 @@ function buildCreativeAssets(
           normalizeArtifactText(landingDetails.subheadline) ||
           normalizeArtifactText(stringValue(assetPreviews?.landing_page_headline))
         : asset.type === 'image_ad'
-          ? normalizeArtifactText(scriptDetails.metaAdHook) ||
+          ? normalizeArtifactText(perFamilyHook(resolvedAsset?.filePath || null)) ||
+            normalizeArtifactText(scriptDetails.metaAdHook) ||
             normalizeArtifactText(fallbackScripts.metaAdHook) ||
             normalizeArtifactText(stringValue(assetPreviews?.meta_ad_hook))
           : isVideoScript
@@ -993,7 +1018,7 @@ function buildCreativeAssets(
         detailLines.push(`Slug: ${landingDetails.slug}`);
       }
     } else if (asset.type === 'image_ad') {
-      detailLines.push(`Ad hook: ${scriptDetails.metaAdHook || fallbackScripts.metaAdHook || normalizeArtifactText(stringValue(assetPreviews?.meta_ad_hook)) || ARTIFACT_UNAVAILABLE_TEXT}`);
+      detailLines.push(`Ad hook: ${perFamilyHook(resolvedAsset?.filePath || null) || scriptDetails.metaAdHook || fallbackScripts.metaAdHook || normalizeArtifactText(stringValue(assetPreviews?.meta_ad_hook)) || ARTIFACT_UNAVAILABLE_TEXT}`);
     } else if (isVideoScript) {
       detailLines.push(`Opening line: ${scriptDetails.shortVideoOpeningLine || fallbackScripts.shortVideoOpeningLine || normalizeArtifactText(stringValue(assetPreviews?.video_opening_line)) || ARTIFACT_UNAVAILABLE_TEXT}`);
       if ((scriptDetails.shortVideoBeats[0] || fallbackScripts.shortVideoBeats[0])) {

--- a/default/memory/2026-04-14-1110.md
+++ b/default/memory/2026-04-14-1110.md
@@ -1,0 +1,15 @@
+# Session artifact removed
+
+This file previously contained a raw generated session log with internal runtime metadata,
+execution traces, and conversational history.
+
+The sensitive log content has been intentionally removed from version control.
+If session artifacts are needed locally for debugging, keep them out of the repository
+and store only sanitized summaries in committed Markdown files.
+
+## Session metadata
+
+- **Date**: 2026-04-14 11:10:19 UTC
+- **Session Key**: agent:main:main
+- **Source**: webchat
+- **Sanitized on**: 2026-04-15

--- a/docs/briefs/2026-04-14-brief.md
+++ b/docs/briefs/2026-04-14-brief.md
@@ -1,0 +1,40 @@
+# Daily brief — 2026-04-14
+
+Generated Apr 14, 2026, 08:08 PDT.
+
+## Priorities for today
+- Keep `aries-app` boundary-safe and prevent sibling-project drift.
+- Reconcile docs, routes, and tests against executable `aries-app` truth.
+- Strengthen marketing flow runtime validation and approval safety.
+- Improve local setup clarity for Postgres and OpenClaw-backed development.
+- Keep automation scripts fast, truthful, and scoped to this repository.
+
+## Overnight activity
+- f772ee7 feat(marketing): move stage-4 preflight and launch review before approve_stage_4 gate (41 seconds ago)
+- bcd2f9e feat(operations): add runtime-error intake and standup automation (#88) (4 hours ago)
+- 4dbd545 Merge master into codex/20260414-update (4 hours ago)
+- cdb1bb8 chore(deps): bump diff from 7.0.0 to 8.0.4 in /incubator/micro-saas/2026-04-12-termsight/prototype in the npm_and_yarn group across 1 directory (#85) (7 hours ago)
+- f1ea4c9 feat(operations): add runtime-error intake and standup orchestration (8 hours ago)
+
+## Pending action items
+- No open backlog items found in ROADMAP.md or HEARTBEAT.md.
+
+## Needs attention
+- M .env.example
+- M AGENTS.md
+- M CLAUDE.md
+- M DELEGATION-RULES.md
+- M DOCKER.md
+- M IDENTITY.md
+- M MEMORY.md
+- M PRIORITIES.md
+- M PRODUCTION_HANDOFF.md
+- M PROTECTED_SYSTEMS.md
+
+## Overnight automation note
+## Build: Use shared LoadingStateGrid in review item detail screen
+
+- **Chosen improvement:** Replace inline loading text in review-item.tsx with shared LoadingStateGrid component for consistent loading UX and accessibility
+- **Files touched:** `frontend/aries-v1/review-item.tsx`
+- **Build result:** `npm run build` passed, no errors
+- **Verification:** Runtime verification unavailable (no running dev server)

--- a/docs/briefs/2026-04-15-brief.md
+++ b/docs/briefs/2026-04-15-brief.md
@@ -1,0 +1,31 @@
+# Daily brief — 2026-04-15
+
+Generated Apr 15, 2026, 08:01 PDT.
+
+## Priorities for today
+- No open priority bullets found in PRIORITIES.md.
+
+## Overnight activity
+- No git activity recorded in the last 24 hours.
+
+## Pending action items
+- No open backlog items found in ROADMAP.md or HEARTBEAT.md.
+
+## Needs attention
+- M  backend/marketing/artifact-collector.ts
+- M  backend/marketing/brand-identity.ts
+- M  backend/marketing/dashboard-content.ts
+- M  backend/marketing/runtime-views.ts
+- MM data/feedback-processing-log.json
+- A  data/nightly-build-log.json
+- A  data/runtime-error-incidents.json
+- A  default/memory/2026-04-14-1110.md
+- M  docs/SYSTEM-REFERENCE.md
+- A  docs/briefs/2026-04-14-brief.md
+
+## Overnight automation note
+## Overnight self-improvement — Apr 15, 2026, 04:00 PDT
+- focus: docs-drift
+- findings: 12
+- low-risk fixes applied: 0
+- examples: PRODUCTION_HANDOFF.md | README-runtime.md | README.md | ROUTE_MANIFEST.md | SETUP.md

--- a/frontend/aries-v1/campaign-workspace-state.ts
+++ b/frontend/aries-v1/campaign-workspace-state.ts
@@ -336,8 +336,8 @@ export function deriveWorkspaceHeaderState(
     title:
       status.reviewBundle?.campaignName?.trim() ||
       sourceDomain ||
-      status.dashboard.campaign?.name ||
       status.tenantName ||
+      status.dashboard.campaign?.name ||
       `Campaign ${status.jobId}`,
     sourceDomain,
     sourceUrl,

--- a/lobster/bin/page-designer
+++ b/lobster/bin/page-designer
@@ -66,7 +66,7 @@ def main() -> int:
 
     page_assets = {
         "landing_page": {
-            "slug": f"/{brand_slug}/campaign",
+            "slug": "/",
             "hero_headline": hero_headline,
             "hero_subheadline": hero_subheadline,
             "problem_statement": problem_statement,

--- a/tests/creative-review-per-family.test.ts
+++ b/tests/creative-review-per-family.test.ts
@@ -1,0 +1,298 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const previousLocalLobsterCwd = process.env.OPENCLAW_LOCAL_LOBSTER_CWD;
+  const previousOpenClawLobsterCwd = process.env.OPENCLAW_LOBSTER_CWD;
+  const previousStage1CacheDir = process.env.LOBSTER_STAGE1_CACHE_DIR;
+  const previousStage2CacheDir = process.env.LOBSTER_STAGE2_CACHE_DIR;
+  const previousStage3CacheDir = process.env.LOBSTER_STAGE3_CACHE_DIR;
+  const previousStage4CacheDir = process.env.LOBSTER_STAGE4_CACHE_DIR;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-creative-per-family-'));
+  const lobsterRoot = path.join(dataRoot, 'lobster');
+
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+  process.env.OPENCLAW_LOCAL_LOBSTER_CWD = lobsterRoot;
+  process.env.OPENCLAW_LOBSTER_CWD = lobsterRoot;
+  process.env.LOBSTER_STAGE1_CACHE_DIR = path.join(dataRoot, 'lobster-stage1-cache');
+  process.env.LOBSTER_STAGE2_CACHE_DIR = path.join(dataRoot, 'lobster-stage2-cache');
+  process.env.LOBSTER_STAGE3_CACHE_DIR = path.join(dataRoot, 'lobster-stage3-cache');
+  process.env.LOBSTER_STAGE4_CACHE_DIR = path.join(dataRoot, 'lobster-stage4-cache');
+
+  try {
+    return await run(dataRoot);
+  } finally {
+    if (previousCodeRoot === undefined) {
+      delete process.env.CODE_ROOT;
+    } else {
+      process.env.CODE_ROOT = previousCodeRoot;
+    }
+    if (previousDataRoot === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = previousDataRoot;
+    }
+    if (previousLocalLobsterCwd === undefined) {
+      delete process.env.OPENCLAW_LOCAL_LOBSTER_CWD;
+    } else {
+      process.env.OPENCLAW_LOCAL_LOBSTER_CWD = previousLocalLobsterCwd;
+    }
+    if (previousOpenClawLobsterCwd === undefined) {
+      delete process.env.OPENCLAW_LOBSTER_CWD;
+    } else {
+      process.env.OPENCLAW_LOBSTER_CWD = previousOpenClawLobsterCwd;
+    }
+    if (previousStage1CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE1_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE1_CACHE_DIR = previousStage1CacheDir;
+    }
+    if (previousStage2CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE2_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE2_CACHE_DIR = previousStage2CacheDir;
+    }
+    if (previousStage3CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE3_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE3_CACHE_DIR = previousStage3CacheDir;
+    }
+    if (previousStage4CacheDir === undefined) {
+      delete process.env.LOBSTER_STAGE4_CACHE_DIR;
+    } else {
+      process.env.LOBSTER_STAGE4_CACHE_DIR = previousStage4CacheDir;
+    }
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+test('buildCampaignWorkspaceView uses per-family hooks for Meta image ad cards instead of the shared hook', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const { buildCampaignWorkspaceView } = await import('../backend/marketing/workspace-views');
+
+    const jobId = 'mkt_per_family_hook_test';
+    const tenantId = 'tenant_per_family_hook';
+    const stage3RunId = 'run-prod-per-family';
+    const brandSlug = 'per-family-test-brand';
+
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    const scriptwriterCachePath = path.join(process.env.LOBSTER_STAGE3_CACHE_DIR!, stage3RunId, 'scriptwriter.json');
+    const campaignRoot = path.join(process.env.OPENCLAW_LOBSTER_CWD!, 'output', `${brandSlug}-campaign`);
+    const adImagesDir = path.join(campaignRoot, 'ad-images');
+    const image1Path = path.join(adImagesDir, 'meta-outcome-proof.png');
+    const image2Path = path.join(adImagesDir, 'meta-problem-to-promise.png');
+
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await mkdir(path.dirname(scriptwriterCachePath), { recursive: true });
+    await mkdir(adImagesDir, { recursive: true });
+
+    await writeFile(image1Path, 'png-placeholder-1', 'utf8');
+    await writeFile(image2Path, 'png-placeholder-2', 'utf8');
+
+    await writeFile(
+      scriptwriterCachePath,
+      JSON.stringify({
+        script_assets: {
+          meta_ad_scripts_by_family: {
+            'meta-outcome-proof': {
+              family_id: 'meta-outcome-proof',
+              family_name: 'Outcome Proof',
+              funnel_stage: 'consideration',
+              hook: 'See the results operators get before their launch even starts.',
+              body: 'Every operator leaves with a proven launch system.',
+              proof_points: ['Outcome clarity', 'Operator proof'],
+              primary_cta: 'Book a call',
+            },
+            'meta-problem-to-promise': {
+              family_id: 'meta-problem-to-promise',
+              family_name: 'Problem to Promise',
+              funnel_stage: 'awareness',
+              hook: 'Most launches stall because the message never gets clear.',
+              body: 'We fix that in a single sprint.',
+              proof_points: ['Clear message', 'Fast launch'],
+              primary_cta: 'Get started',
+            },
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'marketing_job_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: tenantId,
+        state: 'approval_required',
+        status: 'awaiting_approval',
+        current_stage: 'publish',
+        stage_order: ['research', 'strategy', 'production', 'publish'],
+        stages: {
+          research: {
+            stage: 'research',
+            status: 'completed',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: 'run-research-pf',
+            summary: null,
+            primary_output: null,
+            outputs: {},
+            artifacts: [],
+            errors: [],
+          },
+          strategy: {
+            stage: 'strategy',
+            status: 'completed',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: 'run-strategy-pf',
+            summary: null,
+            primary_output: { run_id: 'run-strategy-pf' },
+            outputs: {},
+            artifacts: [],
+            errors: [],
+          },
+          production: {
+            stage: 'production',
+            status: 'completed',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: stage3RunId,
+            summary: null,
+            primary_output: { run_id: stage3RunId },
+            outputs: {},
+            artifacts: [],
+            errors: [],
+          },
+          publish: {
+            stage: 'publish',
+            status: 'awaiting_approval',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: null,
+            summary: null,
+            primary_output: null,
+            outputs: {
+              approval_id: 'mkta_publish_pf',
+              workflow_step_id: 'approve_stage_4',
+            },
+            artifacts: [],
+            errors: [],
+          },
+        },
+        approvals: {
+          current: {
+            stage: 'publish',
+            status: 'awaiting_approval',
+            approval_id: 'mkta_publish_pf',
+            workflow_name: 'marketing-pipeline',
+            workflow_step_id: 'approve_stage_4',
+            title: 'Creative review required',
+            message: 'Review creative assets before publish.',
+            requested_at: '2026-04-15T00:00:00.000Z',
+            resume_token: 'resume-publish-pf',
+            action_label: 'Review creative',
+            publish_config: {
+              platforms: ['meta-ads'],
+              live_publish_platforms: ['meta-ads'],
+              video_render_platforms: [],
+            },
+          },
+          history: [],
+        },
+        publish_config: {
+          platforms: ['meta-ads'],
+          live_publish_platforms: ['meta-ads'],
+          video_render_platforms: [],
+        },
+        brand_kit: {
+          path: path.join(dataRoot, 'generated', 'validated', tenantId, 'brand-kit.json'),
+          source_url: 'https://per-family.example',
+          canonical_url: 'https://per-family.example',
+          brand_name: 'Per Family Test Brand',
+          logo_urls: ['https://per-family.example/logo.png'],
+          colors: {
+            primary: '#111111',
+            secondary: '#f5f5f5',
+            accent: '#c24d2c',
+            palette: ['#111111', '#f5f5f5', '#c24d2c'],
+          },
+          font_families: ['Manrope'],
+          external_links: [],
+          extracted_at: '2026-04-15T00:00:00.000Z',
+          brand_voice_summary: 'Proof-led and direct.',
+        },
+        inputs: {
+          request: {
+            brandUrl: 'https://per-family.example',
+            brandSlug: brandSlug,
+          },
+          brand_url: 'https://per-family.example',
+          competitor_url: null,
+          competitor_facebook_url: null,
+        },
+        errors: [],
+        last_error: null,
+        history: [],
+        created_at: '2026-04-15T00:00:00.000Z',
+        updated_at: '2026-04-15T00:00:00.000Z',
+      }, null, 2),
+      'utf8',
+    );
+
+    const view = buildCampaignWorkspaceView(jobId);
+
+    assert.notEqual(view.creativeReview, null, 'creativeReview should be populated');
+
+    const imageAdAssets = view.creativeReview!.assets.filter(
+      (asset) => asset.notes.some((note) => note.startsWith('Ad hook:')),
+    );
+
+    assert.equal(imageAdAssets.length >= 2, true, 'expected at least 2 image_ad assets with Ad hook notes');
+
+    const adHooks = imageAdAssets.map((asset) => {
+      const hookNote = asset.notes.find((note) => note.startsWith('Ad hook:'));
+      return hookNote ?? '';
+    });
+
+    assert.equal(
+      adHooks.every((hook) => hook.length > 0),
+      true,
+      'all Ad hook notes should be non-empty',
+    );
+    assert.notEqual(
+      adHooks[0],
+      adHooks[1],
+      `the two image_ad cards should have different Ad hook values but both got: "${adHooks[0]}"`,
+    );
+
+    const allHookText = adHooks.join('\n');
+    assert.equal(
+      allHookText.includes('See the results operators get before their launch even starts.'),
+      true,
+      'expected outcome-proof family hook to appear',
+    );
+    assert.equal(
+      allHookText.includes('Most launches stall because the message never gets clear.'),
+      true,
+      'expected problem-to-promise family hook to appear',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Wave 1 of the 2026-04-15 session followups plan. Five focused fixes for issues caught during the live Framex demo.

- **T02 — Per-family hooks**: Each Meta image_ad card now resolves its hook via `meta_ad_scripts_by_family` so the four creative families show their own copy instead of all sharing the first family's hook. New `familyIdFromImagePath` + `perFamilyHook` helpers in `backend/marketing/workspace-views.ts`, with the existing shared-hook chain preserved as fallback.
- **T03 — Header brand name**: `deriveWorkspaceHeaderState` now puts `tenantName` ahead of `dashboard.campaign.name` so titles render as `frameX` instead of synthetic stage-slugs like `7-stage2-plan`.
- **T04 — Landing page URL**: `lobster/bin/page-designer` no longer emits `/N/campaign` for `landing_page.slug` (now `"/"`), and `extractDestinationUrl` in `dashboard-content.ts` strips any leaked `/N/` prefix as a defensive guard at the dashboard layer.
- **T05 — Memory hygiene**: Replaced the raw 2026-04-14-1110 webchat session dump with a sanitized stub.
- **T06 — Daily briefs**: Committed the April 14 and April 15 daily briefs.

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm run lint` (banned patterns + boundary check)
- [ ] `tsx --test tests/creative-review-per-family.test.ts` to validate per-family hook resolution
- [ ] Spin up dev server, load a mid-stage campaign, confirm the header title shows the brand name (not `N-stage2-plan`)
- [ ] Open Launch Status for a finished campaign, confirm publish item destination URLs no longer contain `/N/campaign`
- [ ] Open Creative Review for a finished campaign, confirm each Meta image card shows a different `Ad hook:` line tied to its family

🤖 Generated with [Claude Code](https://claude.com/claude-code)