### PR TITLE
fix(audit-v3): homepage polish, dashboard cleanup, docs dev-command leak, per-page titles

### DIFF
--- a/app/[...publicPath]/route.ts
+++ b/app/[...publicPath]/route.ts
@@ -69,8 +69,8 @@ const NOT_FOUND_HTML = `<!doctype html>
   <body>
     <main class="card">
       <p class="eyebrow">404</p>
-      <h1>This route doesn&rsquo;t exist in the Aries runtime</h1>
-      <p>Head back to the homepage or go to login.</p>
+      <h1>Page not found</h1>
+      <p>The page you&rsquo;re looking for doesn&rsquo;t exist. Head back to the homepage or sign in.</p>
       <div class="actions">
         <a class="primary" href="/">Back to home</a>
         <a class="secondary" href="/login">Go to login</a>

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
     {
       status: 'error',
       reason: 'contact_not_configured',
-      message: 'Contact intake is not configured in this Aries runtime yet.',
+      message: 'The contact form is not available right now. Please try again later.',
       request: {
         name: safeString(body.name),
         email: safeString(body.email),

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,13 +1,14 @@
 import AppShellLayout from '../../frontend/app-shell/layout';
 import AriesHomeDashboard from '@/frontend/aries-v1/home-dashboard';
-import { getLatestPmBoardStandup } from '@/lib/pm-board-standup';
+
+export const metadata = {
+  title: 'Dashboard — Aries AI',
+};
 
 export default function DashboardPage() {
-  const latestStandup = getLatestPmBoardStandup();
-
   return (
     <AppShellLayout currentRouteId="home">
-      <AriesHomeDashboard latestStandup={latestStandup} />
+      <AriesHomeDashboard />
     </AppShellLayout>
   );
 }

--- a/app/documentation/page.tsx
+++ b/app/documentation/page.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import MarketingLayout from '../../frontend/marketing/MarketingLayout';
 import Docs from '../../frontend/documentation/Docs';
 
+export const metadata = {
+  title: 'Documentation — Aries AI',
+  description: 'Getting started with Aries AI — how to create your first campaign, connect channels, and approve creative.',
+};
+
 export default function DocumentationPage() {
   return (
     <MarketingLayout>
       <Docs />
-      <div className="hidden sr-only">
-        Direct architecture. Execution boundary.
-        npx next dev -p 8100 --turbopack
-        Commands engineers should run before shipping docs changes.
-      </div>
     </MarketingLayout>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,15 +1,19 @@
 import Link from 'next/link';
 
+export const metadata = {
+  title: 'Page not found — Aries AI',
+};
+
 export default function NotFound() {
   return (
     <div className="min-h-screen bg-background text-white flex items-center justify-center px-6">
       <div className="glass rounded-[2.5rem] p-10 md:p-14 max-w-2xl text-center">
         <p className="text-xs uppercase tracking-[0.3em] text-primary mb-4">404</p>
         <h1 className="text-5xl md:text-6xl font-bold mb-5">
-          This route doesn&apos;t exist in the <span className="text-gradient">Aries runtime</span>
+          <span className="text-gradient">Page not found</span>
         </h1>
         <p className="text-white/60 text-lg mb-8">
-          Head back to the homepage or go to login.
+          The page you&apos;re looking for doesn&apos;t exist. Head back to the homepage or sign in.
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Link href="/" className="px-8 py-4 rounded-full bg-gradient-to-r from-primary to-secondary text-white font-semibold shadow-xl shadow-primary/20">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,10 +1,14 @@
 import MarketingLayout from '@/frontend/marketing/MarketingLayout';
 
+export const metadata = {
+  title: 'Privacy Policy — Aries AI',
+};
+
 const PRINCIPLES = [
-  'Collect only data needed to run tenant workflows and show runtime status.',
-  'Use tenant context and authorization checks to prevent cross-tenant access.',
-  'Keep generated artifacts and approval states in controlled runtime storage.',
-  'Limit browser responses to safe DTOs and authenticated asset routes.',
+  'We only collect the information needed to run your campaigns and show you the status of your work.',
+  'Your campaign data stays tied to your account — other customers cannot see it.',
+  'Drafts, generated assets, and approval history are kept in secure storage that only your team can access.',
+  'We never publish or launch anything without your explicit approval.',
 ] as const;
 
 export default function PrivacyPage() {
@@ -16,7 +20,7 @@ export default function PrivacyPage() {
             <p className="text-xs uppercase tracking-[0.3em] text-primary mb-3">Legal</p>
             <h1 className="text-4xl font-bold mb-3">Privacy Policy</h1>
             <p className="text-white/60">
-              This policy outlines how Aries handles tenant campaign data and runtime artifacts.
+              This policy explains what information Aries collects to run your marketing campaigns and how it&apos;s protected.
             </p>
           </div>
           <div className="glass rounded-[2rem] p-6">
@@ -27,6 +31,15 @@ export default function PrivacyPage() {
                 </li>
               ))}
             </ul>
+          </div>
+          <div className="glass rounded-[2rem] p-6 text-white/70 leading-relaxed">
+            <p>
+              Questions about your data or want to request export or deletion? Email{' '}
+              <a href="mailto:support@sugarandleather.com" className="underline hover:text-white">
+                support@sugarandleather.com
+              </a>
+              .
+            </p>
           </div>
         </div>
       </section>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,21 +1,25 @@
 import MarketingLayout from '@/frontend/marketing/MarketingLayout';
 
+export const metadata = {
+  title: 'Terms of Service — Aries AI',
+};
+
 const SECTIONS = [
   {
-    title: 'Service scope',
-    body: 'Aries provides campaign orchestration, marketing workflow automation, and related analytics surfaces for tenant-authorized operators.',
+    title: 'What Aries does',
+    body: 'Aries plans, creates, and helps you launch marketing campaigns. You can review every piece of work before anything goes live.',
   },
   {
     title: 'Acceptable use',
-    body: 'You agree to use the service for lawful business activity and avoid content that violates platform rules, intellectual property rights, or privacy obligations.',
+    body: 'You agree to use Aries for lawful business activity and to follow each ad platform\u2019s own rules. Don\u2019t use Aries to create content that infringes copyright, violates privacy, or misleads people.',
   },
   {
-    title: 'Data handling',
-    body: 'Campaign inputs and generated artifacts are processed for workflow execution and status reporting. Tenant boundaries and route authorization controls apply.',
+    title: 'Your data',
+    body: 'We use the information you provide to generate campaigns and show you the status of your work. We don\u2019t share your campaign data with other customers, and we don\u2019t sell it.',
   },
   {
-    title: 'Operational changes',
-    body: 'The service may evolve over time. Material updates to these terms should be reviewed periodically by account owners and operators.',
+    title: 'Changes to these terms',
+    body: 'We may update these terms as the product evolves. When we make material changes, we\u2019ll notify account owners so you have time to review.',
   },
 ] as const;
 
@@ -28,7 +32,7 @@ export default function TermsPage() {
             <p className="text-xs uppercase tracking-[0.3em] text-primary mb-3">Legal</p>
             <h1 className="text-4xl font-bold mb-3">Terms of Service</h1>
             <p className="text-white/60">
-              These terms summarize the service boundary for Aries runtime and campaign operations.
+              A plain-language summary of what Aries does for you and what we expect from you.
             </p>
           </div>
           <div className="grid gap-4">

--- a/frontend/aries-v1/home-dashboard.tsx
+++ b/frontend/aries-v1/home-dashboard.tsx
@@ -12,9 +12,8 @@ import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { LoadingStateGrid } from './components';
 import DashboardHomePresenter from './presenters/dashboard-home-presenter';
 import { createDashboardHomeViewModel } from './view-models/dashboard-home';
-import type { PmBoardStandupSnapshot } from '@/lib/pm-board-standup';
 
-export default function AriesHomeDashboard({ latestStandup = null }: { latestStandup?: PmBoardStandupSnapshot | null }) {
+export default function AriesHomeDashboard() {
   const campaigns = useRuntimeCampaigns({ autoLoad: true });
   const reviews = useRuntimeReviews({ autoLoad: true });
   const profile = useBusinessProfile({ autoLoad: true });
@@ -55,7 +54,6 @@ export default function AriesHomeDashboard({ latestStandup = null }: { latestSta
   return (
     <DashboardHomePresenter
       model={model}
-      latestStandup={latestStandup}
       channelsState={integrations.isLoading ? 'loading' : integrations.error ? 'error' : 'ready'}
       channelsErrorMessage={customerSafeUiErrorMessage(
         integrations.error?.message ?? null,

--- a/frontend/aries-v1/presenters/dashboard-home-presenter.tsx
+++ b/frontend/aries-v1/presenters/dashboard-home-presenter.tsx
@@ -6,7 +6,6 @@ import { motion } from 'motion/react';
 import {
   ArrowRight,
   CheckCheck,
-  ChevronDown,
   ChevronRight,
   Globe2,
   Layers3,
@@ -15,13 +14,11 @@ import {
   Zap,
 } from 'lucide-react';
 
-import { EmptyStatePanel, ShellPanel, StatusChip } from '@/frontend/aries-v1/components';
+import { ShellPanel, StatusChip } from '@/frontend/aries-v1/components';
 import type { DashboardHomeViewModel } from '@/frontend/aries-v1/view-models/dashboard-home';
-import type { PmBoardStandupSnapshot } from '@/lib/pm-board-standup';
 
 export interface DashboardHomePresenterProps {
   model: DashboardHomeViewModel;
-  latestStandup?: PmBoardStandupSnapshot | null;
   channelsState?: 'loading' | 'ready' | 'error';
   channelsErrorMessage?: string | null;
   /** When set, connected channels with `canDisconnect` show a Disconnect control. */
@@ -40,7 +37,6 @@ type OrbitSurface = {
 
 export default function DashboardHomePresenter({
   model,
-  latestStandup = null,
   channelsState = 'ready',
   channelsErrorMessage,
   onChannelDisconnect,
@@ -542,91 +538,7 @@ export default function DashboardHomePresenter({
             )}
           </div>
         </motion.section>
-
-        <motion.section
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.32 }}
-          className="md:col-span-2"
-        >
-          <ShellPanel eyebrow="PM Board Standup" title={latestStandup ? latestStandup.title : 'Latest standup not available yet'}>
-            {latestStandup ? (
-              <div className="space-y-5">
-                <div className="flex flex-wrap items-center gap-3">
-                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.05] px-3 py-1.5 text-xs font-medium uppercase tracking-[0.18em] text-white/70">
-                    {latestStandup.date}
-                  </span>
-                  <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium uppercase tracking-[0.18em] ${latestStandup.status === 'complete' ? 'border-emerald-400/25 bg-emerald-400/10 text-emerald-100' : latestStandup.status === 'failed' ? 'border-rose-400/25 bg-rose-400/10 text-rose-100' : 'border-amber-400/25 bg-amber-400/10 text-amber-100'}`}>
-                    {latestStandup.status}
-                  </span>
-                  <span className="text-sm text-white/45">PM Board is the work-state source of truth. This panel surfaces the latest persisted standup artifact.</span>
-                </div>
-
-                <div className="grid gap-4 md:grid-cols-3">
-                  <StandupInfoCard label="Board path" value={latestStandup.boardPath || 'Not recorded'} />
-                  <StandupInfoCard label="Transcript" value={latestStandup.transcriptPath} />
-                  <StandupInfoCard label="Chief reports" value={latestStandup.reportDirectory || 'Not recorded'} />
-                </div>
-
-                <div className="rounded-[1.5rem] border border-white/[0.08] bg-black/20 p-5">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/35">Top summary</p>
-                  <p className="mt-3 text-sm leading-7 text-white/70">{latestStandup.preview}</p>
-                </div>
-
-                <details className="rounded-[1.5rem] border border-white/[0.08] bg-white/[0.04]">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-left">
-                    <div>
-                      <p className="text-sm font-semibold text-white">Read full standup</p>
-                      <p className="mt-1 text-sm text-white/50">Expand to read the actual persisted standup transcript in the dashboard.</p>
-                    </div>
-                    <span className="inline-flex items-center gap-2 text-sm text-white/60">
-                      Expand
-                      <ChevronDown className="h-4 w-4" />
-                    </span>
-                  </summary>
-                  <div className="border-t border-white/[0.08] px-5 py-5">
-                    <pre className="max-h-[34rem] overflow-auto whitespace-pre-wrap break-words rounded-[1rem] border border-white/[0.08] bg-black/25 p-4 text-sm leading-7 text-white/72">{latestStandup.transcriptBody}</pre>
-                  </div>
-                </details>
-
-                <div className="grid gap-3 md:grid-cols-3">
-                  {latestStandup.chiefs.map((chief) => (
-                    <div key={chief.chiefId} className="rounded-[1.5rem] border border-white/[0.08] bg-white/[0.04] p-5">
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <p className="text-sm font-semibold text-white">{chief.title}</p>
-                          <p className="mt-1 text-xs uppercase tracking-[0.22em] text-white/35">{chief.reportStatus}</p>
-                        </div>
-                        <span className="text-xs text-white/45">{chief.currentStatus}</span>
-                      </div>
-                      <div className="mt-4 space-y-2 text-sm text-white/60">
-                        <p><span className="text-white/35">Task:</span> {chief.activeTaskId || 'None recorded'}</p>
-                        <p><span className="text-white/35">Blockers:</span> {chief.blockedCount}</p>
-                        <p><span className="text-white/35">Routing:</span> {chief.needsRouting ? 'Needed' : 'Clear'}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : (
-              <EmptyStatePanel
-                compact
-                title="No standup artifacts found"
-                description="No persisted standup transcript was found in /home/node/.openclaw/projects/shared/teams/meetings."
-              />
-            )}
-          </ShellPanel>
-        </motion.section>
       </div>
-    </div>
-  );
-}
-
-function StandupInfoCard(props: { label: string; value: string }) {
-  return (
-    <div className="rounded-[1.25rem] border border-white/[0.08] bg-white/[0.04] p-4">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/35">{props.label}</p>
-      <p className="mt-2 break-all text-sm leading-6 text-white/70">{props.value}</p>
     </div>
   );
 }

--- a/frontend/aries-v1/view-models/calendar.ts
+++ b/frontend/aries-v1/view-models/calendar.ts
@@ -80,7 +80,7 @@ export function createCalendarViewModel(campaigns: RuntimeCampaignListItem[]): C
       eyebrow: 'Calendar',
       title: 'What is going out and when',
       description:
-        'This calendar restores the visual month view while staying honest: every tile comes from Aries runtime schedule events that already exist.',
+        'A month-at-a-glance view of everything scheduled to go out — every tile reflects a real campaign step.',
       metrics: [
         {
           label: 'Upcoming items',

--- a/frontend/donor/marketing/chrome.tsx
+++ b/frontend/donor/marketing/chrome.tsx
@@ -81,12 +81,14 @@ export function DonorNavbar({ heroMode = false }: { heroMode?: boolean }) {
       )}
     >
       <div className="max-w-7xl mx-auto flex items-center justify-between gap-6">
-        <a href="/" className="flex items-center gap-2">
-          <AriesMark className={cn('transition-opacity duration-300', showIcon ? 'opacity-100' : 'opacity-0')} />
-          <span className="text-xl font-bold tracking-tight text-white" style={{ opacity: headerOpacity }}>
+        <a href="/" className="flex items-center gap-2" aria-label="Aries AI — home">
+          <AriesMark
+            className={cn('transition-opacity duration-300', showIcon ? 'opacity-100' : 'opacity-0')}
+            decorative
+          />
+          <span className="text-xl font-bold tracking-tight text-white" aria-hidden="true" style={{ opacity: headerOpacity }}>
             Aries AI
           </span>
-          <span className="sr-only">Aries AI</span>
         </a>
 
         <div className="hidden md:flex items-center gap-8" style={headerOverlayStyle}>

--- a/frontend/donor/marketing/home-page.tsx
+++ b/frontend/donor/marketing/home-page.tsx
@@ -526,7 +526,7 @@ function Hero() {
                 </div>
                 <span className="font-bold text-white">Scheduled</span>
               </div>
-              <p className="text-sm font-medium text-white/50 tracking-tight">Thu, Apr 2 at 8:30 AM</p>
+              <p className="text-sm font-medium text-white/50 tracking-tight">Next Thu at 8:30 AM</p>
             </motion.div>
           </div>
         </div>
@@ -1227,18 +1227,21 @@ function EarlyAccessSignup() {
           source: 'marketing-homepage',
         }),
       });
-      const result = (await response.json()) as { message?: string };
+
+      // Parse defensively — an empty body, HTML error page, or CDN 502 would
+      // otherwise surface as a raw "Unexpected end of JSON input" to the user.
+      const result = (await response.json().catch(() => ({}))) as { message?: string };
 
       if (!response.ok) {
-        throw new Error(result.message || 'We could not save your email right now.');
+        throw new Error(result.message || 'We could not save your email right now. Please try again in a moment.');
       }
 
       setStatus('success');
       setMessage(result.message || "You're on the early access list.");
       setEmail('');
-    } catch (error) {
+    } catch {
       setStatus('error');
-      setMessage(error instanceof Error ? error.message : 'We could not save your email right now.');
+      setMessage('We could not save your email right now. Please try again in a moment.');
     }
   }
 
@@ -1259,7 +1262,7 @@ function EarlyAccessSignup() {
                 Early access
               </span>
               <h2 className="mt-6 text-4xl font-light leading-tight md:text-[52px]">
-                Sign in to get <span className="text-gradient">early access</span>
+                Request <span className="text-gradient">early access</span>
               </h2>
               <p className="mt-6 max-w-2xl text-lg leading-8 text-white/62">
                 Join the first group of businesses getting Aries for campaign planning, approval-safe creative, launch scheduling, and clear weekly results.
@@ -1288,7 +1291,12 @@ function EarlyAccessSignup() {
               </div>
             </div>
 
-            <form onSubmit={handleSubmit} className="flex min-h-[390px] flex-col justify-center rounded-[2rem] border border-white/10 bg-black/25 p-5 shadow-2xl shadow-black/20">
+            <form
+              method="post"
+              action="/api/early-access"
+              onSubmit={handleSubmit}
+              className="flex min-h-[390px] flex-col justify-center rounded-[2rem] border border-white/10 bg-black/25 p-5 shadow-2xl shadow-black/20"
+            >
               <label className="block text-sm font-semibold text-white/80" htmlFor="early-access-email">
                 Work email
               </label>

--- a/frontend/donor/marketing/home-page.tsx
+++ b/frontend/donor/marketing/home-page.tsx
@@ -1239,9 +1239,13 @@ function EarlyAccessSignup() {
       setStatus('success');
       setMessage(result.message || "You're on the early access list.");
       setEmail('');
-    } catch {
+    } catch (error) {
       setStatus('error');
-      setMessage('We could not save your email right now. Please try again in a moment.');
+      setMessage(
+        error instanceof Error && error.message
+          ? error.message
+          : 'We could not save your email right now. Please try again in a moment.',
+      );
     }
   }
 
@@ -1303,6 +1307,7 @@ function EarlyAccessSignup() {
               <div className="mt-3 flex flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row">
                 <input
                   id="early-access-email"
+                  name="email"
                   type="email"
                   value={email}
                   onChange={(event) => setEmail(event.target.value)}

--- a/frontend/donor/ui.tsx
+++ b/frontend/donor/ui.tsx
@@ -9,6 +9,9 @@ export interface AriesMarkProps {
   sizes?: string;
   priority?: boolean;
   style?: CSSProperties;
+  /** Marks the image as decorative (alt=""). Use when an ancestor already
+   *  provides the accessible name (e.g. a brand link with aria-label). */
+  decorative?: boolean;
 }
 
 export function AriesMark({
@@ -17,11 +20,15 @@ export function AriesMark({
   sizes = '80px',
   priority = false,
   style,
+  decorative = false,
 }: AriesMarkProps) {
+  // When an ancestor already provides the accessible name (e.g. a brand link
+  // with aria-label="Aries AI — home"), callers pass `decorative` so this
+  // image doesn't add a redundant announcement.
   return (
     <Image
       src="/ariesai-logo.webp"
-      alt="Aries AI Logo"
+      alt={decorative ? '' : 'Aries AI Logo'}
       width={500}
       height={500}
       sizes={sizes}

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -256,11 +256,17 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
 
               <button
                 type="submit"
-                disabled={submitting}
-                className="w-full rounded-full bg-gradient-to-r from-primary to-secondary px-6 py-4 text-white font-semibold shadow-xl shadow-primary/20 disabled:opacity-60"
+                disabled={submitting || !websiteUrl.trim()}
+                className="w-full rounded-full bg-gradient-to-r from-primary to-secondary px-6 py-4 text-white font-semibold shadow-xl shadow-primary/20 disabled:opacity-60 disabled:cursor-not-allowed"
+                aria-describedby={!websiteUrl.trim() ? 'start-campaign-hint' : undefined}
               >
                 {submitting ? 'Starting campaign...' : 'Start campaign'}
               </button>
+              {!websiteUrl.trim() && !submitting && (
+                <p id="start-campaign-hint" className="mt-2 text-center text-xs text-white/45">
+                  Enter a website URL to start the campaign.
+                </p>
+              )}
 
               {errorText ? (
                 <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-red-100">{errorText}</div>

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -258,7 +258,7 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
                 type="submit"
                 disabled={submitting || !websiteUrl.trim()}
                 className="w-full rounded-full bg-gradient-to-r from-primary to-secondary px-6 py-4 text-white font-semibold shadow-xl shadow-primary/20 disabled:opacity-60 disabled:cursor-not-allowed"
-                aria-describedby={!websiteUrl.trim() ? 'start-campaign-hint' : undefined}
+                aria-describedby={!websiteUrl.trim() && !submitting ? 'start-campaign-hint' : undefined}
               >
                 {submitting ? 'Starting campaign...' : 'Start campaign'}
               </button>

--- a/tests/public-marketing-pages.test.ts
+++ b/tests/public-marketing-pages.test.ts
@@ -69,7 +69,7 @@ test('public marketing pages return valid elements with expected route shells an
     const homeSource = readRepoFile('frontend/donor/marketing/home-page.tsx');
     const chromeSource = readRepoFile('frontend/donor/marketing/chrome.tsx');
     assert.match(homeSource, /Nothing goes live without your approval/);
-    assert.match(homeSource, /Plan, create, approve, launch, and/);
+    assert.match(homeSource, /Plan campaigns, approve creative, launch safely/);
     assert.match(homeSource, /Start with your business/);
     assert.match(homeSource, /\/onboarding\/start/);
     assert.doesNotMatch(homeSource, /\/onboarding\/pipeline-intake/);


### PR DESCRIPTION
## Summary

Net-new findings from the April-16 production audit that aren't already covered by #117 / #118 / earlier waves.

## Critical

- **`/documentation` leaked the literal dev command** \`npx next dev -p 8100 --turbopack\` in a \`<div className=\"hidden sr-only\">\` block. Removed entirely ([app/documentation/page.tsx](app/documentation/page.tsx)).
- **Homepage early-access form exposed \"Unexpected end of JSON input\"** to users on empty/non-JSON responses (CDN 502, HTML error pages). Parses defensively with \`.catch(() => ({}))\` and renders a friendly retry message. Also added \`method=\"post\"\` + \`action=\"/api/early-access\"\` so non-JS submissions don't fall back to GET with email in query string ([frontend/donor/marketing/home-page.tsx](frontend/donor/marketing/home-page.tsx)).

## High / Medium

- **Dashboard \"PM Board Standup\" panel** showed filesystem paths (\`/home/node/.openclaw/projects/shared/teams/meetings\`), transcript dumps, chief task IDs to customers. Removed panel + plumbing through 3 files ([frontend/aries-v1/presenters/dashboard-home-presenter.tsx](frontend/aries-v1/presenters/dashboard-home-presenter.tsx), [home-dashboard.tsx](frontend/aries-v1/home-dashboard.tsx), [app/dashboard/page.tsx](app/dashboard/page.tsx)).
- **New Campaign \"Start campaign\" button** enabled without required URL. Now disabled until \`websiteUrl.trim()\` + aria-described hint ([frontend/marketing/new-job.tsx](frontend/marketing/new-job.tsx)).
- **Duplicate accessible name** (\`Aries AI Logo Aries AI Aries AI\`) on homepage nav. Added \`aria-label=\"Aries AI — home\"\` on the brand link, \`decorative\` prop on AriesMark for alt=\"\", aria-hidden on visible wordmark ([chrome.tsx](frontend/donor/marketing/chrome.tsx), [ui.tsx](frontend/donor/ui.tsx)).
- **Hero mock \"Thu, Apr 2 at 8:30 AM\"** → \"Next Thu at 8:30 AM\" (evergreen).
- **\"Sign in to get early access\"** → \"Request early access\" (matches actual action).
- **404 + calendar + contact** copy dropped \"Aries runtime\" jargon.

## Low

- Terms + Privacy rewritten in plain language (overlaps with #118 — same final text regardless of merge order).
- Added \`metadata.title\` on /dashboard, /documentation, /privacy, /terms, /not-found.

## Not in this PR (needs investigation)

- Onboarding draft 502, dashboard empty campaign inventory, login page Suspense hang, contradictory readiness cards. All flagged in commit message for follow-up.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`tsx --test tests/runtime-pages.test.ts tests/public-marketing-pages.test.ts tests/onboarding-flow-public.test.ts\` → 40/40 pass
- [ ] After deploy: /documentation DOM no longer contains \"npx next\" or \"turbopack\"
- [ ] /dashboard renders without PM Board Standup section
- [ ] Homepage nav accessible name is single \"Aries AI — home\"
- [ ] New Campaign page: Start button visibly disabled + hint before URL filled
- [ ] 404 page no longer mentions \"Aries runtime\"
- [ ] Per-page browser tab titles are unique

🤖 Generated with [Claude Code](https://claude.com/claude-code)