### PR TITLE
fix(ui): demo-polish bundle - onboarding step 5, brand review buttons, post-approval CTA

### DIFF
--- a/frontend/aries-v1/campaign-workspace.tsx
+++ b/frontend/aries-v1/campaign-workspace.tsx
@@ -311,6 +311,8 @@ export default function AriesCampaignWorkspace(props: { campaignId: string; init
                 ? () => void submitReviewDecision(status.brandReview!.reviewId, 'changes_requested')
                 : undefined
             }
+            nextStageHref={`/dashboard/campaigns/${encodeURIComponent(props.campaignId)}?view=strategy`}
+            nextStageLabel="Go to Strategy Review"
           />
         </div>
       ) : null}
@@ -336,6 +338,8 @@ export default function AriesCampaignWorkspace(props: { campaignId: string; init
               ? () => void submitReviewDecision(status.strategyReview!.reviewId, 'changes_requested', status.approval?.approvalId)
               : undefined
           }
+          nextStageHref={`/dashboard/campaigns/${encodeURIComponent(props.campaignId)}?view=creative`}
+          nextStageLabel="Go to Creative Review"
         />
       ) : null}
 
@@ -666,10 +670,16 @@ function StageReviewSurface(props: {
   busy: boolean;
   onApprove?: () => void;
   onChangesRequested?: () => void;
+  /** Shown after this review is approved so the user has a clear next step
+   * (e.g. "Go to Strategy Review") instead of the stale "Approve" button. */
+  nextStageHref?: string;
+  nextStageLabel?: string;
 }) {
   if (!props.review) {
     return <GateFallbackPanel eyebrow="Checkpoint" fallback={props.fallback} />;
   }
+
+  const isApproved = props.review.status === 'approved';
 
   return (
     <div className="space-y-4">
@@ -723,14 +733,22 @@ function StageReviewSurface(props: {
             </ShellPanel>
           ) : null}
 
-          <ReviewDecisionCard
-            note={props.note}
-            onNoteChange={props.onNoteChange}
-            busy={props.busy}
-            onApprove={props.onApprove}
-            onChangesRequested={props.onChangesRequested}
-            placeholder={props.review.notePlaceholder}
-          />
+          {isApproved && props.nextStageHref ? (
+            <ApprovedNextStageCard
+              href={props.nextStageHref}
+              label={props.nextStageLabel || 'Continue to next review'}
+              stageLabel={reviewSurfaceLabel(props.review.reviewType)}
+            />
+          ) : (
+            <ReviewDecisionCard
+              note={props.note}
+              onNoteChange={props.onNoteChange}
+              busy={props.busy}
+              onApprove={isApproved ? undefined : props.onApprove}
+              onChangesRequested={isApproved ? undefined : props.onChangesRequested}
+              placeholder={props.review.notePlaceholder}
+            />
+          )}
 
           <HistoryCard history={props.review.history} />
         </div>
@@ -872,6 +890,27 @@ function PublishStatusSurface(props: {
   );
 }
 
+function ApprovedNextStageCard(props: { href: string; label: string; stageLabel: string }) {
+  return (
+    <ShellPanel eyebrow={`${props.stageLabel} approved`} title="Ready for the next review">
+      <div className="space-y-4">
+        <p className="text-sm leading-7 text-white/65">
+          This review has been approved. Continue to the next stage to keep the campaign moving.
+        </p>
+        <Link
+          href={props.href}
+          style={{ color: '#11161c' }}
+          className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold transition hover:translate-y-[-1px]"
+        >
+          <CheckCircle2 className="h-4 w-4" />
+          {props.label}
+          <ArrowUpRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </ShellPanel>
+  );
+}
+
 function ReviewDecisionCard(props: {
   note: string;
   onNoteChange: (value: string) => void | null;
@@ -896,7 +935,11 @@ function ReviewDecisionCard(props: {
               type="button"
               onClick={props.onApprove}
               disabled={props.busy}
-              className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] disabled:opacity-60"
+              /* Inline color bypasses any cascade conflict so the approval
+                 label is always visible even if utility layering changes
+                 elsewhere. Belt-and-suspenders for the demo-critical CTA. */
+              style={{ color: '#11161c' }}
+              className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold disabled:opacity-60"
             >
               <CheckCircle2 className="h-4 w-4" />
               {props.busy ? 'Saving...' : 'Approve'}

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -527,7 +527,6 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   const creatingDraftRef = useRef(false);
   const localSaveTimerRef = useRef<number | null>(null);
   const savedIndicatorTimerRef = useRef<number | null>(null);
-  const transitionTimerRef = useRef<number | null>(null);
   const submittingRef = useRef(false);
   const deferredWebsiteUrl = useDeferredValue(websiteUrl.trim());
 
@@ -816,15 +815,6 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
     markSaved,
   ]);
 
-  useEffect(() => {
-    return () => {
-      if (transitionTimerRef.current) {
-        window.clearTimeout(transitionTimerRef.current);
-        transitionTimerRef.current = null;
-      }
-    };
-  }, []);
-
   // Check for local draft on mount and offer to restore.
   useEffect(() => {
     if (resumeChecked) return;
@@ -1039,15 +1029,15 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       clearLocalDraft();
 
       if (props.initialAuthenticated) {
-        // Full-screen transition for ~1.8s before redirecting so the user
-        // sees a clear "we've got it, building your campaign" state instead
-        // of a blank screen while the server-side resume page materializes
-        // the campaign. Timer is tracked in a ref so unmount can cancel it.
+        // Show the full-screen "Building your first campaign plan" state and
+        // navigate immediately. The transition component stays mounted until
+        // Next.js finishes server-rendering /onboarding/resume (which can
+        // take 10-30s while the marketing job materializes), so the user
+        // sees continuous feedback without the 1.8s timer race that caused
+        // earlier "button loops to the same page" reports where the timer
+        // and the unmount cleanup fought each other.
         setShowTransition(true);
-        transitionTimerRef.current = window.setTimeout(() => {
-          transitionTimerRef.current = null;
-          router.push(`/onboarding/resume?draft=${encodeURIComponent(activeDraftId)}`);
-        }, 1800);
+        router.push(`/onboarding/resume?draft=${encodeURIComponent(activeDraftId)}`);
         return;
       }
 
@@ -1789,7 +1779,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                     {submitting
                       ? 'Saving setup...'
                       : props.initialAuthenticated
-                        ? 'Continue to workspace'
+                        ? 'Continue to Dashboard'
                         : 'Save and continue'}
                     <ArrowRight className="h-4 w-4" />
                   </button>

--- a/frontend/aries-v1/review-item.tsx
+++ b/frontend/aries-v1/review-item.tsx
@@ -281,7 +281,11 @@ export default function AriesReviewItemScreen(props: { reviewId: string }) {
                 type="button"
                 onClick={() => void applyDecision('approve')}
                 disabled={busy}
-                className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] disabled:opacity-60"
+                /* Inline color is a cascade-proof belt-and-suspenders for
+                   the approval CTA so the label is always visible on the
+                   white pill even if utility layering shifts elsewhere. */
+                style={{ color: '#11161c' }}
+                className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold disabled:opacity-60"
               >
                 <CheckCircle2 className="h-4 w-4" />
                 {busy ? 'Saving...' : reviewItem.currentVersion.cta || 'Approve'}


### PR DESCRIPTION
## Summary

Three demo-blocking fixes bundled together because they're small and on adjacent code.

### Item 2 - Onboarding step 5 button loop + rename

- Button label: "Continue to workspace" -> **"Continue to Dashboard"** (destination clarity).
- Removed the 1.8s pre-navigation timer and its unmount-cleanup ref. The timer was racing with the useEffect cleanup during component re-renders, which produced the "button has to be clicked multiple times" symptom. Navigation now fires immediately while the full-screen "Building your first campaign plan" state stays mounted during the server-side campaign materialization.

### Item 3 - Brand review Approve button text invisible

The "Approve" label on the white pill button was unreadable on the brand review page and on `/review/[reviewId]`. Added inline `style={{ color: '#11161c' }}` as a cascade-proof fallback on both approval CTAs. This bypasses any Tailwind v4 utility-layer cascade conflicts regardless of source.

### Item 6 - Post-approval button -> "Go to Strategy Review"

After a reviewer approves a stage, the button stayed labelled "Approve" which was confusing. `StageReviewSurface` now accepts optional `nextStageHref` + `nextStageLabel` props; when `review.status === 'approved'` and those props are passed, it renders an `ApprovedNextStageCard` with the "Go to <next> Review" Link instead of the stale decision card.

Wired in for:
- brand approved -> "Go to Strategy Review"
- strategy approved -> "Go to Creative Review"

Creative -> publish is left alone because publish isn't a review (it's a launch state).

## Files

- `frontend/aries-v1/onboarding-flow.tsx` - button label + removed timer + unused ref cleanup
- `frontend/aries-v1/campaign-workspace.tsx` - new `ApprovedNextStageCard`, inline color on approve button, `nextStageHref`/`nextStageLabel` props wired for brand + strategy
- `frontend/aries-v1/review-item.tsx` - inline color on approve button

## Test plan

- [ ] Onboarding flow step 5: single click on "Continue to Dashboard" navigates to resume -> dashboard without needing to click again
- [ ] `/dashboard/brand-review`: approval button text is visible
- [ ] `/dashboard/brand-review`: after approving, card becomes "Brand review approved / Go to Strategy Review" linking to `?view=strategy`
- [ ] `/dashboard/strategy-review`: same pattern; after approving, "Go to Creative Review"
- [ ] `/review/[reviewId]`: approve button text is visible
- [ ] npm run verify passes

## Verification

- npm run typecheck: clean
- Scoped tests (`campaign-workspace-state`, `onboarding-flow-public`, `onboarding-resume`): 16/16 pass

## Follow-ups (separate PRs)

- Item 4: `/dashboard/campaigns` nav vs review routing
- Item 5: Supporting Materials links open raw markdown / download instead of rendering
- Item 1: Delete campaigns feature

Co-Authored-By: Claude Opus 4.6