### PR TITLE
[codex] Harden VM deploy against conflicted git state

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,34 @@ jobs:
 
           repo_path="${REPO_PATH}"
 
+          has_unresolved_conflicts() {
+            [[ -n "$(git -C "${repo_path}" ls-files --unmerged | head -n1)" ]]
+          }
+
+          list_conflicted_files() {
+            git -c core.quotepath=false -C "${repo_path}" diff --name-only --diff-filter=U
+          }
+
+          fail_for_conflicted_vm_state() {
+            local reason="$1"
+            local conflicted_files
+            conflicted_files="$(list_conflicted_files)"
+
+            echo "ERROR: ${reason}" >&2
+            echo "ERROR: The VM working tree is in a conflicted merge state. Local VM changes are authoritative and were not modified by this deploy." >&2
+            if [[ -n "${conflicted_files}" ]]; then
+              echo "ERROR: Conflicted files:" >&2
+              while IFS= read -r conflicted_file; do
+                [[ -n "${conflicted_file}" ]] || continue
+                echo "  - ${conflicted_file}" >&2
+              done <<< "${conflicted_files}"
+            else
+              echo "ERROR: Conflicted files could not be determined automatically; inspect git status on the VM." >&2
+            fi
+            echo "ERROR: SSH into the VM, reconcile the conflicts manually, and sync the authoritative changes back to the repo before retrying deploy." >&2
+            exit 1
+          }
+
           resolve_checkout_target() {
             local requested="$1"
             case "${requested}" in
@@ -173,6 +201,9 @@ jobs:
 
           stashed=0
           if [[ -n "$(git -C "${repo_path}" status --porcelain --untracked-files=no)" ]]; then
+            if has_unresolved_conflicts || [[ -f "$(git -C "${repo_path}" rev-parse --git-path MERGE_HEAD)" ]]; then
+              fail_for_conflicted_vm_state "Refusing to stash VM-local changes before deploy because the repository already has unresolved conflicts."
+            fi
             echo "VM has tracked local changes — stashing before deploy."
             git -C "${repo_path}" stash push -m "auto-stash: deploy ${TARGET_CHECKOUT_REF}" --quiet
             stashed=1
@@ -221,7 +252,9 @@ jobs:
 
           if [[ "${stashed}" == "1" ]]; then
             echo "Restoring stashed local changes."
-            git -C "${repo_path}" stash pop --quiet || echo "WARN: stash pop had conflicts; stash preserved." >&2
+            if ! git -C "${repo_path}" stash pop --quiet; then
+              fail_for_conflicted_vm_state "Restoring stashed VM-local changes created conflicts during deploy."
+            fi
           fi
 
           if [[ "${backed_up_any}" == "1" ]]; then


### PR DESCRIPTION
## Summary
This hardens the VM deploy workflow so it fails fast when the remote checkout is already in a conflicted merge state, instead of falling through to a cryptic `git stash push` failure.

## What changed
- added an early guard before `git stash push` that detects unresolved conflicts via `git ls-files --unmerged` and `MERGE_HEAD`
- surfaces a clear, actionable error that lists conflicted files and tells the operator to SSH into the VM and reconcile manually
- changed `git stash pop` handling so a non-zero exit now fails the deploy loudly with the same conflicted-file report instead of warning and continuing into checkout / compose-up

## Why
A prior deploy left unresolved conflicts on the VM after `stash pop`, and every later deploy died at `git stash push` with `needs merge`. The VM's tracked local edits are authoritative per project policy, so the workflow must stop and ask for manual reconciliation rather than discard or auto-resolve them.

## Validation
- `npm run typecheck` ✅
- `npm run lint` ❌ fails due to pre-existing repo-boundary violations in `app/ops/page.tsx`, `backend/aries-os/workspace-contract.ts`, and `frontend/aries-os/*`
- `npm test` ❌ fails due to pre-existing unrelated test failures in `tests/review-surfaces-public.test.ts` and `tests/tenant/business-profile.test.ts`
- `npm run workspace:verify` ❌ fails in this managed git worktree because the script expects the canonical path `/home/node/openclaw/aries-app`

## Context
Related failing workflow run: https://github.com/DeliciousHouse/aries-app/actions/runs/24473715772

No tracker issue number was available to link for auto-closing.