### PR TITLE
fix(ui): white-pill button visibility + clickable asset previews on /dashboard/posts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,42 +25,49 @@ html {
   }
 }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  overflow-x: clip;
-  background: var(--color-background);
-  color: #fff;
-  font-family: var(--font-sans);
-  line-height: 1.6;
-}
+@layer base {
+  body {
+    margin: 0;
+    min-height: 100vh;
+    overflow-x: clip;
+    background: var(--color-background);
+    color: #fff;
+    font-family: var(--font-sans);
+    line-height: 1.6;
+  }
 
-body ::selection {
-  background-color: rgba(124, 58, 237, 0.3);
-}
+  body ::selection {
+    background-color: rgba(124, 58, 237, 0.3);
+  }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
+  /* Keep anchor color/decoration inheritable, but inside @layer base so
+     Tailwind utility classes (e.g. `text-[#11161c]` on a white pill button)
+     can still override. Without this, unlayered selectors beat utilities in
+     the Tailwind v4 cascade and buttons like "Approve launch review" render
+     invisible (white text on white bg). */
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 
-img {
-  display: block;
-  max-width: 100%;
-  height: auto;
-}
+  img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
 
-button,
-input,
-textarea,
-select {
-  font: inherit;
+  button,
+  input,
+  textarea,
+  select {
+    font: inherit;
+  }
 }
 
 .container {

--- a/frontend/aries-v1/campaign-list.tsx
+++ b/frontend/aries-v1/campaign-list.tsx
@@ -34,7 +34,7 @@ export default function AriesCampaignListScreen() {
         action={
           <Link
             href="/dashboard/campaigns/new"
-            className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold !text-[#11161c] transition-colors hover:!text-[#11161c]"
+            className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] transition-colors"
           >
             Create first campaign
             <ArrowRight className="h-4 w-4" />
@@ -52,7 +52,7 @@ export default function AriesCampaignListScreen() {
         action={
           <Link
             href="/dashboard/campaigns/new"
-            className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2.5 text-sm font-semibold !text-[#11161c] transition-colors hover:!text-[#11161c]"
+            className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-[#11161c] transition-colors"
           >
             <Plus className="h-4 w-4" />
             New campaign

--- a/frontend/aries-v1/latest-campaign-view.tsx
+++ b/frontend/aries-v1/latest-campaign-view.tsx
@@ -45,7 +45,7 @@ export default function AriesLatestCampaignView(props: {
         action={
           <Link
             href="/dashboard/campaigns/new"
-            className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold !text-[#11161c] transition-colors hover:!text-[#11161c]"
+            className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] transition-colors"
           >
             New Campaign
           </Link>

--- a/frontend/aries-v1/posts-screen.tsx
+++ b/frontend/aries-v1/posts-screen.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, ExternalLink, FileImage, Globe, PauseCircle, Play, Send } f
 
 import MediaPreview from '@/frontend/components/media-preview';
 import { useRuntimePosts } from '@/hooks/use-runtime-posts';
+import { safeHref } from '@/lib/safe-href';
 import type {
   AriesDashboardAsset,
   AriesDashboardPost,
@@ -137,7 +138,9 @@ function publishToInventory(item: AriesDashboardPublishItem, assetsById: Map<str
 }
 
 function previewCard(item: InventoryItem) {
-  const openHref = item.previewUrl || item.destinationUrl || null
+  // Fall back to destinationUrl only if previewUrl is absent OR fails scheme
+  // validation — keeps clickability while rejecting javascript:/data:/etc.
+  const openHref = safeHref(item.previewUrl) || safeHref(item.destinationUrl)
   return (
     <MediaPreview
       src={item.previewUrl}
@@ -244,73 +247,79 @@ export default function AriesPostsScreen() {
       {grouped.map((group) => (
         <ShellPanel key={group.status} eyebrow="Inventory" title={statusSectionTitle(group.status)}>
           <div className="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
-            {group.items.map((item) => (
-              <article key={item.id} className="overflow-hidden rounded-[1.6rem] border border-white/10 bg-white/[0.04]">
-                <div className="p-4">
-                  {previewCard(item)}
-                </div>
-                <div className="space-y-4 border-t border-white/8 px-5 py-5">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/35">{item.typeLabel}</p>
-                      <h3 className="text-lg font-semibold text-white">{item.title}</h3>
-                      <p className="text-sm text-white/55">{item.campaignName} · {item.platformLabel}</p>
+            {group.items.map((item) => {
+              // Validate hrefs once per item so the conditional rendering and
+              // the anchor `href=` agree, and unsafe schemes are never rendered.
+              const safePreviewHref = safeHref(item.previewUrl)
+              const safeDestinationHref = safeHref(item.destinationUrl)
+              return (
+                <article key={item.id} className="overflow-hidden rounded-[1.6rem] border border-white/10 bg-white/[0.04]">
+                  <div className="p-4">
+                    {previewCard(item)}
+                  </div>
+                  <div className="space-y-4 border-t border-white/8 px-5 py-5">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/35">{item.typeLabel}</p>
+                        <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                        <p className="text-sm text-white/55">{item.campaignName} · {item.platformLabel}</p>
+                      </div>
+                      <StatusChip status={item.status} />
                     </div>
-                    <StatusChip status={item.status} />
-                  </div>
 
-                  <p className="text-sm leading-6 text-white/60">{item.summary}</p>
+                    <p className="text-sm leading-6 text-white/60">{item.summary}</p>
 
-                  <div className="space-y-2 text-sm text-white/55">
-                    <div>{item.funnelLabel}</div>
-                    <div>{item.provenanceLabel}</div>
-                    {item.previewUrl ? (
-                      <a
-                        href={item.previewUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 text-primary transition hover:text-primary/80"
-                      >
-                        {item.previewContentType === 'text/html' ? (
-                          <Globe className="h-4 w-4" />
-                        ) : item.previewContentType?.startsWith('video/') ? (
-                          <Play className="h-4 w-4" />
-                        ) : (
-                          <FileImage className="h-4 w-4" />
-                        )}
-                        <span>
-                          {item.kind === 'publish'
-                            ? 'Open publish package'
-                            : item.previewContentType?.startsWith('video/')
-                              ? 'Open video preview'
-                              : item.previewContentType === 'text/html'
-                                ? 'Open landing page'
-                                : 'Open asset preview'}
+                    <div className="space-y-2 text-sm text-white/55">
+                      <div>{item.funnelLabel}</div>
+                      <div>{item.provenanceLabel}</div>
+                      {safePreviewHref ? (
+                        <a
+                          href={safePreviewHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-2 text-primary transition hover:text-primary/80"
+                        >
+                          {item.previewContentType === 'text/html' ? (
+                            <Globe className="h-4 w-4" />
+                          ) : item.previewContentType?.startsWith('video/') ? (
+                            <Play className="h-4 w-4" />
+                          ) : (
+                            <FileImage className="h-4 w-4" />
+                          )}
+                          <span>
+                            {item.kind === 'publish'
+                              ? 'Open publish package'
+                              : item.previewContentType?.startsWith('video/')
+                                ? 'Open video preview'
+                                : item.previewContentType === 'text/html'
+                                  ? 'Open landing page'
+                                  : 'Open asset preview'}
+                          </span>
+                          <ExternalLink className="h-4 w-4" />
+                        </a>
+                      ) : null}
+                      {safeDestinationHref ? (
+                        <a
+                          href={safeDestinationHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-2 text-white transition hover:text-white/75"
+                        >
+                          <Globe className="h-4 w-4 text-white/50" />
+                          <span className="truncate">{safeDestinationHref}</span>
+                          <ExternalLink className="h-4 w-4" />
+                        </a>
+                      ) : !safePreviewHref ? (
+                        <span className="inline-flex items-center gap-2">
+                          {item.status === 'published_to_meta_paused' ? <PauseCircle className="h-4 w-4 text-white/50" /> : <Send className="h-4 w-4 text-white/50" />}
+                          No preview or destination yet
                         </span>
-                        <ExternalLink className="h-4 w-4" />
-                      </a>
-                    ) : null}
-                    {item.destinationUrl ? (
-                      <a
-                        href={item.destinationUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 text-white transition hover:text-white/75"
-                      >
-                        <Globe className="h-4 w-4 text-white/50" />
-                        <span className="truncate">{item.destinationUrl}</span>
-                        <ExternalLink className="h-4 w-4" />
-                      </a>
-                    ) : !item.previewUrl ? (
-                      <span className="inline-flex items-center gap-2">
-                        {item.status === 'published_to_meta_paused' ? <PauseCircle className="h-4 w-4 text-white/50" /> : <Send className="h-4 w-4 text-white/50" />}
-                        No preview or destination yet
-                      </span>
-                    ) : null}
+                      ) : null}
+                    </div>
                   </div>
-                </div>
-              </article>
-            ))}
+                </article>
+              )
+            })}
           </div>
         </ShellPanel>
       ))}

--- a/frontend/aries-v1/posts-screen.tsx
+++ b/frontend/aries-v1/posts-screen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { ArrowRight, ExternalLink, FileImage, FileText, Globe, PauseCircle, Send } from 'lucide-react';
+import { ArrowRight, ExternalLink, FileImage, Globe, PauseCircle, Play, Send } from 'lucide-react';
 
 import MediaPreview from '@/frontend/components/media-preview';
 import { useRuntimePosts } from '@/hooks/use-runtime-posts';
@@ -137,14 +137,16 @@ function publishToInventory(item: AriesDashboardPublishItem, assetsById: Map<str
 }
 
 function previewCard(item: InventoryItem) {
+  const openHref = item.previewUrl || item.destinationUrl || null
   return (
     <MediaPreview
       src={item.previewUrl}
       alt={item.title}
       contentType={item.previewContentType}
+      href={openHref}
       className="h-28 overflow-hidden rounded-[1.2rem] border border-white/8 bg-black/20"
       emptyLabel={item.kind === 'asset' ? 'Preview pending' : item.kind === 'publish' ? 'Publish preview pending' : 'Post preview pending'}
-      nonImageLabel={item.kind === 'asset' ? 'Asset preview available' : item.kind === 'publish' ? 'Publish package available' : 'Post preview available'}
+      nonImageLabel={item.kind === 'asset' ? 'Open asset preview' : item.kind === 'publish' ? 'Open publish package' : 'Open post preview'}
     />
   )
 }
@@ -262,18 +264,49 @@ export default function AriesPostsScreen() {
                   <div className="space-y-2 text-sm text-white/55">
                     <div>{item.funnelLabel}</div>
                     <div>{item.provenanceLabel}</div>
+                    {item.previewUrl ? (
+                      <a
+                        href={item.previewUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 text-primary transition hover:text-primary/80"
+                      >
+                        {item.previewContentType === 'text/html' ? (
+                          <Globe className="h-4 w-4" />
+                        ) : item.previewContentType?.startsWith('video/') ? (
+                          <Play className="h-4 w-4" />
+                        ) : (
+                          <FileImage className="h-4 w-4" />
+                        )}
+                        <span>
+                          {item.kind === 'publish'
+                            ? 'Open publish package'
+                            : item.previewContentType?.startsWith('video/')
+                              ? 'Open video preview'
+                              : item.previewContentType === 'text/html'
+                                ? 'Open landing page'
+                                : 'Open asset preview'}
+                        </span>
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                    ) : null}
                     {item.destinationUrl ? (
-                      <a href={item.destinationUrl} className="inline-flex items-center gap-2 text-white transition hover:text-white/75">
+                      <a
+                        href={item.destinationUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 text-white transition hover:text-white/75"
+                      >
                         <Globe className="h-4 w-4 text-white/50" />
                         <span className="truncate">{item.destinationUrl}</span>
                         <ExternalLink className="h-4 w-4" />
                       </a>
-                    ) : (
+                    ) : !item.previewUrl ? (
                       <span className="inline-flex items-center gap-2">
                         {item.status === 'published_to_meta_paused' ? <PauseCircle className="h-4 w-4 text-white/50" /> : <Send className="h-4 w-4 text-white/50" />}
-                        No destination URL
+                        No preview or destination yet
                       </span>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </article>

--- a/frontend/components/media-preview.tsx
+++ b/frontend/components/media-preview.tsx
@@ -11,6 +11,13 @@ type MediaPreviewProps = {
   imageClassName?: string;
   emptyLabel?: string;
   nonImageLabel?: string;
+  /**
+   * When set, wraps the preview (image or fallback label) in an anchor that
+   * opens `href` in a new tab. Lets callers make the thumbnail a click target
+   * for videos, landing pages, or any non-image asset where inline rendering
+   * only shows a placeholder.
+   */
+  href?: string | null;
 };
 
 function imageLike(src: string | null | undefined, contentType?: string | null): boolean {
@@ -39,26 +46,34 @@ export default function MediaPreview(props: MediaPreviewProps) {
     return null;
   }, [failed, props.contentType, props.emptyLabel, props.nonImageLabel, props.src]);
 
-  if (!presentation && props.src) {
+  const inner = !presentation && props.src ? (
+    /* eslint-disable-next-line @next/next/no-img-element */
+    <img
+      src={props.src}
+      alt={props.alt}
+      className={props.imageClassName || 'h-full w-full object-cover'}
+      onError={() => setFailed(true)}
+    />
+  ) : (
+    <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-white/45 transition-colors group-hover:text-white/70">
+      {presentation?.icon}
+      <span className="px-4 text-xs font-medium uppercase tracking-[0.2em]">{presentation?.label}</span>
+    </div>
+  );
+
+  if (props.href) {
     return (
-      <div className={props.className}>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={props.src}
-          alt={props.alt}
-          className={props.imageClassName || 'h-full w-full object-cover'}
-          onError={() => setFailed(true)}
-        />
-      </div>
+      <a
+        href={props.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={props.alt}
+        className={`${props.className ?? ''} group block transition hover:brightness-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary`}
+      >
+        {inner}
+      </a>
     );
   }
 
-  return (
-    <div className={props.className}>
-      <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-white/45">
-        {presentation?.icon}
-        <span className="px-4 text-xs font-medium uppercase tracking-[0.2em]">{presentation?.label}</span>
-      </div>
-    </div>
-  );
+  return <div className={props.className}>{inner}</div>;
 }

--- a/frontend/components/media-preview.tsx
+++ b/frontend/components/media-preview.tsx
@@ -3,6 +3,8 @@
 import { useMemo, useState } from 'react';
 import { FileImage, FileText, Globe } from 'lucide-react';
 
+import { safeHref } from '@/lib/safe-href';
+
 type MediaPreviewProps = {
   src?: string | null;
   alt: string;
@@ -61,10 +63,14 @@ export default function MediaPreview(props: MediaPreviewProps) {
     </div>
   );
 
-  if (props.href) {
+  // Guard against `javascript:` / `data:` / other non-http(s) schemes leaking
+  // in via tenant-provided or pipeline-generated URLs; fall back to the
+  // non-link rendering if the href is not safe to navigate to.
+  const validatedHref = safeHref(props.href);
+  if (validatedHref) {
     return (
       <a
-        href={props.href}
+        href={validatedHref}
         target="_blank"
         rel="noopener noreferrer"
         aria-label={props.alt}

--- a/lib/safe-href.ts
+++ b/lib/safe-href.ts
@@ -1,0 +1,51 @@
+/**
+ * Validate an href before rendering it as an anchor target.
+ *
+ * Accepts:
+ *   - Absolute http(s) URLs (`https://example.com/foo`)
+ *   - Same-origin relative paths (`/foo`, `./foo`, `../foo`)
+ *   - Query- or fragment-only refs (`?x=1`, `#section`)
+ *
+ * Rejects:
+ *   - `javascript:`, `data:`, `file:`, `vbscript:`, or any non-http(s) scheme
+ *   - Scheme-relative URLs (`//example.com/...`) because their effective
+ *     scheme depends on the current page protocol and it makes phishing-style
+ *     host swaps easy to hide
+ *   - Empty / whitespace-only strings and non-string input
+ *
+ * Use this on any href that originates outside our own codebase
+ * (tenant-provided URLs, pipeline-generated URLs, runtime state, etc.)
+ * before passing it to `<a href=...>` or `<Link href=...>`. See
+ * `backend/marketing/brand-kit.ts#isLikelyFirstPartyLogo` for the equivalent
+ * server-side guard on logo URLs.
+ */
+export function safeHref(href: string | null | undefined): string | null {
+  if (typeof href !== 'string') return null;
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  // Scheme-relative URLs (//example.com/...) — reject; their scheme depends
+  // on the current page, and this makes phishing-style host swaps easy to hide.
+  if (trimmed.startsWith('//')) return null;
+
+  // Same-origin relative paths and fragment/query-only refs are safe.
+  if (
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../') ||
+    trimmed.startsWith('?') ||
+    trimmed.startsWith('#')
+  ) {
+    return trimmed;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return trimmed;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/tests/safe-href.test.ts
+++ b/tests/safe-href.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { safeHref } from '../lib/safe-href';
+
+describe('safeHref', () => {
+  it('accepts absolute http and https URLs', () => {
+    assert.equal(safeHref('https://example.com/foo'), 'https://example.com/foo');
+    assert.equal(safeHref('http://example.com/foo'), 'http://example.com/foo');
+    assert.equal(
+      safeHref('https://cdn.example.com/assets/abc.webp?v=1#x'),
+      'https://cdn.example.com/assets/abc.webp?v=1#x',
+    );
+  });
+
+  it('accepts same-origin relative paths and fragment/query-only refs', () => {
+    assert.equal(safeHref('/assets/foo.png'), '/assets/foo.png');
+    assert.equal(safeHref('./foo.png'), './foo.png');
+    assert.equal(safeHref('../foo.png'), '../foo.png');
+    assert.equal(safeHref('?search=x'), '?search=x');
+    assert.equal(safeHref('#section'), '#section');
+  });
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(safeHref('  https://example.com/foo  '), 'https://example.com/foo');
+  });
+
+  it('rejects javascript:, data:, vbscript:, and file: schemes', () => {
+    assert.equal(safeHref('javascript:alert(1)'), null);
+    assert.equal(safeHref('JavaScript:alert(1)'), null);
+    assert.equal(safeHref('  javascript:alert(1)  '), null);
+    assert.equal(safeHref('data:text/html,<script>alert(1)</script>'), null);
+    assert.equal(safeHref('vbscript:msgbox'), null);
+    assert.equal(safeHref('file:///etc/passwd'), null);
+  });
+
+  it('rejects scheme-relative URLs', () => {
+    assert.equal(safeHref('//evil.example.com/steal'), null);
+    assert.equal(safeHref('//example.com'), null);
+  });
+
+  it('rejects mailto, tel, and other non-http(s) schemes', () => {
+    assert.equal(safeHref('mailto:foo@example.com'), null);
+    assert.equal(safeHref('tel:+1234567890'), null);
+    assert.equal(safeHref('ftp://example.com/file'), null);
+  });
+
+  it('rejects empty / whitespace / non-string input', () => {
+    assert.equal(safeHref(''), null);
+    assert.equal(safeHref('   '), null);
+    assert.equal(safeHref(null), null);
+    assert.equal(safeHref(undefined), null);
+    // @ts-expect-error -- intentionally passing wrong type at runtime
+    assert.equal(safeHref(42), null);
+    // @ts-expect-error -- intentionally passing wrong type at runtime
+    assert.equal(safeHref({ href: 'https://example.com' }), null);
+  });
+
+  it('rejects malformed URLs that throw from the URL constructor', () => {
+    assert.equal(safeHref('http:// not a url'), null);
+    assert.equal(safeHref('https:'), null);
+  });
+});


### PR DESCRIPTION
## Summary

Two related frontend bugs that made key interactions disappear.

### 1. White-pill buttons invisible across the app

`app/globals.css` had unlayered `body { color: #fff }` and `a { color: inherit; text-decoration: none }` rules. In Tailwind v4 these beat `@layer utilities` regardless of source order, so every `<Link className="bg-white ... text-[#11161c]">` rendered as **white text on a white pill**.

Affected surfaces included:
- "Approve launch review" CTA on the campaign workspace (reported via screenshot)
- `NextActionCard` on the dashboard home
- Landing page CTA
- Onboarding "Continue" buttons
- Review-item approval buttons
- Business profile save buttons

**Fix:** wrap the element-reset block in `app/globals.css` in `@layer base` so utility text-color classes can override it (idiomatic Tailwind v4).

Also dropped the local `!text-[#11161c]` / `hover:!text-[#11161c]` workarounds in `campaign-list.tsx` and `latest-campaign-view.tsx` since they are no longer needed.

### 2. Posts page: "assets available" text with no click target

`/dashboard/posts` rendered each inventory card's `<MediaPreview>` as non-interactive. Image assets showed the thumbnail but had no way to open the full-res version; non-image assets (videos, landing pages, PDFs) showed a static text label like "Asset preview available" with no click target, so users could not actually view the generated posts and videos.

**Fix:**
- `frontend/components/media-preview.tsx` — add an optional `href` prop. When set, wraps the preview (image or fallback tile) in an `<a target="_blank" rel="noopener noreferrer">` with hover/focus affordance. Backward-compatible; existing callers unchanged.
- `frontend/aries-v1/posts-screen.tsx`:
  - pass `href={item.previewUrl || item.destinationUrl}` to MediaPreview
  - relabel fallback copy to "Open …" to signal clickability
  - add an explicit coloured action row ("Open preview" / "Open video preview" / "Open landing page" / "Open publish package") in each card's meta section, mirroring the pattern `review-item.tsx` already uses; icon varies by content type (Play / Globe / FileImage)
  - tighten the "No destination URL" empty state so it only renders when neither a preview nor a destination exists.

## Follow-ups not in this PR

- The "Queue / What is ready now" panel list items are still non-clickable — needs `assetsById` lookup hoisted above that section.
- `campaign-list.tsx` still uses `MediaPreview` without an `href`; same one-line fix would make those campaign rollup thumbnails clickable.
- A dedicated asset-detail page / in-page modal remains a bigger UX project. Opening `previewUrl` in a new tab is the minimum viable solution.

## Test plan

- [ ] Hard-reload `/dashboard/posts`; confirm every inventory card with a non-image asset shows a clickable "Open …" action and that clicking opens the asset in a new tab
- [ ] On image assets, confirm the thumbnail itself is a click target (hover shows brightened affordance)
- [ ] Hard-reload any surface with a white-pill CTA (home dashboard Next Action, `/dashboard/campaigns` list, `/onboarding/start`, landing page, campaign workspace "Approve launch review") and confirm the dark navy text + arrow icon are visible again
- [ ] `npm run verify` passes locally (pre-existing `lib/email.ts` resend error is unrelated and present on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)