### PR TITLE
sync: reconcile VM-local edits in inventory-paperclip-workspaces and runtime-precheck

### DIFF
--- a/scripts/inventory-paperclip-workspaces.mjs
+++ b/scripts/inventory-paperclip-workspaces.mjs
@@ -1,0 +1,117 @@
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync } from 'node:child_process';
+
+const paperclipRoot = path.resolve(
+  process.env.ARIES_PAPERCLIP_WORKSPACES_ROOT || '/home/bkam/.paperclip/instances/default/workspaces'
+);
+
+function runGit(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function safeGit(cwd, args) {
+  try {
+    return runGit(cwd, args);
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeCanonicalRoot(candidateRoot) {
+  return ['package.json', 'README-runtime.md', 'app', 'backend', 'tests'].every((marker) =>
+    existsSync(path.join(candidateRoot, marker))
+  );
+}
+
+function resolveCanonicalRoot() {
+  const explicitRoot = process.env.ARIES_CANONICAL_REPO_ROOT?.trim();
+  if (explicitRoot) {
+    return path.resolve(explicitRoot);
+  }
+
+  const defaultRoot = path.resolve('/app/aries-app');
+  if (looksLikeCanonicalRoot(defaultRoot)) {
+    return defaultRoot;
+  }
+
+  return path.resolve(process.cwd());
+}
+
+const canonicalRoot = resolveCanonicalRoot();
+
+const canonicalHead = safeGit(canonicalRoot, ['rev-parse', 'HEAD']);
+const canonicalBranch = safeGit(canonicalRoot, ['rev-parse', '--abbrev-ref', 'HEAD']);
+const entries = [];
+
+if (!existsSync(paperclipRoot)) {
+  console.log(JSON.stringify({
+    canonical: {
+      path: canonicalRoot,
+      branch: canonicalBranch,
+      head: canonicalHead,
+    },
+    workspaces: [],
+  }, null, 2));
+  process.exit(0);
+}
+
+for (const workspaceId of readdirSync(paperclipRoot)) {
+  const workspacePath = path.join(paperclipRoot, workspaceId);
+  const repoPath = path.join(workspacePath, 'aries-app');
+
+  if (path.resolve(workspacePath) === canonicalRoot || path.resolve(repoPath) === canonicalRoot) {
+    continue;
+  }
+
+  if (existsSync(path.join(repoPath, '.git'))) {
+    const head = safeGit(repoPath, ['rev-parse', 'HEAD']);
+    const branch = safeGit(repoPath, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    const statusOutput = safeGit(repoPath, ['status', '--short']) || '';
+    const dirtyFiles = statusOutput
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => line.replace(/^[A-Z? ]+/, '').trim());
+
+    let classification = 'canonical_match';
+    if (head !== canonicalHead && dirtyFiles.length > 0) {
+      classification = 'dirty_recovery_candidate';
+    } else if (head !== canonicalHead) {
+      classification = 'stale_clone';
+    } else if (dirtyFiles.length > 0) {
+      classification = 'dirty_recovery_candidate';
+    }
+
+    entries.push({
+      workspaceId,
+      path: repoPath,
+      classification,
+      branch,
+      head,
+      dirtyFiles,
+    });
+    continue;
+  }
+
+  if (existsSync(workspacePath)) {
+    entries.push({
+      workspaceId,
+      path: workspacePath,
+      classification: 'agent_home_only',
+      branch: null,
+      head: null,
+      dirtyFiles: [],
+    });
+  }
+}
+
+console.log(JSON.stringify({
+  canonical: {
+    path: canonicalRoot,
+    branch: canonicalBranch,
+    head: canonicalHead,
+  },
+  workspaces: entries.sort((a, b) => a.workspaceId.localeCompare(b.workspaceId)),
+}, null, 2));

--- a/scripts/runtime-precheck.mjs
+++ b/scripts/runtime-precheck.mjs
@@ -1,12 +1,33 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+function resolveGitRoot() {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+function looksLikeRepoRoot(candidate) {
+  if (!candidate) {
+    return false;
+  }
+
+  const resolved = path.resolve(candidate);
+  return fs.existsSync(path.join(resolved, 'package.json')) && fs.existsSync(path.join(resolved, 'app'));
+}
 
 const explicitCodeRoot = process.env.CODE_ROOT?.trim();
-const candidateRoot = explicitCodeRoot ? path.resolve(explicitCodeRoot) : null;
-const root =
-  candidateRoot && fs.existsSync(path.join(candidateRoot, 'package.json'))
-    ? candidateRoot
-    : process.cwd();
+const root = looksLikeRepoRoot(explicitCodeRoot)
+  ? path.resolve(explicitCodeRoot)
+  : looksLikeRepoRoot(process.cwd())
+    ? process.cwd()
+    : resolveGitRoot();
 
 const required = [
   'package.json',


### PR DESCRIPTION
## Summary
- preserve the production VM versions of `scripts/inventory-paperclip-workspaces.mjs` and `scripts/runtime-precheck.mjs`
- add a backup copy under `.deploy-backups/2026-04-15-conflicts` before syncing the changes
- keep the VM-local behavior so deploy recovery can be reviewed and merged without losing runtime-specific logic

## Context
- Failing run: https://github.com/DeliciousHouse/aries-app/actions/runs/24473715772
- Backup path on VM: `/home/node/openclaw/aries-app/.deploy-backups/2026-04-15-conflicts`
- Merging this PR unblocks Deploy to VM by reconciling the production VM script divergence.
