### PR TITLE
fix(deploy): preserve VM-local untracked files colliding with checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,11 +180,33 @@ jobs:
 
           git -C "${repo_path}" fetch --prune --tags origin
           checkout_target="$(resolve_checkout_target "${TARGET_CHECKOUT_REF}")"
+
+          # Preserve VM-local untracked files that would collide with tracked paths in
+          # the target ref. Remote-side work (e.g. daily-brief automation) is authoritative
+          # per the Aries publishing model, so we move collisions aside into a backup dir
+          # rather than losing them to a failed `git checkout`.
+          backup_dir="${repo_path}/.deploy-backups/$(date -u +%Y%m%dT%H%M%SZ)"
+          backed_up_any=0
+          while IFS= read -r untracked_file; do
+            [[ -z "${untracked_file}" ]] && continue
+            if git -C "${repo_path}" cat-file -e "${checkout_target}:${untracked_file}" 2>/dev/null; then
+              dest="${backup_dir}/${untracked_file}"
+              mkdir -p "$(dirname "${dest}")"
+              mv "${repo_path}/${untracked_file}" "${dest}"
+              echo "WARN: preserved VM-local untracked file that collides with ${checkout_target}: ${untracked_file} -> ${dest}" >&2
+              backed_up_any=1
+            fi
+          done < <(git -C "${repo_path}" ls-files --others --exclude-standard)
+
           git -C "${repo_path}" checkout --detach "${checkout_target}"
 
           if [[ "${stashed}" == "1" ]]; then
             echo "Restoring stashed local changes."
             git -C "${repo_path}" stash pop --quiet || echo "WARN: stash pop had conflicts; stash preserved." >&2
+          fi
+
+          if [[ "${backed_up_any}" == "1" ]]; then
+            echo "WARN: one or more VM-local untracked files were backed up under ${backup_dir}; reconcile manually." >&2
           fi
 
           cd "${repo_path}"


### PR DESCRIPTION
## Summary
- Deploy workflow has been failing on master (run [24468957592](https://github.com/DeliciousHouse/aries-app/actions/runs/24468957592)) because `git checkout --detach` on the VM aborts when VM-local untracked files (e.g. the daily-brief automation's `docs/briefs/2026-04-15-brief.md`) collide with paths that are now tracked upstream.
- Before checkout, walk the VM's untracked files (respecting `.gitignore`) and for any that already exist in the target tree, move them aside into a timestamped `.deploy-backups/<ts>/` directory and log a clear warning.
- Non-colliding untracked files are left alone — `git checkout` does not touch them, so there's no need to stash-and-restore them. Tracked-change stash/pop behavior is unchanged.

Per the durable Aries directive, VM-side work (daily briefs, runtime artifacts) is authoritative and must be preserved, not blown away. Backups land under `.deploy-backups/<UTC-timestamp>/<original-path>` so operators can reconcile them out-of-band.

## Test plan
- [ ] Deploy workflow runs successfully on next push to master (VM currently has colliding `docs/briefs/2026-04-15-brief.md`).
- [ ] Verify the warning line surfaces in the workflow logs when a collision is preserved.
- [ ] Confirm the backed-up file appears under `.deploy-backups/<ts>/docs/briefs/2026-04-15-brief.md` on the VM after deploy.
- [ ] Subsequent deploys with no untracked collisions should behave exactly as before (no new warnings, no backup dir created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)