### PR TITLE
fix: site audit wave 5 — strengthen hero copy (UX-13)

### DIFF
--- a/frontend/donor/marketing/home-page.tsx
+++ b/frontend/donor/marketing/home-page.tsx
@@ -346,7 +346,7 @@ function Hero() {
           <motion.div style={{ opacity: useTransform(smoothProgress, [0, 0.05], [1, 0]) }} className="mb-8">
             <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full glass-reflection relative">
               <Sparkles className="w-4 h-4 text-primary" />
-              <span className="text-sm font-medium text-white/80">Nothing goes live without your approval</span>
+              <span className="text-sm font-medium text-white/80">The system small businesses actually use to grow</span>
             </div>
           </motion.div>
 
@@ -357,8 +357,8 @@ function Hero() {
             }}
             className="text-3xl md:text-[3rem] lg:text-[4rem] font-bold tracking-tight mb-8 leading-[1.1]"
           >
-            Plan, create, approve, launch, and <br />
-            <span className="text-gradient">improve your marketing</span>
+            Marketing without a system is expensive. <br />
+            <span className="text-gradient">Aries gives you the system.</span>
           </motion.h1>
 
           <motion.p
@@ -368,7 +368,7 @@ function Hero() {
             }}
             className="max-w-2xl mx-auto text-[1rem] text-white/60 mb-12"
           >
-            Aries gives business owners a calm workspace to see what is running, what needs approval, what is scheduled next, what is working, and what to do now.
+            Plan campaigns, approve creative, launch safely. Nothing goes live without your approval — and you always know what is running, what needs your sign-off, and what is working.
           </motion.p>
 
           <motion.div


### PR DESCRIPTION
## Summary

Wave 5 of the site audit. Rewrites the landing page hero to lead with pain before solution (UX-13).

### The problem

The old hero led with reassurance:

- **Eyebrow:** "Nothing goes live without your approval"
- **H1:** "Plan, create, approve, launch, and improve your marketing"
- **Body:** "Aries gives business owners a calm workspace to see what is running..."

For the ICP (small business owners), this is backwards. They aren't primarily afraid of bad launches — they're overwhelmed, time-starved, and unsure whether marketing is working. Leading with reassurance before naming the pain feels like a solution searching for a problem.

### The fix

Pain-first, then solution. Approval-safe positioning is preserved but moves from hero promise to body proof, where it's more credible.

- **Eyebrow:** "The system small businesses actually use to grow"
- **H1:** "Marketing without a system is expensive. Aries gives you the system."
- **Body:** "Plan campaigns, approve creative, launch safely. Nothing goes live without your approval — and you always know what is running, what needs your sign-off, and what is working."

## Files changed (1)

- \`frontend/donor/marketing/home-page.tsx\` (+4 / -4)

## Test plan

- [ ] Visit / → confirm new hero copy renders
- [ ] Confirm the pain section further down the page still makes sense with the new hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)