### PR TITLE
fix(brand-kit): strip HTML from brand identity + quarantine stale per-tenant validated docs

### DIFF
--- a/backend/marketing/brand-identity.ts
+++ b/backend/marketing/brand-identity.ts
@@ -154,13 +154,21 @@ export function recordMatchesCurrentSource(
   record: Record<string, unknown> | null,
   currentSourceUrl?: string | null,
 ): boolean {
-  const currentFingerprint = normalizeSourceFingerprint(currentSourceUrl);
-  if (!record || !currentFingerprint) {
+  if (!record) {
     return true;
   }
 
+  const currentFingerprint = normalizeSourceFingerprint(currentSourceUrl);
+  if (!currentFingerprint) {
+    return true;
+  }
+
+  // When a current source URL is known, reject records we cannot positively
+  // attribute to that source. Previously an unfingerprinted record was treated
+  // as matching any source, which let stale tenant-scoped files from prior
+  // campaigns leak into the current campaign's approval payload.
   const recordFingerprint = sourceFingerprintFromRecord(record);
-  return !recordFingerprint || recordFingerprint === currentFingerprint;
+  return recordFingerprint === currentFingerprint;
 }
 
 type BuildBrandIdentityInput = {

--- a/backend/marketing/brand-kit.ts
+++ b/backend/marketing/brand-kit.ts
@@ -132,6 +132,22 @@ function normalizeWhitespace(value: string): string {
   return decodeHtmlEntities(value).replace(/\s+/g, ' ').trim();
 }
 
+// Strip nested tags (including framework markers like Angular's `_ngcontent-*`
+// and raw `style="..."` / `class="..."` attribute remnants) and decode entities
+// so values scraped from rendered DOM fragments don't leak raw HTML into
+// brand-kit fields. Applied wherever we pull visible text out of a tag's inner
+// HTML — titles, h1s, image alts.
+function stripHtmlTags(value: string): string {
+  return normalizeWhitespace(
+    value
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ' ')
+      .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  );
+}
+
 function normalizeColor(value: string): string | null {
   const trimmed = value.trim().toLowerCase();
   if (!trimmed || trimmed === 'transparent') {
@@ -244,7 +260,7 @@ function extractMetaContent(html: string, attribute: string, key: string): strin
 
 function extractTitle(html: string): string | null {
   const title = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] || '';
-  return normalizeWhitespace(title) || null;
+  return stripHtmlTags(title) || null;
 }
 
 function extractLinkCandidates(html: string, relNeedle: string): string[] {
@@ -296,7 +312,7 @@ function extractInlineCss(html: string): string[] {
 function extractTextByTag(html: string, tagName: string): string[] {
   return Array.from(
     html.matchAll(new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)<\\/${tagName}>`, 'gi')),
-    (match) => normalizeWhitespace(match[1] || ''),
+    (match) => stripHtmlTags(match[1] || ''),
   ).filter(Boolean);
 }
 
@@ -524,7 +540,12 @@ function brandNameScore(candidate: string, url: string): number {
 }
 
 function cleanBrandNameCandidate(candidate: string, url: string): string | null {
-  const normalized = normalizeWhitespace(candidate);
+  // Defense in depth: if a candidate arrives with nested HTML (because an
+  // upstream extractor returned raw inner HTML instead of visible text),
+  // strip it here before scoring. Otherwise brand_name can persist as a
+  // literal `<span ...>Welcome to </span><span ...>N</span>...` blob and
+  // leak into the brand identity preview / font preview cards.
+  const normalized = stripHtmlTags(candidate);
   if (!normalized) {
     return null;
   }
@@ -876,11 +897,18 @@ export function normalizeBrandKitSignals(input: BrandKitSignalsInput | null | un
 
 function normalizePersistedBrandKit(brandKit: TenantBrandKit): TenantBrandKit {
   const normalizedSignals = normalizeBrandKitSignals(brandKit);
+  // Re-sanitize brand_name on load so brand-kit.json files written before
+  // the HTML-stripping fix don't keep rendering raw markup in the preview.
+  // Fall back to the original trimmed value if sanitization would empty it —
+  // assertTenantBrandKit rejects empty brand names.
+  const sanitizedBrandName =
+    cleanBrandNameCandidate(brandKit.brand_name || '', brandKit.source_url || '') ||
+    normalizeWhitespace(brandKit.brand_name || '');
   return {
     tenant_id: brandKit.tenant_id,
     source_url: brandKit.source_url,
     canonical_url: brandKit.canonical_url ?? null,
-    brand_name: brandKit.brand_name,
+    brand_name: sanitizedBrandName,
     logo_urls: normalizedSignals.logo_urls,
     colors: normalizedSignals.colors,
     font_families: normalizedSignals.font_families,

--- a/backend/marketing/brand-kit.ts
+++ b/backend/marketing/brand-kit.ts
@@ -140,11 +140,16 @@ function normalizeWhitespace(value: string): string {
 // this helper exists to prevent. Applied wherever we pull visible text out of
 // a tag's inner HTML — titles, h1s, image alts.
 function stripHtmlTags(value: string): string {
+  // Closing tags use `<\/name\b[^>]*>` instead of `<\/name>` so HTML variants
+  // that include trailing whitespace or attributes on the close tag (e.g.
+  // `</script >`, `</style foo>`) are still recognized. The narrow
+  // `<\/name>` form leaves the script/style body intact as literal text,
+  // which is what CodeQL's "Bad HTML filtering regexp" rule flags.
   return decodeHtmlEntities(value)
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ' ')
-    .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, ' ')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript\b[^>]*>/gi, ' ')
+    .replace(/<svg\b[^>]*>[\s\S]*?<\/svg\b[^>]*>/gi, ' ')
     .replace(/<[^>]+>/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();

--- a/backend/marketing/brand-kit.ts
+++ b/backend/marketing/brand-kit.ts
@@ -132,20 +132,22 @@ function normalizeWhitespace(value: string): string {
   return decodeHtmlEntities(value).replace(/\s+/g, ' ').trim();
 }
 
-// Strip nested tags (including framework markers like Angular's `_ngcontent-*`
-// and raw `style="..."` / `class="..."` attribute remnants) and decode entities
-// so values scraped from rendered DOM fragments don't leak raw HTML into
-// brand-kit fields. Applied wherever we pull visible text out of a tag's inner
-// HTML — titles, h1s, image alts.
+// Decode entities FIRST, then strip nested tags (including framework markers
+// like Angular's `_ngcontent-*` and raw `style="..."` / `class="..."` attribute
+// remnants). The order matters: if we tag-stripped before decoding, entity-
+// encoded markup like `&lt;span&gt;...` would survive the tag pass and then
+// become literal `<span>` text after decode, re-introducing the raw-HTML leak
+// this helper exists to prevent. Applied wherever we pull visible text out of
+// a tag's inner HTML — titles, h1s, image alts.
 function stripHtmlTags(value: string): string {
-  return normalizeWhitespace(
-    value
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
-      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ' ')
-      .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, ' ')
-      .replace(/<[^>]+>/g, ' '),
-  );
+  return decodeHtmlEntities(value)
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ' ')
+    .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function normalizeColor(value: string): string | null {

--- a/backend/marketing/orchestrator.ts
+++ b/backend/marketing/orchestrator.ts
@@ -66,6 +66,7 @@ import {
   tenantBrandKitPath,
   type TenantBrandKit,
 } from './brand-kit';
+import { invalidateValidatedProfilesIfSourceChanged } from './validated-profile-store';
 
 export type StartMarketingJobRequest = {
   tenantId: string;
@@ -1083,13 +1084,18 @@ export async function startMarketingJob(input: StartMarketingJobRequest): Promis
   const brandCampaignInput = ensureBrandCampaignInput(input);
 
   const jobId = makeMarketingJobId();
+  const tenantId = input.tenantId.trim();
+  // Quarantine tenant-scoped validated docs (brand-profile / website-analysis /
+  // business-profile) from a prior campaign so they cannot bleed into the new
+  // campaign's approval payloads when the brand URL has changed.
+  invalidateValidatedProfilesIfSourceChanged(tenantId, brandCampaignInput.brandUrl);
   const { brandKit, filePath } = await extractAndSaveTenantBrandKit({
-    tenantId: input.tenantId.trim(),
+    tenantId,
     brandUrl: brandCampaignInput.brandUrl,
   });
   const doc = createMarketingJobRuntimeDocument({
     jobId,
-    tenantId: input.tenantId.trim(),
+    tenantId,
     payload: input.payload,
     brandKit: runtimeBrandKitReference(brandKit, filePath),
     createdBy: input.createdBy ?? null,

--- a/backend/marketing/publish-review.ts
+++ b/backend/marketing/publish-review.ts
@@ -812,7 +812,14 @@ function buildFallbackPublishReviewBundle(
     resolveMarketingArtifactPath(stringValue(recordValue(reviewPayload?.artifact_paths)?.preview_path)) ||
     stringArray(platformPreviews[0]?.media_paths)[0] ||
     null;
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id);
+  const runtimeSourceUrl =
+    stringValue(runtimeDoc.inputs.request?.websiteUrl) ||
+    stringValue(runtimeDoc.inputs.request?.brandUrl) ||
+    stringValue(runtimeDoc.inputs.brand_url) ||
+    '';
+  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+    currentSourceUrl: runtimeSourceUrl || null,
+  });
   const validatedLandingHooks = recordValue(validatedProfile.hooks)?.['landing-page'];
   const validatedLandingHook =
     Array.isArray(validatedLandingHooks)

--- a/backend/marketing/validated-profile-store.ts
+++ b/backend/marketing/validated-profile-store.ts
@@ -1,9 +1,14 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync } from 'node:fs';
 
 import type { MarketingBrandIdentity } from '@/lib/api/marketing';
 import { sanitizeLegacyCompetitorUrl } from '@/lib/marketing-competitor';
 import { resolveDataPath } from '@/lib/runtime-paths';
-import { buildMarketingBrandIdentity, recordMatchesCurrentSource } from './brand-identity';
+import {
+  buildMarketingBrandIdentity,
+  normalizeSourceFingerprint,
+  recordMatchesCurrentSource,
+  sourceFingerprintFromRecord,
+} from './brand-identity';
 
 function stringValue(value: unknown): string | null {
   if (typeof value === 'string' && value.trim()) {
@@ -102,6 +107,55 @@ export function tenantBusinessProfilePath(tenantId: string): string {
 
 export function tenantBrandKitPath(tenantId: string): string {
   return resolveDataPath('generated', 'validated', tenantId, 'brand-kit.json');
+}
+
+/**
+ * Quarantine tenant-scoped validated docs that were written for a different
+ * source URL than the campaign now starting. Prevents stale brand-profile /
+ * website-analysis / business-profile content from bleeding into the new
+ * campaign's approval payloads. Files with no recoverable source fingerprint
+ * are quarantined too, because we cannot verify they belong to the new source.
+ *
+ * Renames the offending file to `<name>.stale-<ts>.json` rather than deleting,
+ * so operators can still inspect prior state. brand-kit.json is handled
+ * separately by extractAndSaveTenantBrandKit and is not touched here.
+ */
+export function invalidateValidatedProfilesIfSourceChanged(
+  tenantId: string,
+  newSourceUrl: string | null | undefined,
+): { quarantined: string[] } {
+  const currentFingerprint = normalizeSourceFingerprint(newSourceUrl);
+  if (!currentFingerprint) {
+    return { quarantined: [] };
+  }
+
+  const candidates: string[] = [
+    tenantBrandProfilePath(tenantId),
+    tenantWebsiteAnalysisPath(tenantId),
+    tenantBusinessProfilePath(tenantId),
+  ];
+
+  const quarantined: string[] = [];
+  const stamp = Date.now();
+  for (const filePath of candidates) {
+    if (!existsSync(filePath)) {
+      continue;
+    }
+    const record = readJsonIfExists(filePath);
+    const recordFingerprint = sourceFingerprintFromRecord(record);
+    if (recordFingerprint && recordFingerprint === currentFingerprint) {
+      continue;
+    }
+    const staleName = filePath.replace(/\.json$/, `.stale-${stamp}.json`);
+    try {
+      renameSync(filePath, staleName);
+      quarantined.push(filePath);
+    } catch {
+      // If rename fails (e.g. cross-device), leave the file; the tightened
+      // matcher will still reject it at read time.
+    }
+  }
+  return { quarantined };
 }
 
 export type ValidatedMarketingProfileDocs = {

--- a/backend/marketing/validated-profile-store.ts
+++ b/backend/marketing/validated-profile-store.ts
@@ -120,10 +120,17 @@ export function tenantBrandKitPath(tenantId: string): string {
  * so operators can still inspect prior state. brand-kit.json is handled
  * separately by extractAndSaveTenantBrandKit and is not touched here.
  */
+export type QuarantinedValidatedProfile = {
+  /** Path the file lived at before quarantine (does not exist post-rename). */
+  originalPath: string;
+  /** Path the file now lives at, so operators/logs can locate it. */
+  stalePath: string;
+};
+
 export function invalidateValidatedProfilesIfSourceChanged(
   tenantId: string,
   newSourceUrl: string | null | undefined,
-): { quarantined: string[] } {
+): { quarantined: QuarantinedValidatedProfile[] } {
   const currentFingerprint = normalizeSourceFingerprint(newSourceUrl);
   if (!currentFingerprint) {
     return { quarantined: [] };
@@ -135,7 +142,7 @@ export function invalidateValidatedProfilesIfSourceChanged(
     tenantBusinessProfilePath(tenantId),
   ];
 
-  const quarantined: string[] = [];
+  const quarantined: QuarantinedValidatedProfile[] = [];
   const stamp = Date.now();
   for (const filePath of candidates) {
     if (!existsSync(filePath)) {
@@ -146,10 +153,10 @@ export function invalidateValidatedProfilesIfSourceChanged(
     if (recordFingerprint && recordFingerprint === currentFingerprint) {
       continue;
     }
-    const staleName = filePath.replace(/\.json$/, `.stale-${stamp}.json`);
+    const stalePath = filePath.replace(/\.json$/, `.stale-${stamp}.json`);
     try {
-      renameSync(filePath, staleName);
-      quarantined.push(filePath);
+      renameSync(filePath, stalePath);
+      quarantined.push({ originalPath: filePath, stalePath });
     } catch {
       // If rename fails (e.g. cross-device), leave the file; the tightened
       // matcher will still reject it at read time.

--- a/tests/marketing-brand-kit.test.ts
+++ b/tests/marketing-brand-kit.test.ts
@@ -270,6 +270,48 @@ test('extractBrandKitFromWebsite strips nested HTML markup from the brand name c
   }
 });
 
+test('extractBrandKitFromWebsite strips entity-encoded HTML markup from the brand name', async () => {
+  // Regression for PR #135 review: if tag-stripping runs BEFORE entity decoding,
+  // `&lt;span&gt;...` survives the tag pass and becomes literal `<span>` text
+  // after decode, re-introducing the exact raw-HTML leak stripHtmlTags exists
+  // to prevent. Entities must be decoded first, then tags stripped.
+  const originalFetch = globalThis.fetch;
+  const brandUrl = 'https://entity-nwa.example';
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (url === brandUrl) {
+      return createFetchResponse(
+        `<!doctype html>
+        <html>
+          <head><title>Entity Co</title></head>
+          <body>
+            <h1>&lt;span _ngcontent-x style=&quot;font-family:Cinzel&quot;&gt;Welcome to &lt;/span&gt;&lt;span&gt;Entity Co&lt;/span&gt;</h1>
+          </body>
+        </html>`,
+        'text/html; charset=utf-8',
+      );
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    const { extractBrandKitFromWebsite } = await import('../backend/marketing/brand-kit');
+    const brandKit = await extractBrandKitFromWebsite({
+      tenantId: 'entity-nwa',
+      brandUrl,
+    });
+    assert.doesNotMatch(brandKit.brand_name, /<\/?[a-z]/i, `brand_name leaked literal HTML: ${brandKit.brand_name}`);
+    assert.doesNotMatch(brandKit.brand_name, /&lt;|&gt;|&quot;/i, `brand_name leaked raw entities: ${brandKit.brand_name}`);
+    assert.doesNotMatch(brandKit.brand_name, /_ngcontent-/i, `brand_name leaked Angular marker: ${brandKit.brand_name}`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('normalizePersistedBrandKit sanitizes HTML markup in a cached brand_name on load', async () => {
   await withRuntimeEnv(async () => {
     const { saveTenantBrandKit, loadTenantBrandKit } = await import('../backend/marketing/brand-kit');

--- a/tests/marketing-brand-kit.test.ts
+++ b/tests/marketing-brand-kit.test.ts
@@ -270,6 +270,49 @@ test('extractBrandKitFromWebsite strips nested HTML markup from the brand name c
   }
 });
 
+test('stripHtmlTags handles <script>/<style>/</svg>/</noscript> close-tag variants with whitespace or attributes', async () => {
+  // Regression for CodeQL "Bad HTML filtering regexp" alert. The narrow
+  // `<\/script>` pattern would miss `</script >` or `</script foo>`, so the
+  // script body would survive into brand_name as literal text. The site
+  // below nests a malicious-looking <script> inside the H1 using each
+  // close-tag variant.
+  const originalFetch = globalThis.fetch;
+  const brandUrl = 'https://malformed-close.example';
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (url === brandUrl) {
+      return createFetchResponse(
+        `<!doctype html>
+        <html>
+          <head><title>Malformed Co</title></head>
+          <body>
+            <h1>Real <script>alert('leak-1')</script > Brand <style foo>body{display:none}</style > <noscript >tracker</noscript x> <svg attr><path/></svg > Co</h1>
+          </body>
+        </html>`,
+        'text/html; charset=utf-8',
+      );
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    const { extractBrandKitFromWebsite } = await import('../backend/marketing/brand-kit');
+    const brandKit = await extractBrandKitFromWebsite({
+      tenantId: 'malformed-co',
+      brandUrl,
+    });
+    assert.doesNotMatch(brandKit.brand_name, /alert\(/, `script body leaked: ${brandKit.brand_name}`);
+    assert.doesNotMatch(brandKit.brand_name, /display:none/, `style body leaked: ${brandKit.brand_name}`);
+    assert.doesNotMatch(brandKit.brand_name, /tracker/, `noscript body leaked: ${brandKit.brand_name}`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('extractBrandKitFromWebsite strips entity-encoded HTML markup from the brand name', async () => {
   // Regression for PR #135 review: if tag-stripping runs BEFORE entity decoding,
   // `&lt;span&gt;...` survives the tag pass and becomes literal `<span>` text

--- a/tests/marketing-brand-kit.test.ts
+++ b/tests/marketing-brand-kit.test.ts
@@ -216,6 +216,86 @@ function installRenderedColorBrandSiteFetchMock(capture?: { calls: number }): ()
   };
 }
 
+test('extractBrandKitFromWebsite strips nested HTML markup from the brand name candidates', async () => {
+  // Regression: an Angular/React-rendered H1 can contain nested `<span>`s with
+  // inline `style` / `_ngcontent-*` attributes. The previous extractor returned
+  // inner HTML as the brand name, so the preview card showed raw `<span ...>`
+  // tags as the brand heading and as each font preview's sample text.
+  const originalFetch = globalThis.fetch;
+  const brandUrl = 'https://nwaeventco.example';
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (url === brandUrl) {
+      return createFetchResponse(
+        `<!doctype html>
+        <html>
+          <head>
+            <title>NWA Event Co. | Home</title>
+            <link href="${brandUrl}/styles.css" rel="stylesheet" />
+          </head>
+          <body>
+            <h1>
+              <span _ngcontent-ng-c1473099053 style="font-family: 'Cinzel', serif;">Welcome to </span>
+              <span _ngcontent-ng-c1473099053 style="font-family: 'Cinzel Decorative', serif;">N</span>
+              <span _ngcontent-ng-c1473099053 style="font-family: 'Cinzel', serif;">WA Event Co.</span>
+            </h1>
+          </body>
+        </html>`,
+        'text/html; charset=utf-8',
+      );
+    }
+    if (url === `${brandUrl}/styles.css`) {
+      return createFetchResponse(`body { font-family: "Cinzel", serif; }`, 'text/css');
+    }
+    return new Response('not found', { status: 404 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    const { extractBrandKitFromWebsite } = await import('../backend/marketing/brand-kit');
+    const brandKit = await extractBrandKitFromWebsite({
+      tenantId: 'nwaeventco',
+      brandUrl,
+    });
+
+    assert.ok(brandKit.brand_name, 'brand_name should be extracted');
+    assert.doesNotMatch(brandKit.brand_name, /<\/?[a-z]/i, `brand_name leaked HTML: ${brandKit.brand_name}`);
+    assert.doesNotMatch(brandKit.brand_name, /_ngcontent-/i, `brand_name leaked Angular marker: ${brandKit.brand_name}`);
+    assert.doesNotMatch(brandKit.brand_name, /font-family/i, `brand_name leaked style attribute: ${brandKit.brand_name}`);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('normalizePersistedBrandKit sanitizes HTML markup in a cached brand_name on load', async () => {
+  await withRuntimeEnv(async () => {
+    const { saveTenantBrandKit, loadTenantBrandKit } = await import('../backend/marketing/brand-kit');
+    saveTenantBrandKit('nwaeventco', {
+      tenant_id: 'nwaeventco',
+      source_url: 'https://nwaeventco.example',
+      canonical_url: 'https://nwaeventco.example',
+      brand_name:
+        '<span _ngcontent-ng-c1473099053 style="font-family: \'Cinzel\', serif;">Welcome to </span>' +
+        '<span _ngcontent-ng-c1473099053>N</span>' +
+        '<span _ngcontent-ng-c1473099053>WA Event Co.</span>',
+      logo_urls: [],
+      colors: { primary: null, secondary: null, accent: null, palette: [] },
+      font_families: [],
+      external_links: [],
+      extracted_at: new Date().toISOString(),
+      brand_voice_summary: null,
+      offer_summary: null,
+    });
+    const loaded = loadTenantBrandKit('nwaeventco');
+    assert.ok(loaded);
+    assert.doesNotMatch(loaded!.brand_name, /<\/?[a-z]/i);
+    assert.doesNotMatch(loaded!.brand_name, /_ngcontent-/i);
+  });
+});
+
 test('extractBrandKitFromWebsite derives logo, palette, fonts, and social links from the canonical brand site', async () => {
   const restoreFetch = installBrandSiteFetchMock();
 

--- a/tests/marketing-validated-profile-source-leak.test.ts
+++ b/tests/marketing-validated-profile-source-leak.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-source-leak-'));
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+  try {
+    return await run(dataRoot);
+  } finally {
+    if (previousCodeRoot === undefined) delete process.env.CODE_ROOT;
+    else process.env.CODE_ROOT = previousCodeRoot;
+    if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previousDataRoot;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+async function writeValidatedDocs(
+  dataRoot: string,
+  tenantId: string,
+  docs: {
+    brandProfile?: Record<string, unknown>;
+    websiteAnalysis?: Record<string, unknown>;
+    businessProfile?: Record<string, unknown>;
+  },
+): Promise<{ brandProfilePath: string; websiteAnalysisPath: string; businessProfilePath: string }> {
+  const validatedDir = path.join(dataRoot, 'generated', 'validated', tenantId);
+  await mkdir(validatedDir, { recursive: true });
+  const brandProfilePath = path.join(validatedDir, 'brand-profile.json');
+  const websiteAnalysisPath = path.join(validatedDir, 'website-analysis.json');
+  const businessProfilePath = path.join(validatedDir, 'business-profile.json');
+  if (docs.brandProfile) await writeFile(brandProfilePath, JSON.stringify(docs.brandProfile, null, 2));
+  if (docs.websiteAnalysis) await writeFile(websiteAnalysisPath, JSON.stringify(docs.websiteAnalysis, null, 2));
+  if (docs.businessProfile) await writeFile(businessProfilePath, JSON.stringify(docs.businessProfile, null, 2));
+  return { brandProfilePath, websiteAnalysisPath, businessProfilePath };
+}
+
+test('recordMatchesCurrentSource rejects records whose fingerprint cannot be recovered when a current URL is supplied', async () => {
+  const { recordMatchesCurrentSource } = await import('../backend/marketing/brand-identity');
+  const unfingerprinted = { brand_name: 'Legacy Brand' } as Record<string, unknown>;
+  const fingerprinted = { canonical_url: 'https://nwaeventco.com/', brand_name: 'NWA Event Co' } as Record<string, unknown>;
+  const mismatched = { canonical_url: 'https://mejuri.com/', brand_name: 'Mejuri' } as Record<string, unknown>;
+
+  assert.equal(recordMatchesCurrentSource(unfingerprinted, 'https://nwaeventco.com'), false, 'unfingerprinted record must not leak through');
+  assert.equal(recordMatchesCurrentSource(mismatched, 'https://nwaeventco.com'), false, 'mismatched fingerprint must be rejected');
+  assert.equal(recordMatchesCurrentSource(fingerprinted, 'https://nwaeventco.com'), true, 'matching fingerprint must pass');
+
+  assert.equal(recordMatchesCurrentSource(unfingerprinted, null), true, 'no currentSourceUrl => existence-check semantics');
+  assert.equal(recordMatchesCurrentSource(null, 'https://nwaeventco.com'), true, 'null record => vacuously true');
+});
+
+test('loadValidatedMarketingProfileSnapshot hides stale tenant docs when currentSourceUrl is supplied', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const { loadValidatedMarketingProfileSnapshot } = await import('../backend/marketing/validated-profile-store');
+    await writeValidatedDocs(dataRoot, 'tenant_nwa', {
+      brandProfile: {
+        canonical_url: 'https://mejuri.com/',
+        brand_name: 'Mejuri',
+        offer: 'Handcrafted 14k gold jewelry for daily wear.',
+      },
+      websiteAnalysis: {
+        // Intentionally no source URL — represents a legacy/unfingerprinted file.
+        brand_analysis: { brand_promise: 'Everyday fine jewelry' },
+      },
+      businessProfile: {
+        canonical_url: 'https://nwaeventco.com/',
+        business_name: 'NWA Event Co.',
+      },
+    });
+
+    const snapshot = loadValidatedMarketingProfileSnapshot('tenant_nwa', {
+      currentSourceUrl: 'https://nwaeventco.com',
+    });
+
+    // Mismatched brand-profile must not leak its Mejuri fields into the snapshot.
+    assert.notEqual(snapshot.businessName === 'Mejuri', true, 'Mejuri business name must not leak');
+    assert.doesNotMatch(String(snapshot.offer ?? ''), /handcrafted 14k gold/i, 'Mejuri offer must not leak');
+
+    // Unfingerprinted website-analysis must not influence the snapshot either.
+    // (brand_promise would otherwise surface via validatedProfile.brandIdentity.)
+    assert.doesNotMatch(String(snapshot.brandIdentity?.promise ?? ''), /everyday fine jewelry/i, 'unfingerprinted brand_promise must not leak');
+  });
+});
+
+test('invalidateValidatedProfilesIfSourceChanged quarantines mismatched and unfingerprinted docs and returns both paths', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const {
+      invalidateValidatedProfilesIfSourceChanged,
+      loadValidatedMarketingProfileSnapshot,
+    } = await import('../backend/marketing/validated-profile-store');
+    const { brandProfilePath, websiteAnalysisPath, businessProfilePath } = await writeValidatedDocs(
+      dataRoot,
+      'tenant_nwa',
+      {
+        brandProfile: { canonical_url: 'https://mejuri.com/', brand_name: 'Mejuri' },
+        websiteAnalysis: { brand_analysis: { summary: 'Legacy summary' } },
+        businessProfile: { canonical_url: 'https://nwaeventco.com/', business_name: 'NWA Event Co.' },
+      },
+    );
+
+    const result = invalidateValidatedProfilesIfSourceChanged('tenant_nwa', 'https://nwaeventco.com');
+
+    // The mismatched brand-profile and the unfingerprinted website-analysis must both be quarantined;
+    // the matching business-profile must remain.
+    const originalPaths = result.quarantined.map((entry) => entry.originalPath);
+    assert.equal(originalPaths.includes(brandProfilePath), true, 'brand-profile must be quarantined');
+    assert.equal(originalPaths.includes(websiteAnalysisPath), true, 'unfingerprinted website-analysis must be quarantined');
+    assert.equal(originalPaths.includes(businessProfilePath), false, 'matching business-profile must be preserved');
+
+    for (const entry of result.quarantined) {
+      assert.equal(existsSync(entry.originalPath), false, 'original path must no longer exist');
+      assert.equal(existsSync(entry.stalePath), true, 'stale path must exist');
+      assert.match(entry.stalePath, /\.stale-\d+\.json$/);
+    }
+
+    // After quarantine, loadValidatedMarketingProfileSnapshot must not see the stale content even
+    // if a later caller forgets to pass currentSourceUrl.
+    const snapshot = loadValidatedMarketingProfileSnapshot('tenant_nwa');
+    assert.notEqual(snapshot.businessName, 'Mejuri', 'Mejuri data must not return after quarantine');
+
+    // Sanity check: both the business-profile.json (preserved) and the new .stale- files live side by side.
+    const listing = readdirSync(path.dirname(businessProfilePath));
+    assert.equal(listing.includes('business-profile.json'), true);
+    assert.equal(listing.some((name) => name.endsWith('.stale-' + /* stamp */ '')), false); // shape-only assertion already covered above
+    assert.equal((await readFile(businessProfilePath, 'utf8')).includes('NWA Event Co.'), true);
+  });
+});
+
+test('invalidateValidatedProfilesIfSourceChanged is a no-op when no current source URL is provided', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const { invalidateValidatedProfilesIfSourceChanged } = await import('../backend/marketing/validated-profile-store');
+    const { brandProfilePath } = await writeValidatedDocs(dataRoot, 'tenant_nwa', {
+      brandProfile: { canonical_url: 'https://anything.com/', brand_name: 'Anything' },
+    });
+    const result = invalidateValidatedProfilesIfSourceChanged('tenant_nwa', null);
+    assert.deepEqual(result.quarantined, []);
+    assert.equal(existsSync(brandProfilePath), true, 'file must remain untouched when source is unknown');
+  });
+});


### PR DESCRIPTION
## Summary

The Research approval card was showing data from a completely different campaign, with fields interleaved from three brands — and once that was fixed, the brand identity preview for `nwaeventco.com` rendered raw Angular HTML (`<span _ngcontent-...>Welcome to </span>`) as the brand heading and inside every font preview. Two related bugs:

1. **Cross-campaign leak via tenant-scoped validated docs.**
   - `generated/validated/{tenantId}/brand-profile.json`, `website-analysis.json`, and `business-profile.json` are keyed by tenant only and never cleaned between campaigns.
   - `recordMatchesCurrentSource` treated records whose source fingerprint could not be recovered as matching *any* URL, so an old Mejuri brief leaked into a new NWA Event Co. approval card.
2. **Raw HTML leak into `brand_name` / fonts preview.**
   - `extractTextByTag` returned inner HTML of `<h1>` unchanged, so an Angular-rendered H1 with nested `<span style="font-family: ...">` fragments became the persisted `brand_name`. The onboarding preview renders `brand_name` as both the heading and the sample text of each font preview card, making the failure visible everywhere.

## Fix

- `backend/marketing/brand-identity.ts` — tighten `recordMatchesCurrentSource`: when a current source URL is provided, records without a recoverable fingerprint no longer match.
- `backend/marketing/validated-profile-store.ts` — new `invalidateValidatedProfilesIfSourceChanged(tenantId, newSourceUrl)` helper renames mismatched or unfingerprinted validated docs to `*.stale-<ts>.json` so they can be inspected but cannot influence the new campaign.
- `backend/marketing/orchestrator.ts` — `startMarketingJob` calls the invalidation helper before the brand kit is extracted.
- `backend/marketing/publish-review.ts` — `loadValidatedMarketingProfileSnapshot` now receives `currentSourceUrl` derived from the runtime doc.
- `backend/marketing/brand-kit.ts` — add `stripHtmlTags`, apply in `extractTextByTag` / `extractTitle`, use defensively in `cleanBrandNameCandidate`, and re-sanitize brand_name on load via `normalizePersistedBrandKit` so already-persisted noisy brand kits self-heal.

## Tests

- Two new regression tests in `tests/marketing-brand-kit.test.ts`:
  - `extractBrandKitFromWebsite strips nested HTML markup from the brand name candidates`
  - `normalizePersistedBrandKit sanitizes HTML markup in a cached brand_name on load`

## Test plan

- [x] `npm run typecheck`
- [x] `npm run verify`
- [x] `tests/marketing-brand-kit.test.ts` — 13 tests pass (incl. 2 new)
- [x] Docker image rebuild + container restart verified healthy locally

## Notes

- Two unrelated pre-existing failures in `tests/marketing-brand-identity-parity.test.ts` and `tests/marketing-validated-runtime.test.ts` come from the Python `lobster/bin/brand-profile-db-contract` quality gate (`quality_gate_failed:brand_profile.hooks.meta:too_few_items`) and are not touched by this change — reproduced on clean HEAD.
- The tightened source matcher is backward-compatible for callers that intentionally omit `currentSourceUrl` (e.g. `tenantHasStoredBusinessProfileState`) — they still see an any-records-present check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)