### PR TITLE
feat(auth): site audit wave 4 — self-serve password reset (C3)

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -65,7 +65,10 @@ export async function POST(req: Request) {
       return successResponse();
     }
 
-    const code = crypto.randomInt(100000, 999999).toString();
+    // crypto.randomInt(min, max) uses an EXCLUSIVE upper bound. Using 999999
+    // would never actually produce 999999. Keep the inclusive 100000..999999
+    // six-digit range by passing 1000000 as the exclusive max.
+    const code = crypto.randomInt(100000, 1000000).toString();
     const codeHash = crypto.createHash('sha256').update(code).digest('hex');
 
     await client.query(

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import crypto from 'node:crypto';
+
+import pool from '@/lib/db';
+import { sendPasswordResetEmail } from '@/lib/email';
+
+type ForgotPasswordBody = {
+  email?: unknown;
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function successResponse() {
+  return NextResponse.json({ success: true });
+}
+
+function normalizeEmail(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function POST(req: Request) {
+  let body: ForgotPasswordBody = {};
+  try {
+    body = (await req.json()) as ForgotPasswordBody;
+  } catch {
+    body = {};
+  }
+
+  const email = normalizeEmail(body.email);
+
+  // Always return success to prevent email enumeration.
+  if (!email || !EMAIL_RE.test(email)) {
+    return successResponse();
+  }
+
+  let client;
+  try {
+    client = await pool.connect();
+
+    const userResult = await client.query(
+      `SELECT id, password_hash FROM users WHERE LOWER(email) = LOWER($1) LIMIT 1`,
+      [email],
+    );
+
+    if ((userResult.rowCount ?? 0) === 0) {
+      return successResponse();
+    }
+
+    const user = userResult.rows[0] as { id: number; password_hash: string | null };
+    if (!user.password_hash || user.password_hash === 'oauth_managed') {
+      return successResponse();
+    }
+
+    const rateResult = await client.query(
+      `SELECT COUNT(*)::int AS count
+         FROM password_resets
+        WHERE email = $1
+          AND created_at > now() - interval '1 hour'`,
+      [email],
+    );
+    const recentCount = Number(rateResult.rows[0]?.count ?? 0);
+    if (recentCount >= 3) {
+      return successResponse();
+    }
+
+    const code = crypto.randomInt(100000, 999999).toString();
+    const codeHash = crypto.createHash('sha256').update(code).digest('hex');
+
+    await client.query(
+      `INSERT INTO password_resets (user_id, email, code_hash, expires_at)
+       VALUES ($1, $2, $3, now() + interval '15 minutes')`,
+      [user.id, email, codeHash],
+    );
+
+    try {
+      await sendPasswordResetEmail(email, code);
+    } catch (err) {
+      console.error('[forgot-password] email send failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return successResponse();
+  } catch (error) {
+    console.error('[forgot-password] unexpected error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // Still return success to avoid leaking state to clients.
+    return successResponse();
+  } finally {
+    client?.release();
+  }
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -69,19 +69,31 @@ export async function POST(req: Request) {
   try {
     client = await pool.connect();
 
+    // Brute-force protection: only consider rows that are unused, unexpired,
+    // AND have fewer than MAX_ATTEMPTS_PER_ROW failed verification attempts.
+    // On every mismatch below we increment the attempts counter, so a given
+    // reset row can be guessed at most MAX_ATTEMPTS_PER_ROW times before it
+    // is effectively locked. Combined with the 3-per-hour rate limit in
+    // forgot-password, an attacker gets at most ~15 guesses per email per hour
+    // against a 10^6 keyspace.
+    const MAX_ATTEMPTS_PER_ROW = 5;
+
     const rows = await client.query(
-      `SELECT id, user_id, code_hash
+      `SELECT id, user_id, code_hash, attempts
          FROM password_resets
         WHERE email = $1
           AND used_at IS NULL
           AND expires_at > now()
+          AND attempts < $2
         ORDER BY created_at DESC
         LIMIT 5`,
-      [email],
+      [email, MAX_ATTEMPTS_PER_ROW],
     );
 
     let match: { id: number; user_id: number } | null = null;
-    for (const row of rows.rows as Array<{ id: number; user_id: number; code_hash: string }>) {
+    const candidateIds: number[] = [];
+    for (const row of rows.rows as Array<{ id: number; user_id: number; code_hash: string; attempts: number }>) {
+      candidateIds.push(row.id);
       if (timingSafeHexEqual(hashedSubmitted, row.code_hash)) {
         match = { id: row.id, user_id: row.user_id };
         break;
@@ -89,6 +101,17 @@ export async function POST(req: Request) {
     }
 
     if (!match) {
+      // Increment the failed-attempts counter on every candidate row we
+      // checked. A row that hits MAX_ATTEMPTS_PER_ROW is excluded from
+      // future candidate queries above — effectively locking it without
+      // marking it used_at (so we keep the used_at column meaning "a real
+      // reset consumed this row" rather than "got brute-forced away").
+      if (candidateIds.length > 0) {
+        await client.query(
+          `UPDATE password_resets SET attempts = attempts + 1 WHERE id = ANY($1::bigint[])`,
+          [candidateIds],
+        );
+      }
       return errorResponse('Invalid or expired code');
     }
 

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server';
+import crypto from 'node:crypto';
+import bcrypt from 'bcryptjs';
+
+import pool from '@/lib/db';
+
+type ResetPasswordBody = {
+  email?: unknown;
+  code?: unknown;
+  password?: unknown;
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CODE_RE = /^\d{6}$/;
+// Matches the existing password policy in frontend/auth/reset-password-form.tsx:
+// 8+ chars, at least one uppercase, one digit, one special character.
+const PASSWORD_RE = /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/;
+
+function errorResponse(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function normalizeEmail(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function timingSafeHexEqual(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length !== b.length) return false;
+  try {
+    const bufA = Buffer.from(a, 'hex');
+    const bufB = Buffer.from(b, 'hex');
+    if (bufA.length !== bufB.length || bufA.length === 0) return false;
+    return crypto.timingSafeEqual(bufA, bufB);
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: Request) {
+  let body: ResetPasswordBody = {};
+  try {
+    body = (await req.json()) as ResetPasswordBody;
+  } catch {
+    body = {};
+  }
+
+  const email = normalizeEmail(body.email);
+  const code = typeof body.code === 'string' ? body.code.trim() : '';
+  const password = typeof body.password === 'string' ? body.password : '';
+
+  if (!email || !EMAIL_RE.test(email)) {
+    return errorResponse('Invalid or expired code');
+  }
+  if (!CODE_RE.test(code)) {
+    return errorResponse('Invalid or expired code');
+  }
+  if (!PASSWORD_RE.test(password)) {
+    return errorResponse(
+      'Password must be at least 8 characters and include an uppercase letter, a number, and a special character.',
+    );
+  }
+
+  const hashedSubmitted = crypto.createHash('sha256').update(code).digest('hex');
+
+  let client;
+  try {
+    client = await pool.connect();
+
+    const rows = await client.query(
+      `SELECT id, user_id, code_hash
+         FROM password_resets
+        WHERE email = $1
+          AND used_at IS NULL
+          AND expires_at > now()
+        ORDER BY created_at DESC
+        LIMIT 5`,
+      [email],
+    );
+
+    let match: { id: number; user_id: number } | null = null;
+    for (const row of rows.rows as Array<{ id: number; user_id: number; code_hash: string }>) {
+      if (timingSafeHexEqual(hashedSubmitted, row.code_hash)) {
+        match = { id: row.id, user_id: row.user_id };
+        break;
+      }
+    }
+
+    if (!match) {
+      return errorResponse('Invalid or expired code');
+    }
+
+    const passwordHash = await bcrypt.hash(password, 12);
+
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `UPDATE users SET password_hash = $1 WHERE id = $2`,
+        [passwordHash, match.user_id],
+      );
+      await client.query(
+        `UPDATE password_resets SET used_at = now() WHERE id = $1`,
+        [match.id],
+      );
+      await client.query(
+        `UPDATE password_resets SET used_at = now() WHERE email = $1 AND used_at IS NULL`,
+        [email],
+      );
+      await client.query('COMMIT');
+    } catch (txError) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // ignore rollback errors
+      }
+      throw txError;
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[reset-password] unexpected error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return errorResponse('Unable to reset password right now.', 500);
+  } finally {
+    client?.release();
+  }
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -11,19 +11,19 @@ export default function ForgotPasswordPage() {
     }
   };
 
-  const handleSubmit = (email: string, code: string) => {
-    // Navigate to reset password or show success
-    console.log('Recovery code sent to:', email);
+  const handleSubmit = (email: string) => {
+    // The API always returns success (no email-enumeration oracle); send the
+    // user to the next step where they'll enter the code delivered via email.
     window.location.href = `/reset-password?email=${encodeURIComponent(email)}`;
   };
 
   return (
     <AuthLayout>
       <div className="flex justify-center w-full">
-        <ForgotPasswordForm 
-          onNavigate={handleNavigate} 
-          onSubmit={handleSubmit} 
-          isLoading={false} 
+        <ForgotPasswordForm
+          onNavigate={handleNavigate}
+          onSubmit={handleSubmit}
+          isLoading={false}
         />
       </div>
     </AuthLayout>

--- a/app/login/page-client.tsx
+++ b/app/login/page-client.tsx
@@ -37,10 +37,12 @@ export default function LoginPageClient() {
     () => resolveLoginErrorCode(searchParams.get('error'), searchParams.get('code')),
     [searchParams],
   );
-  const savedMessage = useMemo(
-    () => savedDraftMessage(searchParams.get('draftSaved'), searchParams.get('businessName')),
-    [searchParams],
-  );
+  const savedMessage = useMemo(() => {
+    if (searchParams.get('reset') === 'success') {
+      return 'Password updated — sign in with your new password';
+    }
+    return savedDraftMessage(searchParams.get('draftSaved'), searchParams.get('businessName'));
+  }, [searchParams]);
   const signupHref = useMemo(() => {
     const params = new URLSearchParams();
     if (callbackUrl) {

--- a/app/reset-password/page-client.tsx
+++ b/app/reset-password/page-client.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import AuthLayout from '../../frontend/auth/auth-layout';
+import ResetPasswordForm from '../../frontend/auth/reset-password-form';
+
+export default function ResetPasswordPageClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const email = searchParams.get('email') || '';
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleNavigate = (view: string) => {
+    if (view === 'login') {
+      router.push('/login');
+    }
+  };
+
+  const handleSubmit = async (
+    submittedEmail: string,
+    code: string,
+    password: string,
+  ): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const response = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: submittedEmail, code, password }),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || 'Failed to update password. Try again.');
+      }
+
+      router.push('/login?reset=success');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <div className="flex justify-center w-full">
+        <ResetPasswordForm
+          email={email}
+          onNavigate={handleNavigate}
+          onSubmit={handleSubmit}
+          isLoading={isLoading}
+        />
+      </div>
+    </AuthLayout>
+  );
+}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react';
+
+import AuthLayout from '../../frontend/auth/auth-layout';
+import ResetPasswordPageClient from './page-client';
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthLayout>
+          <div className="mx-auto max-w-md rounded-2xl border border-white/10 bg-white/5 px-6 py-10 text-center text-white/70">
+            Loading password reset…
+          </div>
+        </AuthLayout>
+      }
+    >
+      <ResetPasswordPageClient />
+    </Suspense>
+  );
+}

--- a/frontend/auth/ForgotPasswordForm.tsx
+++ b/frontend/auth/ForgotPasswordForm.tsx
@@ -2,14 +2,12 @@
 
 import React, { useState } from 'react';
 import { AuthView } from '../types';
-import { recordPasswordResetRequest } from '../services/supabase';
-import { sendOTPEmail } from '../services/emailService';
 import { AriesMark } from '@/frontend/donor/ui';
 
 
 interface ForgotPasswordFormProps {
   onNavigate: (view: AuthView) => void;
-  onSubmit: (email: string, code: string) => void;
+  onSubmit: (email: string) => void;
   isLoading: boolean;
 }
 
@@ -30,18 +28,20 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
 
 
     try {
-      const code = Math.floor(100000 + Math.random() * 900000).toString();
-      await recordPasswordResetRequest(email, code);
-      const result = await sendOTPEmail(email, code, 'reset');
+      const response = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
 
-
-      if (result.success) {
-        onSubmit(email, code);
-      } else {
-        setError(result.error || "Delivery failed. Please ensure the email is correct.");
+      // The API always returns success to prevent email enumeration.
+      // Surface transport failures as a generic error, otherwise proceed.
+      if (!response.ok) {
+        setError('Unable to send recovery code right now. Please try again.');
+        return;
       }
 
-
+      onSubmit(email);
     } catch (err: any) {
       setError("An unexpected error occurred. Please try again.");
     } finally {
@@ -76,7 +76,7 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
       {/* Glassmorphic Form Card */}
       <div className="glass p-8 md:p-10 rounded-2xl border border-white/10 relative overflow-hidden">
         <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-primary via-secondary to-primary" />
-        
+
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label className="block text-sm font-medium text-white/80 mb-1.5">Account Email</label>
@@ -103,7 +103,7 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
             disabled={isLoading || parentLoading || !email}
             className="w-full py-3 px-4 bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-white font-medium rounded-xl transition-all shadow-[0_0_20px_rgba(124,58,237,0.3)] hover:shadow-[0_0_30px_rgba(124,58,237,0.5)] flex items-center justify-center gap-2 disabled:opacity-60"
           >
-            {isLoading || parentLoading ? 'Locating Account...' : 'Send Recovery Code'}
+            {isLoading || parentLoading ? 'Sending Code...' : 'Send Recovery Code'}
           </button>
         </form>
       </div>

--- a/frontend/auth/login-form.tsx
+++ b/frontend/auth/login-form.tsx
@@ -86,7 +86,9 @@ const LoginForm: React.FC<LoginFormProps> = ({
           <div>
             <div className="flex items-center justify-between mb-1.5">
               <label className="block text-sm font-medium text-white/80">Password</label>
-              <span className="text-sm text-white/40">Password reset is not self-serve yet</span>
+              <Link href="/forgot-password" className="text-sm text-white/60 hover:text-white transition-colors">
+                Forgot password?
+              </Link>
             </div>
             <div className="relative">
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">

--- a/frontend/auth/reset-password-form.tsx
+++ b/frontend/auth/reset-password-form.tsx
@@ -81,7 +81,7 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
               type="text"
               inputMode="numeric"
               autoComplete="one-time-code"
-              pattern="\d{6}"
+              pattern="[0-9]{6}"
               maxLength={6}
               required
               className="auth-input tracking-[0.4em] text-center"

--- a/frontend/auth/reset-password-form.tsx
+++ b/frontend/auth/reset-password-form.tsx
@@ -1,19 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import { AuthView } from '../types';
-import { updateLoginPassword, markResetCodeUsed } from '../services/supabase';
 import { BrandLogo } from '@/components/redesign/brand/logo';
 
 
 interface ResetPasswordFormProps {
   email: string;
-  otpCode: string;
+  otpCode?: string;
   onNavigate: (view: AuthView) => void;
-  onSubmit: () => void;
+  onSubmit: (email: string, code: string, password: string) => void | Promise<void>;
   isLoading: boolean;
 }
 
 
 const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, onNavigate, onSubmit, isLoading }) => {
+  const [code, setCode] = useState(otpCode ?? '');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -35,11 +35,16 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
     setError(null);
 
 
+    if (!/^\d{6}$/.test(code.trim())) {
+      setError("Enter the 6-digit code from your email.");
+      return;
+    }
+
     if (password !== confirmPassword) {
       setError("Passwords do not match.");
       return;
     }
-    
+
     const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/;
     if (!passwordRegex.test(password)) {
       setError("Password must be at least 8 characters long and include an uppercase letter, a number, and a special character.");
@@ -47,18 +52,12 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
     }
 
 
-
     try {
-      await updateLoginPassword(email, password);
-      await markResetCodeUsed(email, otpCode);
-      onSubmit();
+      await onSubmit(email, code.trim(), password);
     } catch (err: any) {
-      setError(err.message || "Failed to update password. Try again.");
+      setError(err?.message || "Failed to update password. Try again.");
     }
   };
-
-
-  const inputStyle = "w-full px-[16px] py-[10px] rounded-xl border border-white/20 bg-black/10 text-white placeholder-[#851028] placeholder:font-medium placeholder:text-[15px] focus:outline-none focus:border-white/40 transition-all text-[15px]";
 
 
   return (
@@ -77,6 +76,21 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
       <div className="auth-card animate-in fade-in zoom-in-95 duration-500">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
+            <label className="auth-label">Recovery Code</label>
+            <input
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              pattern="\d{6}"
+              maxLength={6}
+              required
+              className="auth-input tracking-[0.4em] text-center"
+              placeholder="123456"
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            />
+          </div>
+          <div className="space-y-2">
             <label className="auth-label">New Password</label>
             <input type="password" required className="auth-input" placeholder="••••••••" value={password} onChange={(e) => setPassword(e.target.value)} />
           </div>
@@ -87,9 +101,9 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
 
 
           {error && (
-            <div className="rounded-xl border border-red-500/20 bg-gradient-to-r from-red-500/15 via-red-500/5 to-transparent backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.3)] flex items-center gap-3 animate-in fade-in slide-in-from-top-3 duration-500" 
-                 style={{ 
-                   padding: '16px', 
+            <div className="rounded-xl border border-red-500/20 bg-gradient-to-r from-red-500/15 via-red-500/5 to-transparent backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.3)] flex items-center gap-3 animate-in fade-in slide-in-from-top-3 duration-500"
+                 style={{
+                   padding: '16px',
                    marginBottom: '32px',
                    borderLeft: '4px solid #EF4444'
                  }}>
@@ -99,9 +113,9 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
               </div>
-              <span className="text-red-100/90 font-bold tracking-normal leading-snug" 
-                    style={{ 
-                      fontSize: '10px', 
+              <span className="text-red-100/90 font-bold tracking-normal leading-snug"
+                    style={{
+                      fontSize: '10px',
                       textTransform: 'capitalize',
                       letterSpacing: '0.02em'
                     }}>
@@ -113,7 +127,7 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
 
           <button
             type="submit"
-            disabled={isLoading || !password}
+            disabled={isLoading || !password || !code}
             className="auth-primary-button"
           >
             {isLoading ? 'Updating...' : 'UPDATE PASSWORD'}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,102 @@
+// lib/email.ts
+//
+// Outbound transactional email helpers.
+//
+// Environment variables:
+//   RESEND_API_KEY   API key for the Resend SDK. If missing, emails are
+//                    logged and the promise resolves without throwing — this
+//                    keeps dev environments usable without a real key and
+//                    avoids leaking a "not configured" oracle back to callers.
+//   EMAIL_FROM       Fully-qualified "From" header, e.g.
+//                    `Aries AI <noreply@aries.sugarandleather.com>`. Falls
+//                    back to that default value when unset.
+
+import { Resend } from 'resend';
+
+const DEFAULT_FROM = 'Aries AI <noreply@aries.sugarandleather.com>';
+
+function renderHtml(code: string): string {
+  return `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#0b0b0f;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,sans-serif;color:#f5f5f7;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0b0b0f;padding:32px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background:#15151b;border:1px solid rgba(255,255,255,0.08);border-radius:16px;padding:40px 32px;">
+            <tr>
+              <td style="text-align:center;">
+                <div style="font-size:13px;letter-spacing:0.25em;text-transform:uppercase;color:rgba(255,255,255,0.55);margin-bottom:8px;">Aries AI</div>
+                <h1 style="font-size:22px;font-weight:600;color:#ffffff;margin:0 0 16px;">Reset your password</h1>
+                <p style="font-size:15px;line-height:1.5;color:rgba(255,255,255,0.7);margin:0 0 28px;">Use the verification code below to finish resetting your Aries AI password.</p>
+                <div style="display:inline-block;padding:18px 28px;background:linear-gradient(135deg,rgba(124,58,237,0.25),rgba(236,72,153,0.2));border:1px solid rgba(124,58,237,0.45);border-radius:12px;font-size:32px;font-weight:700;letter-spacing:0.4em;color:#ffffff;">${code}</div>
+                <p style="font-size:13px;color:rgba(255,255,255,0.5);margin:28px 0 0;">This code expires in 15 minutes.</p>
+                <p style="font-size:13px;color:rgba(255,255,255,0.4);margin:16px 0 0;">If you didn't request this, you can safely ignore this email.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}
+
+function renderText(code: string): string {
+  return [
+    'Aries AI password reset',
+    '',
+    `Your verification code: ${code}`,
+    '',
+    'This code expires in 15 minutes.',
+    "If you didn't request this, you can safely ignore this email.",
+  ].join('\n');
+}
+
+type TestHook = (email: string, code: string) => void | Promise<void>;
+
+function readTestHook(): TestHook | null {
+  const hook = (globalThis as Record<string, unknown>).__ARIES_EMAIL_TEST_HOOK__;
+  return typeof hook === 'function' ? (hook as TestHook) : null;
+}
+
+export async function sendPasswordResetEmail(email: string, code: string): Promise<void> {
+  const testHook = readTestHook();
+  if (testHook) {
+    await testHook(email, code);
+    return;
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.EMAIL_FROM || DEFAULT_FROM;
+
+  if (!apiKey) {
+    console.warn(
+      '[email] RESEND_API_KEY not set; skipping send for password reset email.',
+      { to: email },
+    );
+    return;
+  }
+
+  try {
+    const resend = new Resend(apiKey);
+    const result = await resend.emails.send({
+      from,
+      to: email,
+      subject: 'Reset your Aries AI password',
+      html: renderHtml(code),
+      text: renderText(code),
+    });
+
+    if ((result as { error?: unknown } | null)?.error) {
+      console.error('[email] Resend returned an error for password reset email.', {
+        to: email,
+        error: (result as { error: unknown }).error,
+      });
+    }
+  } catch (error) {
+    console.error('[email] Failed to send password reset email.', {
+      to: email,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "recharts": "^3.8.0",
+        "resend": "^4.8.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.183.2"
@@ -1289,6 +1290,24 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@react-email/render": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+      "integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3",
+        "react-promise-suspense": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@react-spring/animated": {
       "version": "9.7.5",
       "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
@@ -1503,6 +1522,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -2449,6 +2481,15 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/detect-gpu": {
       "version": "5.0.70",
       "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
@@ -2466,6 +2507,61 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -2505,6 +2601,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-toolkit": {
@@ -2573,6 +2681,12 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "license": "MIT"
     },
     "node_modules/fflate": {
@@ -2668,6 +2782,41 @@
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
       "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -2771,6 +2920,15 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/lie": {
       "version": "3.3.0",
@@ -3302,6 +3460,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -3309,6 +3480,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/pg": {
@@ -3506,6 +3686,21 @@
         "preact": ">=10"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -3585,6 +3780,15 @@
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
     },
     "node_modules/react-reconciler": {
       "version": "0.27.0",
@@ -3753,6 +3957,18 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/resend": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.8.0.tgz",
+      "integrity": "sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3770,6 +3986,18 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "^3.8.0",
+    "resend": "^4.8.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.183.2"

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -168,8 +168,15 @@ async function initDb() {
         code_hash TEXT NOT NULL,
         expires_at TIMESTAMPTZ NOT NULL,
         used_at TIMESTAMPTZ,
+        attempts INT NOT NULL DEFAULT 0,
         created_at TIMESTAMPTZ NOT NULL DEFAULT now()
       );
+
+      -- Add attempts column to existing deployments that predate brute-force
+      -- protection. ADD COLUMN IF NOT EXISTS is a no-op when the column
+      -- already exists, so this is safe to re-run.
+      ALTER TABLE password_resets
+        ADD COLUMN IF NOT EXISTS attempts INT NOT NULL DEFAULT 0;
 
       CREATE INDEX IF NOT EXISTS idx_password_resets_email_created
         ON password_resets (email, created_at DESC);

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -159,7 +159,22 @@ async function initDb() {
         updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
       );
     `);
-    
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS password_resets (
+        id BIGSERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        email TEXT NOT NULL,
+        code_hash TEXT NOT NULL,
+        expires_at TIMESTAMPTZ NOT NULL,
+        used_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_password_resets_email_created
+        ON password_resets (email, created_at DESC);
+    `);
+
     console.log('Database initialized successfully.');
   } catch (err) {
     console.error('Error initializing database:', err);

--- a/tests/password-reset.test.ts
+++ b/tests/password-reset.test.ts
@@ -1,0 +1,392 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import test, { type TestContext } from 'node:test';
+
+import bcrypt from 'bcryptjs';
+
+import pool from '../lib/db';
+
+type QueryResult<T = Record<string, unknown>> = { rows: T[]; rowCount: number };
+type QueryHandler = (sql: string, params?: unknown[]) => Promise<QueryResult> | QueryResult;
+
+function installDbMock(t: TestContext, handler: QueryHandler): void {
+  const fakeClient = {
+    query: async (sql: string, params?: unknown[]) => handler(String(sql), params ?? []),
+    release: () => {},
+  };
+  t.mock.method(pool, 'connect', async () => fakeClient as unknown as Awaited<ReturnType<typeof pool.connect>>);
+  t.mock.method(pool, 'query', (async (sql: string, params?: unknown[]) =>
+    handler(String(sql), params ?? [])) as typeof pool.query);
+}
+
+function installEmailHook(t: TestContext): Array<{ email: string; code: string }> {
+  const calls: Array<{ email: string; code: string }> = [];
+  (globalThis as Record<string, unknown>).__ARIES_EMAIL_TEST_HOOK__ = (email: string, code: string) => {
+    calls.push({ email, code });
+  };
+  t.after(() => {
+    delete (globalThis as Record<string, unknown>).__ARIES_EMAIL_TEST_HOOK__;
+  });
+  return calls;
+}
+
+type PasswordResetRow = {
+  id: number;
+  user_id: number;
+  email: string;
+  code_hash: string;
+  expires_at: Date;
+  used_at: Date | null;
+  created_at: Date;
+};
+
+type UserRow = {
+  id: number;
+  email: string;
+  password_hash: string;
+};
+
+function createState(options: {
+  users?: UserRow[];
+  resets?: PasswordResetRow[];
+} = {}) {
+  const users: UserRow[] = options.users ?? [];
+  const resets: PasswordResetRow[] = options.resets ?? [];
+  let nextResetId = resets.reduce((max, row) => Math.max(max, row.id), 0) + 1;
+  let transactionDepth = 0;
+
+  const handler: QueryHandler = async (sql, params = []) => {
+    const text = sql.trim();
+
+    if (text === 'BEGIN') {
+      transactionDepth += 1;
+      return { rows: [], rowCount: 0 };
+    }
+    if (text === 'COMMIT' || text === 'ROLLBACK') {
+      transactionDepth = Math.max(0, transactionDepth - 1);
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (text.includes('FROM users') && text.includes('LOWER(email)')) {
+      const email = String(params[0] ?? '').toLowerCase();
+      const user = users.find((row) => row.email.toLowerCase() === email);
+      return { rows: user ? [user] : [], rowCount: user ? 1 : 0 };
+    }
+
+    if (text.includes('COUNT(*)') && text.includes('password_resets')) {
+      const email = String(params[0] ?? '');
+      const now = Date.now();
+      const oneHourAgo = now - 60 * 60 * 1000;
+      const count = resets.filter(
+        (row) => row.email === email && row.created_at.getTime() > oneHourAgo,
+      ).length;
+      return { rows: [{ count }], rowCount: 1 };
+    }
+
+    if (text.startsWith('INSERT INTO password_resets')) {
+      const [userId, email, codeHash] = params as [number, string, string];
+      const row: PasswordResetRow = {
+        id: nextResetId++,
+        user_id: userId,
+        email,
+        code_hash: codeHash,
+        expires_at: new Date(Date.now() + 15 * 60 * 1000),
+        used_at: null,
+        created_at: new Date(),
+      };
+      resets.push(row);
+      return { rows: [row], rowCount: 1 };
+    }
+
+    if (text.startsWith('SELECT id, user_id, code_hash')) {
+      const email = String(params[0] ?? '');
+      const now = Date.now();
+      const rows = resets
+        .filter((row) => row.email === email && row.used_at === null && row.expires_at.getTime() > now)
+        .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+        .slice(0, 5)
+        .map((row) => ({ id: row.id, user_id: row.user_id, code_hash: row.code_hash }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (text.startsWith('UPDATE users SET password_hash')) {
+      const [passwordHash, userId] = params as [string, number];
+      const user = users.find((row) => row.id === userId);
+      if (user) user.password_hash = passwordHash;
+      return { rows: [], rowCount: user ? 1 : 0 };
+    }
+
+    if (text.startsWith('UPDATE password_resets SET used_at = now() WHERE id =')) {
+      const id = Number(params[0]);
+      const row = resets.find((r) => r.id === id);
+      if (row) row.used_at = new Date();
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+
+    if (text.startsWith('UPDATE password_resets SET used_at = now() WHERE email')) {
+      const email = String(params[0] ?? '');
+      let count = 0;
+      for (const row of resets) {
+        if (row.email === email && row.used_at === null) {
+          row.used_at = new Date();
+          count += 1;
+        }
+      }
+      return { rows: [], rowCount: count };
+    }
+
+    throw new Error(`Unhandled SQL in password-reset test harness: ${text}`);
+  };
+
+  return { users, resets, handler };
+}
+
+function hashCode(code: string): string {
+  return crypto.createHash('sha256').update(code).digest('hex');
+}
+
+function jsonRequest(url: string, body: unknown): Request {
+  return new Request(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+test('forgot-password: valid email sends a 6-digit code and returns success', async (t) => {
+  const state = createState({
+    users: [{ id: 42, email: 'user@example.com', password_hash: '$2a$12$abcdef' }],
+  });
+  installDbMock(t, state.handler);
+  const emailCalls = installEmailHook(t);
+
+  const route = await import('../app/api/auth/forgot-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/forgot-password', { email: 'User@Example.com' }),
+  );
+  const body = (await response.json()) as { success: boolean };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.success, true);
+  assert.equal(emailCalls.length, 1);
+  assert.equal(emailCalls[0].email, 'user@example.com');
+  assert.match(emailCalls[0].code, /^\d{6}$/);
+  assert.equal(state.resets.length, 1);
+  assert.equal(state.resets[0].code_hash, hashCode(emailCalls[0].code));
+});
+
+test('forgot-password: unknown email returns success without sending email', async (t) => {
+  const state = createState({ users: [] });
+  installDbMock(t, state.handler);
+  const emailCalls = installEmailHook(t);
+
+  const route = await import('../app/api/auth/forgot-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/forgot-password', { email: 'missing@example.com' }),
+  );
+  const body = (await response.json()) as { success: boolean };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.success, true);
+  assert.equal(emailCalls.length, 0);
+  assert.equal(state.resets.length, 0);
+});
+
+test('forgot-password: OAuth-managed account returns success without sending email', async (t) => {
+  const state = createState({
+    users: [{ id: 9, email: 'oauth@example.com', password_hash: 'oauth_managed' }],
+  });
+  installDbMock(t, state.handler);
+  const emailCalls = installEmailHook(t);
+
+  const route = await import('../app/api/auth/forgot-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/forgot-password', { email: 'oauth@example.com' }),
+  );
+  const body = (await response.json()) as { success: boolean };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.success, true);
+  assert.equal(emailCalls.length, 0);
+});
+
+test('forgot-password: 4th request within an hour is rate-limited silently', async (t) => {
+  const now = Date.now();
+  const email = 'rate@example.com';
+  const state = createState({
+    users: [{ id: 7, email, password_hash: '$2a$12$abcdef' }],
+    resets: [1, 2, 3].map((i) => ({
+      id: i,
+      user_id: 7,
+      email,
+      code_hash: hashCode(String(100000 + i)),
+      expires_at: new Date(now + 15 * 60 * 1000),
+      used_at: null,
+      created_at: new Date(now - i * 60 * 1000),
+    })),
+  });
+  installDbMock(t, state.handler);
+  const emailCalls = installEmailHook(t);
+
+  const route = await import('../app/api/auth/forgot-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/forgot-password', { email }),
+  );
+  const body = (await response.json()) as { success: boolean };
+
+  assert.equal(response.status, 200);
+  assert.equal(body.success, true);
+  assert.equal(emailCalls.length, 0, 'rate-limited requests must not trigger email send');
+  assert.equal(state.resets.length, 3, 'no new password_resets row should be inserted');
+});
+
+test('reset-password: correct code updates password, marks code used, and invalidates siblings', async (t) => {
+  const code = '654321';
+  const email = 'reset@example.com';
+  const originalHash = '$2a$12$OLDHASHVALUEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+  const state = createState({
+    users: [{ id: 55, email, password_hash: originalHash }],
+    resets: [
+      {
+        id: 1,
+        user_id: 55,
+        email,
+        code_hash: hashCode(code),
+        expires_at: new Date(Date.now() + 10 * 60 * 1000),
+        used_at: null,
+        created_at: new Date(),
+      },
+      {
+        id: 2,
+        user_id: 55,
+        email,
+        code_hash: hashCode('111111'),
+        expires_at: new Date(Date.now() + 10 * 60 * 1000),
+        used_at: null,
+        created_at: new Date(Date.now() - 1000),
+      },
+    ],
+  });
+  installDbMock(t, state.handler);
+
+  const route = await import('../app/api/auth/reset-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/reset-password', {
+      email,
+      code,
+      password: 'NewPass!1',
+    }),
+  );
+  const body = (await response.json()) as { success?: boolean; error?: string };
+
+  assert.equal(response.status, 200, `expected 200 got ${response.status} (${body.error})`);
+  assert.equal(body.success, true);
+  const user = state.users.find((row) => row.id === 55)!;
+  assert.notEqual(user.password_hash, originalHash, 'password_hash should be updated');
+  assert.ok(await bcrypt.compare('NewPass!1', user.password_hash), 'new password should verify');
+  for (const row of state.resets) {
+    assert.ok(row.used_at instanceof Date, `reset row ${row.id} should be marked used`);
+  }
+});
+
+test('reset-password: wrong code returns 400 and leaves password untouched', async (t) => {
+  const email = 'wrong@example.com';
+  const originalHash = '$2a$12$ORIGINALHASHVALUEYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY';
+  const state = createState({
+    users: [{ id: 77, email, password_hash: originalHash }],
+    resets: [
+      {
+        id: 1,
+        user_id: 77,
+        email,
+        code_hash: hashCode('222222'),
+        expires_at: new Date(Date.now() + 10 * 60 * 1000),
+        used_at: null,
+        created_at: new Date(),
+      },
+    ],
+  });
+  installDbMock(t, state.handler);
+
+  const route = await import('../app/api/auth/reset-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/reset-password', {
+      email,
+      code: '999999',
+      password: 'NewPass!1',
+    }),
+  );
+  const body = (await response.json()) as { error?: string };
+
+  assert.equal(response.status, 400);
+  assert.match(body.error ?? '', /invalid or expired/i);
+  const user = state.users.find((row) => row.id === 77)!;
+  assert.equal(user.password_hash, originalHash, 'password_hash must not change on bad code');
+  assert.equal(state.resets[0].used_at, null, 'code must not be marked used on mismatch');
+});
+
+test('reset-password: expired code returns 400', async (t) => {
+  const code = '333333';
+  const email = 'expired@example.com';
+  const state = createState({
+    users: [{ id: 81, email, password_hash: '$2a$12$SOMETHING' }],
+    resets: [
+      {
+        id: 1,
+        user_id: 81,
+        email,
+        code_hash: hashCode(code),
+        expires_at: new Date(Date.now() - 60 * 1000),
+        used_at: null,
+        created_at: new Date(Date.now() - 20 * 60 * 1000),
+      },
+    ],
+  });
+  installDbMock(t, state.handler);
+
+  const route = await import('../app/api/auth/reset-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/reset-password', {
+      email,
+      code,
+      password: 'NewPass!1',
+    }),
+  );
+  const body = (await response.json()) as { error?: string };
+
+  assert.equal(response.status, 400);
+  assert.match(body.error ?? '', /invalid or expired/i);
+});
+
+test('reset-password: already-used code returns 400', async (t) => {
+  const code = '444444';
+  const email = 'used@example.com';
+  const state = createState({
+    users: [{ id: 91, email, password_hash: '$2a$12$SOMETHING' }],
+    resets: [
+      {
+        id: 1,
+        user_id: 91,
+        email,
+        code_hash: hashCode(code),
+        expires_at: new Date(Date.now() + 10 * 60 * 1000),
+        used_at: new Date(),
+        created_at: new Date(),
+      },
+    ],
+  });
+  installDbMock(t, state.handler);
+
+  const route = await import('../app/api/auth/reset-password/route');
+  const response = await route.POST(
+    jsonRequest('http://localhost/api/auth/reset-password', {
+      email,
+      code,
+      password: 'NewPass!1',
+    }),
+  );
+  const body = (await response.json()) as { error?: string };
+
+  assert.equal(response.status, 400);
+  assert.match(body.error ?? '', /invalid or expired/i);
+});

--- a/tests/password-reset.test.ts
+++ b/tests/password-reset.test.ts
@@ -37,6 +37,7 @@ type PasswordResetRow = {
   code_hash: string;
   expires_at: Date;
   used_at: Date | null;
+  attempts: number;
   created_at: Date;
 };
 
@@ -92,6 +93,7 @@ function createState(options: {
         code_hash: codeHash,
         expires_at: new Date(Date.now() + 15 * 60 * 1000),
         used_at: null,
+        attempts: 0,
         created_at: new Date(),
       };
       resets.push(row);
@@ -100,13 +102,37 @@ function createState(options: {
 
     if (text.startsWith('SELECT id, user_id, code_hash')) {
       const email = String(params[0] ?? '');
+      const maxAttempts = Number(params[1] ?? Number.MAX_SAFE_INTEGER);
       const now = Date.now();
       const rows = resets
-        .filter((row) => row.email === email && row.used_at === null && row.expires_at.getTime() > now)
+        .filter(
+          (row) =>
+            row.email === email &&
+            row.used_at === null &&
+            row.expires_at.getTime() > now &&
+            row.attempts < maxAttempts,
+        )
         .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
         .slice(0, 5)
-        .map((row) => ({ id: row.id, user_id: row.user_id, code_hash: row.code_hash }));
+        .map((row) => ({
+          id: row.id,
+          user_id: row.user_id,
+          code_hash: row.code_hash,
+          attempts: row.attempts,
+        }));
       return { rows, rowCount: rows.length };
+    }
+
+    if (text.startsWith('UPDATE password_resets SET attempts = attempts + 1')) {
+      const ids = (params[0] as number[]) ?? [];
+      let count = 0;
+      for (const row of resets) {
+        if (ids.includes(row.id)) {
+          row.attempts += 1;
+          count += 1;
+        }
+      }
+      return { rows: [], rowCount: count };
     }
 
     if (text.startsWith('UPDATE users SET password_hash')) {
@@ -219,7 +245,8 @@ test('forgot-password: 4th request within an hour is rate-limited silently', asy
       id: i,
       user_id: 7,
       email,
-      code_hash: hashCode(String(100000 + i)),
+      attempts: 0,
+        code_hash: hashCode(String(100000 + i)),
       expires_at: new Date(now + 15 * 60 * 1000),
       used_at: null,
       created_at: new Date(now - i * 60 * 1000),
@@ -251,6 +278,7 @@ test('reset-password: correct code updates password, marks code used, and invali
         id: 1,
         user_id: 55,
         email,
+        attempts: 0,
         code_hash: hashCode(code),
         expires_at: new Date(Date.now() + 10 * 60 * 1000),
         used_at: null,
@@ -260,6 +288,7 @@ test('reset-password: correct code updates password, marks code used, and invali
         id: 2,
         user_id: 55,
         email,
+        attempts: 0,
         code_hash: hashCode('111111'),
         expires_at: new Date(Date.now() + 10 * 60 * 1000),
         used_at: null,
@@ -299,6 +328,7 @@ test('reset-password: wrong code returns 400 and leaves password untouched', asy
         id: 1,
         user_id: 77,
         email,
+        attempts: 0,
         code_hash: hashCode('222222'),
         expires_at: new Date(Date.now() + 10 * 60 * 1000),
         used_at: null,
@@ -335,6 +365,7 @@ test('reset-password: expired code returns 400', async (t) => {
         id: 1,
         user_id: 81,
         email,
+        attempts: 0,
         code_hash: hashCode(code),
         expires_at: new Date(Date.now() - 60 * 1000),
         used_at: null,
@@ -368,6 +399,7 @@ test('reset-password: already-used code returns 400', async (t) => {
         id: 1,
         user_id: 91,
         email,
+        attempts: 0,
         code_hash: hashCode(code),
         expires_at: new Date(Date.now() + 10 * 60 * 1000),
         used_at: new Date(),
@@ -389,4 +421,55 @@ test('reset-password: already-used code returns 400', async (t) => {
 
   assert.equal(response.status, 400);
   assert.match(body.error ?? '', /invalid or expired/i);
+});
+
+test('reset-password: failed attempts accumulate and lock the row after MAX_ATTEMPTS', async (t) => {
+  const email = 'locktest@example.com';
+  const realCode = '424242';
+  const state = createState({
+    users: [{ id: 101, email, password_hash: '$2a$12$old' }],
+    resets: [
+      {
+        id: 7001,
+        user_id: 101,
+        email,
+        attempts: 0,
+        code_hash: hashCode(realCode),
+        expires_at: new Date(Date.now() + 10 * 60 * 1000),
+        used_at: null,
+        created_at: new Date(),
+      },
+    ],
+  });
+  installDbMock(t, state.handler);
+
+  const route = await import('../app/api/auth/reset-password/route');
+
+  // Fire 5 wrong guesses — row attempts should increment each time.
+  for (let i = 0; i < 5; i += 1) {
+    const response = await route.POST(
+      jsonRequest('http://localhost/api/auth/reset-password', {
+        email,
+        code: '000000',
+        password: 'NewPass!1',
+      }),
+    );
+    assert.equal(response.status, 400);
+  }
+  assert.equal(state.resets[0].attempts, 5, 'row should have 5 failed attempts recorded');
+
+  // Now the correct code should ALSO be rejected — row is locked because
+  // attempts >= MAX_ATTEMPTS_PER_ROW (5). User must request a new code.
+  const lockedResponse = await route.POST(
+    jsonRequest('http://localhost/api/auth/reset-password', {
+      email,
+      code: realCode,
+      password: 'NewPass!1',
+    }),
+  );
+  const lockedBody = (await lockedResponse.json()) as { error?: string };
+  assert.equal(lockedResponse.status, 400);
+  assert.match(lockedBody.error ?? '', /invalid or expired/i);
+  // User password must NOT have been updated.
+  assert.equal(state.users[0].password_hash, '$2a$12$old');
 });


### PR DESCRIPTION
## Summary

Wave 4 of the site audit — a full self-serve password reset feature. Closes C3 from the audit ("No self-serve password reset — users can be permanently locked out").

Replaces the login page's static "Password reset is not self-serve yet" with a working Forgot password? link. Request a code by email → enter the 6-digit code + new password → sign in with the new password.

## Architecture

- **DB:** new \`password_resets\` table (user_id FK, email, code_hash, expires_at, used_at, created_at) + index on (email, created_at DESC)
- **Email:** Resend SDK wrapped in \`lib/email.ts\`, branded HTML + plain-text fallback. Needs \`RESEND_API_KEY\` and \`EMAIL_FROM\` env vars.
- **APIs:** \`POST /api/auth/forgot-password\` (always returns success, no oracle) and \`POST /api/auth/reset-password\` (validates code + updates password transactionally)
- **Pages:** \`/forgot-password\` already existed; new \`/reset-password\` page added; login page shows a success banner on \`?reset=success\`

## Security

- No email enumeration — both forgot-password paths return identical success responses
- Codes stored as SHA-256, never plaintext
- \`crypto.timingSafeEqual\` for constant-time comparison
- Rate limited via DB count (max 3 per email per hour)
- Single-use codes via \`used_at\`; all siblings invalidated on successful reset
- 15-minute TTL enforced in the WHERE clause
- OAuth-managed users (\`password_hash='oauth_managed'\`) silently skipped
- Transactional password update with bcrypt cost 12

## Tests

\`tests/password-reset.test.ts\` — 8/8 passing:

1. forgot-password with valid email sends code
2. forgot-password with unknown email returns success (no oracle)
3. forgot-password with OAuth-managed email silently skips
4. forgot-password rate limit silently blocks 4th request in 1hr
5. reset-password with correct code updates password + invalidates siblings
6. reset-password with wrong code returns error (password unchanged)
7. reset-password with expired code returns error
8. reset-password with already-used code returns error

Mocks \`pool.connect\` + \`pool.query\` via \`t.mock.method\`, email send via a \`globalThis\` test hook.

## Files (13)

### Created
- \`app/api/auth/forgot-password/route.ts\`
- \`app/api/auth/reset-password/route.ts\`
- \`app/reset-password/page.tsx\` + \`page-client.tsx\`
- \`lib/email.ts\` (Resend integration)
- \`tests/password-reset.test.ts\` (8 tests)

### Modified
- \`scripts/init-db.js\` (new table + index)
- \`package.json\` + \`package-lock.json\` (\`resend@^4.0.0\`)
- \`frontend/auth/login-form.tsx\` (Forgot password? link)
- \`frontend/auth/ForgotPasswordForm.tsx\` (wired to API, removed dead stubs)
- \`frontend/auth/reset-password-form.tsx\` (added OTP input, wired to API, removed dead stubs)
- \`app/forgot-password/page.tsx\` (new onSubmit signature)
- \`app/login/page-client.tsx\` (success banner on \`?reset=success\`)

## Deploy checklist

Before merging:
- [ ] Add \`RESEND_API_KEY\` to production env vars (get from https://resend.com dashboard)
- [ ] Add \`EMAIL_FROM\` — default is \`Aries AI <noreply@aries.sugarandleather.com>\`; adjust if a different from address is desired
- [ ] Verify the from domain in Resend (must be DNS-verified before emails will send)

After merge:
- [ ] Run \`npm run db:init\` on the VM (or next deploy picks it up) to create the \`password_resets\` table

## Test plan

- [ ] \`tsx --test tests/password-reset.test.ts\` — confirmed 8/8 pass locally
- [ ] Visit /login → click "Forgot password?" → enter test email
- [ ] Check inbox for 6-digit code email
- [ ] Visit /reset-password?email=... → enter code + new password
- [ ] Login with new password → success banner "Password updated — sign in with your new password"
- [ ] Request 4 codes in under an hour → confirm 4th request silently succeeds but no email is sent (rate limit)
- [ ] Try reset with wrong code → confirm error, password unchanged
- [ ] Try reset with already-used code → confirm error
- [ ] Wait 16 minutes, try reset with expired code → confirm error

🤖 Generated with [Claude Code](https://claude.com/claude-code)