### PR TITLE
feat(automation): ci-watcher issue -> ao spawn dispatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ data/generated/
 data/runtime/
 data/validated/
 data/draft/
+# ci-watcher-dispatch automation runtime log — appended every run, local-only.
+data/ci-watcher-dispatch-log.json
 
 # Runtime session state (local only)
 state/

--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -77,7 +77,7 @@ This workspace now includes runtime-error intake/repair automation alongside the
 - **Schedule:** `*/15 * * * *` `America/Los_Angeles`
 - **Script:** `node scripts/automations/ci-watcher-dispatch.mjs`
 - **What it does:** queries open GitHub issues labeled `ci-watcher` in `DeliciousHouse/aries-app`, inspects existing `ao` sessions for the `aries-app` project, and runs `ao spawn <issue-number>` for every ci-watcher issue that does **not** already have a matching session. Every action (spawned / skipped / errored) is appended to `data/ci-watcher-dispatch-log.json`.
-- **De-duplication:** matches by issue number against `session.issueId` across **all** sessions returned by `ao session ls --json`, regardless of status. Once `ao session cleanup` removes a terminal session the issue becomes eligible to spawn again (e.g. when CI is reopened after a merge).
+- **De-duplication:** matches by issue number against `session.issueId` across **all** sessions returned by `ao session ls -p aries-app --json`, regardless of status. Once `ao session cleanup` removes a terminal session the issue becomes eligible to spawn again (e.g. when CI is reopened after a merge).
 - **Fail-safe:** `gh` or `ao` errors are logged and the script exits `0` so the cron never gets taken down by transient API blips.
 - **Complementary to the remote CI watcher trigger:** the remote trigger files ci-watcher issues; this dispatcher is the local side that assigns an ao worker to each one.
 

--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -72,7 +72,16 @@ This workspace now includes runtime-error intake/repair automation alongside the
 - **Script:** `node scripts/automations/runtime-error-intake.mjs scan`
 - **What it does:** runs bounded health checks, opens or reopens runtime incidents in `data/runtime-error-incidents.json`, auto-resolves incidents that no longer reproduce, and emits a concise incident summary for announce delivery.
 
-### 8) Runtime error repair loop
+### 8) CI watcher dispatcher
+
+- **Schedule:** `*/15 * * * *` `America/Los_Angeles`
+- **Script:** `node scripts/automations/ci-watcher-dispatch.mjs`
+- **What it does:** queries open GitHub issues labeled `ci-watcher` in `DeliciousHouse/aries-app`, inspects existing `ao` sessions for the `aries-app` project, and runs `ao spawn <issue-number>` for every ci-watcher issue that does **not** already have a matching session. Every action (spawned / skipped / errored) is appended to `data/ci-watcher-dispatch-log.json`.
+- **De-duplication:** matches by issue number against `session.issueId` across **all** sessions returned by `ao session ls --json`, regardless of status. Once `ao session cleanup` removes a terminal session the issue becomes eligible to spawn again (e.g. when CI is reopened after a merge).
+- **Fail-safe:** `gh` or `ao` errors are logged and the script exits `0` so the cron never gets taken down by transient API blips.
+- **Complementary to the remote CI watcher trigger:** the remote trigger files ci-watcher issues; this dispatcher is the local side that assigns an ao worker to each one.
+
+### 9) Runtime error repair loop
 
 - **Schedule:** `10,40 * * * *` `America/Los_Angeles`
 - **Skill:** `skills/aries-runtime-error-repair-loop/SKILL.md`
@@ -146,6 +155,7 @@ These are the schedules encoded in `scripts/automations/manifest.mjs`:
 - `0 18 * * *` — GitHub feedback daily summary
 - `5,35 * * * *` — runtime error intake
 - `10,40 * * * *` — runtime error repair loop
+- `*/15 * * * *` — ci watcher dispatcher
 - `45 21 * * *` — rolling OS documentation
 
 ## Verification commands
@@ -159,6 +169,7 @@ node scripts/automations/daily-brief.mjs --dry-run
 node scripts/automations/feedback-connector.mjs sync --dry-run
 node scripts/automations/feedback-daily-summary.mjs --dry-run
 node scripts/automations/runtime-error-intake.mjs scan --dry-run
+node scripts/automations/ci-watcher-dispatch.mjs --dry-run
 node scripts/automations/rolling-system-reference.mjs --dry-run
 ```
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "automation:feedback-connector": "node scripts/automations/feedback-connector.mjs sync",
     "automation:feedback-summary": "node scripts/automations/feedback-daily-summary.mjs",
     "automation:runtime-error-intake": "node scripts/automations/runtime-error-intake.mjs scan",
+    "automation:ci-watcher-dispatch": "node scripts/automations/ci-watcher-dispatch.mjs",
     "automation:system-reference": "node scripts/automations/rolling-system-reference.mjs",
     "automation:install": "node scripts/automations/install-openclaw-crons.mjs",
     "automation:verify": "node scripts/automations/verify-automations.mjs"

--- a/scripts/automations/ci-watcher-dispatch.mjs
+++ b/scripts/automations/ci-watcher-dispatch.mjs
@@ -1,0 +1,162 @@
+import process from 'node:process'
+import {
+  emitSummary,
+  parseArgs,
+  preflightOrExit,
+  repoRoot,
+  run,
+} from './lib/common.mjs'
+import {
+  CI_WATCHER_LABEL,
+  CI_WATCHER_PROJECT,
+  CI_WATCHER_REPO,
+  ciWatcherLogPath,
+  parseIssuesJson,
+  parseSessionsJson,
+  planDispatch,
+  readLog,
+  recordEvents,
+  writeLog,
+} from './lib/ci-watcher-dispatch.mjs'
+
+const flags = parseArgs()
+const dryRun = flags.has('--dry-run')
+const preflightOnly = flags.has('--preflight')
+
+preflightOrExit(
+  'CI WATCHER DISPATCH',
+  { binaries: ['gh', 'ao'] },
+  { preflightOnly },
+)
+
+if (preflightOnly) {
+  process.exit(0)
+}
+
+function logLine(event) {
+  const { action, issue, reason, detail } = event
+  const parts = [`- ${action}`]
+  if (typeof issue === 'number') parts.push(`issue=#${issue}`)
+  if (reason) parts.push(`reason=${reason}`)
+  if (detail) parts.push(`detail=${detail}`)
+  return parts.join(' ')
+}
+
+function fetchIssues() {
+  const result = run('gh', [
+    'issue',
+    'list',
+    '--repo',
+    CI_WATCHER_REPO,
+    '--label',
+    CI_WATCHER_LABEL,
+    '--state',
+    'open',
+    '--json',
+    'number,title,labels',
+    '--limit',
+    '100',
+  ])
+  if (!result.ok) {
+    return { ok: false, error: result.stderr.trim() || `gh exited ${result.code}`, issues: [] }
+  }
+  return { ok: true, issues: parseIssuesJson(result.stdout) }
+}
+
+function fetchSessions() {
+  const result = run('ao', ['session', 'ls', '-p', CI_WATCHER_PROJECT, '--json'])
+  if (!result.ok) {
+    return { ok: false, error: result.stderr.trim() || `ao exited ${result.code}`, sessions: [] }
+  }
+  return { ok: true, sessions: parseSessionsJson(result.stdout) }
+}
+
+function spawnSession(issueNumber) {
+  const result = run('ao', ['spawn', String(issueNumber)], { cwd: repoRoot })
+  if (!result.ok) {
+    return {
+      ok: false,
+      error: (result.stderr || result.stdout || `ao exited ${result.code}`).trim(),
+    }
+  }
+  return { ok: true }
+}
+
+const summaryLines = [`CI WATCHER DISPATCH ${dryRun ? '[dry-run]' : ''}`.trim()]
+const events = []
+
+try {
+  const issuesResult = fetchIssues()
+  if (!issuesResult.ok) {
+    events.push({ action: 'error', stage: 'gh-issue-list', detail: issuesResult.error })
+    summaryLines.push(`- gh-issue-list failed: ${issuesResult.error}`)
+  }
+
+  const sessionsResult = fetchSessions()
+  if (!sessionsResult.ok) {
+    events.push({ action: 'error', stage: 'ao-session-ls', detail: sessionsResult.error })
+    summaryLines.push(`- ao-session-ls failed: ${sessionsResult.error}`)
+  }
+
+  if (issuesResult.ok && sessionsResult.ok) {
+    const { toSpawn, toSkip } = planDispatch({
+      issues: issuesResult.issues,
+      sessions: sessionsResult.sessions,
+    })
+
+    summaryLines.push(
+      `- open ci-watcher issues: ${issuesResult.issues.length}`,
+      `- sessions inspected: ${sessionsResult.sessions.length}`,
+      `- skipped (existing session): ${toSkip.length}`,
+      `- ${dryRun ? 'would spawn' : 'spawn attempts'}: ${toSpawn.length}`,
+    )
+
+    for (const skip of toSkip) {
+      events.push({ action: 'skipped', issue: skip.number, reason: skip.reason })
+    }
+
+    for (const target of toSpawn) {
+      if (dryRun) {
+        events.push({ action: 'would-spawn', issue: target.number })
+        continue
+      }
+      const spawnResult = spawnSession(target.number)
+      if (spawnResult.ok) {
+        events.push({ action: 'spawned', issue: target.number })
+      } else {
+        events.push({ action: 'error', stage: 'ao-spawn', issue: target.number, detail: spawnResult.error })
+      }
+    }
+  }
+} catch (error) {
+  events.push({
+    action: 'error',
+    stage: 'dispatcher',
+    detail: error instanceof Error ? error.message : String(error),
+  })
+  summaryLines.push(`- dispatcher error: ${error instanceof Error ? error.message : String(error)}`)
+}
+
+if (events.length === 0) {
+  events.push({ action: 'noop' })
+}
+
+for (const event of events) {
+  summaryLines.push(logLine(event))
+}
+
+if (!dryRun) {
+  try {
+    const log = readLog()
+    writeLog(recordEvents(log, events), ciWatcherLogPath)
+  } catch (error) {
+    summaryLines.push(
+      `- log-write warning: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
+emitSummary(summaryLines)
+// Fail-safe: never take the cron down on transient errors. Individual failures
+// are recorded in the log and summary above.
+process.exit(0)

--- a/scripts/automations/ci-watcher-dispatch.mjs
+++ b/scripts/automations/ci-watcher-dispatch.mjs
@@ -34,9 +34,10 @@ if (preflightOnly) {
 }
 
 function logLine(event) {
-  const { action, issue, reason, detail } = event
+  const { action, issue, stage, reason, detail } = event
   const parts = [`- ${action}`]
   if (typeof issue === 'number') parts.push(`issue=#${issue}`)
+  if (stage) parts.push(`stage=${stage}`)
   if (reason) parts.push(`reason=${reason}`)
   if (detail) parts.push(`detail=${detail}`)
   return parts.join(' ')

--- a/scripts/automations/lib/ci-watcher-dispatch.mjs
+++ b/scripts/automations/lib/ci-watcher-dispatch.mjs
@@ -1,0 +1,113 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { ensureDir, repoRoot } from './common.mjs'
+
+export const ciWatcherLogPath = path.join(repoRoot, 'data', 'ci-watcher-dispatch-log.json')
+export const CI_WATCHER_LABEL = 'ci-watcher'
+export const CI_WATCHER_REPO = 'DeliciousHouse/aries-app'
+export const CI_WATCHER_PROJECT = 'aries-app'
+
+const MAX_LOG_ENTRIES = 500
+
+function emptyLog() {
+  return {
+    version: 1,
+    description:
+      'Dispatcher log for ao worker sessions spawned from GitHub issues tagged ci-watcher. Appended by scripts/automations/ci-watcher-dispatch.mjs.',
+    lastRunAt: null,
+    events: [],
+  }
+}
+
+export function readLog(logPath = ciWatcherLogPath) {
+  try {
+    const raw = readFileSync(logPath, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && Array.isArray(parsed.events)) {
+      return { ...emptyLog(), ...parsed }
+    }
+  } catch {
+    /* fall through */
+  }
+  return emptyLog()
+}
+
+export function writeLog(log, logPath = ciWatcherLogPath) {
+  ensureDir(path.dirname(logPath))
+  const trimmed = {
+    ...log,
+    events: log.events.slice(-MAX_LOG_ENTRIES),
+  }
+  writeFileSync(logPath, `${JSON.stringify(trimmed, null, 2)}\n`)
+}
+
+export function normalizeIssueRef(value) {
+  if (value === null || value === undefined) return ''
+  return String(value).trim().toLowerCase()
+}
+
+export function buildSessionIssueSet(sessions) {
+  const set = new Set()
+  for (const session of Array.isArray(sessions) ? sessions : []) {
+    const ref = normalizeIssueRef(session?.issueId)
+    if (ref) set.add(ref)
+  }
+  return set
+}
+
+export function planDispatch({ issues, sessions }) {
+  const sessionIssues = buildSessionIssueSet(sessions)
+  const toSpawn = []
+  const toSkip = []
+
+  for (const issue of Array.isArray(issues) ? issues : []) {
+    if (!issue || typeof issue.number !== 'number') continue
+    const ref = normalizeIssueRef(issue.number)
+    if (sessionIssues.has(ref)) {
+      toSkip.push({ number: issue.number, title: issue.title || '', reason: 'existing-session' })
+      continue
+    }
+    toSpawn.push({ number: issue.number, title: issue.title || '' })
+  }
+
+  return { toSpawn, toSkip }
+}
+
+export function parseIssuesJson(raw) {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed
+      .map((entry) => {
+        if (!entry || typeof entry !== 'object') return null
+        const number = typeof entry.number === 'number' ? entry.number : Number(entry.number)
+        if (!Number.isFinite(number)) return null
+        return { number, title: typeof entry.title === 'string' ? entry.title : '' }
+      })
+      .filter(Boolean)
+  } catch {
+    return []
+  }
+}
+
+export function parseSessionsJson(raw) {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((entry) => entry && typeof entry === 'object')
+  } catch {
+    return []
+  }
+}
+
+export function recordEvents(log, events, now = new Date()) {
+  const stamp = now.toISOString()
+  const stamped = events.map((event) => ({ at: stamp, ...event }))
+  return {
+    ...log,
+    lastRunAt: stamp,
+    events: [...log.events, ...stamped],
+  }
+}

--- a/scripts/automations/manifest.mjs
+++ b/scripts/automations/manifest.mjs
@@ -66,6 +66,16 @@ export const automationJobs = [
     purpose: 'Deliver the daily batch summary for non-critical GitHub feedback items that were processed and logged.',
   },
   {
+    id: 'aries-ci-watcher-dispatch',
+    name: 'Aries CI watcher dispatcher',
+    cron: '*/15 * * * *',
+    tz: 'America/Los_Angeles',
+    message:
+      'Work in /home/node/openclaw/aries-app. Run node scripts/automations/ci-watcher-dispatch.mjs. For every open GitHub issue labeled ci-watcher that has no matching ao session, this spawns an ao worker (ao spawn <issue>). Dedup is by issueId so the same issue never double-spawns. Return only the concise dispatcher summary.',
+    purpose:
+      'Auto-spawn ao worker sessions for open ci-watcher issues filed by the remote CI watcher trigger, deduplicating against existing ao sessions by issue number.',
+  },
+  {
     id: 'aries-runtime-error-intake',
     name: 'Aries runtime error intake',
     cron: '5,35 * * * *',

--- a/scripts/automations/verify-automations.mjs
+++ b/scripts/automations/verify-automations.mjs
@@ -9,6 +9,7 @@ const preflightScripts = [
   'scripts/automations/feedback-connector.mjs',
   'scripts/automations/feedback-daily-summary.mjs',
   'scripts/automations/runtime-error-intake.mjs',
+  'scripts/automations/ci-watcher-dispatch.mjs',
   'scripts/automations/rolling-system-reference.mjs',
   'scripts/automations/weekly-review.mjs',
 ]

--- a/scripts/automations/verify-automations.mjs
+++ b/scripts/automations/verify-automations.mjs
@@ -19,6 +19,7 @@ const dryRunScripts = [
   'scripts/automations/daily-standup.mjs',
   'scripts/automations/feedback-connector.mjs',
   'scripts/automations/feedback-daily-summary.mjs',
+  'scripts/automations/ci-watcher-dispatch.mjs',
   'scripts/automations/rolling-system-reference.mjs',
   'scripts/automations/weekly-review.mjs',
 ]

--- a/tests/ci-watcher-dispatch.test.ts
+++ b/tests/ci-watcher-dispatch.test.ts
@@ -1,0 +1,92 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+// @ts-ignore relative .mjs automation module has no generated declaration surface yet
+const modPromise = import('../scripts/automations/lib/ci-watcher-dispatch.mjs')
+
+test('planDispatch spawns issues with no matching session', async () => {
+  const mod = await modPromise
+  const plan = mod.planDispatch({
+    issues: [
+      { number: 42, title: 'CI: build failing' },
+      { number: 43, title: 'CI: tsc failing' },
+    ],
+    sessions: [
+      { id: 'aa-1', issueId: null, status: 'working' },
+    ],
+  })
+  assert.equal(plan.toSpawn.length, 2)
+  assert.deepEqual(
+    plan.toSpawn.map((x: { number: number }) => x.number).sort(),
+    [42, 43],
+  )
+  assert.equal(plan.toSkip.length, 0)
+})
+
+test('planDispatch skips issues that already have a session (any status)', async () => {
+  const mod = await modPromise
+  const plan = mod.planDispatch({
+    issues: [
+      { number: 42, title: 'CI: build failing' },
+      { number: 43, title: 'CI: tsc failing' },
+      { number: 44, title: 'CI: lint failing' },
+    ],
+    sessions: [
+      { id: 'aa-9', issueId: '42', status: 'working' },
+      // Non-terminal sessions should dedup — even completed/merged ones still present in ls.
+      { id: 'aa-8', issueId: '43', status: 'merged' },
+      { id: 'aa-7', issueId: null, status: 'working' },
+    ],
+  })
+  assert.equal(plan.toSkip.length, 2)
+  assert.deepEqual(
+    plan.toSkip.map((x: { number: number }) => x.number).sort(),
+    [42, 43],
+  )
+  assert.equal(plan.toSpawn.length, 1)
+  assert.equal(plan.toSpawn[0].number, 44)
+})
+
+test('planDispatch matches issueId as string even when issue number is numeric', async () => {
+  const mod = await modPromise
+  const plan = mod.planDispatch({
+    issues: [{ number: 100, title: 'CI' }],
+    sessions: [{ id: 'aa-1', issueId: 100, status: 'working' }],
+  })
+  assert.equal(plan.toSpawn.length, 0)
+  assert.equal(plan.toSkip.length, 1)
+})
+
+test('parseIssuesJson tolerates malformed payloads', async () => {
+  const mod = await modPromise
+  assert.deepEqual(mod.parseIssuesJson(''), [])
+  assert.deepEqual(mod.parseIssuesJson('not-json'), [])
+  assert.deepEqual(mod.parseIssuesJson('{"not":"array"}'), [])
+  const ok = mod.parseIssuesJson(
+    JSON.stringify([
+      { number: 1, title: 'a' },
+      { number: '2', title: 'b' },
+      { title: 'missing number' },
+    ]),
+  )
+  assert.deepEqual(ok, [
+    { number: 1, title: 'a' },
+    { number: 2, title: 'b' },
+  ])
+})
+
+test('parseSessionsJson tolerates malformed payloads', async () => {
+  const mod = await modPromise
+  assert.deepEqual(mod.parseSessionsJson(''), [])
+  assert.deepEqual(mod.parseSessionsJson('not-json'), [])
+  assert.deepEqual(mod.parseSessionsJson('{"not":"array"}'), [])
+  const ok = mod.parseSessionsJson(
+    JSON.stringify([
+      { id: 'aa-1', issueId: '7' },
+      'invalid',
+      null,
+    ]),
+  )
+  assert.equal(ok.length, 1)
+  assert.equal(ok[0].id, 'aa-1')
+})


### PR DESCRIPTION
## Summary

- Adds a new local automation, `scripts/automations/ci-watcher-dispatch.mjs`, that every 15 minutes queries open GitHub issues labeled `ci-watcher` in `DeliciousHouse/aries-app` and runs `ao spawn <issue>` for each one that does not already have a matching session.
- De-duplication matches by `issueId` across **all** sessions returned by `ao session ls -p aries-app --json`, regardless of status, so the same issue can't double-spawn while its session is still visible; once `ao session cleanup` removes a terminal session the issue becomes eligible to spawn again.
- Fail-safe: `gh` / `ao` errors are recorded to `data/ci-watcher-dispatch-log.json` and the script exits `0` so a transient API blip can never take the cron down.
- Pairs with the remote CI watcher trigger, which only files issues — this is the local orchestrator side that turns those issues into worker sessions.

## What's in the diff

- `scripts/automations/ci-watcher-dispatch.mjs` — entry point, supports `--preflight` / `--dry-run` like the rest of the automation suite.
- `scripts/automations/lib/ci-watcher-dispatch.mjs` — pure helpers (issue/session JSON parsing, dedup planning, log I/O) so the logic is unit-testable.
- `scripts/automations/manifest.mjs` — registers the new job at `*/15 * * * *` `America/Los_Angeles`; picked up by `npm run automation:install`.
- `scripts/automations/verify-automations.mjs` — includes the new script in the preflight sweep.
- `package.json` — adds `npm run automation:ci-watcher-dispatch` for manual invocation.
- `tests/ci-watcher-dispatch.test.ts` — unit tests for the dedup plan and defensive JSON parsers.
- `docs/automations/README.md` — runbook entry explaining what it does and how de-dup works.
- `.gitignore` — ignores the new `data/ci-watcher-dispatch-log.json` runtime artifact.

## Test plan

- [x] `node scripts/automations/ci-watcher-dispatch.mjs --preflight` reports binaries OK.
- [x] `node scripts/automations/ci-watcher-dispatch.mjs --dry-run` against the current repo returns `open ci-watcher issues: 0` cleanly and does not write a log file.
- [x] Inline sanity run of `planDispatch` / `parseIssuesJson` / `parseSessionsJson` passes (node_modules is not installed in this worktree, so `tsx --test` cannot run, but the same cases are covered by `tests/ci-watcher-dispatch.test.ts`).
- [ ] Full regression suite (`npm run verify`) — to be run in CI since tsx is not available locally here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)