### PR TITLE
fix: site audit wave 3 — onboarding validation (pipeline-intake)

### DIFF
--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -270,6 +270,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [urlPreview, setUrlPreview] = useState<UrlPreviewResponse | null>(null);
+  const [previewRefreshCounter, setPreviewRefreshCounter] = useState(0);
   const [draftId, setDraftId] = useState(draftParam);
   const [creatingDraft, setCreatingDraft] = useState(false);
   const [loadedDraftId, setLoadedDraftId] = useState<string | null>(null);
@@ -501,7 +502,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [ariesApi, deferredWebsiteUrl, draftId]);
+  }, [ariesApi, deferredWebsiteUrl, draftId, previewRefreshCounter]);
 
   function toggleChannel(channelId: string) {
     setSelectedChannels((current) =>
@@ -853,10 +854,11 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                         onClick={() => {
                           setUrlPreview(null);
                           setPreviewError(null);
-                          // Re-trigger fetch by resetting and restoring the website URL
-                          const url = websiteUrl;
-                          setWebsiteUrl('');
-                          setTimeout(() => setWebsiteUrl(url), 0);
+                          // Bump the refresh counter — the preview useEffect
+                          // lists it in deps, so incrementing is enough to
+                          // re-run the fetch without churning websiteUrl (and
+                          // without the fragile setTimeout batching trick).
+                          setPreviewRefreshCounter((n) => n + 1);
                         }}
                         className="inline-flex items-center gap-2 rounded-full border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-sm font-medium text-amber-200 transition hover:bg-amber-400/20"
                       >

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -821,6 +821,49 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
 
               {currentStep.key === 'brand' ? (
                 <div className="space-y-6">
+                  {previewLoading ? (
+                    <div className="rounded-[2rem] border border-white/10 bg-[linear-gradient(160deg,rgba(255,255,255,0.06),rgba(255,255,255,0.03))] p-6 animate-pulse">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#ba8cff] mb-4">Analyzing your site...</p>
+                      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+                        <div className="space-y-4">
+                          <div className="h-8 w-48 rounded-[0.75rem] bg-white/10" />
+                          <div className="h-4 w-64 rounded-[0.5rem] bg-white/[0.06]" />
+                          <div className="space-y-2">
+                            <div className="h-3 w-full rounded-[0.5rem] bg-white/[0.06]" />
+                            <div className="h-3 w-5/6 rounded-[0.5rem] bg-white/[0.06]" />
+                            <div className="h-3 w-4/6 rounded-[0.5rem] bg-white/[0.06]" />
+                          </div>
+                          <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="h-20 rounded-[1rem] bg-white/[0.05]" />
+                            <div className="h-20 rounded-[1rem] bg-white/[0.05]" />
+                          </div>
+                        </div>
+                        <div className="grid gap-4">
+                          <div className="h-32 rounded-[1.5rem] bg-white/[0.05]" />
+                          <div className="h-20 rounded-[1.5rem] bg-white/[0.05]" />
+                        </div>
+                      </div>
+                    </div>
+                  ) : previewError ? (
+                    <div className="rounded-[2rem] border border-amber-400/20 bg-amber-400/[0.06] p-6">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-amber-300 mb-3">Brand analysis failed</p>
+                      <p className="text-sm leading-7 text-amber-100/80 mb-4">{previewError}</p>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setUrlPreview(null);
+                          setPreviewError(null);
+                          // Re-trigger fetch by resetting and restoring the website URL
+                          const url = websiteUrl;
+                          setWebsiteUrl('');
+                          setTimeout(() => setWebsiteUrl(url), 0);
+                        }}
+                        className="inline-flex items-center gap-2 rounded-full border border-amber-400/30 bg-amber-400/10 px-4 py-2 text-sm font-medium text-amber-200 transition hover:bg-amber-400/20"
+                      >
+                        Retry analysis
+                      </button>
+                    </div>
+                  ) : (
                   <div className="rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(151,93,255,0.12),transparent_28%),linear-gradient(160deg,rgba(255,255,255,0.06),rgba(255,255,255,0.03))] p-6">
                     <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
                       <div className="space-y-4">
@@ -856,6 +899,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                       </div>
                     </div>
                   </div>
+                  )}
 
                   {preview?.externalLinks && preview.externalLinks.length > 0 ? (
                     <div className="rounded-[1.6rem] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] p-5">

--- a/frontend/onboarding/pipeline-intake/components/SystemPreviewPanel.tsx
+++ b/frontend/onboarding/pipeline-intake/components/SystemPreviewPanel.tsx
@@ -66,6 +66,8 @@ const CHANNEL_LABELS: Record<Channel, string> = {
   youtube: 'YouTube',
   linkedin: 'LinkedIn',
   x: 'X (Twitter)',
+  'meta-ads': 'Meta Ads',
+  email: 'Email',
 };
 
 export default function SystemPreviewPanel({ channels, mode }: SystemPreviewPanelProps) {

--- a/frontend/onboarding/pipeline-intake/index.tsx
+++ b/frontend/onboarding/pipeline-intake/index.tsx
@@ -37,7 +37,11 @@ export default function PipelineIntake() {
   };
 
   const handleSubmit = async () => {
-    if (!goal || !mode || channels.length === 0 || !brandUrl || !competitorUrl) return;
+    if (!brandUrl) { setSubmitError('Enter your brand URL on Step 1 before launching.'); return; }
+    if (!competitorUrl) { setSubmitError('Enter a competitor URL on Step 2 before launching.'); return; }
+    if (!goal) { setSubmitError('Select a campaign goal on Step 3 before launching.'); return; }
+    if (channels.length === 0) { setSubmitError('Select at least one channel on Step 4 before launching.'); return; }
+    if (!mode) { setSubmitError('Select an execution mode before launching.'); return; }
 
     const payload: PipelineInput = {
       brand_url: brandUrl,

--- a/frontend/onboarding/pipeline-intake/index.tsx
+++ b/frontend/onboarding/pipeline-intake/index.tsx
@@ -41,7 +41,7 @@ export default function PipelineIntake() {
     if (!competitorUrl) { setSubmitError('Enter a competitor URL on Step 2 before launching.'); return; }
     if (!goal) { setSubmitError('Select a campaign goal on Step 3 before launching.'); return; }
     if (channels.length === 0) { setSubmitError('Select at least one channel on Step 4 before launching.'); return; }
-    if (!mode) { setSubmitError('Select an execution mode before launching.'); return; }
+    if (!mode) { setSubmitError('Select an execution mode on Step 5 before launching.'); return; }
 
     const payload: PipelineInput = {
       brand_url: brandUrl,

--- a/frontend/onboarding/pipeline-intake/steps/ChannelsStep.tsx
+++ b/frontend/onboarding/pipeline-intake/steps/ChannelsStep.tsx
@@ -7,6 +7,12 @@ import type { Channel } from '../types';
 // Simple text icons since we don't have brand SVGs
 const CHANNEL_OPTIONS: SelectionOption[] = [
   {
+    value: 'meta-ads',
+    label: 'Meta (Facebook + Instagram Ads)',
+    description: 'Paid ads on Facebook and Instagram via Meta Business Suite.',
+    icon: <span className="text-base">📣</span>,
+  },
+  {
     value: 'tiktok',
     label: 'TikTok',
     description: 'Short-form video — massive reach, high engagement',
@@ -14,7 +20,7 @@ const CHANNEL_OPTIONS: SelectionOption[] = [
   },
   {
     value: 'instagram',
-    label: 'Instagram',
+    label: 'Instagram (Organic + Reels)',
     description: 'Reels, stories, carousel — visual-first audience',
     icon: <span className="text-base">📸</span>,
   },
@@ -35,6 +41,12 @@ const CHANNEL_OPTIONS: SelectionOption[] = [
     label: 'X (Twitter)',
     description: 'Real-time conversation — trending topics and brand voice',
     icon: <span className="text-base">✖️</span>,
+  },
+  {
+    value: 'email',
+    label: 'Email Marketing',
+    description: 'Automated email campaigns and sequences.',
+    icon: <span className="text-base">✉️</span>,
   },
 ];
 

--- a/frontend/onboarding/pipeline-intake/types.ts
+++ b/frontend/onboarding/pipeline-intake/types.ts
@@ -1,5 +1,5 @@
 export type Goal = "lead_generation" | "content_growth" | "product_sales" | "brand_awareness";
-export type Channel = "tiktok" | "instagram" | "youtube" | "linkedin" | "x";
+export type Channel = "tiktok" | "instagram" | "youtube" | "linkedin" | "x" | "meta-ads" | "email";
 export type ExecutionMode = "strategy_only" | "strategy_plus_assets" | "full_pipeline";
 
 export interface PipelineInput {


### PR DESCRIPTION
## Summary

Wave 3 of the site audit. Three fixes for the pipeline-intake campaign creation flow.

### C4 — Silent failure on ExecutionStep (final step)
\`handleSubmit\` returned early with no feedback when required fields were missing, leaving users stranded on Step 5 with a non-working button and no hint of what's wrong. Now validates each field in step order and surfaces a specific error message identifying which field is missing. The \`submitError\` banner was already rendered in the UI so no new UX plumbing was needed.

### M5 — Missing channels
Added Email Marketing and Meta Ads to the pipeline-intake channel list (previously only TikTok, Instagram, YouTube, LinkedIn, X). These are the two highest-leverage channels for the core ICP. Also clarified the Instagram label to "Instagram (Organic + Reels)" so users understand the distinction from paid Meta ads.

### H3 / M8 — Brand Identity step feedback
The Brand Identity step (legacy v1) was showing only passive placeholder cards with no loading, deferred, or error state. The component already had \`previewLoading\` and \`previewError\` state but wasn't surfacing it. Added:
- **Loading state**: full-width pulsing skeleton with "Analyzing your site..." label
- **Error state**: amber-tinted error card with a "Retry analysis" button
- **Normal state**: unchanged (existing preview card)

Users now see live feedback during site analysis instead of wondering if the feature is broken.

## Files changed (4)

- \`frontend/aries-v1/onboarding-flow.tsx\` (+44 lines — skeleton + error UI)
- \`frontend/onboarding/pipeline-intake/index.tsx\` (validation errors)
- \`frontend/onboarding/pipeline-intake/steps/ChannelsStep.tsx\` (channels)
- \`frontend/onboarding/pipeline-intake/types.ts\` (Channel type)

## Test plan

- [ ] Pipeline-intake: advance to Step 5 without selecting channels → click Launch → confirm "Select at least one channel on Step 4 before launching."
- [ ] Confirm similar specific messages for each missing-field scenario (brandUrl, competitorUrl, goal, mode)
- [ ] Confirm ChannelsStep now shows Meta Ads and Email Marketing entries; Instagram reads "Instagram (Organic + Reels)"
- [ ] v1 onboarding: enter a URL on Step 2, advance to Step 3 → confirm the pulsing skeleton appears while analysis runs
- [ ] Trigger an analysis error (invalid URL or network error) → confirm the amber error card with Retry button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)