### PR TITLE
fix(audit): login enumeration oracle, privacy/terms copy, missing channels, approver placeholder, reset-password empty-param

### DIFF
--- a/app/login/page-client.tsx
+++ b/app/login/page-client.tsx
@@ -1,17 +1,12 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 
 import AuthLayout from '../../frontend/auth/auth-layout';
 import LoginForm from '../../frontend/auth/login-form';
-import { EMAIL_DOES_NOT_EXIST_ERROR } from '@/lib/auth-error-message';
-import {
-  getLoginAuthErrorMessage,
-  resolveLoginErrorCode,
-  shouldRedirectLoginToSignup,
-} from '@/lib/login-auth-error';
+import { getLoginAuthErrorMessage } from '@/lib/login-auth-error';
 
 function savedDraftMessage(draftSaved: string | null, businessName: string | null): string | null {
   if (draftSaved !== '1') {
@@ -33,10 +28,6 @@ export default function LoginPageClient() {
   const [authError, setAuthError] = useState<string | null>(null);
   const callbackUrl = '/auth/post-login';
   const defaultEmail = searchParams.get('email') || '';
-  const queryErrorCode = useMemo(
-    () => resolveLoginErrorCode(searchParams.get('error'), searchParams.get('code')),
-    [searchParams],
-  );
   const savedMessage = useMemo(() => {
     if (searchParams.get('reset') === 'success') {
       return 'Password updated — sign in with your new password';
@@ -71,18 +62,6 @@ export default function LoginPageClient() {
     [searchParams],
   );
 
-  useEffect(() => {
-    if (queryErrorCode !== EMAIL_DOES_NOT_EXIST_ERROR) {
-      return;
-    }
-
-    const email = searchParams.get('email') || '';
-    if (typeof window !== 'undefined') {
-      window.alert("Email doesn't exist. Please sign up.");
-    }
-    router.replace(`/signup?email=${encodeURIComponent(email)}&notice=${EMAIL_DOES_NOT_EXIST_ERROR}`);
-  }, [queryErrorCode, router, searchParams]);
-
   const handleGoogleSuccess = () => {
     setIsLoading(true);
     setAuthError(null);
@@ -111,15 +90,6 @@ export default function LoginPageClient() {
       }
 
       if (result.error) {
-        if (shouldRedirectLoginToSignup(result.error, result.code)) {
-          if (typeof window !== 'undefined') {
-            window.alert("Email doesn't exist. Please sign up.");
-          }
-          router.push(`/signup?email=${encodeURIComponent(email)}&notice=${EMAIL_DOES_NOT_EXIST_ERROR}`);
-          router.refresh();
-          return;
-        }
-
         setAuthError(
           getLoginAuthErrorMessage(
             result.error,

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,10 +1,10 @@
 import MarketingLayout from '@/frontend/marketing/MarketingLayout';
 
 const PRINCIPLES = [
-  'Collect only data needed to run tenant workflows and show runtime status.',
-  'Use tenant context and authorization checks to prevent cross-tenant access.',
-  'Keep generated artifacts and approval states in controlled runtime storage.',
-  'Limit browser responses to safe DTOs and authenticated asset routes.',
+  'We only collect the information needed to run your campaigns and show you the status of your work.',
+  'Your campaign data stays tied to your account — other customers cannot see it.',
+  'Drafts, generated assets, and approval history are kept in secure storage that only your team can access.',
+  'We never publish or launch anything without your explicit approval.',
 ] as const;
 
 export default function PrivacyPage() {
@@ -16,7 +16,7 @@ export default function PrivacyPage() {
             <p className="text-xs uppercase tracking-[0.3em] text-primary mb-3">Legal</p>
             <h1 className="text-4xl font-bold mb-3">Privacy Policy</h1>
             <p className="text-white/60">
-              This policy outlines how Aries handles tenant campaign data and runtime artifacts.
+              This policy explains what information Aries collects to run your marketing campaigns and how it&apos;s protected.
             </p>
           </div>
           <div className="glass rounded-[2rem] p-6">
@@ -27,6 +27,15 @@ export default function PrivacyPage() {
                 </li>
               ))}
             </ul>
+          </div>
+          <div className="glass rounded-[2rem] p-6 text-white/70 leading-relaxed">
+            <p>
+              Questions about your data or want to request export or deletion? Email{' '}
+              <a href="mailto:support@sugarandleather.com" className="underline hover:text-white">
+                support@sugarandleather.com
+              </a>
+              .
+            </p>
           </div>
         </div>
       </section>

--- a/app/reset-password/page-client.tsx
+++ b/app/reset-password/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import AuthLayout from '../../frontend/auth/auth-layout';
@@ -9,8 +9,28 @@ import ResetPasswordForm from '../../frontend/auth/reset-password-form';
 export default function ResetPasswordPageClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const email = searchParams.get('email') || '';
+  const email = (searchParams.get('email') || '').trim();
   const [isLoading, setIsLoading] = useState(false);
+
+  // Without an email we have nothing to submit against /api/auth/reset-password
+  // (the server requires email + code + password). Send the user back to
+  // /forgot-password to start from the top instead of rendering a form that
+  // can only fail.
+  useEffect(() => {
+    if (!email) {
+      router.replace('/forgot-password');
+    }
+  }, [email, router]);
+
+  if (!email) {
+    return (
+      <AuthLayout>
+        <div className="mx-auto max-w-md rounded-2xl border border-white/10 bg-white/5 px-6 py-10 text-center text-white/70">
+          Redirecting to password reset request…
+        </div>
+      </AuthLayout>
+    );
+  }
 
   const handleNavigate = (view: string) => {
     if (view === 'login') {

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -2,20 +2,20 @@ import MarketingLayout from '@/frontend/marketing/MarketingLayout';
 
 const SECTIONS = [
   {
-    title: 'Service scope',
-    body: 'Aries provides campaign orchestration, marketing workflow automation, and related analytics surfaces for tenant-authorized operators.',
+    title: 'What Aries does',
+    body: 'Aries plans, creates, and helps you launch marketing campaigns. You can review every piece of work before anything goes live.',
   },
   {
     title: 'Acceptable use',
-    body: 'You agree to use the service for lawful business activity and avoid content that violates platform rules, intellectual property rights, or privacy obligations.',
+    body: 'You agree to use Aries for lawful business activity and to follow each ad platform\u2019s own rules. Don\u2019t use Aries to create content that infringes copyright, violates privacy, or misleads people.',
   },
   {
-    title: 'Data handling',
-    body: 'Campaign inputs and generated artifacts are processed for workflow execution and status reporting. Tenant boundaries and route authorization controls apply.',
+    title: 'Your data',
+    body: 'We use the information you provide to generate campaigns and show you the status of your work. We don\u2019t share your campaign data with other customers, and we don\u2019t sell it.',
   },
   {
-    title: 'Operational changes',
-    body: 'The service may evolve over time. Material updates to these terms should be reviewed periodically by account owners and operators.',
+    title: 'Changes to these terms',
+    body: 'We may update these terms as the product evolves. When we make material changes, we\u2019ll notify account owners so you have time to review.',
   },
 ] as const;
 
@@ -28,7 +28,7 @@ export default function TermsPage() {
             <p className="text-xs uppercase tracking-[0.3em] text-primary mb-3">Legal</p>
             <h1 className="text-4xl font-bold mb-3">Terms of Service</h1>
             <p className="text-white/60">
-              These terms summarize the service boundary for Aries runtime and campaign operations.
+              A plain-language summary of what you can expect from Aries and what we expect from you.
             </p>
           </div>
           <div className="grid gap-4">

--- a/auth.ts
+++ b/auth.ts
@@ -6,7 +6,6 @@ import pool from "./lib/db";
 import { resolveAuthRuntimeConfig } from "./lib/auth-runtime-config";
 import {
   DATABASE_UNAVAILABLE_ERROR,
-  EMAIL_DOES_NOT_EXIST_ERROR,
   GOOGLE_SIGN_IN_REQUIRED_ERROR,
 } from "./lib/auth-error-message";
 import { ensureUserJourneySchema } from "./lib/auth-user-journey";
@@ -25,10 +24,6 @@ const authRuntime = resolveAuthRuntimeConfig(process.env);
 
 class DatabaseUnavailableCredentialsError extends CredentialsSignin {
   code = DATABASE_UNAVAILABLE_ERROR;
-}
-
-class EmailDoesNotExistCredentialsError extends CredentialsSignin {
-  code = EMAIL_DOES_NOT_EXIST_ERROR;
 }
 
 class GoogleSignInRequiredCredentialsError extends CredentialsSignin {
@@ -77,7 +72,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           );
 
           if ((result.rowCount ?? 0) === 0) {
-            throw new EmailDoesNotExistCredentialsError();
+            // Don't signal "email not found" distinctly — that was a user
+            // enumeration oracle. Return null (generic "Invalid email or
+            // password") just like a wrong-password outcome. The signup CTA
+            // below the login form handles the legitimate "I don't have an
+            // account" UX without needing a server-side signal.
+            return null;
           }
 
           const row = result.rows[0] as {

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -90,6 +90,21 @@ const CHANNEL_OPTIONS: ChannelOption[] = [
     description: 'Organic posts, stories, and reels on Instagram.',
   },
   {
+    id: 'email',
+    label: 'Email Marketing',
+    description: 'Automated email campaigns and sequences.',
+  },
+  {
+    id: 'tiktok',
+    label: 'TikTok',
+    description: 'Short-form video ads and organic content.',
+  },
+  {
+    id: 'youtube',
+    label: 'YouTube',
+    description: 'Video ads, shorts, and channel content.',
+  },
+  {
     id: 'google-business',
     label: 'Google Business',
     description: 'Local presence, reviews, and Google Maps visibility.',
@@ -195,21 +210,21 @@ function urlChipFromValue(value: string): UrlChipState {
 function recommendedChannelsForBusinessType(businessType: string): string[] {
   const normalized = businessType.trim().toLowerCase();
   if (!normalized) {
-    return ['meta-ads', 'instagram-organic'];
+    return ['meta-ads', 'instagram'];
   }
   const localKeywords = ['local', 'restaurant', 'retail', 'service', 'salon', 'clinic', 'store', 'shop'];
   const saasKeywords = ['saas', 'software', 'b2b', 'agency', 'platform', 'technology', 'tech'];
   const ecomKeywords = ['ecommerce', 'e-commerce', 'commerce', 'dtc', 'direct-to-consumer', 'online store', 'brand'];
   if (localKeywords.some((kw) => normalized.includes(kw))) {
-    return ['meta-ads', 'instagram-organic', 'google-business'];
+    return ['meta-ads', 'instagram', 'google-business'];
   }
   if (saasKeywords.some((kw) => normalized.includes(kw))) {
     return ['linkedin', 'meta-ads', 'email'];
   }
   if (ecomKeywords.some((kw) => normalized.includes(kw))) {
-    return ['meta-ads', 'instagram-organic', 'email', 'tiktok'];
+    return ['meta-ads', 'instagram', 'email', 'tiktok'];
   }
-  return ['meta-ads', 'instagram-organic'];
+  return ['meta-ads', 'instagram'];
 }
 
 function firstPresent(...values: Array<string | null | undefined>): string | null {
@@ -1327,7 +1342,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                         onChange={(event) => setApproverName(event.target.value)}
                         onBlur={() => markTouched('approverName')}
                         className={fieldInputClassName}
-                        placeholder="Audrey"
+                        placeholder="Your name"
                       />
                     </Field>
                     <Field

--- a/lib/auth-error-message.ts
+++ b/lib/auth-error-message.ts
@@ -4,7 +4,11 @@ export const GOOGLE_SIGN_IN_REQUIRED_ERROR = "GoogleSignInRequired";
 
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
   CredentialsSignin: "Invalid email or password.",
-  [EMAIL_DOES_NOT_EXIST_ERROR]: "Email doesn't exist. Please sign up.",
+  // Kept for defense-in-depth so any lingering surface that still emits this
+  // code shows the same generic response as wrong-password (no enumeration).
+  // The server no longer emits it — see auth.ts authorize() — but a stale
+  // client referencing the old query param still renders the safe string.
+  [EMAIL_DOES_NOT_EXIST_ERROR]: "Invalid email or password.",
   [GOOGLE_SIGN_IN_REQUIRED_ERROR]:
     "This account uses Google sign-in. Continue with Google to access it.",
   AccessDenied:

--- a/lib/login-auth-error.ts
+++ b/lib/login-auth-error.ts
@@ -1,7 +1,4 @@
-import {
-  getAuthErrorMessage,
-  EMAIL_DOES_NOT_EXIST_ERROR,
-} from "./auth-error-message";
+import { getAuthErrorMessage } from "./auth-error-message";
 
 export function resolveLoginErrorCode(
   error: string | null | undefined,
@@ -20,13 +17,6 @@ export function resolveLoginErrorCode(
   }
 
   return code;
-}
-
-export function shouldRedirectLoginToSignup(
-  error: string | null | undefined,
-  code: string | null | undefined,
-): boolean {
-  return resolveLoginErrorCode(error, code) === EMAIL_DOES_NOT_EXIST_ERROR;
 }
 
 export function getLoginAuthErrorMessage(

--- a/tests/auth/auth-error-message.test.ts
+++ b/tests/auth/auth-error-message.test.ts
@@ -11,7 +11,10 @@ test("returns null when there is no auth error", () => {
 test("maps known auth errors to user-facing guidance", () => {
   assert.match(getAuthErrorMessage("AccessDenied") ?? "", /database connection/i);
   assert.match(getAuthErrorMessage("DatabaseUnavailable") ?? "", /Postgres database/i);
-  assert.match(getAuthErrorMessage("EmailDoesNotExist") ?? "", /please sign up/i);
+  // The EmailDoesNotExist code must not surface a distinct user-facing string
+  // — that was an email-enumeration oracle. We map it to the same generic
+  // "Invalid email or password." response as plain CredentialsSignin.
+  assert.equal(getAuthErrorMessage("EmailDoesNotExist"), "Invalid email or password.");
   assert.match(getAuthErrorMessage("GoogleSignInRequired") ?? "", /continue with google/i);
   assert.match(getAuthErrorMessage("Configuration") ?? "", /AUTH_SECRET/i);
   assert.match(getAuthErrorMessage("UntrustedHost") ?? "", /AUTH_TRUST_HOST=true/i);

--- a/tests/auth/login-auth-error.test.ts
+++ b/tests/auth/login-auth-error.test.ts
@@ -4,7 +4,6 @@ import test from "node:test";
 import {
   getLoginAuthErrorMessage,
   resolveLoginErrorCode,
-  shouldRedirectLoginToSignup,
 } from "../../lib/login-auth-error";
 
 test("uses the credentials code when Auth.js returns a custom credentials error", () => {
@@ -22,9 +21,14 @@ test("falls back to CredentialsSignin when Auth.js returns the default credentia
   assert.equal(resolveLoginErrorCode("CredentialsSignin", undefined), "CredentialsSignin");
 });
 
-test("flags unknown-email credentials failures for signup redirect", () => {
-  assert.equal(shouldRedirectLoginToSignup("CredentialsSignin", "EmailDoesNotExist"), true);
-  assert.equal(shouldRedirectLoginToSignup("CredentialsSignin", "credentials"), false);
+test("does not expose an 'email doesn't exist' user-facing message (enumeration protection)", () => {
+  // Even if some stale client still has the old code in the query string, we
+  // render the generic credentials-invalid message — the server side of this
+  // fix (auth.ts authorize()) no longer emits this code at all.
+  assert.equal(
+    getLoginAuthErrorMessage("CredentialsSignin", "EmailDoesNotExist", null),
+    "Invalid email or password.",
+  );
 });
 
 test("shows a Google-specific message for Google-managed accounts", () => {


### PR DESCRIPTION
## Summary

Addresses six findings from the production audit of aries.sugarandleather.com:

- **Critical:** kill the login email-enumeration oracle. Unknown emails + wrong passwords now produce identical responses. Removed the \`window.alert()\` and auto-redirect to /signup.
- **High:** restore missing Email / TikTok / YouTube channel options in the onboarding channel step. Fix the \`instagram-organic\` recommender id that didn't match any CHANNEL_OPTIONS entry.
- **Medium:** rewrite /privacy + /terms in user-facing language (removed "tenant workflows", "cross-tenant", "safe DTOs", "runtime artifacts", "tenant-authorized operators").
- **Medium:** replace the launch-approver \"Audrey\" placeholder with \"Your name\".
- **Medium:** /reset-password without an email query param now redirects to /forgot-password instead of rendering a form that can only fail.

## Not in this PR

- Catastrophic TTFB (infra issue, not a code fix here).
- Reset-password 500 on bogus code (the \`password_resets\` table is almost certainly missing on the VM — fix by running \`npm run db:init\` against the prod DB; the migration at [scripts/init-db.js:164](scripts/init-db.js#L164) is idempotent).
- Wave 6 autosave not deployed (deploy state, not code).
- /pricing + /about 404 (intentionally absent).
- aria-pressed + focus-ring contrast (covered by Wave 7 PR #114).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`tsx --test tests/auth/*.test.ts tests/onboarding-flow-public.test.ts tests/password-reset.test.ts\` → 21/21 pass
- [ ] After deploy: submit known-bad and known-good emails to /login — both should return identical "Invalid email or password." inline, no alert dialog, no redirect
- [ ] Visit /privacy and /terms — copy reads in plain language, no "tenant"/"runtime" jargon
- [ ] Onboarding channel step — Meta, Instagram, Email, TikTok, YouTube, Google Business, LinkedIn all visible
- [ ] Business step — approver placeholder reads "Your name"
- [ ] /reset-password with no email param — auto-redirects to /forgot-password

🤖 Generated with [Claude Code](https://claude.com/claude-code)