### PR TITLE
fix(deploy): harden untracked-file backup loop (PR #96 follow-up)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,10 @@ jobs:
           backed_up_any=0
           # Scope the scan to exclude .deploy-backups/ so prior runs' backups
           # do not pile up in the ls-files output on subsequent deploys.
-          while IFS= read -r untracked_file; do
+          # Use -z so filenames with special characters or embedded newlines
+          # are parsed safely, and force core.quotepath=false so git never
+          # C-escapes high-byte characters in the emitted path stream.
+          while IFS= read -r -d '' untracked_file; do
             [[ -z "${untracked_file}" ]] && continue
             if git -C "${repo_path}" cat-file -e "${checkout_target}:${untracked_file}" 2>/dev/null; then
               src="${repo_path}/${untracked_file}"
@@ -197,7 +200,10 @@ jobs:
               # Under `set -e`, a concurrent writer removing the file between
               # ls-files and mv would abort the deploy. Guard the source and
               # demote any mv failure to a warning so deploys remain robust.
-              if [[ ! -e "${src}" ]]; then
+              # Also back up broken symlinks (-L) — they still exist in the
+              # working tree and still block `git checkout` as an untracked-
+              # path collision, even though `-e` returns false on them.
+              if [[ ! -e "${src}" && ! -L "${src}" ]]; then
                 echo "WARN: skipped backup for VM-local untracked file that no longer exists: ${untracked_file}" >&2
                 continue
               fi
@@ -209,7 +215,7 @@ jobs:
                 echo "WARN: failed to back up VM-local untracked file; continuing deploy: ${untracked_file}" >&2
               fi
             fi
-          done < <(git -C "${repo_path}" ls-files --others --exclude-standard --exclude=.deploy-backups/)
+          done < <(git -c core.quotepath=false -C "${repo_path}" ls-files --others --exclude-standard --exclude=.deploy-backups/ -z)
 
           git -C "${repo_path}" checkout --detach "${checkout_target}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,16 +187,29 @@ jobs:
           # rather than losing them to a failed `git checkout`.
           backup_dir="${repo_path}/.deploy-backups/$(date -u +%Y%m%dT%H%M%SZ)"
           backed_up_any=0
+          # Scope the scan to exclude .deploy-backups/ so prior runs' backups
+          # do not pile up in the ls-files output on subsequent deploys.
           while IFS= read -r untracked_file; do
             [[ -z "${untracked_file}" ]] && continue
             if git -C "${repo_path}" cat-file -e "${checkout_target}:${untracked_file}" 2>/dev/null; then
+              src="${repo_path}/${untracked_file}"
               dest="${backup_dir}/${untracked_file}"
+              # Under `set -e`, a concurrent writer removing the file between
+              # ls-files and mv would abort the deploy. Guard the source and
+              # demote any mv failure to a warning so deploys remain robust.
+              if [[ ! -e "${src}" ]]; then
+                echo "WARN: skipped backup for VM-local untracked file that no longer exists: ${untracked_file}" >&2
+                continue
+              fi
               mkdir -p "$(dirname "${dest}")"
-              mv "${repo_path}/${untracked_file}" "${dest}"
-              echo "WARN: preserved VM-local untracked file that collides with ${checkout_target}: ${untracked_file} -> ${dest}" >&2
-              backed_up_any=1
+              if mv "${src}" "${dest}"; then
+                echo "WARN: preserved VM-local untracked file that collides with ${checkout_target}: ${untracked_file} -> ${dest}" >&2
+                backed_up_any=1
+              else
+                echo "WARN: failed to back up VM-local untracked file; continuing deploy: ${untracked_file}" >&2
+              fi
             fi
-          done < <(git -C "${repo_path}" ls-files --others --exclude-standard)
+          done < <(git -C "${repo_path}" ls-files --others --exclude-standard --exclude=.deploy-backups/)
 
           git -C "${repo_path}" checkout --detach "${checkout_target}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ publish/*.js.map
 agent-orchestrator.local.yaml
 agent-orchestrator.local.yml
 
+# Deploy-time collision backups — written by .github/workflows/deploy.yml
+# when VM-local untracked files would collide with the target ref. Growing
+# this under the repo root on every deploy would slow subsequent ls-files
+# scans; keep the dir local-only and out of git.
+.deploy-backups/
+
 # Private keys (never commit)
 
 # Logs


### PR DESCRIPTION
## Summary

Two of the three Copilot review comments on PR #96.

- **Gitignore \`.deploy-backups/\`** — each deploy appends a timestamped subtree, so subsequent \`ls-files --others\` scans grow linearly with backup history. Ignoring the dir keeps it out of both \`ls-files\` output and local \`git status\`. Also adds \`--exclude=.deploy-backups/\` to the \`ls-files\` call as a belt-and-suspenders guard in case the ignore file hasn't been pulled on the VM yet.
- **Guard the mv under \`set -e\`** — if anything else on the VM deletes an untracked file between the \`ls-files\` emit and the \`mv\`, the deploy currently aborts. Now checks \`-e\` on the source first and demotes \`mv\` failure to a warning. \`backed_up_any=1\` only on the successful-mv branch so the post-step reconcile warning stays accurate.

## Skipped intentionally

Copilot's third comment (file/dir-swap collision detection via dry-run checkout or \`ls-tree\`) is valid in theory but every real collision on this repo is path-for-path (generated briefs, standups, superpowers plans, campaign output). The 30-line associative-array fix isn't worth the complexity until we actually see a file/dir swap block a deploy.

## Test plan

- [ ] Trigger a deploy → confirm \`.deploy-backups/\` no longer appears in \`ls-files --others\` output
- [ ] Trigger a deploy with a deliberately-stale untracked file → confirm it's backed up once, then verify a second deploy doesn't re-scan the backup
- [ ] Simulate a vanished file by adding \`rm "\${src}"\` between the \`-e\` check and the \`mv\` (temporarily) → confirm the deploy continues with a WARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)