### PR TITLE
Wave 2: approval flow hardening (Bug A debounce + 502 retry)

### DIFF
--- a/frontend/aries-v1/review-item.tsx
+++ b/frontend/aries-v1/review-item.tsx
@@ -63,6 +63,7 @@ export default function AriesReviewItemScreen(props: { reviewId: string }) {
   // where a single user click produced two approval POSTs and the pipeline
   // advanced two gates at once, skipping the launch-review surface entirely.
   const submittingRef = useRef(false);
+  const lastSubmitAt = useRef(0);
 
   const decisionSummary = useMemo(() => {
     if (!item?.lastDecision) return null;
@@ -91,8 +92,15 @@ export default function AriesReviewItemScreen(props: { reviewId: string }) {
   const reviewItem = item;
 
   async function applyDecision(action: 'approve' | 'changes_requested' | 'reject') {
-    if (submittingRef.current) return;
+    // Bug A hardening: the ref lock alone doesn't catch a second click that
+    // fires after the first POST resolves but before the component re-renders
+    // (observed on approve_stage_4_publish where the first POST returns 200
+    // and a duplicate follow-up hits the gateway lock for ~4s). A 1s floor
+    // between submits at the same call site is a cheap belt-and-suspenders.
+    const now = Date.now();
+    if (submittingRef.current || now - lastSubmitAt.current < 1000) return;
     submittingRef.current = true;
+    lastSubmitAt.current = now;
     try {
       const approvalId =
         reviewItem.reviewType === 'workflow_approval' && reviewItem.currentVersion.id.startsWith('approval:')

--- a/lib/api/aries-v1.ts
+++ b/lib/api/aries-v1.ts
@@ -1,4 +1,4 @@
-import { requestJson, type ApiClientOptions } from './http';
+import { requestJson, requestJsonWithRetry, type ApiClientOptions } from './http';
 import type {
   MarketingCampaignStatusHistoryEntry,
   MarketingDashboardAsset,
@@ -338,10 +338,15 @@ export function createAriesV1Api(options: ApiClientOptions = {}) {
       return requestJson<ReviewItemResponse>(`/api/marketing/reviews/${encodeURIComponent(reviewId)}`, { method: 'GET' }, options);
     },
     decideReview(reviewId: string, body: ReviewDecisionRequest) {
-      return requestJson<ReviewItemResponse>(`/api/marketing/reviews/${encodeURIComponent(reviewId)}/decision`, {
-        method: 'POST',
-        body: JSON.stringify(body),
-      }, options);
+      return requestJsonWithRetry<ReviewItemResponse>(
+        `/api/marketing/reviews/${encodeURIComponent(reviewId)}/decision`,
+        {
+          method: 'POST',
+          body: JSON.stringify(body),
+        },
+        { retryOn: [502, 503, 504], maxAttempts: 2, backoffMs: 500 },
+        options,
+      );
     },
     getBusinessProfile() {
       return requestJson<BusinessProfileResponse>('/api/business/profile', { method: 'GET' }, options);

--- a/lib/api/http.ts
+++ b/lib/api/http.ts
@@ -136,3 +136,41 @@ export async function requestJson<TResponse>(
 
   return body as TResponse;
 }
+
+export interface RequestJsonRetryPolicy {
+  retryOn: number[];
+  maxAttempts: number;
+  backoffMs: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function requestJsonWithRetry<TResponse>(
+  path: string,
+  options: RequestJsonOptions = {},
+  policy: RequestJsonRetryPolicy,
+  clientOptions: ApiClientOptions = {}
+): Promise<TResponse> {
+  const attempts = Math.max(1, policy.maxAttempts);
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await requestJson<TResponse>(path, options, clientOptions);
+    } catch (error) {
+      lastError = error;
+      const isRetryable =
+        error instanceof ApiRequestError && policy.retryOn.includes(error.status);
+      const hasMoreAttempts = attempt < attempts - 1;
+      if (!isRetryable || !hasMoreAttempts) {
+        throw error;
+      }
+      const delay = policy.backoffMs * 2 ** attempt;
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}

--- a/lib/api/http.ts
+++ b/lib/api/http.ts
@@ -175,5 +175,7 @@ export async function requestJsonWithRetry<TResponse>(
       await sleep(delay);
     }
   }
-  throw lastError;
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`requestJsonWithRetry: unexpected fallthrough after ${attempts} attempts`);
 }

--- a/lib/api/http.ts
+++ b/lib/api/http.ts
@@ -155,7 +155,10 @@ export async function requestJsonWithRetry<TResponse>(
   policy: RequestJsonRetryPolicy,
   clientOptions: ApiClientOptions = {}
 ): Promise<TResponse> {
-  const attempts = Math.max(1, policy.maxAttempts);
+  const normalizedMaxAttempts = Number.isFinite(policy.maxAttempts)
+    ? Math.trunc(policy.maxAttempts)
+    : 1;
+  const attempts = Math.max(1, normalizedMaxAttempts);
   let lastError: unknown;
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {

--- a/tests/decide-review-retry.test.ts
+++ b/tests/decide-review-retry.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createAriesV1Api } from '../lib/api/aries-v1';
+import { ApiRequestError } from '../lib/api/http';
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeReviewItemResponseBody(id: string) {
+  return {
+    review: {
+      id,
+      jobId: 'job_demo',
+      campaignId: 'camp_demo',
+      campaignName: 'Demo',
+      reviewType: 'creative',
+      workflowState: 'in_review',
+      workflowStage: 'production',
+      title: 'Demo Creative',
+      channel: 'instagram',
+      placement: 'feed',
+      scheduledFor: '2026-04-16T00:00:00.000Z',
+      status: 'approved',
+      summary: '',
+      currentVersion: {
+        id: 'v1',
+        label: 'v1',
+        headline: '',
+        supportingText: '',
+        cta: '',
+        notes: [],
+      },
+      lastDecision: null,
+      sections: [],
+      attachments: [],
+      history: [],
+    },
+  };
+}
+
+function makeStubFetch(
+  responses: Array<() => Response>,
+): { fetchImpl: typeof fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  let index = 0;
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    calls.push({ url, init });
+    const factory = responses[index] ?? responses[responses.length - 1];
+    index += 1;
+    if (!factory) {
+      throw new Error('unexpected fetch call');
+    }
+    return factory();
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+test('decideReview retries once on 502 and returns the eventual 200 body', async () => {
+  const okBody = makeReviewItemResponseBody('rv_demo');
+  const { fetchImpl, calls } = makeStubFetch([
+    () => jsonResponse(502, {}),
+    () => jsonResponse(200, okBody),
+  ]);
+  const api = createAriesV1Api({ baseUrl: 'http://test.invalid', fetchImpl });
+
+  const result = await api.decideReview('rv_demo', {
+    action: 'approve',
+    actedBy: 'tester@example.com',
+  });
+
+  assert.equal(calls.length, 2, 'should have retried exactly once');
+  assert.equal(
+    calls[0].url,
+    'http://test.invalid/api/marketing/reviews/rv_demo/decision',
+  );
+  assert.equal(result.review.id, 'rv_demo');
+});
+
+test('decideReview rethrows ApiRequestError with status 502 when both attempts fail', async () => {
+  const { fetchImpl, calls } = makeStubFetch([
+    () => jsonResponse(502, { error: 'bad gateway' }),
+    () => jsonResponse(502, { error: 'bad gateway' }),
+  ]);
+  const api = createAriesV1Api({ baseUrl: 'http://test.invalid', fetchImpl });
+
+  await assert.rejects(
+    () =>
+      api.decideReview('rv_demo', {
+        action: 'approve',
+        actedBy: 'tester@example.com',
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ApiRequestError, 'should preserve typed error');
+      assert.equal((err as ApiRequestError).status, 502);
+      return true;
+    },
+  );
+  assert.equal(calls.length, 2, 'should stop after maxAttempts');
+});
+
+test('decideReview does not retry on a first-call 200', async () => {
+  const okBody = makeReviewItemResponseBody('rv_demo');
+  const { fetchImpl, calls } = makeStubFetch([() => jsonResponse(200, okBody)]);
+  const api = createAriesV1Api({ baseUrl: 'http://test.invalid', fetchImpl });
+
+  const result = await api.decideReview('rv_demo', {
+    action: 'approve',
+    actedBy: 'tester@example.com',
+  });
+
+  assert.equal(calls.length, 1, 'retry must not fire on success');
+  assert.equal(result.review.id, 'rv_demo');
+});
+
+test('decideReview does not retry on a non-retryable 400', async () => {
+  const { fetchImpl, calls } = makeStubFetch([
+    () => jsonResponse(400, { error: 'invalid_action' }),
+    () => jsonResponse(200, makeReviewItemResponseBody('rv_demo')),
+  ]);
+  const api = createAriesV1Api({ baseUrl: 'http://test.invalid', fetchImpl });
+
+  await assert.rejects(
+    () =>
+      api.decideReview('rv_demo', {
+        action: 'approve',
+        actedBy: 'tester@example.com',
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ApiRequestError);
+      assert.equal((err as ApiRequestError).status, 400);
+      return true;
+    },
+  );
+  assert.equal(calls.length, 1, 'non-retryable status must not trigger retry');
+});

--- a/tests/review-decision-idempotency.test.ts
+++ b/tests/review-decision-idempotency.test.ts
@@ -135,79 +135,81 @@ test('approve_stage_4_publish: duplicate recordMarketingReviewDecision does not 
       return response;
     });
 
-    const { startMarketingJob } = await import('../backend/marketing/jobs-start');
-    const { approveMarketingJob } = await import('../backend/marketing/jobs-approve');
-    const { listMarketingApprovalRecordsForJob } = await import('../backend/marketing/approval-store');
-    const { recordMarketingReviewDecision } = await import('../backend/marketing/runtime-views');
+    try {
+      const { startMarketingJob } = await import('../backend/marketing/jobs-start');
+      const { approveMarketingJob } = await import('../backend/marketing/jobs-approve');
+      const { listMarketingApprovalRecordsForJob } = await import('../backend/marketing/approval-store');
+      const { recordMarketingReviewDecision } = await import('../backend/marketing/runtime-views');
 
-    const tenantId = 'tenant-bug-a-publish';
-    const started = await startMarketingJob({
-      tenantId,
-      jobType: 'brand_campaign',
-      payload: { brandUrl: 'https://brand.example', competitorUrl: 'https://betterup.com' },
-    });
-
-    const advance = async (stepId: string, stage: 'strategy' | 'production' | 'publish') => {
-      const records = listMarketingApprovalRecordsForJob(started.jobId);
-      const approvalId = records.find((record) => record.workflow_step_id === stepId)?.approval_id;
-      assert.equal(typeof approvalId, 'string', `missing approval record for ${stepId}`);
-      const result = await approveMarketingJob({
-        jobId: started.jobId,
+      const tenantId = 'tenant-bug-a-publish';
+      const started = await startMarketingJob({
         tenantId,
-        approvedBy: 'operator',
-        approvedStages: [stage],
-        approvalId,
+        jobType: 'brand_campaign',
+        payload: { brandUrl: 'https://brand.example', competitorUrl: 'https://betterup.com' },
       });
-      assert.equal(result.status, 'resumed', `${stepId} did not resume: ${result.reason}`);
-    };
 
-    await advance('approve_stage_2', 'strategy');
-    await advance('approve_stage_3', 'production');
-    await advance('approve_stage_4', 'publish');
+      const advance = async (stepId: string, stage: 'strategy' | 'production' | 'publish') => {
+        const records = listMarketingApprovalRecordsForJob(started.jobId);
+        const approvalId = records.find((record) => record.workflow_step_id === stepId)?.approval_id;
+        assert.equal(typeof approvalId, 'string', `missing approval record for ${stepId}`);
+        const result = await approveMarketingJob({
+          jobId: started.jobId,
+          tenantId,
+          approvedBy: 'operator',
+          approvedStages: [stage],
+          approvalId,
+        });
+        assert.equal(result.status, 'resumed', `${stepId} did not resume: ${result.reason}`);
+      };
 
-    const records = listMarketingApprovalRecordsForJob(started.jobId);
-    const pausedPublishId = records.find((record) => record.workflow_step_id === 'approve_stage_4_publish')?.approval_id;
-    assert.equal(typeof pausedPublishId, 'string', 'expected approve_stage_4_publish checkpoint to exist');
+      await advance('approve_stage_2', 'strategy');
+      await advance('approve_stage_3', 'production');
+      await advance('approve_stage_4', 'publish');
 
-    const countResumeToken = (token: string) =>
-      calls.filter((entry) => entry.action === 'resume' && entry.token === token).length;
-    assert.equal(countResumeToken('resume_publish_paused'), 0, 'resume_publish_paused should not have run yet');
+      const records = listMarketingApprovalRecordsForJob(started.jobId);
+      const pausedPublishId = records.find((record) => record.workflow_step_id === 'approve_stage_4_publish')?.approval_id;
+      assert.equal(typeof pausedPublishId, 'string', 'expected approve_stage_4_publish checkpoint to exist');
 
-    const reviewId = `${started.jobId}::approval`;
-    const firstDecision = await recordMarketingReviewDecision({
-      tenantId,
-      reviewId,
-      action: 'approve',
-      actedBy: 'Client reviewer',
-      note: '',
-      approvalId: pausedPublishId,
-    });
-    assert.ok(firstDecision, 'first decision should return a review item');
+      const countResumeToken = (token: string) =>
+        calls.filter((entry) => entry.action === 'resume' && entry.token === token).length;
+      assert.equal(countResumeToken('resume_publish_paused'), 0, 'resume_publish_paused should not have run yet');
 
-    const secondDecision = await recordMarketingReviewDecision({
-      tenantId,
-      reviewId,
-      action: 'approve',
-      actedBy: 'Client reviewer',
-      note: '',
-      approvalId: pausedPublishId,
-    });
-    assert.ok(secondDecision, 'duplicate decision should still return a review item, not null');
+      const reviewId = `${started.jobId}::approval`;
+      const firstDecision = await recordMarketingReviewDecision({
+        tenantId,
+        reviewId,
+        action: 'approve',
+        actedBy: 'Client reviewer',
+        note: '',
+        approvalId: pausedPublishId,
+      });
+      assert.ok(firstDecision, 'first decision should return a review item');
 
-    assert.equal(
-      countResumeToken('resume_publish_paused'),
-      1,
-      'duplicate recordMarketingReviewDecision must not re-invoke the paused-publish resume',
-    );
+      const secondDecision = await recordMarketingReviewDecision({
+        tenantId,
+        reviewId,
+        action: 'approve',
+        actedBy: 'Client reviewer',
+        note: '',
+        approvalId: pausedPublishId,
+      });
+      assert.ok(secondDecision, 'duplicate decision should still return a review item, not null');
 
-    const finalRecords = listMarketingApprovalRecordsForJob(started.jobId);
-    const finalPausedPublish = finalRecords.find((record) => record.approval_id === pausedPublishId);
-    assert.ok(finalPausedPublish, 'paused-publish record should still exist');
-    assert.ok(
-      finalPausedPublish.status === 'approved' || finalPausedPublish.status === 'consumed',
-      `expected terminal status, got ${finalPausedPublish.status}`,
-    );
+      assert.equal(
+        countResumeToken('resume_publish_paused'),
+        1,
+        'duplicate recordMarketingReviewDecision must not re-invoke the paused-publish resume',
+      );
 
-    clearInvoker();
+      const finalRecords = listMarketingApprovalRecordsForJob(started.jobId);
+      const finalPausedPublish = finalRecords.find((record) => record.approval_id === pausedPublishId);
+      assert.ok(finalPausedPublish, 'paused-publish record should still exist');
+      assert.ok(
+        finalPausedPublish.status === 'approved' || finalPausedPublish.status === 'consumed',
+        `expected terminal status, got ${finalPausedPublish.status}`,
+      );
+    } finally {
+      clearInvoker();
+    }
   });
 });

--- a/tests/review-decision-idempotency.test.ts
+++ b/tests/review-decision-idempotency.test.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { installBrandExampleFetchMock } from './helpers/brand-example-fetch';
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+type LobsterInvoker = (payload: Record<string, unknown>) => unknown | Promise<unknown>;
+
+async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const previousOpenClawLobsterCwd = process.env.OPENCLAW_LOBSTER_CWD;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-review-idempotency-'));
+
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+  process.env.OPENCLAW_LOBSTER_CWD = path.join(PROJECT_ROOT, 'lobster');
+  const restoreFetch = installBrandExampleFetchMock();
+
+  try {
+    return await run(dataRoot);
+  } finally {
+    restoreFetch();
+    if (previousCodeRoot === undefined) {
+      delete process.env.CODE_ROOT;
+    } else {
+      process.env.CODE_ROOT = previousCodeRoot;
+    }
+    if (previousDataRoot === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = previousDataRoot;
+    }
+    if (previousOpenClawLobsterCwd === undefined) {
+      delete process.env.OPENCLAW_LOBSTER_CWD;
+    } else {
+      process.env.OPENCLAW_LOBSTER_CWD = previousOpenClawLobsterCwd;
+    }
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+function setInvoker(impl: LobsterInvoker): void {
+  (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__ = impl;
+}
+
+function clearInvoker(): void {
+  delete (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__;
+}
+
+function cannedGatewayResponse(action: string, token: string): Record<string, unknown> | null {
+  if (action === 'run') {
+    return {
+      ok: true,
+      status: 'needs_approval',
+      output: [{ run_id: 'run-research' }],
+      requiresApproval: { resumeToken: 'resume_strategy', prompt: 'Approve strategy.' },
+    };
+  }
+  if (action === 'resume' && token === 'resume_strategy') {
+    return {
+      ok: true,
+      status: 'needs_approval',
+      output: [{
+        run_id: 'run-strategy',
+        strategy_handoff: {
+          run_id: 'run-strategy',
+          core_message: 'Launch campaigns with operator control.',
+          primary_cta: 'Book a walkthrough',
+        },
+      }],
+      requiresApproval: { resumeToken: 'resume_production', prompt: 'Approve production.' },
+    };
+  }
+  if (action === 'resume' && token === 'resume_production') {
+    return {
+      ok: true,
+      status: 'needs_approval',
+      output: [{
+        run_id: 'run-production',
+        production_handoff: {
+          run_id: 'run-production',
+          production_brief: { core_message: 'Launch campaigns with operator control.' },
+          contract_handoffs: {
+            static: { platform_contract_paths: ['output/static/meta-ads.json'] },
+            video: { platform_contract_paths: ['output/video/tiktok.json'] },
+          },
+        },
+      }],
+      requiresApproval: { resumeToken: 'resume_publish_review', prompt: 'Approve launch review.' },
+    };
+  }
+  if (action === 'resume' && token === 'resume_publish_review') {
+    return {
+      ok: true,
+      status: 'needs_approval',
+      output: [{ run_id: 'run-publish-review', review_bundle: { campaign_name: 'Stage 4 launch review' } }],
+      requiresApproval: {
+        resumeToken: 'resume_publish_paused',
+        prompt: 'Approve Meta campaign creation as paused.',
+      },
+    };
+  }
+  if (action === 'resume' && token === 'resume_publish_paused') {
+    return {
+      ok: true,
+      status: 'ok',
+      output: [{
+        run_id: 'run-publish-paused',
+        summary: { message: 'Paused ads created.' },
+      }],
+      requiresApproval: null,
+    };
+  }
+  return null;
+}
+
+test('approve_stage_4_publish: duplicate recordMarketingReviewDecision does not re-invoke gateway resume', async () => {
+  await withRuntimeEnv(async () => {
+    const calls: Array<{ action: string; token: string }> = [];
+    setInvoker((payload) => {
+      const args = (payload.args as Record<string, unknown> | undefined) ?? {};
+      const action = String(args.action || '');
+      const token = String(args.token || '');
+      calls.push({ action, token });
+      const response = cannedGatewayResponse(action, token);
+      if (!response) {
+        throw new Error(`Unexpected OpenClaw invocation: action=${action} token=${token}`);
+      }
+      return response;
+    });
+
+    const { startMarketingJob } = await import('../backend/marketing/jobs-start');
+    const { approveMarketingJob } = await import('../backend/marketing/jobs-approve');
+    const { listMarketingApprovalRecordsForJob } = await import('../backend/marketing/approval-store');
+    const { recordMarketingReviewDecision } = await import('../backend/marketing/runtime-views');
+
+    const tenantId = 'tenant-bug-a-publish';
+    const started = await startMarketingJob({
+      tenantId,
+      jobType: 'brand_campaign',
+      payload: { brandUrl: 'https://brand.example', competitorUrl: 'https://betterup.com' },
+    });
+
+    const advance = async (stepId: string, stage: 'strategy' | 'production' | 'publish') => {
+      const records = listMarketingApprovalRecordsForJob(started.jobId);
+      const approvalId = records.find((record) => record.workflow_step_id === stepId)?.approval_id;
+      assert.equal(typeof approvalId, 'string', `missing approval record for ${stepId}`);
+      const result = await approveMarketingJob({
+        jobId: started.jobId,
+        tenantId,
+        approvedBy: 'operator',
+        approvedStages: [stage],
+        approvalId,
+      });
+      assert.equal(result.status, 'resumed', `${stepId} did not resume: ${result.reason}`);
+    };
+
+    await advance('approve_stage_2', 'strategy');
+    await advance('approve_stage_3', 'production');
+    await advance('approve_stage_4', 'publish');
+
+    const records = listMarketingApprovalRecordsForJob(started.jobId);
+    const pausedPublishId = records.find((record) => record.workflow_step_id === 'approve_stage_4_publish')?.approval_id;
+    assert.equal(typeof pausedPublishId, 'string', 'expected approve_stage_4_publish checkpoint to exist');
+
+    const countResumeToken = (token: string) =>
+      calls.filter((entry) => entry.action === 'resume' && entry.token === token).length;
+    assert.equal(countResumeToken('resume_publish_paused'), 0, 'resume_publish_paused should not have run yet');
+
+    const reviewId = `${started.jobId}::approval`;
+    const firstDecision = await recordMarketingReviewDecision({
+      tenantId,
+      reviewId,
+      action: 'approve',
+      actedBy: 'Client reviewer',
+      note: '',
+      approvalId: pausedPublishId,
+    });
+    assert.ok(firstDecision, 'first decision should return a review item');
+
+    const secondDecision = await recordMarketingReviewDecision({
+      tenantId,
+      reviewId,
+      action: 'approve',
+      actedBy: 'Client reviewer',
+      note: '',
+      approvalId: pausedPublishId,
+    });
+    assert.ok(secondDecision, 'duplicate decision should still return a review item, not null');
+
+    assert.equal(
+      countResumeToken('resume_publish_paused'),
+      1,
+      'duplicate recordMarketingReviewDecision must not re-invoke the paused-publish resume',
+    );
+
+    const finalRecords = listMarketingApprovalRecordsForJob(started.jobId);
+    const finalPausedPublish = finalRecords.find((record) => record.approval_id === pausedPublishId);
+    assert.ok(finalPausedPublish, 'paused-publish record should still exist');
+    assert.ok(
+      finalPausedPublish.status === 'approved' || finalPausedPublish.status === 'consumed',
+      `expected terminal status, got ${finalPausedPublish.status}`,
+    );
+
+    clearInvoker();
+  });
+});


### PR DESCRIPTION
## Summary

Wave 2 of the 2026-04-15 session followups plan. Two parallel Opus investigations into live-demo flakiness.

### T07 — Bug A double-POST on `approve_stage_4_publish`

The existing `submittingRef` useRef lock in `review-item.tsx` catches same-render reentry but lets a rapid second click through after the first POST resolves. Observed in the live demo: reqid 998=200, reqid 999=pending for 4s while the orchestrator's `withMarketingApprovalLock` wait-loop held the duplicate against `advancePublishStage`. The backend is already correctly idempotent (terminal-status short-circuit at `orchestrator.ts:1289`), but the frontend shouldn't be sending the duplicate at all.

**Fix:** Added a `lastSubmitAt` ref with a 1-second floor between `applyDecision` calls. Cheap belt-and-suspenders on top of the existing lock.

**New test:** `tests/review-decision-idempotency.test.ts` drives a full pipeline run through `approve_stage_4_publish`, calls `recordMarketingReviewDecision` twice with the same `approvalId`, and asserts `resume_publish_paused` fires exactly once.

### T08 — 502s during creative review approvals

Two approvals during the live walkthrough returned 502 with empty body; logs traced it to undici `fetch failed` from `backend/openclaw/gateway-client.ts` (single TCP reset surfaced by Caddy as 502 since `read_timeout` is unlimited). Not a Caddy timeout, not a pool exhaustion — just a transient upstream stream death.

**Fix:** Added `requestJsonWithRetry<T>` to `lib/api/http.ts` with exponential backoff and typed-error preservation on final failure. `decideReview` now opts in with `{ retryOn: [502, 503, 504], maxAttempts: 2, backoffMs: 500 }`. Scope is deliberately narrow — no retry on GETs or other mutations.

**New test:** `tests/decide-review-retry.test.ts` covers four cases: retry-then-succeed, retry-exhausts, no-retry-on-success, no-retry-on-400.

### Follow-up flagged

Server-side retry + an undici `Agent` with explicit `connect.timeout` and `bodyTimeout` on `invokeGateway` in `gateway-client.ts` would kill the root cause instead of papering over it. Deliberately out of scope for this PR — tracked for a later wave.

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `tsx --test tests/decide-review-retry.test.ts`
- [ ] `tsx --test tests/review-decision-idempotency.test.ts`
- [ ] Spin up dev server, run through a campaign to the publish gate, rapid double-click Approve — confirm only one POST fires
- [ ] Simulate 502 with a proxy (or temporarily stub gateway-client to throw), confirm `decideReview` transparently retries and succeeds

## Merge ordering note

PR #91 (Wave 1) should merge first. This PR targets master and does not touch any files PR #91 modifies, so there are no conflicts; ordering is only for mental model cleanliness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)