### PR TITLE
fix(aries-v1): make Launch-ready items clickable (GH#139 symptom 3)

### DIFF
--- a/frontend/aries-v1/campaign-workspace.tsx
+++ b/frontend/aries-v1/campaign-workspace.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { ArrowUpRight, CheckCircle2, MessageSquareText, XCircle } from 'lucide-react';
 
 import MediaPreview from '@/frontend/components/media-preview';
+import { safeHref } from '@/lib/safe-href';
 import { useMarketingJobStatus } from '@/hooks/use-marketing-job-status';
 import type {
   MarketingCampaignStatusHistoryEntry,
@@ -864,8 +865,10 @@ function PublishStatusSurface(props: {
           <EmptyStatePanel compact title={props.overview.emptyTitle} description={props.overview.emptyDescription} />
         ) : (
           <div className="space-y-3">
-            {props.publishItems.map((item) => (
-              <div key={item.id} className="rounded-[1.25rem] border border-white/8 bg-black/12 px-4 py-4">
+            {props.publishItems.map((item) => {
+              const hrefCandidate = safeHref(item.destinationUrl);
+              const isExternal = hrefCandidate ? /^https?:\/\//i.test(hrefCandidate) : false;
+              const itemBody = (
                 <div className="flex items-start justify-between gap-3">
                   <div className="space-y-1">
                     <p className="text-sm font-medium text-white">{item.title}</p>
@@ -877,8 +880,34 @@ function PublishStatusSurface(props: {
                     {workflowStateLabel(item.status)}
                   </StatusChip>
                 </div>
-              </div>
-            ))}
+              );
+              const cardClass = `block rounded-[1.25rem] border border-white/8 bg-black/12 px-4 py-4 ${hrefCandidate ? 'transition hover:border-white/20 hover:bg-black/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/30' : ''}`;
+              if (hrefCandidate && isExternal) {
+                return (
+                  <a
+                    key={item.id}
+                    href={hrefCandidate}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cardClass}
+                  >
+                    {itemBody}
+                  </a>
+                );
+              }
+              if (hrefCandidate) {
+                return (
+                  <Link key={item.id} href={hrefCandidate} className={cardClass}>
+                    {itemBody}
+                  </Link>
+                );
+              }
+              return (
+                <div key={item.id} className={cardClass}>
+                  {itemBody}
+                </div>
+              );
+            })}
           </div>
         )}
       </ShellPanel>


### PR DESCRIPTION
Part of #139.

## Scope
Addresses **only** symptom 3 from #139: "Items in the Launch Ready Items list are not clickable." The other four symptoms (readiness-gate lie, 0 asset count, progress bar stuck at 16%, active form for already-resolved approvals) are handled by #141 — zero file overlap between the two PRs.

## Change
In `frontend/aries-v1/campaign-workspace.tsx` the `PublishStatusSurface` rendered each publish item as a non-interactive `<div>`, so the user could not drill into anything the page called "launch-ready."

Each row is now wrapped in a link when a safe `destinationUrl` exists:
- **External http(s) URLs** → `<a target="_blank" rel="noopener noreferrer">`
- **Relative / same-origin paths** → `next/link`
- **No destination yet** → stays a plain `<div>` (no phantom hover/focus affordance)

All hrefs go through `lib/safe-href#safeHref`, so `javascript:`, `data:`, `vbscript:` and scheme-relative inputs are rejected before reaching the DOM. Hover/focus-visible states are only attached when the row is actually navigable.

## Validation
- `npx tsc --noEmit -p tsconfig.check.json` — clean
- `npm run validate:repo-boundary` — ok (416 files)
- `npm run validate:banned-patterns` — ok

## Not in this PR
- Nothing from #141's surface (`workspace-views.ts`, `campaign-workspace-state.ts`, `job-approve.tsx`, the Brand assets metric card).
- No backend changes.

Refs #139. Coordinates with #141.