### PR TITLE
fix(marketing): don't leak CLI guidance (launch_approved=true) into the approval UI

### DIFF
--- a/backend/marketing/real-artifacts.ts
+++ b/backend/marketing/real-artifacts.ts
@@ -181,7 +181,45 @@ export function normalizeArtifactText(value: string | null | undefined): string 
   if (!normalized || isLowSignalGeneratedText(normalized)) {
     return null;
   }
-  return normalized;
+  return stripCliIdioms(normalized);
+}
+
+// CLI-facing instructions occasionally leak from workflow scripts into fields
+// that surface directly in the approval UI (approval_message, summary,
+// core_message). The most recent offender was
+//   "Reply with approval and rerun with launch_approved=true to generate ..."
+// — a developer instruction aimed at whoever was invoking the lobster pipeline
+// on the command line, which rendered verbatim inside the cyan approval card.
+// This helper is a defense-in-depth pass: producers (e.g. lobster/bin/*) are
+// the primary fix, but we also scrub the rendered text so a future regression
+// elsewhere can't leak the same pattern to end users.
+// Order matters: rewrite whole CLI-instruction sentences BEFORE stripping the
+// inner flag tokens, otherwise the outer sentence-level pattern no longer
+// matches once the flag token is gone and we're left with grammatically
+// broken halves like "Reply with approval and to generate publish-ready assets."
+const CLI_IDIOM_REWRITES: Array<[RegExp, string]> = [
+  // "Reply/Respond with approval and (re-run|rerun|retry|invoke|restart) ..."
+  // sentence — strip the whole sentence up to the next period, because the
+  // trailing clause ("to generate publish-ready assets") is still CLI guidance
+  // even after the flag name is scrubbed.
+  [/\s*(?:reply|respond)\s+with\s+approval\s+and\s+(?:re[- ]?run|rerun|retry|invoke|restart)\b[^.]*\.?\s*/gi, ' '],
+  // Standalone "rerun with foo_bar=true/false ..." sentence (no "reply with
+  // approval and" preamble), also up to the next period.
+  [/\s*(?:re[- ]?run|rerun|retry|invoke|restart)\s+with\s+[a-z0-9_-]+\s*=\s*(?:true|false)\b[^.]*\.?\s*/gi, ' '],
+  // Bare `flag=true` / `flag=false` tokens left behind after the rewrites above
+  // or appearing standalone in other fields.
+  [/\b[a-z][a-z0-9_-]*\s*=\s*(?:true|false)\b/gi, ''],
+  // Long-form CLI flags that shouldn't appear in UI copy.
+  [/\s--[a-z][a-z0-9-]*(?:=[^\s.,;]+)?/gi, ''],
+];
+
+function stripCliIdioms(value: string): string {
+  let result = value;
+  for (const [pattern, replacement] of CLI_IDIOM_REWRITES) {
+    result = result.replace(pattern, replacement);
+  }
+  // Collapse any double-spaces / leftover punctuation introduced by rewrites.
+  return result.replace(/\s+([.,;:!?])/g, '$1').replace(/\s{2,}/g, ' ').trim();
 }
 
 export function explicitArtifactValue(value: string | null | undefined, fallback = ARTIFACT_UNAVAILABLE_TEXT): string {

--- a/lobster/bin/launch-review-preview
+++ b/lobster/bin/launch-review-preview
@@ -728,10 +728,19 @@ def main() -> int:
     run_id = ensure_run_id(data.get("run_id", ""), brand_slug, data.get("campaign_name", ""))
     plan = data.get("publish_plan", {})
     launch_approved = _as_bool(args.launch_approved)
+    # Keep this string strictly user-facing. The prior version ended with
+    # "Reply with approval and rerun with launch_approved=true to generate
+    # publish-ready assets." — a CLI instruction aimed at whoever was
+    # invoking the workflow directly, which then surfaced verbatim inside
+    # the approval card in the web UI. That kind of developer-facing idiom
+    # (flag names, rerun/retry guidance, "=true/false") must not appear in
+    # approval_message; the frontend sanitizer is defense-in-depth only.
+    campaign_name_text = data.get("campaign_name", brand_slug)
     approval_message = (
-        f"Approval needed: marketing pipeline launch review for {data.get('campaign_name', brand_slug)}. "
-        f"Static assets: {plan.get('static_contract_count', 0)}. Video assets: {plan.get('video_contract_count', 0)}. "
-        "Reply with approval and rerun with launch_approved=true to generate publish-ready assets."
+        f"Launch review for {campaign_name_text} is ready. "
+        f"This package covers {plan.get('static_contract_count', 0)} static assets "
+        f"and {plan.get('video_contract_count', 0)} video assets. "
+        "Approve to move these into publish-ready production, or request changes to keep the package open for revision."
     )
     review_bundle = _build_review_bundle(data, "", approval_message, launch_approved)
     _validate_review_bundle(review_bundle)

--- a/tests/marketing-approval-message-sanitizer.test.ts
+++ b/tests/marketing-approval-message-sanitizer.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeArtifactText } from '../backend/marketing/real-artifacts';
+
+test('normalizeArtifactText strips "rerun with flag=true" CLI guidance from approval-facing copy', () => {
+  const leaked =
+    'Approval needed: marketing pipeline launch review for Acme Growth Testing Plan. ' +
+    'Static assets: 6. Video assets: 8. ' +
+    'Reply with approval and rerun with launch_approved=true to generate publish-ready assets.';
+  const cleaned = normalizeArtifactText(leaked) || '';
+  assert.doesNotMatch(cleaned, /launch_approved=true/i, `CLI flag leaked: ${cleaned}`);
+  assert.doesNotMatch(cleaned, /\brerun\b/i, `"rerun" verb leaked: ${cleaned}`);
+  assert.doesNotMatch(cleaned, /reply with approval/i, `CLI preamble leaked: ${cleaned}`);
+  // The factual, user-relevant bits (asset counts) must survive.
+  assert.match(cleaned, /Static assets: 6/);
+  assert.match(cleaned, /Video assets: 8/);
+});
+
+test('normalizeArtifactText strips bare foo=true / --flag tokens', () => {
+  assert.equal(
+    normalizeArtifactText('Please pass launch_approved=true to continue.'),
+    'Please pass to continue.',
+  );
+  const withLongFlag = normalizeArtifactText('Run the command --verbose=loud to see output.') || '';
+  assert.doesNotMatch(withLongFlag, /--verbose/);
+});
+
+test('normalizeArtifactText leaves clean marketing copy untouched', () => {
+  const copy = 'Handcrafted 14k gold jewelry designed for daily wear at accessible price points.';
+  assert.equal(normalizeArtifactText(copy), copy);
+});
+
+test('normalizeArtifactText still strips the "rerun" variant with a hyphen or extra spaces', () => {
+  const variants = [
+    'Reply with approval and re-run with launch_approved=true to generate publish-ready assets.',
+    'Reply with approval and retry with LAUNCH_APPROVED=TRUE to move forward.',
+  ];
+  for (const value of variants) {
+    const cleaned = normalizeArtifactText(value) || '';
+    assert.doesNotMatch(cleaned, /launch_approved\s*=\s*true/i, `variant leaked: ${value} -> ${cleaned}`);
+    assert.doesNotMatch(cleaned, /\bre-?run\b/i);
+    assert.doesNotMatch(cleaned, /\bretry\b/i);
+  }
+});


### PR DESCRIPTION
## Summary

The stage-4 launch-review approval card was rendering a cyan banner ending with

> "Reply with approval and rerun with \`launch_approved=true\` to generate publish-ready assets."

That's developer guidance for whoever is invoking the lobster pipeline on the command line, not user-facing copy. It made the UI look like a half-wired internal tool instead of a review surface a client can act on.

## Fix

Two layers so one layer can't silently regress the other:

1. **Producer — \`lobster/bin/launch-review-preview\`**: rewrite the \`approval_message\` string to frame the package in user terms. New message:

   > "Launch review for \<campaign\> is ready. This package covers N static assets and M video assets. Approve to move these into publish-ready production, or request changes to keep the package open for revision."

2. **Defense-in-depth — \`backend/marketing/real-artifacts.ts\`**: \`normalizeArtifactText\` now runs every approval-facing string through a new \`stripCliIdioms\` pass that rewrites CLI-style guidance out of copy before it reaches the UI. Covers:
   - "Reply/Respond with approval and (re-run|rerun|retry|invoke|restart) …" sentences
   - "rerun/retry with \`foo=true\` …" sentences (including hyphen and uppercase variants)
   - bare \`flag=true\` / \`flag=false\` tokens
   - \`--long-flag\` style tokens

   Order is critical: sentence-level rewrites run BEFORE single-token rewrites so the broader pattern still matches; otherwise we'd be left with grammatically broken halves like "Reply with approval and to generate publish-ready assets." A comment in the source spells this out.

Because \`normalizeArtifactText\` is the gate for every user-visible artifact field — approval_message, core_message, offer_summary, headline, subheadline, cta, hook, opening line, etc. — a future regression elsewhere in the lobster pipeline that leaks the same pattern is also scrubbed.

## Tests

- 4 new regression tests in \`tests/marketing-approval-message-sanitizer.test.ts\`:
  - strips the exact offending string; keeps user-relevant asset counts
  - strips bare \`foo=true\` / \`--flag\` tokens
  - leaves clean marketing copy untouched
  - handles \`re-run\` / \`retry\` / uppercase variants
- \`npm run typecheck\`, \`npm run verify\`: green
- Re-ran marketing-approval-persistence / marketing-flow-smoke / marketing-job-flow / marketing-brand-kit / marketing-validated-profile-source-leak: 41 tests pass, zero regressions

## Out of scope

The user also reported asset-fetch 404s across the board, a progress bar stuck at 16%, and Launch Status showing "ready for launch" while assets are still generating. Those are separate bugs that need more investigation — I'll file them as follow-up issues rather than roll them into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)