### PR TITLE
docs: address remaining Copilot comments on PR #130

### DIFF
--- a/backend/marketing/runtime-views.ts
+++ b/backend/marketing/runtime-views.ts
@@ -823,9 +823,10 @@ function firstCheckpointSections(
 // Document/artifact attachments get the polished in-app viewer at
 // /materials/[jobId]/[assetId] instead of the raw /api/.../assets/... URL.
 // The raw route still serves bytes (e.g. the image <img src>), but opening
-// a brand bible or website brand analysis markdown file in a new tab now
-// renders styled HTML through the viewer rather than a black raw-text tab
-// or a forced file download.
+// one of the four document attachments this function routes —
+// research-summary, brand-kit-json, brand-bible-markdown, or
+// brand-design-system — in a new tab now renders styled HTML through the
+// viewer rather than a black raw-text tab or a forced file download.
 function viewerUrl(jobId: string, assetId: string): string {
   return `/materials/${encodeURIComponent(jobId)}/${encodeURIComponent(assetId)}`;
 }

--- a/lib/simple-markdown.ts
+++ b/lib/simple-markdown.ts
@@ -14,9 +14,9 @@
  *   - Paragraphs (blank-line separated)
  *
  * HTML-escapes everything before applying markdown rules, so rendered
- * output is safe to drop into a server-rendered page without dangerouslyXYZ
- * concerns on the source markdown itself. The caller still controls how
- * the resulting HTML is embedded.
+ * output is safe to drop into a server-rendered page without
+ * dangerouslySetInnerHTML concerns on the source markdown itself. The
+ * caller still controls how the resulting HTML is embedded.
  *
  * Prefer marked / remark / react-markdown if we end up needing tables,
  * GFM extensions, or tighter CommonMark compliance. This is deliberately


### PR DESCRIPTION
## Summary

Two doc-only fixes Copilot flagged on [#130](https://github.com/DeliciousHouse/aries-app/pull/130) that didn't make it into the earlier follow-up commit there (46eb1dd handled the three code-level comments; these two are just comment/docstring accuracy).

### 1. `lib/simple-markdown.ts:19` — placeholder leaked into shipped docstring

The doc comment contained a stray `dangerouslyXYZ` placeholder that was obviously leftover from drafting:

> HTML-escapes everything before applying markdown rules, so rendered output is safe to drop into a server-rendered page without **dangerouslyXYZ** concerns…

Replaced with the intended reference (`dangerouslySetInnerHTML`) so the safety statement reads correctly.

### 2. `backend/marketing/runtime-views.ts:828` — comment lists an attachment the code doesn't route

The block comment above `viewerUrl()` mentioned "brand bible or website brand analysis markdown", but `firstCheckpointAttachments()` only routes four attachments through the viewer: `research-summary`, `brand-kit-json`, `brand-bible-markdown`, `brand-design-system`. There is no `website-brand-analysis` attachment. Updated the comment to list the actual four ids so a future edit doesn't assume a fifth route exists.

## Verification

- `npm run typecheck` clean
- No runtime/behavior changes — comments and one docstring word only

## Test plan

- [ ] Confirm `npm run verify` passes

Co-Authored-By: Claude Opus 4.6