### PR TITLE
fix(marketing): restore CTAs, nav login, StatusChip, runtime paths + wire calendar filters

### DIFF
--- a/frontend/aries-v1/channel-integrations-screen.tsx
+++ b/frontend/aries-v1/channel-integrations-screen.tsx
@@ -4,7 +4,7 @@ import type { IntegrationCardAction } from '@/lib/api/integrations';
 import { useIntegrations } from '@/hooks/use-integrations';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
-import { EmptyStatePanel, LoadingStateGrid, ShellPanel } from './components';
+import { EmptyStatePanel, LoadingStateGrid, ShellPanel, StatusChip } from './components';
 
 export default function AriesChannelIntegrationsScreen() {
   const integrations = useIntegrations({ autoLoad: true });
@@ -92,16 +92,35 @@ export default function AriesChannelIntegrationsScreen() {
                         <p className="text-sm font-medium text-white">{card.display_name}</p>
                         <p className="text-sm text-white/45">{card.description}</p>
                       </div>
-                      {primaryAction ? (
-                        <button
-                          type="button"
-                          onClick={() => void handleIntegrationAction(primaryAction.action, card.platform)}
-                          disabled={integrations.busyAction === `${card.platform}:${primaryAction.action}`}
-                          className={primaryAction.className}
+                      <div className="flex items-center gap-3 shrink-0">
+                        <StatusChip
+                          status={
+                            card.connection_state === 'connected'
+                              ? 'approved'
+                              : card.connection_state === 'reauth_required'
+                                ? 'changes_requested'
+                                : 'draft'
+                          }
                         >
-                          {primaryAction.label}
-                        </button>
-                      ) : null}
+                          {card.connection_state === 'connected'
+                            ? 'Connected'
+                            : card.connection_state === 'reauth_required'
+                              ? 'Needs attention'
+                              : card.connection_state === 'disabled'
+                                ? 'Setup needed'
+                                : 'Not connected'}
+                        </StatusChip>
+                        {primaryAction ? (
+                          <button
+                            type="button"
+                            onClick={() => void handleIntegrationAction(primaryAction.action, card.platform)}
+                            disabled={integrations.busyAction === `${card.platform}:${primaryAction.action}`}
+                            className={primaryAction.className}
+                          >
+                            {primaryAction.label}
+                          </button>
+                        ) : null}
+                      </div>
                     </div>
                   </div>
                 );

--- a/frontend/donor/marketing/chrome.tsx
+++ b/frontend/donor/marketing/chrome.tsx
@@ -109,6 +109,12 @@ export function DonorNavbar({ heroMode = false }: { heroMode?: boolean }) {
         <div className="hidden md:flex items-center gap-4" style={headerOverlayStyle}>
           <a
             href="/login"
+            className="px-5 py-2 rounded-full border border-white/12 bg-white/5 text-sm font-medium text-white/85 transition-all hover:bg-white/10"
+          >
+            Log in
+          </a>
+          <a
+            href="/onboarding/start"
             className="px-5 py-2 rounded-full bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-sm font-medium transition-all shadow-lg shadow-primary/20 flex items-center gap-2 text-white"
           >
             Start with your business <ArrowRight className="w-4 h-4" />
@@ -147,6 +153,13 @@ export function DonorNavbar({ heroMode = false }: { heroMode?: boolean }) {
             <div className="flex flex-col gap-4 pt-4 border-t border-white/10">
               <a
                 href="/login"
+                className="w-full py-3 flex justify-center rounded-xl border border-white/12 bg-white/5 font-medium text-white"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Log in
+              </a>
+              <a
+                href="/onboarding/start"
                 className="w-full py-3 flex justify-center rounded-xl bg-gradient-to-r from-primary to-secondary font-medium text-white"
                 onClick={() => setIsMobileMenuOpen(false)}
               >

--- a/frontend/donor/marketing/home-page.tsx
+++ b/frontend/donor/marketing/home-page.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState, type ComponentType, type FormEvent, type SVGProps } from 'react';
 
 import {
+  ArrowRight,
   BarChart3,
   Check,
   ChevronLeft,
@@ -15,6 +16,7 @@ import {
   Linkedin,
   MoreHorizontal,
   PenTool,
+  Play,
   Plus,
   RefreshCw,
   Search,
@@ -638,14 +640,26 @@ function Hero() {
               opacity: useTransform(smoothProgress, [0, 0.05], [1, 0]),
               y: useTransform(smoothProgress, [0, 0.05], [0, -20]),
             }}
-            className="mx-auto w-full max-w-3xl"
+            className="flex flex-col sm:flex-row items-center justify-center gap-4"
           >
-            <EarlyAccessForm
-              source="marketing-hero"
-              emailInputId="hero-early-access-email"
-              variant="hero"
-              buttonLabel="Get early access"
-            />
+            <a
+              href="/onboarding/start"
+              className="w-full sm:w-auto px-8 py-4 rounded-full bg-gradient-to-r from-primary to-secondary text-white font-semibold shadow-xl shadow-primary/20 hover:scale-105 transition-transform flex items-center justify-center gap-2"
+            >
+              Start with your business <ArrowRight className="w-5 h-5" />
+            </a>
+            <a
+              href="/login"
+              className="w-full sm:w-auto px-8 py-4 rounded-full bg-white/5 border border-white/10 text-white font-semibold hover:bg-white/10 transition-all flex items-center justify-center gap-2"
+            >
+              Log in
+            </a>
+            <a
+              href="/#how-it-works"
+              className="w-full sm:w-auto px-8 py-4 rounded-full bg-white/5 border border-white/10 text-white font-semibold hover:bg-white/10 transition-all flex items-center justify-center gap-2"
+            >
+              <Play className="w-5 h-5 fill-current" /> See how it works
+            </a>
           </motion.div>
 
           <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
@@ -1177,6 +1191,8 @@ function ContentCalendar() {
   const [activeDate, setActiveDate] = useState('10');
   const [currentWeek, setCurrentWeek] = useState<'current' | 'next'>('current');
   const [viewMode, setViewMode] = useState<'week' | 'month'>('week');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [activePlatforms, setActivePlatforms] = useState<string[]>([]);
 
   const platforms = [
     { name: 'X / Twitter' },
@@ -1199,10 +1215,24 @@ function ContentCalendar() {
     CONTENT_CALENDAR_SCHEDULE.find((entry) => entry.date === date)?.posts || [];
 
   const displayedSchedule = useMemo(() => {
-    return currentWeek === 'current'
-      ? CONTENT_CALENDAR_SCHEDULE.filter((item) => ['6', '7', '8', '9', '10', '11', '12'].includes(item.date))
-      : CONTENT_CALENDAR_SCHEDULE.filter((item) => ['13', '14', '15', '16', '17', '18', '19'].includes(item.date));
-  }, [currentWeek]);
+    const weekDates = currentWeek === 'current'
+      ? ['6', '7', '8', '9', '10', '11', '12']
+      : ['13', '14', '15', '16', '17', '18', '19'];
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return CONTENT_CALENDAR_SCHEDULE
+      .filter((item) => weekDates.includes(item.date))
+      .map((day) => ({
+        ...day,
+        posts: day.posts.filter((post) => {
+          const matchesSearch = normalizedSearch.length === 0
+            || post.title.toLowerCase().includes(normalizedSearch);
+          const matchesPlatform = activePlatforms.length === 0
+            || activePlatforms.includes(post.platform);
+          return matchesSearch && matchesPlatform;
+        }),
+      }));
+  }, [currentWeek, searchTerm, activePlatforms]);
 
   return (
     <section id="calendar" className="py-24 relative overflow-hidden">
@@ -1248,7 +1278,9 @@ function ContentCalendar() {
               <input
                 type="text"
                 placeholder="Search posts..."
-                className="w-full bg-black/30 border border-white/10 rounded-xl py-2 pl-10 pr-4 text-sm focus:outline-none focus:border-primary/50 transition-colors"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                className="w-full bg-black/30 border border-white/10 rounded-xl py-2 pl-10 pr-4 text-sm text-white focus:outline-none focus:border-primary/50 transition-colors"
               />
             </div>
 
@@ -1256,16 +1288,46 @@ function ContentCalendar() {
               <div>
                 <h4 className="text-xs font-bold uppercase tracking-widest text-white/30 mb-4">Platforms</h4>
                 <div className="space-y-2">
-                  {platforms.map((platform) => (
-                    <div key={platform.name} className="flex items-center justify-between p-3 rounded-xl hover:bg-white/5 transition-colors cursor-pointer group">
-                      <div className="flex items-center gap-3">
-                        <span className="text-sm font-medium text-white/70 group-hover:text-white transition-colors">
-                          {platform.name}
-                        </span>
-                      </div>
-                      <div className="w-2 h-2 rounded-full bg-primary" />
-                    </div>
-                  ))}
+                  {platforms.map((platform) => {
+                    const isActive = activePlatforms.includes(platform.name);
+                    return (
+                      <button
+                        key={platform.name}
+                        type="button"
+                        onClick={() =>
+                          setActivePlatforms((current) =>
+                            current.includes(platform.name)
+                              ? current.filter((name) => name !== platform.name)
+                              : [...current, platform.name],
+                          )
+                        }
+                        aria-pressed={isActive}
+                        className={cn(
+                          'w-full flex items-center justify-between p-3 rounded-xl transition-colors cursor-pointer group text-left',
+                          isActive ? 'bg-white/10' : 'hover:bg-white/5',
+                        )}
+                      >
+                        <div className="flex items-center gap-3">
+                          <span
+                            className={cn(
+                              'text-sm font-medium transition-colors',
+                              isActive ? 'text-white' : 'text-white/70 group-hover:text-white',
+                            )}
+                          >
+                            {platform.name}
+                          </span>
+                        </div>
+                        <div
+                          className={cn(
+                            'w-2 h-2 rounded-full transition-all',
+                            isActive
+                              ? 'bg-primary scale-125 shadow-[0_0_8px_rgba(124,58,237,0.5)]'
+                              : 'bg-white/10',
+                          )}
+                        />
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
 

--- a/lib/runtime-paths.ts
+++ b/lib/runtime-paths.ts
@@ -70,7 +70,7 @@ export function resolveDataRoot(): string {
   const candidates = [HOST_SHARED_DATA_ROOT, HOST_TEMP_DATA_ROOT, CONTAINER_DATA_ROOT]
     .map((candidate) => normalizeRoot(candidate));
 
-  return candidates.find((candidate) => existsSync(candidate)) || resolveCodeRoot();
+  return candidates.find((candidate) => existsSync(candidate)) || normalizeRoot(HOST_SHARED_DATA_ROOT);
 }
 
 export function resolveCodePath(...segments: string[]): string {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Rolls back over-reaching frontend changes from PR #123 that were not part of
the intended orbit-responsiveness + early-access work:

- home-page.tsx: restore three hero CTAs (Start with your business / Log in /
  See how it works). Keep the new orbit responsiveness math, MOBILE_PLATFORM_LAYOUT,
  DESKTOP_RING_SCALES, and dynamic OrbitLine/OrbitPlatform sizing.
- chrome.tsx: restore desktop + mobile navbar "Log in" link; point
  "Start with your business" back at /onboarding/start.
- channel-integrations-screen.tsx: restore StatusChip next to the new
  Connect / Reconnect / Disconnect action button so users see connection
  state at a glance.
- lib/runtime-paths.ts: revert DATA_ROOT fallback from resolveCodeRoot() to
  HOST_SHARED_DATA_ROOT; prevents generated artifacts from landing inside
  the source tree on fresh machines.
- next-env.d.ts: revert import path back to ./.next/types/routes.d.ts; the
  ./.next/dev/... variant is dev-only and breaks next build.

Port from calendarchange branch (d2bed62) — wire up previously dead Calendar
UI:

- ContentCalendar: add searchTerm + activePlatforms state, bind the search
  input (case-insensitive title substring), and make platform sidebar rows
  keyboard-accessible toggle buttons that filter displayedSchedule.

Verification: npm run typecheck clean (pre-existing resend error unrelated);
public-marketing-pages and runtime-pages tests 36/36 pass; npm run verify
passed locally.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
