### PR TITLE
chore: gitignore agent-orchestrator.local.yaml for ao notifier secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ publish/*.js.map
 .env.production.local
 .env.*.local
 
+# Local ao orchestrator config (holds secrets like notifier webhooks).
+# Loaded via AO_CONFIG_PATH env var; never commit.
+agent-orchestrator.local.yaml
+agent-orchestrator.local.yml
+
 # Private keys (never commit)
 
 # Logs


### PR DESCRIPTION
## Summary
- Add `agent-orchestrator.local.yaml` / `.yml` to `.gitignore` so a local ao orchestrator config holding notifier secrets (Discord webhook, Slack, etc.) can live next to the base config without risk of being committed.
- The ao config loader (`@aoagents/ao-core/dist/config.js`) supports `AO_CONFIG_PATH` as a full-file override, but it does **not** merge `*.local.yaml` files and does **not** interpolate `${ENV_VAR}` in YAML values (verified in `parseYaml` call and `loadConfig`). So a full local override file is the only supported way to keep notifier credentials out of version control.

## Why this approach
The only built-in loader override is `AO_CONFIG_PATH` (see `findConfigFile` in `ao-core/config.js`). No merge layer exists, and the Discord notifier plugin reads `webhookUrl` directly from its block (no env-var fallback). A local `.local.yaml` file selected via `AO_CONFIG_PATH` is the cleanest way to:
- keep the base `agent-orchestrator.yaml` free of secrets
- survive future ao upgrades (uses a supported mechanism, no patches)
- stay git-safe by being explicitly ignored

## Usage (for maintainers)
1. Copy the base config to `agent-orchestrator.local.yaml` (ignored by this rule).
2. Add a notifier block, e.g.:
   ```yaml
   defaults:
     notifiers: [discord]
   notifiers:
     discord:
       plugin: discord
       webhookUrl: https://discord.com/api/webhooks/...
   ```
3. Point ao at it:
   ```bash
   export AO_CONFIG_PATH=$(pwd)/agent-orchestrator.local.yaml
   ```
4. Verify: `ao doctor` should show `PASS notifiers.discord (plugin: discord)` and no `[notifier-discord] No webhookUrl configured` warning.

## Test plan
- [x] `git check-ignore -v agent-orchestrator.local.yaml` returns the new rule
- [x] `AO_CONFIG_PATH=... ao doctor` reports `PASS notifiers.discord (plugin: discord)` and the `No webhookUrl configured` warning is gone
- [x] Running `ao doctor` without `AO_CONFIG_PATH` still shows the warning (confirms override is what's fixing it, not a side effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)