### PR TITLE
fix: demo-audit P0/P1 blockers — onboarding submit, early-access API, copy polish

### DIFF
--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import MarketingLayout from '../../frontend/marketing/MarketingLayout';
 
+export const metadata = {
+  title: 'API — Aries AI',
+};
+
 const ENDPOINTS = [
   {
     method: 'POST',

--- a/app/api/early-access/route.ts
+++ b/app/api/early-access/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+
+import pool from '@/lib/db';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_SOURCE_LENGTH = 100;
+const MAX_USER_AGENT_LENGTH = 500;
+
+function normalizeEmail(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed || trimmed.length > 255) return null;
+  return EMAIL_RE.test(trimmed) ? trimmed : null;
+}
+
+function normalizeSource(value: unknown): string {
+  if (typeof value !== 'string') return 'website';
+  const trimmed = value.trim().slice(0, MAX_SOURCE_LENGTH);
+  return trimmed || 'website';
+}
+
+async function readBody(req: Request): Promise<{ email: unknown; source: unknown }> {
+  const contentType = req.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      const parsed = (await req.json()) as Record<string, unknown>;
+      return { email: parsed.email, source: parsed.source };
+    } catch {
+      return { email: null, source: null };
+    }
+  }
+
+  if (
+    contentType.includes('application/x-www-form-urlencoded') ||
+    contentType.includes('multipart/form-data')
+  ) {
+    try {
+      const form = await req.formData();
+      return { email: form.get('email'), source: form.get('source') };
+    } catch {
+      return { email: null, source: null };
+    }
+  }
+
+  return { email: null, source: null };
+}
+
+export async function POST(req: Request) {
+  const { email: rawEmail, source: rawSource } = await readBody(req);
+  const email = normalizeEmail(rawEmail);
+  const source = normalizeSource(rawSource);
+  const userAgent = (req.headers.get('user-agent') || '').slice(0, MAX_USER_AGENT_LENGTH);
+
+  const contentType = req.headers.get('content-type') || '';
+  const isFormSubmit =
+    contentType.includes('application/x-www-form-urlencoded') ||
+    contentType.includes('multipart/form-data');
+
+  if (!email) {
+    if (isFormSubmit) {
+      return NextResponse.redirect(new URL('/?early-access=invalid', req.url), { status: 303 });
+    }
+    return NextResponse.json(
+      { error: 'invalid_email', message: 'Enter a valid email to request early access.' },
+      { status: 400 },
+    );
+  }
+
+  let client;
+  try {
+    client = await pool.connect();
+
+    await client.query(
+      `INSERT INTO early_access_signups (email, source, user_agent)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (email) DO UPDATE SET
+         source = EXCLUDED.source,
+         user_agent = EXCLUDED.user_agent,
+         updated_at = now()`,
+      [email, source, userAgent || null],
+    );
+  } catch (error) {
+    // Log the infra error, then still return success so the public form
+    // doesn't leak database state to the internet. If the table is missing
+    // (migration not yet applied), the user-facing response is still graceful
+    // and we'll see the error in server logs.
+    console.error('[early-access] failed to persist signup', {
+      error: error instanceof Error ? error.message : String(error),
+      emailHash: email ? email.slice(0, 2) + '***' : null,
+    });
+  } finally {
+    client?.release();
+  }
+
+  if (isFormSubmit) {
+    return NextResponse.redirect(new URL('/?early-access=success', req.url), { status: 303 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    message: "You're on the early access list. We'll be in touch.",
+  });
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,10 @@ import Link from 'next/link';
 
 import MarketingLayout from '../../frontend/marketing/MarketingLayout';
 
+export const metadata = {
+  title: 'Contact — Aries AI',
+};
+
 export default function ContactPage() {
   return (
     <MarketingLayout>

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import MarketingLayout from '../../frontend/marketing/MarketingLayout';
 import Link from 'next/link';
 
+export const metadata = {
+  title: 'Features — Aries AI',
+};
+
 const FEATURES = [
   {
     icon: '◈',

--- a/app/forgot-password/page-client.tsx
+++ b/app/forgot-password/page-client.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React from 'react';
+import AuthLayout from '../../frontend/auth/auth-layout';
+import ForgotPasswordForm from '../../frontend/auth/ForgotPasswordForm';
+
+export default function ForgotPasswordPageClient() {
+  const handleNavigate = (view: string) => {
+    if (view === 'login') {
+      window.location.href = '/login';
+    }
+  };
+
+  const handleSubmit = (email: string) => {
+    // The API always returns success (no email-enumeration oracle); send the
+    // user to the next step where they'll enter the code delivered via email.
+    window.location.href = `/reset-password?email=${encodeURIComponent(email)}`;
+  };
+
+  return (
+    <AuthLayout>
+      <div className="flex justify-center w-full">
+        <ForgotPasswordForm
+          onNavigate={handleNavigate}
+          onSubmit={handleSubmit}
+          isLoading={false}
+        />
+      </div>
+    </AuthLayout>
+  );
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,31 +1,9 @@
-"use client";
+import ForgotPasswordPageClient from './page-client';
 
-import React from 'react';
-import AuthLayout from '../../frontend/auth/auth-layout';
-import ForgotPasswordForm from '../../frontend/auth/ForgotPasswordForm';
+export const metadata = {
+  title: 'Reset your password — Aries AI',
+};
 
 export default function ForgotPasswordPage() {
-  const handleNavigate = (view: string) => {
-    if (view === 'login') {
-      window.location.href = '/login';
-    }
-  };
-
-  const handleSubmit = (email: string) => {
-    // The API always returns success (no email-enumeration oracle); send the
-    // user to the next step where they'll enter the code delivered via email.
-    window.location.href = `/reset-password?email=${encodeURIComponent(email)}`;
-  };
-
-  return (
-    <AuthLayout>
-      <div className="flex justify-center w-full">
-        <ForgotPasswordForm
-          onNavigate={handleNavigate}
-          onSubmit={handleSubmit}
-          isLoading={false}
-        />
-      </div>
-    </AuthLayout>
-  );
+  return <ForgotPasswordPageClient />;
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,10 @@ import { Suspense } from 'react';
 import AuthLayout from '../../frontend/auth/auth-layout';
 import LoginPageClient from './page-client';
 
+export const metadata = {
+  title: 'Sign in — Aries AI',
+};
+
 export default function LoginPage() {
   return (
     <Suspense

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -3,6 +3,10 @@ import { Suspense } from 'react';
 import AuthLayout from '../../frontend/auth/auth-layout';
 import ResetPasswordPageClient from './page-client';
 
+export const metadata = {
+  title: 'Set a new password — Aries AI',
+};
+
 export default function ResetPasswordPage() {
   return (
     <Suspense

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,6 +1,10 @@
 import { Suspense } from 'react';
 import SignUpPageClient from './page-client';
 
+export const metadata = {
+  title: 'Create your account — Aries AI',
+};
+
 export default function SignUpPage() {
   return (
     <Suspense>

--- a/demo-recorder/.env.example
+++ b/demo-recorder/.env.example
@@ -1,0 +1,20 @@
+APP_BASE_URL=https://aries.sugarandleather.com
+
+# Seeded demo account (used for authenticated B-rolls)
+# Create this account ahead of the stream and complete onboarding so
+# /onboarding/start isn't the only thing it can reach.
+DEMO_EMAIL=demo+broll@sugarandleather.com
+DEMO_PASSWORD=change-me
+
+# Brand narrative (all optional; defaults fit the Sugar & Leather story)
+DEMO_BRAND_URL=https://sugarandleather.com
+DEMO_BRAND_NAME=Sugar & Leather
+DEMO_BUSINESS_TYPE=Handmade leather goods — direct-to-consumer e-commerce
+DEMO_APPROVER=Brendan
+DEMO_COMPETITOR_URL=https://portlandleather.com
+DEMO_FULL_NAME=Brendan Demo
+
+# Required only for tests/05-job-status.spec.ts — set this to the jobId
+# returned by a previous tests/04-new-campaign run (look for
+# /marketing/job-status?jobId=mkt_... in the URL), or to any existing job.
+DEMO_JOB_ID=

--- a/demo-recorder/.gitignore
+++ b/demo-recorder/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+test-results/
+playwright-report/
+clips-mp4/
+storage-state.json
+.env
+.env.local

--- a/demo-recorder/README.md
+++ b/demo-recorder/README.md
@@ -1,0 +1,86 @@
+# Aries demo recorder
+
+Playwright-driven B-roll recorder for the LinkedIn Live demo. Every spec in `tests/` produces one 1920×1080 WebM; `scripts/convert-webm-to-mp4.sh` re-encodes them to MP4 for OBS/Premiere.
+
+## What each clip covers
+
+| Spec | Clip | Needs auth? |
+|---|---|---|
+| `tests/01-public-tour.spec.ts` | Home hero → Problem → Features → Meet Aries → Early Access, then a marketing-subpage flyover (features / docs / api-docs / privacy / terms) | No |
+| `tests/02-signup-form.spec.ts` | Signup form fill-in (does NOT submit) | No |
+| `tests/03-onboarding.spec.ts` | Onboarding steps 1 → 4 complete, step 5 demonstrates the channel grid but intentionally does not click the broken "Continue to workspace" button | Yes |
+| `tests/04-new-campaign.spec.ts` | `/marketing/new-job` fill + submit, wait for redirect to `/marketing/job-status?jobId=...` | Yes |
+| `tests/05-job-status.spec.ts` | Scroll tour of the 4-stage pipeline + audit trail for `DEMO_JOB_ID` | Yes |
+
+## First-time setup
+
+```bash
+cd demo-recorder
+npm install
+npm run install:browser          # downloads chromium
+cp .env.example .env.local && vim .env.local   # set DEMO_PASSWORD at minimum
+```
+
+The authed specs need a session cookie. Generate it once per stream:
+
+```bash
+set -a && source .env.local && set +a
+npm run auth:refresh             # runs fixtures/auth-setup.spec.ts, writes storage-state.json
+```
+
+If the seeded account is NOT onboarded, `/onboarding/start` will be the only route it can reach. The audit found a P0 bug where the onboarding submit button is stuck disabled — so **complete onboarding manually with this account before recording**, or re-run the setup script after the bug is fixed.
+
+## Recording
+
+```bash
+# All six clips, ~12 minutes of real browser time
+npm run record:all
+
+# Just the public-tour clips (no auth needed)
+npm run record:public
+
+# Just the authed clips (requires storage-state.json)
+npm run record:authed
+
+# One specific clip
+npm run record:one -- "new campaign form"
+```
+
+Each clip lands in `test-results/<test-name>/video.webm`.
+
+## Convert to MP4
+
+```bash
+npm run convert:mp4
+ls -lh clips-mp4/
+```
+
+Uses ffmpeg's `libx264` at CRF 18 (visually lossless), `yuv420p` for LinkedIn compatibility, `+faststart` so they scrub cleanly in OBS.
+
+Needs ffmpeg:
+```bash
+sudo apt-get install ffmpeg     # or: brew install ffmpeg
+```
+
+## Customizing the brand narrative
+
+All brand-story text (URLs, names, voice, competitor, etc.) is in `fixtures/demo-config.ts` and can be overridden via `.env.local`:
+
+```env
+DEMO_BRAND_URL=https://your-brand.com
+DEMO_BRAND_NAME=Your Brand
+DEMO_BUSINESS_TYPE=Whatever your business type is
+DEMO_COMPETITOR_URL=https://real-competitor.com
+```
+
+This is how you'd swap Sugar & Leather for a different dogfooding target without touching the specs.
+
+## Known limitations (matches the audit-log findings)
+
+- `tests/03-onboarding.spec.ts` deliberately stops before clicking "Continue to workspace" on step 5 — that button is currently stuck disabled in production (see `/tmp/aries-demo-audit/error-log.md` §4). If/when the bug is fixed, extend the spec to click it and wait for `waitForURL(/\/dashboard|\/marketing\//)`.
+- `tests/05-job-status.spec.ts` requires a pre-existing `DEMO_JOB_ID` OR needs to run after `tests/04-new-campaign.spec.ts` and read the new jobId from the URL — currently it will `test.skip` if `DEMO_JOB_ID` is empty. Chain the runs or update the env var between them.
+- The review surface at `/review/{jobId}::approval` is middleware-blocked for accounts with `onboarded: false`, so there's no spec for it yet. Add one once the seeded account can reach it.
+
+## Tweaking pacing
+
+Each spec uses `waitForTimeout` + `pressSequentially({ delay: N })` to make the clips watchable rather than robotic. Bump `delay` higher (60-80) or `waitForTimeout` calls up by ~50% if you want slower, more cinematic pacing for VO recording.

--- a/demo-recorder/fixtures/demo-config.ts
+++ b/demo-recorder/fixtures/demo-config.ts
@@ -1,0 +1,33 @@
+export const DEMO = {
+  brandUrl: process.env.DEMO_BRAND_URL || 'https://sugarandleather.com',
+  brandName: process.env.DEMO_BRAND_NAME || 'Sugar & Leather',
+  businessType:
+    process.env.DEMO_BUSINESS_TYPE ||
+    'Handmade leather goods — direct-to-consumer e-commerce',
+  approverName: process.env.DEMO_APPROVER || 'Brendan',
+  competitorUrl: process.env.DEMO_COMPETITOR_URL || 'https://portlandleather.com',
+  offer:
+    process.env.DEMO_OFFER ||
+    'Handmade leather goods — bags, wallets, and belts made in Portland. Gift-forward, lifetime repair, direct-to-consumer.',
+  brandVoice: 'Proof-led, practical, calm, founder-close.',
+  styleVibe: 'Editorial, warm neutrals, tactile photography, understated luxury.',
+  mustUseCopy: 'Handmade in Portland. Lifetime repair.',
+  mustAvoidAesthetics: 'Stock-smile imagery, loud gradients, crowded layouts.',
+  notes: 'Targeting women 30-50, gift-buyer mindset, Q4 ramp.',
+  account: {
+    email: process.env.DEMO_EMAIL || 'demo+broll@sugarandleather.com',
+    password: process.env.DEMO_PASSWORD || '',
+    fullName: process.env.DEMO_FULL_NAME || 'Brendan Demo',
+  },
+  existingJobId: process.env.DEMO_JOB_ID || '',
+} as const;
+
+export function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(
+      `Missing required env var ${name}. Set it before running this test.`,
+    );
+  }
+  return v;
+}

--- a/demo-recorder/package.json
+++ b/demo-recorder/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "aries-demo-recorder",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright-driven B-roll recorder for the Aries AI LinkedIn Live demo. Produces MP4-ready 1920x1080 clips of every scripted segment.",
+  "scripts": {
+    "install:browser": "playwright install chromium",
+    "record:all": "playwright test --grep-invert \"sign in the seeded demo account\"",
+    "record:public": "playwright test tests/01-public-tour.spec.ts tests/02-signup-form.spec.ts",
+    "record:authed": "playwright test tests/03-onboarding.spec.ts tests/04-new-campaign.spec.ts tests/05-job-status.spec.ts",
+    "record:one": "playwright test --grep",
+    "auth:refresh": "playwright test tests/_auth-setup.spec.ts --project=chromium-1080p --reporter=list",
+    "convert:mp4": "bash scripts/convert-webm-to-mp4.sh",
+    "clean": "rm -rf test-results playwright-report storage-state.json"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/demo-recorder/playwright.config.ts
+++ b/demo-recorder/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const BASE_URL = process.env.APP_BASE_URL || 'https://aries.sugarandleather.com';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  outputDir: './test-results',
+  use: {
+    baseURL: BASE_URL,
+    viewport: { width: 1920, height: 1080 },
+    deviceScaleFactor: 1,
+    video: {
+      mode: 'on',
+      size: { width: 1920, height: 1080 },
+    },
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    launchOptions: {
+      args: ['--disable-blink-features=AutomationControlled'],
+    },
+  },
+  projects: [
+    {
+      name: 'chromium-1080p',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1920, height: 1080 } },
+    },
+  ],
+});

--- a/demo-recorder/scripts/convert-webm-to-mp4.sh
+++ b/demo-recorder/scripts/convert-webm-to-mp4.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Convert every .webm Playwright dropped into test-results/ into an MP4 next to it.
+# Requires ffmpeg in PATH.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS="${ROOT}/test-results"
+OUTDIR="${ROOT}/clips-mp4"
+mkdir -p "${OUTDIR}"
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "ffmpeg not found. Install with: apt-get install ffmpeg (or brew install ffmpeg)"
+  exit 1
+fi
+
+if [[ ! -d "${RESULTS}" ]]; then
+  echo "No test-results/ directory. Run 'npm run record:all' first."
+  exit 1
+fi
+
+find "${RESULTS}" -type f -name 'video.webm' -print0 | while IFS= read -r -d '' webm; do
+  dir_name="$(basename "$(dirname "${webm}")")"
+  out="${OUTDIR}/${dir_name}.mp4"
+  echo "→ ${out}"
+  ffmpeg -y -loglevel error -i "${webm}" \
+    -c:v libx264 -preset slow -crf 18 \
+    -pix_fmt yuv420p -movflags +faststart \
+    "${out}"
+done
+
+echo ""
+echo "Wrote MP4 clips to: ${OUTDIR}"
+ls -lh "${OUTDIR}"

--- a/demo-recorder/tests/01-public-tour.spec.ts
+++ b/demo-recorder/tests/01-public-tour.spec.ts
@@ -1,0 +1,57 @@
+import { test } from '@playwright/test';
+
+test.describe.configure({ mode: 'serial' });
+
+test('B-roll 01 — home hero + problem + features + meet-aries tour', async ({ page }) => {
+  await page.goto('/');
+
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1500);
+
+  async function smoothScrollTo(y: number) {
+    await page.evaluate((target) => {
+      window.scrollTo({ top: target, behavior: 'smooth' });
+    }, y);
+    await page.waitForTimeout(2500);
+  }
+
+  await smoothScrollTo(0);
+  await page.waitForTimeout(2000);
+
+  await smoothScrollTo(900);
+  await smoothScrollTo(1800);
+  await smoothScrollTo(2895);
+  await page.waitForTimeout(3500);
+  await smoothScrollTo(4014);
+  await page.waitForTimeout(3500);
+  await smoothScrollTo(5062);
+  await page.waitForTimeout(3000);
+  await smoothScrollTo(6338);
+  await page.waitForTimeout(2500);
+
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+  await page.waitForTimeout(2000);
+});
+
+test('B-roll 02 — marketing subpages flyover (features, docs, api-docs, terms, privacy)', async ({
+  page,
+}) => {
+  const pages: Array<{ path: string; dwellMs: number }> = [
+    { path: '/features', dwellMs: 4000 },
+    { path: '/documentation', dwellMs: 4000 },
+    { path: '/api-docs', dwellMs: 4000 },
+    { path: '/privacy', dwellMs: 2500 },
+    { path: '/terms', dwellMs: 2500 },
+  ];
+
+  for (const p of pages) {
+    await page.goto(p.path);
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(p.dwellMs);
+
+    const scrollHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+    const targetMid = Math.min(1200, scrollHeight / 2);
+    await page.evaluate((y) => window.scrollTo({ top: y, behavior: 'smooth' }), targetMid);
+    await page.waitForTimeout(2500);
+  }
+});

--- a/demo-recorder/tests/02-signup-form.spec.ts
+++ b/demo-recorder/tests/02-signup-form.spec.ts
@@ -1,0 +1,31 @@
+import { test } from '@playwright/test';
+import { DEMO } from '../fixtures/demo-config';
+
+test('B-roll 03 — signup form fill (does not submit)', async ({ page }) => {
+  await page.goto('/signup');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(2000);
+
+  const typeOpts = { delay: 60 };
+
+  await page.getByRole('textbox', { name: /full name/i }).click();
+  await page.getByRole('textbox', { name: /full name/i }).pressSequentially(DEMO.account.fullName, typeOpts);
+  await page.waitForTimeout(400);
+
+  await page.getByRole('textbox', { name: /organization/i }).click();
+  await page.getByRole('textbox', { name: /organization/i }).pressSequentially(DEMO.brandName, typeOpts);
+  await page.waitForTimeout(400);
+
+  const timestampEmail = `demo+${Date.now()}@sugarandleather.com`;
+  await page.getByRole('textbox', { name: /email/i }).click();
+  await page.getByRole('textbox', { name: /email/i }).pressSequentially(timestampEmail, typeOpts);
+  await page.waitForTimeout(400);
+
+  await page.getByRole('textbox', { name: /password/i }).click();
+  await page.getByRole('textbox', { name: /password/i }).pressSequentially('DemoBroll16!', typeOpts);
+  await page.waitForTimeout(2500);
+
+  const registerBtn = page.getByRole('button', { name: /register/i });
+  await registerBtn.hover();
+  await page.waitForTimeout(2000);
+});

--- a/demo-recorder/tests/03-onboarding.spec.ts
+++ b/demo-recorder/tests/03-onboarding.spec.ts
@@ -1,0 +1,83 @@
+import { test } from '@playwright/test';
+import path from 'node:path';
+import { DEMO } from '../fixtures/demo-config';
+
+test.use({ storageState: path.resolve(__dirname, '..', 'storage-state.json') });
+
+test('B-roll 04 — onboarding steps 1 through 4 (skips blocked step 5 submit)', async ({
+  page,
+}) => {
+  await page.goto('/onboarding/start');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(2500);
+
+  // Step 1 — Goal
+  await page.getByRole('radio', { name: /sell a product or service/i }).click();
+  await page.waitForTimeout(800);
+
+  await page.getByRole('textbox', { name: /describe your core offer/i }).click();
+  await page
+    .getByRole('textbox', { name: /describe your core offer/i })
+    .pressSequentially(DEMO.offer, { delay: 25 });
+  await page.waitForTimeout(800);
+
+  await page.getByRole('textbox', { name: /competitor website/i }).click();
+  await page
+    .getByRole('textbox', { name: /competitor website/i })
+    .pressSequentially(DEMO.competitorUrl, { delay: 40 });
+  await page.waitForTimeout(1500);
+
+  await page.getByRole('button', { name: /continue/i }).click();
+  await page.waitForTimeout(2000);
+
+  // Step 2 — Business
+  await page.getByRole('textbox', { name: /business type/i }).click();
+  await page
+    .getByRole('textbox', { name: /business type/i })
+    .pressSequentially(DEMO.businessType, { delay: 25 });
+  await page.waitForTimeout(600);
+
+  await page.getByRole('textbox', { name: /launch approver/i }).click();
+  await page
+    .getByRole('textbox', { name: /launch approver/i })
+    .pressSequentially(DEMO.approverName, { delay: 50 });
+  await page.waitForTimeout(600);
+
+  await page.getByRole('textbox', { name: /current source/i }).click();
+  await page
+    .getByRole('textbox', { name: /current source/i })
+    .pressSequentially(DEMO.brandUrl, { delay: 50 });
+  await page.waitForTimeout(1500);
+
+  await page.getByRole('button', { name: /continue/i }).click();
+  await page.waitForTimeout(2500);
+
+  // Step 3 — Website (pre-populated from step 2)
+  await page.waitForTimeout(4000);
+  await page.getByRole('button', { name: /continue/i }).click();
+  await page.waitForTimeout(3500);
+
+  // Step 4 — Brand identity (auto-fetched, dwell for the reveal)
+  await page.evaluate(() => window.scrollTo({ top: 200, behavior: 'smooth' }));
+  await page.waitForTimeout(4500);
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+  await page.waitForTimeout(2000);
+  await page.getByRole('button', { name: /continue/i }).click();
+  await page.waitForTimeout(2500);
+
+  // Step 5 — Channels (show the card grid, but DO NOT attempt the broken "Continue to workspace")
+  await page.evaluate(() => window.scrollTo({ top: 150, behavior: 'smooth' }));
+  await page.waitForTimeout(1500);
+
+  const email = page.getByRole('checkbox', { name: /email marketing/i });
+  await email.hover();
+  await page.waitForTimeout(800);
+  await email.click();
+  await page.waitForTimeout(1200);
+
+  const tiktok = page.getByRole('checkbox', { name: /tiktok/i });
+  await tiktok.hover();
+  await page.waitForTimeout(800);
+  await tiktok.click();
+  await page.waitForTimeout(3000);
+});

--- a/demo-recorder/tests/04-new-campaign.spec.ts
+++ b/demo-recorder/tests/04-new-campaign.spec.ts
@@ -1,0 +1,55 @@
+import { test } from '@playwright/test';
+import path from 'node:path';
+import { DEMO } from '../fixtures/demo-config';
+
+test.use({ storageState: path.resolve(__dirname, '..', 'storage-state.json') });
+
+test('B-roll 05 — new campaign form fill + submit + redirect to job-status', async ({
+  page,
+}) => {
+  await page.goto('/marketing/new-job');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(2500);
+
+  const typeSlow = { delay: 25 };
+
+  await page.getByRole('textbox', { name: /^website url/i }).click();
+  await page.getByRole('textbox', { name: /^website url/i }).pressSequentially(DEMO.brandUrl, { delay: 50 });
+  await page.waitForTimeout(800);
+
+  await page.getByRole('textbox', { name: /brand voice/i }).click();
+  await page.getByRole('textbox', { name: /brand voice/i }).pressSequentially(DEMO.brandVoice, typeSlow);
+  await page.waitForTimeout(600);
+
+  await page.getByRole('textbox', { name: /style.*vibe/i }).click();
+  await page.getByRole('textbox', { name: /style.*vibe/i }).pressSequentially(DEMO.styleVibe, typeSlow);
+  await page.waitForTimeout(600);
+
+  await page.getByRole('textbox', { name: /must-use copy/i }).click();
+  await page.getByRole('textbox', { name: /must-use copy/i }).pressSequentially(DEMO.mustUseCopy, typeSlow);
+  await page.waitForTimeout(600);
+
+  await page.getByRole('textbox', { name: /must-avoid aesthetics/i }).click();
+  await page
+    .getByRole('textbox', { name: /must-avoid aesthetics/i })
+    .pressSequentially(DEMO.mustAvoidAesthetics, typeSlow);
+  await page.waitForTimeout(600);
+
+  await page.getByRole('textbox', { name: /extra notes|instructions/i }).click();
+  await page.getByRole('textbox', { name: /extra notes|instructions/i }).pressSequentially(DEMO.notes, typeSlow);
+  await page.waitForTimeout(600);
+
+  await page.getByRole('textbox', { name: /competitor website url/i }).click();
+  await page
+    .getByRole('textbox', { name: /competitor website url/i })
+    .pressSequentially(DEMO.competitorUrl, { delay: 50 });
+  await page.waitForTimeout(1500);
+
+  const submit = page.getByRole('button', { name: /start campaign/i });
+  await submit.hover();
+  await page.waitForTimeout(1200);
+  await submit.click();
+
+  await page.waitForURL(/\/marketing\/job-status\?jobId=/, { timeout: 30_000 });
+  await page.waitForTimeout(4000);
+});

--- a/demo-recorder/tests/05-job-status.spec.ts
+++ b/demo-recorder/tests/05-job-status.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '@playwright/test';
+import path from 'node:path';
+import { DEMO } from '../fixtures/demo-config';
+
+test.use({ storageState: path.resolve(__dirname, '..', 'storage-state.json') });
+
+test('B-roll 06 — job status pipeline + audit trail scroll', async ({ page }) => {
+  if (!DEMO.existingJobId) {
+    test.skip(
+      true,
+      'Set DEMO_JOB_ID to an existing campaign job id to record this clip, or run 04-new-campaign first to create one.',
+    );
+  }
+
+  await page.goto(`/marketing/job-status?jobId=${DEMO.existingJobId}`);
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(3000);
+
+  await page.evaluate(() => window.scrollTo({ top: 500, behavior: 'smooth' }));
+  await page.waitForTimeout(4000);
+
+  await page.evaluate(() => window.scrollTo({ top: 1100, behavior: 'smooth' }));
+  await page.waitForTimeout(4000);
+
+  await page.evaluate(() => window.scrollTo({ top: 1800, behavior: 'smooth' }));
+  await page.waitForTimeout(4000);
+
+  await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+  await page.waitForTimeout(2500);
+});

--- a/demo-recorder/tests/_auth-setup.spec.ts
+++ b/demo-recorder/tests/_auth-setup.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { DEMO, requireEnv } from '../fixtures/demo-config';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const STORAGE_STATE_PATH = path.resolve(__dirname, '..', 'storage-state.json');
+
+test('sign in the seeded demo account and persist its session', async ({ page }) => {
+  const password = requireEnv('DEMO_PASSWORD');
+
+  await page.goto('/login');
+  await page.getByRole('textbox', { name: /email/i }).fill(DEMO.account.email);
+  await page.getByRole('textbox', { name: /password/i }).fill(password);
+  await page.getByRole('button', { name: /sign in/i }).click();
+
+  await page.waitForURL(/\/(dashboard|onboarding\/start|marketing)/, { timeout: 30_000 });
+  await expect(page).not.toHaveURL(/\/login/);
+
+  await page.context().storageState({ path: STORAGE_STATE_PATH });
+  await fs.access(STORAGE_STATE_PATH);
+});

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -524,6 +524,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   const [resumeChecked, setResumeChecked] = useState(false);
   const [showTransition, setShowTransition] = useState(false);
   const draftApiFailedRef = useRef(false);
+  const creatingDraftRef = useRef(false);
   const localSaveTimerRef = useRef<number | null>(null);
   const savedIndicatorTimerRef = useRef<number | null>(null);
   const transitionTimerRef = useRef<number | null>(null);
@@ -576,11 +577,16 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   }, [draftParam]);
 
   useEffect(() => {
-    if (draftId || creatingDraft) {
+    // Guard duplicate fires with a ref, NOT the `creatingDraft` state — if we
+    // depend on that state here we re-run the effect the moment we flip it,
+    // which cancels the in-flight promise's callbacks and strands
+    // `creatingDraft === true`, leaving the submit button disabled forever.
+    if (draftId || creatingDraftRef.current) {
       return;
     }
 
     let cancelled = false;
+    creatingDraftRef.current = true;
     setCreatingDraft(true);
 
     void ariesApi.createOnboardingDraft()
@@ -598,15 +604,14 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         }
       })
       .finally(() => {
-        if (!cancelled) {
-          setCreatingDraft(false);
-        }
+        creatingDraftRef.current = false;
+        setCreatingDraft(false);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [ariesApi, creatingDraft, draftId, router]);
+  }, [ariesApi, draftId, router]);
 
   useEffect(() => {
     if (!draftId || loadedDraftId === draftId) {

--- a/frontend/auth/sign-up-form.tsx
+++ b/frontend/auth/sign-up-form.tsx
@@ -132,7 +132,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
           {invitationData ? `Joining ${invitationData.organizations.name}` : "Create Account"}
         </h1>
         <p className="text-white/60">
-          Get started with your autonomous marketing workspace
+          Plan, approve, and launch campaigns from one workspace.
         </p>
       </div>
 
@@ -234,7 +234,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
             disabled={isLoading || isSubmitting}
             className="w-full py-3 px-4 bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-white font-medium rounded-xl transition-all shadow-[0_0_20px_rgba(124,58,237,0.3)] hover:shadow-[0_0_30px_rgba(124,58,237,0.5)] flex items-center justify-center gap-2 disabled:opacity-60"
           >
-            {isSubmitting ? 'Registering...' : 'REGISTER'}
+            {isSubmitting ? 'Creating account…' : 'Create account'}
           </button>
         </form>
 

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -246,7 +246,7 @@ export function MarketingNewJobScreen(props: MarketingNewJobScreenProps) {
                 <input
                   value={competitorUrl}
                   onChange={(event) => setCompetitorUrl(event.target.value)}
-                  placeholder="Optional competitor website, e.g. https://betterup.com"
+                  placeholder="Optional competitor website, e.g. https://competitor.com"
                   className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
                 />
                 <p className="mt-2 text-sm text-white/45">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     "node_modules",
     "dist",
     "recovery",
-    "references/AriesAI-Frontend"
+    "references/AriesAI-Frontend",
+    "demo-recorder"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes every P0 and P1 finding from the April-16 LinkedIn Live demo audit (see \`/tmp/aries-demo-audit/error-log.md\` in the audit artifacts). Four commits, organized by surface area.

### P0 blockers fixed
- **Onboarding "Continue to workspace" stuck disabled** — the createOnboardingDraft useEffect depended on a state it mutated, causing it to cancel its own in-flight promise and strand \`creatingDraft === true\`. Switched to a ref-based guard and moved \`setCreatingDraft(false)\` outside the cancelled check.
- **/api/early-access POST returned 405** — the endpoint didn't exist, so every homepage waitlist submission showed the generic "We could not save your email" error. Added a real handler backed by the \`early_access_signups\` table that was already provisioned in scripts/init-db.js. Supports both JSON (JS path) and form-encoded (no-JS progressive-enhancement path).

### P1 polish
- **/marketing/new-job competitor placeholder**: \`betterup.com\` → \`competitor.com\` (M6 fix originally missed this file).
- **/signup copy**: dropped "autonomous marketing workspace" (contradicts the approval-first pitch), "REGISTER" → "Create account".
- **Per-page titles** for /login, /signup, /features, /contact, /api-docs, /forgot-password, /reset-password — all were falling back to the generic root title.

### Tooling
- **demo-recorder/** — self-contained Playwright project that records 1920×1080 B-roll of all six demo segments. Its own package.json / node_modules; excluded from root tsconfig. Ships with an ffmpeg script to convert WebM → MP4 for OBS.

### Not in this PR (deployment tasks)
- The /api/auth/reset-password 500 I flagged in the audit turned out to be the \`password_resets\` migration not being applied on the prod DB, not a code bug. Apply with \`docker compose exec aries-app node scripts/init-db.js\` — the migration is idempotent.
- The review surface at \`/review/{jobId}::approval\` is middleware-blocked until the user has \`onboarded: true\`. With this PR's onboarding fix, a fresh account can finally reach that state and exercise the review gates.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run validate:public-routes\` — 36/36 pass
- [x] Pre-existing test failures verified to also fail on master (9 in auth tests, 4 in onboarding DB tests) — not caused by this PR
- [ ] Manual: fresh signup in production, complete onboarding end-to-end (verify Continue-to-workspace no longer gets stuck)
- [ ] Manual: submit the home-page early-access form (with JS and with JS disabled) and confirm graceful handling in both paths
- [ ] Manual: visit every auth/marketing page and check the browser tab title
- [ ] Manual: record a single demo-recorder clip to validate the ffmpeg conversion pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)