### PR TITLE
fix(marketing): align publish review asset ids

### DIFF
--- a/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
@@ -9,6 +9,26 @@ const MARKETING_ONBOARDING_REQUIRED = {
   message: 'Complete tenant onboarding before viewing brand campaign assets.',
 } as const;
 
+const ASSET_NOT_FOUND_BODY = JSON.stringify({
+  error: 'Marketing asset not found.',
+  reason: 'marketing_asset_not_found',
+});
+
+function assetNotFoundResponse(
+  jobId: string,
+  assetId: string,
+  cause: 'tenant_mismatch' | 'asset_descriptor_missing' | 'asset_file_missing',
+): Response {
+  // Branch-distinguishing log so operators can tell which of the three 404
+  // paths fired without leaking internal state to the client (the response
+  // body intentionally stays an opaque `marketing_asset_not_found`).
+  console.warn('[marketing-asset-not-found]', { jobId, assetId, cause });
+  return new Response(ASSET_NOT_FOUND_BODY, {
+    status: 404,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
 export async function handleGetMarketingJobAsset(
   jobId: string,
   assetId: string,
@@ -30,26 +50,17 @@ export async function handleGetMarketingJobAsset(
   }
 
   if (runtimeDoc.tenant_id !== tenantResult.tenantContext.tenantId) {
-    return new Response(JSON.stringify({ error: 'Marketing asset not found.', reason: 'marketing_asset_not_found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
+    return assetNotFoundResponse(jobId, assetId, 'tenant_mismatch');
   }
 
   const asset = findMarketingAsset(jobId, runtimeDoc, assetId);
   if (!asset) {
-    return new Response(JSON.stringify({ error: 'Marketing asset not found.', reason: 'marketing_asset_not_found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
+    return assetNotFoundResponse(jobId, assetId, 'asset_descriptor_missing');
   }
 
   const buffer = await readMarketingAssetWithinAllowedRoots(asset.filePath);
   if (!buffer) {
-    return new Response(JSON.stringify({ error: 'Marketing asset not found.', reason: 'marketing_asset_not_found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
+    return assetNotFoundResponse(jobId, assetId, 'asset_file_missing');
   }
 
   // `inline` (not `attachment`) keeps the browser from surprise-downloading

--- a/app/api/marketing/jobs/[jobId]/workspace-assets/[assetId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/workspace-assets/[assetId]/handler.ts
@@ -2,7 +2,7 @@ import { readFile, realpath } from 'node:fs/promises';
 import path from 'node:path';
 
 import { loadCampaignWorkspaceRecord } from '@/backend/marketing/workspace-store';
-import { resolveDataPath } from '@/lib/runtime-paths';
+import { resolveCodeRoot, resolveDataPath } from '@/lib/runtime-paths';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 const MARKETING_ONBOARDING_REQUIRED = {
@@ -11,9 +11,134 @@ const MARKETING_ONBOARDING_REQUIRED = {
   message: 'Complete tenant onboarding before viewing campaign workspace assets.',
 } as const;
 
+const ASSET_NOT_FOUND_BODY = JSON.stringify({
+  error: 'Marketing asset not found.',
+  reason: 'marketing_asset_not_found',
+});
+
+function assetNotFoundResponse(
+  jobId: string,
+  assetId: string,
+  cause:
+    | 'tenant_mismatch'
+    | 'asset_descriptor_missing'
+    | 'asset_file_outside_allowed_root'
+    | 'asset_file_read_failed',
+): Response {
+  console.warn('[marketing-workspace-asset-not-found]', { jobId, assetId, cause });
+  return new Response(ASSET_NOT_FOUND_BODY, {
+    status: 404,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
 function isWithinRoot(root: string, candidate: string): boolean {
   const relative = path.relative(root, candidate);
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+type NormalizedAssetPath =
+  | { kind: 'relative'; path: string }
+  | { kind: 'absolute'; path: string };
+
+function normalizeAssetPath(filePath: string): NormalizedAssetPath | null {
+  const trimmed = filePath.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (path.isAbsolute(trimmed)) {
+    return {
+      kind: 'absolute',
+      path: path.normalize(trimmed),
+    };
+  }
+
+  const segments = trimmed.split(/[\\/]+/).filter(Boolean);
+  if (segments.length === 0 || segments.some((segment) => segment === '.' || segment === '..')) {
+    return null;
+  }
+
+  return {
+    kind: 'relative',
+    path: path.join(...segments),
+  };
+}
+
+function trustedWorkspaceRoots(): string[] {
+  const codeRoot = path.normalize(resolveCodeRoot());
+  return Array.from(
+    new Set([
+      resolveDataPath('generated', 'draft', 'marketing-workspaces'),
+      path.join(codeRoot, 'generated', 'draft', 'marketing-workspaces'),
+      path.join(codeRoot, 'aries-app', 'generated', 'draft', 'marketing-workspaces'),
+    ]),
+  );
+}
+
+function absoluteCompatibilityCandidates(filePath: string): string[] {
+  const normalized = path.normalize(filePath);
+  const candidates = new Set([normalized]);
+  const codeRoot = path.normalize(resolveCodeRoot());
+  const remapPrefixes = [
+    '/home/node/workspace/aries-app',
+    '/app/aries-app',
+    path.join(codeRoot, 'aries-app'),
+  ].map((prefix) => path.normalize(prefix));
+
+  for (const prefix of remapPrefixes) {
+    if (normalized !== prefix && !normalized.startsWith(`${prefix}${path.sep}`)) {
+      continue;
+    }
+
+    const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '');
+    candidates.add(path.join(codeRoot, suffix));
+  }
+
+  return Array.from(candidates);
+}
+
+async function resolveWorkspaceAssetPath(filePath: string): Promise<string | null> {
+  const normalizedPath = normalizeAssetPath(filePath);
+  if (!normalizedPath) {
+    return null;
+  }
+
+  const roots = trustedWorkspaceRoots();
+  const candidates =
+    normalizedPath.kind === 'absolute'
+      ? absoluteCompatibilityCandidates(normalizedPath.path)
+      : roots.map((root) => path.resolve(root, normalizedPath.path));
+
+  for (const candidate of candidates) {
+    for (const root of roots) {
+      if (!isWithinRoot(root, candidate)) {
+        continue;
+      }
+      try {
+        const [resolvedRoot, resolvedCandidate] = await Promise.all([
+          realpath(root).catch(() => root),
+          realpath(candidate),
+        ]);
+        if (!isWithinRoot(resolvedRoot, resolvedCandidate)) {
+          continue;
+        }
+        return resolvedCandidate;
+      } catch (error) {
+        if (
+          error &&
+          typeof error === 'object' &&
+          'code' in error &&
+          (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+        ) {
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  return null;
 }
 
 export async function handleGetMarketingWorkspaceAsset(
@@ -37,37 +162,22 @@ export async function handleGetMarketingWorkspaceAsset(
   }
 
   if (record.tenant_id !== tenantResult.tenantContext.tenantId) {
-    return new Response(JSON.stringify({ error: 'Marketing asset not found.', reason: 'marketing_asset_not_found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
+    return assetNotFoundResponse(jobId, assetId, 'tenant_mismatch');
   }
 
   const asset = record.brief.brandAssets.find((entry) => entry.id === assetId);
   if (!asset) {
-    return new Response(JSON.stringify({ error: 'Marketing asset not found.', reason: 'marketing_asset_not_found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
+    return assetNotFoundResponse(jobId, assetId, 'asset_descriptor_missing');
   }
 
-  const trustedRoot = await realpath(resolveDataPath('generated', 'draft', 'marketing-workspaces')).catch(() =>
-    resolveDataPath('generated', 'draft', 'marketing-workspaces'),
-  );
-  const resolvedPath = await realpath(asset.filePath).catch(() => null);
-  if (!resolvedPath || !isWithinRoot(trustedRoot, resolvedPath)) {
-    return new Response(JSON.stringify({ error: 'Marketing asset not found.', reason: 'marketing_asset_not_found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
+  const resolvedPath = await resolveWorkspaceAssetPath(asset.filePath);
+  if (!resolvedPath) {
+    return assetNotFoundResponse(jobId, assetId, 'asset_file_outside_allowed_root');
   }
 
   const buffer = await readFile(resolvedPath).catch(() => null);
   if (!buffer) {
-    return new Response(JSON.stringify({ error: 'Marketing asset not found.', reason: 'marketing_asset_not_found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
+    return assetNotFoundResponse(jobId, assetId, 'asset_file_read_failed');
   }
 
   return new Response(buffer, {

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -6,6 +6,7 @@ import { resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
 import { listMarketingDashboardAssetsForJob } from './dashboard-content';
 import { collectResearchStageArtifacts, collectStrategyReviewArtifacts } from './artifact-collector';
 import {
+  canonicalizePublishReviewPlatformSlug,
   legacyPublishReviewLinkedAssetId,
   legacyPublishReviewMediaAssetId,
   publishReviewLinkedAssetId,
@@ -141,7 +142,7 @@ function uniqueStrings(values: Array<string | null | undefined>): string[] {
 }
 
 function normalizePublishPreviewSlug(platform: Record<string, unknown>, previewIndex: number): string {
-  return slugify(stringValue(platform.platform_slug, `platform-${previewIndex + 1}`), `platform-${previewIndex + 1}`);
+  return canonicalizePublishReviewPlatformSlug(platform.platform_slug, `platform-${previewIndex + 1}`);
 }
 
 function sniffImageContentType(filePath: string): string | null {

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -5,6 +5,12 @@ import { resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
 
 import { listMarketingDashboardAssetsForJob } from './dashboard-content';
 import { collectResearchStageArtifacts, collectStrategyReviewArtifacts } from './artifact-collector';
+import {
+  legacyPublishReviewLinkedAssetId,
+  legacyPublishReviewMediaAssetId,
+  publishReviewLinkedAssetId,
+  publishReviewMediaAssetId,
+} from './publish-review-asset-ids';
 import { extractPublishReviewBundle } from './publish-review';
 import type { MarketingJobRuntimeDocument } from './runtime-state';
 import { loadValidatedMarketingProfileDocs, loadValidatedMarketingProfileSnapshot } from './validated-profile-store';
@@ -25,15 +31,24 @@ export type MarketingAssetLink = {
 
 function resolveExistingAbsoluteAssetPath(filePath: string): string | null {
   const normalizedPath = path.normalize(filePath);
-  if (existsSync(normalizedPath)) {
-    return normalizedPath;
+  const codeRoot = path.normalize(resolveCodeRoot());
+  const remapPrefixes = [
+    '/home/node/workspace/aries-app',
+    '/app/aries-app',
+    path.join(codeRoot, 'aries-app'),
+  ].map((prefix) => path.normalize(prefix));
+  const candidates = new Set([normalizedPath]);
+
+  for (const prefix of remapPrefixes) {
+    if (normalizedPath !== prefix && !normalizedPath.startsWith(`${prefix}${path.sep}`)) {
+      continue;
+    }
+
+    const suffix = normalizedPath.slice(prefix.length).replace(/^[\\/]+/, '');
+    candidates.add(path.join(codeRoot, suffix));
   }
 
-  const codeRoot = path.normalize(resolveCodeRoot());
-  const legacyCodeRoot = path.join(codeRoot, 'aries-app');
-  if (normalizedPath === legacyCodeRoot || normalizedPath.startsWith(`${legacyCodeRoot}${path.sep}`)) {
-    const suffix = normalizedPath.slice(legacyCodeRoot.length + 1);
-    const candidate = path.join(codeRoot, suffix);
+  for (const candidate of candidates) {
     if (existsSync(candidate)) {
       return candidate;
     }
@@ -123,6 +138,10 @@ function slugify(value: string, fallback = ''): string {
 
 function uniqueStrings(values: Array<string | null | undefined>): string[] {
   return Array.from(new Set(values.map((value) => stringValue(value)).filter(Boolean)));
+}
+
+function normalizePublishPreviewSlug(platform: Record<string, unknown>, previewIndex: number): string {
+  return slugify(stringValue(platform.platform_slug, `platform-${previewIndex + 1}`), `platform-${previewIndex + 1}`);
 }
 
 function sniffImageContentType(filePath: string): string | null {
@@ -402,22 +421,54 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
     addAsset('review-packet-production', stringValue(reviewPacket?.production_review_preview_path) || null, 'Production review preview');
     addAsset('review-packet-canonical', stringValue(reviewPacket?.canonical_review_packet_path) || null, 'Canonical review packet');
 
-    for (const platform of platformPreviews) {
-      const slug = stringValue(platform.platform_slug, 'platform');
+    for (const [previewIndex, platform] of platformPreviews.entries()) {
+      const slug = normalizePublishPreviewSlug(platform, previewIndex);
       const platformName = stringValue(platform.platform_name, slug);
       const assetPaths = recordValue(platform.asset_paths);
 
       stringArray(platform.media_paths).forEach((filePath, index) => {
         addAsset(
-          `platform-preview-${slug}-media-${index + 1}`,
+          publishReviewMediaAssetId({
+            platformSlug: slug,
+            previewIndex,
+            explicitPreviewAssetId: platform.asset_preview_id,
+            mediaIndex: index,
+          }),
           filePath,
           `${platformName} media ${index + 1}`,
           previewFallbacksByPlatform.get(slug) || previewFallbacksByPlatform.get('landing-page') || []
         );
       });
-      addAsset(`platform-preview-${slug}-asset-contract`, stringValue(assetPaths?.contract_path) || null, `${platformName} contract`);
-      addAsset(`platform-preview-${slug}-asset-brief`, stringValue(assetPaths?.brief_path) || null, `${platformName} brief`);
-      addAsset(`platform-preview-${slug}-asset-landing-page`, stringValue(assetPaths?.landing_page_path) || null, `${platformName} landing page`);
+      addAsset(
+        publishReviewLinkedAssetId({
+          platformSlug: slug,
+          previewIndex,
+          explicitPreviewAssetId: platform.asset_preview_id,
+          suffix: 'contract',
+        }),
+        stringValue(assetPaths?.contract_path) || null,
+        `${platformName} contract`,
+      );
+      addAsset(
+        publishReviewLinkedAssetId({
+          platformSlug: slug,
+          previewIndex,
+          explicitPreviewAssetId: platform.asset_preview_id,
+          suffix: 'brief',
+        }),
+        stringValue(assetPaths?.brief_path) || null,
+        `${platformName} brief`,
+      );
+      addAsset(
+        publishReviewLinkedAssetId({
+          platformSlug: slug,
+          previewIndex,
+          explicitPreviewAssetId: platform.asset_preview_id,
+          suffix: 'landing-page',
+        }),
+        stringValue(assetPaths?.landing_page_path) || null,
+        `${platformName} landing page`,
+      );
     }
   }
 
@@ -446,5 +497,59 @@ export function findMarketingAsset(
   runtimeDoc: MarketingJobRuntimeDocument,
   assetId: string
 ): MarketingAssetDescriptor | null {
-  return buildMarketingAssetLibrary(jobId, runtimeDoc).find((asset) => asset.id === assetId) ?? null;
+  const assets = buildMarketingAssetLibrary(jobId, runtimeDoc);
+  const directMatch = assets.find((asset) => asset.id === assetId);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const reviewBundle = extractPublishReviewBundle(runtimeDoc);
+  const platformPreviews = recordArray(reviewBundle?.platform_previews);
+  const legacyToCanonical = new Map<string, string>();
+
+  for (const [previewIndex, platform] of platformPreviews.entries()) {
+    const slug = normalizePublishPreviewSlug(platform, previewIndex);
+    const explicitPreviewAssetId = platform.asset_preview_id;
+
+    stringArray(platform.media_paths).forEach((_, mediaIndex) => {
+      legacyToCanonical.set(
+        legacyPublishReviewMediaAssetId(slug, mediaIndex),
+        publishReviewMediaAssetId({
+          platformSlug: slug,
+          previewIndex,
+          explicitPreviewAssetId,
+          mediaIndex,
+        }),
+      );
+    });
+
+    for (const suffix of ['contract', 'brief', 'landing-page'] as const) {
+      const assetPaths = recordValue(platform.asset_paths);
+      const candidatePath =
+        suffix === 'contract'
+          ? stringValue(assetPaths?.contract_path)
+          : suffix === 'brief'
+            ? stringValue(assetPaths?.brief_path)
+            : stringValue(assetPaths?.landing_page_path);
+      if (!candidatePath) {
+        continue;
+      }
+      legacyToCanonical.set(
+        legacyPublishReviewLinkedAssetId(slug, suffix),
+        publishReviewLinkedAssetId({
+          platformSlug: slug,
+          previewIndex,
+          explicitPreviewAssetId,
+          suffix,
+        }),
+      );
+    }
+  }
+
+  const canonicalId = legacyToCanonical.get(assetId);
+  if (!canonicalId) {
+    return null;
+  }
+
+  return assets.find((asset) => asset.id === canonicalId) ?? null;
 }

--- a/backend/marketing/asset-read.ts
+++ b/backend/marketing/asset-read.ts
@@ -129,10 +129,18 @@ function absoluteCompatibilityCandidates(filePath: string): string[] {
   const normalized = path.normalize(filePath);
   const candidates = new Set([normalized]);
   const codeRoot = path.normalize(resolveCodeRoot());
-  const legacyCodeRoot = path.join(codeRoot, 'aries-app');
+  const remapPrefixes = [
+    '/home/node/workspace/aries-app',
+    '/app/aries-app',
+    path.join(codeRoot, 'aries-app'),
+  ].map((prefix) => path.normalize(prefix));
 
-  if (normalized === legacyCodeRoot || normalized.startsWith(`${legacyCodeRoot}${path.sep}`)) {
-    const suffix = normalized.slice(legacyCodeRoot.length);
+  for (const prefix of remapPrefixes) {
+    if (normalized !== prefix && !normalized.startsWith(`${prefix}${path.sep}`)) {
+      continue;
+    }
+
+    const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '');
     candidates.add(path.join(codeRoot, suffix));
   }
 

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -7,6 +7,7 @@ import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime
 
 import type { MarketingCampaignWindow } from './jobs-status'
 import { extractPublishReviewBundle } from './publish-review'
+import { publishReviewLinkedAssetId, publishReviewMediaAssetId } from './publish-review-asset-ids'
 import {
   campaignRootForBrand as realArtifactCampaignRootForBrand,
   inferBrandSlug,
@@ -1510,7 +1511,11 @@ function resolveDashboardAssetFilePath(
   fallbackPaths: Array<string | null | undefined> = [],
 ): string | null {
   const codeRoot = path.normalize(resolveCodeRoot())
-  const legacyCodeRoot = path.join(codeRoot, 'aries-app')
+  const remapPrefixes = [
+    '/home/node/workspace/aries-app',
+    '/app/aries-app',
+    path.join(codeRoot, 'aries-app'),
+  ].map((prefix) => path.normalize(prefix))
   const roots = [
     resolveDataRoot(),
     resolveCodeRoot(),
@@ -1538,15 +1543,19 @@ function resolveDashboardAssetFilePath(
     }
 
     const normalized = path.normalize(candidate)
-    if (existsSync(normalized)) {
-      return normalized
+    const compatibilityCandidates = new Set([normalized])
+    for (const prefix of remapPrefixes) {
+      if (normalized !== prefix && !normalized.startsWith(`${prefix}${path.sep}`)) {
+        continue
+      }
+
+      const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '')
+      compatibilityCandidates.add(path.join(codeRoot, suffix))
     }
 
-    if (normalized === legacyCodeRoot || normalized.startsWith(`${legacyCodeRoot}${path.sep}`)) {
-      const suffix = normalized.slice(legacyCodeRoot.length + 1)
-      const remapped = path.join(codeRoot, suffix)
-      if (existsSync(remapped)) {
-        return remapped
+    for (const compatibilityCandidate of compatibilityCandidates) {
+      if (existsSync(compatibilityCandidate)) {
+        return compatibilityCandidate
       }
     }
   }
@@ -2008,15 +2017,13 @@ function buildCampaignContentInternal(context: CampaignBuildContext): MarketingD
     const assetPaths = recordValue(preview.asset_paths) ?? {}
     const mediaPaths = asStringArray(preview.media_paths)
     const assetIds: string[] = []
-    // Each platform_preview is a distinct creative concept (e.g., per-family Nano Banana Pro
-    // render). Including the preview index in the asset id keeps every concept addressable
-    // even when several previews share the same platform_slug.
-    const previewAssetPrefix = stringValue(preview.asset_preview_id) || `platform-preview-${platform}-${index + 1}`
-
     mediaPaths.forEach((filePath, mediaIndex) => {
-      const assetId = mediaIndex === 0 && stringValue(preview.asset_preview_id)
-        ? previewAssetPrefix
-        : `${previewAssetPrefix}-media-${mediaIndex + 1}`
+      const assetId = publishReviewMediaAssetId({
+        platformSlug: platform,
+        previewIndex: index,
+        explicitPreviewAssetId: preview.asset_preview_id,
+        mediaIndex,
+      })
       const addedAsset = addAsset({
         id: assetId,
         campaignId,
@@ -2059,7 +2066,12 @@ function buildCampaignContentInternal(context: CampaignBuildContext): MarketingD
         return
       }
       const suffix = label === 'contract' ? 'contract' : label === 'brief' ? 'brief' : 'landing-page'
-      const assetId = `${previewAssetPrefix}-asset-${suffix}`
+      const assetId = publishReviewLinkedAssetId({
+        platformSlug: platform,
+        previewIndex: index,
+        explicitPreviewAssetId: preview.asset_preview_id,
+        suffix,
+      })
       const addedAsset = addAsset({
         id: assetId,
         campaignId,

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -12,7 +12,12 @@ import {
 } from './runtime-state';
 import { buildMarketingAssetLinks, marketingAssetUrl, type MarketingAssetLink } from './asset-library';
 import { resolvePublishReviewBundle } from './publish-review';
-import { publishReviewLinkedAssetId, publishReviewMediaAssetId } from './publish-review-asset-ids';
+import {
+  canonicalizePublishReviewPlatformSlug,
+  publishReviewLinkedAssetId,
+  publishReviewMediaAssetId,
+  publishReviewPreviewAssetPrefix,
+} from './publish-review-asset-ids';
 import {
   ARTIFACT_INCOMPLETE_TEXT,
   ARTIFACT_UNAVAILABLE_TEXT,
@@ -699,7 +704,10 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
         }
       : null,
     platformPreviews: recordArray(reviewBundle.platform_previews).map((entry, index) => {
-      const platformSlug = stringValue(entry.platform_slug, `platform-${index + 1}`);
+      const platformSlug = canonicalizePublishReviewPlatformSlug(
+        entry.platform_slug,
+        `platform-${index + 1}`,
+      );
       const platformName = stringValue(entry.platform_name, `Platform ${index + 1}`);
       const directMediaAssets = stringArray(entry.media_paths)
         .map((_, mediaIndex) =>
@@ -713,8 +721,13 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
           ),
         )
         .filter((asset): asset is MarketingAssetLink => !!asset);
+      const previewId = publishReviewPreviewAssetPrefix({
+        platformSlug,
+        previewIndex: index,
+        explicitPreviewAssetId: entry.asset_preview_id,
+      });
       return {
-        id: `platform-preview-${platformSlug}`,
+        id: previewId,
         platformSlug,
         platformName,
         channelType: stringValue(entry.channel_type, 'draft'),

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -12,6 +12,7 @@ import {
 } from './runtime-state';
 import { buildMarketingAssetLinks, marketingAssetUrl, type MarketingAssetLink } from './asset-library';
 import { resolvePublishReviewBundle } from './publish-review';
+import { publishReviewLinkedAssetId, publishReviewMediaAssetId } from './publish-review-asset-ids';
 import {
   ARTIFACT_INCOMPLETE_TEXT,
   ARTIFACT_UNAVAILABLE_TEXT,
@@ -701,7 +702,16 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
       const platformSlug = stringValue(entry.platform_slug, `platform-${index + 1}`);
       const platformName = stringValue(entry.platform_name, `Platform ${index + 1}`);
       const directMediaAssets = stringArray(entry.media_paths)
-        .map((_, mediaIndex) => linkById.get(`platform-preview-${platformSlug}-media-${mediaIndex + 1}`))
+        .map((_, mediaIndex) =>
+          linkById.get(
+            publishReviewMediaAssetId({
+              platformSlug,
+              previewIndex: index,
+              explicitPreviewAssetId: entry.asset_preview_id,
+              mediaIndex,
+            }),
+          ),
+        )
         .filter((asset): asset is MarketingAssetLink => !!asset);
       return {
         id: `platform-preview-${platformSlug}`,
@@ -723,9 +733,30 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
         ],
         mediaAssets: directMediaAssets.length > 0 ? directMediaAssets : fallbackPlatformMediaAssets(assetLinks, platformSlug),
         assetLinks: [
-          linkById.get(`platform-preview-${platformSlug}-asset-contract`),
-          linkById.get(`platform-preview-${platformSlug}-asset-brief`),
-          linkById.get(`platform-preview-${platformSlug}-asset-landing-page`),
+          linkById.get(
+            publishReviewLinkedAssetId({
+              platformSlug,
+              previewIndex: index,
+              explicitPreviewAssetId: entry.asset_preview_id,
+              suffix: 'contract',
+            }),
+          ),
+          linkById.get(
+            publishReviewLinkedAssetId({
+              platformSlug,
+              previewIndex: index,
+              explicitPreviewAssetId: entry.asset_preview_id,
+              suffix: 'brief',
+            }),
+          ),
+          linkById.get(
+            publishReviewLinkedAssetId({
+              platformSlug,
+              previewIndex: index,
+              explicitPreviewAssetId: entry.asset_preview_id,
+              suffix: 'landing-page',
+            }),
+          ),
         ].filter((asset): asset is MarketingAssetLink => !!asset),
       };
     }),

--- a/backend/marketing/publish-review-asset-ids.ts
+++ b/backend/marketing/publish-review-asset-ids.ts
@@ -22,6 +22,40 @@ type PublishReviewLinkedAssetIdInput = PublishReviewAssetIdInput & {
   suffix: 'contract' | 'brief' | 'landing-page';
 };
 
+export function canonicalizePublishReviewPlatformSlug(value: unknown, fallback = ''): string {
+  const normalized = stringValue(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (!normalized) {
+    return fallback;
+  }
+
+  if (['meta', 'facebook', 'facebook-ads', 'meta-ads', 'meta-ads-manager'].includes(normalized)) {
+    return 'meta-ads';
+  }
+  if (['instagram', 'instagram-feed', 'instagram-reels'].includes(normalized)) {
+    return 'instagram';
+  }
+  if (['x', 'twitter', 'x-post'].includes(normalized)) {
+    return 'x';
+  }
+  if (['youtube', 'youtube-shorts', 'youtube-longform'].includes(normalized)) {
+    return 'youtube';
+  }
+  if (['linkedin', 'linkedin-video'].includes(normalized)) {
+    return 'linkedin';
+  }
+  if (['landing-page', 'landing-page-campaign', 'landing'].includes(normalized)) {
+    return 'landing-page';
+  }
+  if (['short-video', 'video', 'stories', 'instagram-feed-video'].includes(normalized)) {
+    return 'video';
+  }
+  return normalized;
+}
+
 export function publishReviewPreviewAssetPrefix({
   platformSlug,
   previewIndex,

--- a/backend/marketing/publish-review-asset-ids.ts
+++ b/backend/marketing/publish-review-asset-ids.ts
@@ -1,0 +1,55 @@
+function stringValue(value: unknown, fallback = ''): string {
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return fallback;
+}
+
+type PublishReviewAssetIdInput = {
+  platformSlug: string;
+  previewIndex: number;
+  explicitPreviewAssetId?: unknown;
+};
+
+type PublishReviewMediaAssetIdInput = PublishReviewAssetIdInput & {
+  mediaIndex: number;
+};
+
+type PublishReviewLinkedAssetIdInput = PublishReviewAssetIdInput & {
+  suffix: 'contract' | 'brief' | 'landing-page';
+};
+
+export function publishReviewPreviewAssetPrefix({
+  platformSlug,
+  previewIndex,
+  explicitPreviewAssetId,
+}: PublishReviewAssetIdInput): string {
+  return stringValue(explicitPreviewAssetId) || `platform-preview-${platformSlug}-${previewIndex + 1}`;
+}
+
+export function publishReviewMediaAssetId(input: PublishReviewMediaAssetIdInput): string {
+  const explicitPreviewAssetId = stringValue(input.explicitPreviewAssetId);
+  const prefix = publishReviewPreviewAssetPrefix(input);
+  if (explicitPreviewAssetId && input.mediaIndex === 0) {
+    return prefix;
+  }
+  return `${prefix}-media-${input.mediaIndex + 1}`;
+}
+
+export function publishReviewLinkedAssetId(input: PublishReviewLinkedAssetIdInput): string {
+  return `${publishReviewPreviewAssetPrefix(input)}-asset-${input.suffix}`;
+}
+
+export function legacyPublishReviewMediaAssetId(platformSlug: string, mediaIndex: number): string {
+  return `platform-preview-${platformSlug}-media-${mediaIndex + 1}`;
+}
+
+export function legacyPublishReviewLinkedAssetId(
+  platformSlug: string,
+  suffix: 'contract' | 'brief' | 'landing-page',
+): string {
+  return `platform-preview-${platformSlug}-asset-${suffix}`;
+}

--- a/tests/frontend-api-layer.test.ts
+++ b/tests/frontend-api-layer.test.ts
@@ -916,8 +916,8 @@ test('/api/marketing/jobs/:jobId returns stage progress and safe artifact summar
     assert.equal(Array.isArray(body.calendarEvents), true);
     assert.equal((body.calendarEvents as any[]).length, 2);
     assert.equal((body.calendarEvents as any[])[0].platform, 'meta-ads');
-    assert.equal((body.reviewBundle as any).platformPreviews[0].mediaAssets[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-media-1`);
-    assert.equal((body.reviewBundle as any).platformPreviews[0].assetLinks[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-asset-contract`);
+    assert.equal((body.reviewBundle as any).platformPreviews[0].mediaAssets[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-1-media-1`);
+    assert.equal((body.reviewBundle as any).platformPreviews[0].assetLinks[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-1-asset-contract`);
     assert.equal('mediaPaths' in (body.reviewBundle as any).platformPreviews[0], false);
     assert.equal('assetPaths' in (body.reviewBundle as any).platformPreviews[0], false);
     assert.equal(Array.isArray(body.timeline), true);
@@ -1101,12 +1101,12 @@ test('/api/marketing/jobs/:jobId surfaces launch review previews when completed 
     assert.equal(body.assetPreviewCards.length, 1);
     assert.equal(body.assetPreviewCards[0].platformSlug, 'meta-ads');
     assert.equal(body.reviewBundle.platformPreviews.length, 1);
-    assert.equal(body.reviewBundle.platformPreviews[0].mediaAssets[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-media-1`);
+    assert.equal(body.reviewBundle.platformPreviews[0].mediaAssets[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-1-media-1`);
     assert.equal(body.reviewBundle.platformPreviews[0].mediaAssets[0].contentType, 'image/png');
 
     const assetResponse = await handleGetMarketingJobAsset(
       jobId,
-      'platform-preview-meta-ads-media-1',
+      'platform-preview-meta-ads-1-media-1',
       async () => ({
         userId: 'user_123',
         tenantId: 'tenant_real',
@@ -1117,6 +1117,128 @@ test('/api/marketing/jobs/:jobId surfaces launch review previews when completed 
     assert.equal(assetResponse.status, 200);
     assert.equal(assetResponse.headers.get('content-type'), 'image/png');
     assert.equal(await assetResponse.text(), 'png-preview');
+  });
+});
+
+test('/api/marketing/jobs/:jobId keeps same-platform publish review concepts addressable by indexed asset ids', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const { handleGetMarketingJobStatus } = await import('../app/api/marketing/jobs/[jobId]/handler');
+    const { handleGetMarketingJobAsset } = await import('../app/api/marketing/jobs/[jobId]/assets/[assetId]/handler');
+    const jobId = 'mkt_launch_review_multi_preview';
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    const previewOnePath = path.join(process.env.CODE_ROOT!, 'lobster', 'output', 'publish-ready', 'brand-example-stage2-plan', 'meta-ads', 'concept-a.png');
+    const previewTwoPath = path.join(process.env.CODE_ROOT!, 'lobster', 'output', 'publish-ready', 'brand-example-stage2-plan', 'meta-ads', 'concept-b.png');
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await mkdir(path.dirname(previewOnePath), { recursive: true });
+    await writeFile(previewOnePath, 'preview-a', 'utf8');
+    await writeFile(previewTwoPath, 'preview-b', 'utf8');
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'marketing_job_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_real',
+        state: 'approval_required',
+        status: 'awaiting_approval',
+        current_stage: 'publish',
+        stage_order: ['research', 'strategy', 'production', 'publish'],
+        stages: {
+          research: { stage: 'research', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-r', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          strategy: { stage: 'strategy', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-s', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          production: { stage: 'production', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-p', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          publish: {
+            stage: 'publish',
+            status: 'awaiting_approval',
+            started_at: '2026-03-19T00:00:05.000Z',
+            completed_at: null,
+            failed_at: null,
+            run_id: 'run-publish',
+            summary: { summary: 'Approval needed before publish-ready assets are generated.' },
+            primary_output: null,
+            outputs: {
+              review: {
+                review_bundle: {
+                  campaign_name: 'Sugar & Leather April Launch',
+                  approval_message: 'Approval needed before publish-ready assets are generated.',
+                  summary: { core_message: 'Launch the April collection with luxury-first creative.' },
+                  platform_previews: [
+                    {
+                      platform_slug: 'meta-ads',
+                      platform_name: 'Meta Ads',
+                      channel_type: 'paid-social',
+                      summary: 'Concept A preview ready.',
+                      media_paths: [previewOnePath],
+                      asset_paths: {},
+                    },
+                    {
+                      platform_slug: 'meta-ads',
+                      platform_name: 'Meta Ads',
+                      channel_type: 'paid-social',
+                      summary: 'Concept B preview ready.',
+                      media_paths: [previewTwoPath],
+                      asset_paths: {},
+                    },
+                  ],
+                },
+              },
+            },
+            artifacts: [],
+            errors: [],
+          },
+        },
+        approvals: { current: null, history: [] },
+        publish_config: { platforms: ['meta-ads'], live_publish_platforms: ['meta-ads'], video_render_platforms: [] },
+        brand_kit: {
+          path: path.join(dataRoot, 'generated', 'validated', 'tenant_real', 'brand-kit.json'),
+          source_url: 'https://sugarandleather.com',
+          canonical_url: 'https://sugarandleather.com',
+          brand_name: 'Sugar & Leather',
+          logo_urls: [],
+          colors: { primary: '#9c6b3e', secondary: '#f3e9dd', accent: '#3d2410', palette: ['#9c6b3e', '#f3e9dd', '#3d2410'] },
+          font_families: ['Manrope'],
+          external_links: [],
+          extracted_at: '2026-03-18T00:00:00.000Z',
+        },
+        inputs: { request: {}, brand_url: 'https://sugarandleather.com' },
+        errors: [],
+        last_error: null,
+        history: [],
+        created_at: '2026-03-19T00:00:00.000Z',
+        updated_at: '2026-03-19T00:10:05.000Z',
+      }, null, 2),
+    );
+
+    const statusResponse = await handleGetMarketingJobStatus(
+      jobId,
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      }),
+    );
+    const statusBody = (await statusResponse.json()) as Record<string, any>;
+
+    assert.equal(statusResponse.status, 200);
+    assert.equal(statusBody.reviewBundle.platformPreviews.length, 2);
+    assert.equal(statusBody.reviewBundle.platformPreviews[0].mediaAssets[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-1-media-1`);
+    assert.equal(statusBody.reviewBundle.platformPreviews[1].mediaAssets[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-2-media-1`);
+
+    const assetResponse = await handleGetMarketingJobAsset(
+      jobId,
+      'platform-preview-meta-ads-2-media-1',
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      }),
+    );
+
+    assert.equal(assetResponse.status, 200);
+    assert.equal(await assetResponse.text(), 'preview-b');
   });
 });
 
@@ -3260,7 +3382,7 @@ test('/api/marketing/jobs/:jobId reconstructs reviewBundle and publish counts fr
     assert.equal(body.reviewBundle.platformPreviews.length > 0, true);
     assert.equal(body.reviewBundle.platformPreviews.some((preview: { platformSlug: string }) => preview.platformSlug === 'meta-ads'), true);
     assert.equal(body.reviewBundle.platformPreviews.some((preview: { summary: string }) => preview.summary === 'Operator-led launch guidance for April buyers.'), true);
-    assert.equal(body.reviewBundle.platformPreviews.some((preview: { platformSlug: string; mediaAssets: Array<{ url: string }> }) => preview.platformSlug === 'meta-ads' && preview.mediaAssets[0]?.url === `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-media-1`), true);
+    assert.equal(body.reviewBundle.platformPreviews.some((preview: { platformSlug: string; mediaAssets: Array<{ url: string }> }) => preview.platformSlug === 'meta-ads' && preview.mediaAssets[0]?.url === `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-1-media-1`), true);
     assert.equal(body.reviewBundle.platformPreviews.some((preview: { platformSlug: string; assetLinks: unknown[] }) => preview.platformSlug === 'meta-ads' && preview.assetLinks.length > 0), true);
     assert.equal(body.assetPreviewCards.length > 0, true);
     assert.equal(body.dashboard.campaign.counts.publishItems > 0, true);
@@ -4450,6 +4572,388 @@ test('/api/marketing/jobs/:jobId/assets/:assetId supports legacy saved code path
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('content-type'), 'image/png');
     assert.equal(body, 'png-preview');
+  });
+});
+
+test('/api/marketing/jobs/:jobId/assets/:assetId supports legacy saved code paths rooted at /home/node/workspace/aries-app', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingJobAsset } = await import('../app/api/marketing/jobs/[jobId]/assets/[assetId]/handler');
+    const jobId = 'mkt_asset_job_workspace_root';
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    const actualAssetPath = path.join(process.env.CODE_ROOT!, 'lobster', 'output', 'publish-ready', 'brand-example-stage2-plan', 'meta-ads', 'meta-ads.png');
+    const legacySavedPath = actualAssetPath.replace(process.env.CODE_ROOT!, '/home/node/workspace/aries-app');
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await mkdir(path.dirname(actualAssetPath), { recursive: true });
+    await writeFile(actualAssetPath, 'png-preview', 'utf8');
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'marketing_job_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_real',
+        state: 'approval_required',
+        status: 'awaiting_approval',
+        current_stage: 'publish',
+        stage_order: ['research', 'strategy', 'production', 'publish'],
+        stages: {
+          research: { stage: 'research', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-r', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          strategy: { stage: 'strategy', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-s', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          production: { stage: 'production', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-p', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          publish: {
+            stage: 'publish',
+            status: 'awaiting_approval',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: 'run-publish',
+            summary: null,
+            primary_output: {
+              launch_review: {
+                review_bundle: {
+                  campaign_name: 'Sugar & Leather',
+                  summary: {},
+                  platform_previews: [
+                    {
+                      platform_slug: 'meta-ads',
+                      platform_name: 'Meta Ads',
+                      channel_type: 'paid-social',
+                      summary: 'Preview ready',
+                      media_paths: [legacySavedPath],
+                      asset_paths: {},
+                    },
+                  ],
+                },
+              },
+            },
+            outputs: {},
+            artifacts: [],
+            errors: [],
+          },
+        },
+        approvals: { current: null, history: [] },
+        publish_config: { platforms: ['meta-ads'], live_publish_platforms: [], video_render_platforms: [] },
+        brand_kit: {
+          path: path.join(process.env.DATA_ROOT!, 'generated', 'validated', 'tenant_real', 'brand-kit.json'),
+          source_url: 'https://sugarandleather.com',
+          canonical_url: 'https://sugarandleather.com',
+          brand_name: 'Sugar & Leather',
+          logo_urls: [],
+          colors: { primary: '#9c6b3e', secondary: '#f3e9dd', accent: '#3d2410', palette: ['#9c6b3e', '#f3e9dd', '#3d2410'] },
+          font_families: ['Manrope'],
+          external_links: [],
+          extracted_at: '2026-03-18T00:00:00.000Z',
+        },
+        inputs: { request: {}, brand_url: 'https://sugarandleather.com' },
+        errors: [],
+        last_error: null,
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2)
+    );
+
+    const response = await handleGetMarketingJobAsset(
+      jobId,
+      'platform-preview-meta-ads-media-1',
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      })
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'image/png');
+    assert.equal(body, 'png-preview');
+  });
+});
+
+test('/api/marketing/jobs/:jobId/assets/:assetId supports legacy saved code paths rooted at /app/aries-app', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingJobAsset } = await import('../app/api/marketing/jobs/[jobId]/assets/[assetId]/handler');
+    const jobId = 'mkt_asset_job_app_root';
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    const actualAssetPath = path.join(process.env.CODE_ROOT!, 'lobster', 'output', 'publish-ready', 'brand-example-stage2-plan', 'meta-ads', 'meta-ads.png');
+    const legacySavedPath = actualAssetPath.replace(process.env.CODE_ROOT!, '/app/aries-app');
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await mkdir(path.dirname(actualAssetPath), { recursive: true });
+    await writeFile(actualAssetPath, 'png-preview', 'utf8');
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'marketing_job_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_real',
+        state: 'approval_required',
+        status: 'awaiting_approval',
+        current_stage: 'publish',
+        stage_order: ['research', 'strategy', 'production', 'publish'],
+        stages: {
+          research: { stage: 'research', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-r', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          strategy: { stage: 'strategy', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-s', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          production: { stage: 'production', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-p', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          publish: {
+            stage: 'publish',
+            status: 'awaiting_approval',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: 'run-publish',
+            summary: null,
+            primary_output: {
+              launch_review: {
+                review_bundle: {
+                  campaign_name: 'Sugar & Leather',
+                  summary: {},
+                  platform_previews: [
+                    {
+                      platform_slug: 'meta-ads',
+                      platform_name: 'Meta Ads',
+                      channel_type: 'paid-social',
+                      summary: 'Preview ready',
+                      media_paths: [legacySavedPath],
+                      asset_paths: {},
+                    },
+                  ],
+                },
+              },
+            },
+            outputs: {},
+            artifacts: [],
+            errors: [],
+          },
+        },
+        approvals: { current: null, history: [] },
+        publish_config: { platforms: ['meta-ads'], live_publish_platforms: [], video_render_platforms: [] },
+        brand_kit: {
+          path: path.join(process.env.DATA_ROOT!, 'generated', 'validated', 'tenant_real', 'brand-kit.json'),
+          source_url: 'https://sugarandleather.com',
+          canonical_url: 'https://sugarandleather.com',
+          brand_name: 'Sugar & Leather',
+          logo_urls: [],
+          colors: { primary: '#9c6b3e', secondary: '#f3e9dd', accent: '#3d2410', palette: ['#9c6b3e', '#f3e9dd', '#3d2410'] },
+          font_families: ['Manrope'],
+          external_links: [],
+          extracted_at: '2026-03-18T00:00:00.000Z',
+        },
+        inputs: { request: {}, brand_url: 'https://sugarandleather.com' },
+        errors: [],
+        last_error: null,
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2)
+    );
+
+    const response = await handleGetMarketingJobAsset(
+      jobId,
+      'platform-preview-meta-ads-media-1',
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      })
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'image/png');
+    assert.equal(body, 'png-preview');
+  });
+});
+
+test('/api/marketing/jobs/:jobId/workspace-assets/:assetId serves a tenant-scoped uploaded asset from the workspace root', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingWorkspaceAsset } = await import('../app/api/marketing/jobs/[jobId]/workspace-assets/[assetId]/handler');
+    const jobId = 'mkt_workspace_asset_job';
+    const workspaceFile = path.join(
+      process.env.DATA_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'workspace.json',
+    );
+    const assetPath = path.join(
+      process.env.DATA_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'brief-assets',
+      'brief_asset_brand-guidelines.pdf',
+    );
+    await mkdir(path.dirname(workspaceFile), { recursive: true });
+    await mkdir(path.dirname(assetPath), { recursive: true });
+    await writeFile(assetPath, 'workspace-asset', 'utf8');
+    await writeFile(
+      workspaceFile,
+      JSON.stringify({
+        schema_name: 'marketing_campaign_workspace',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        tenant_id: 'tenant_real',
+        workflow_state: 'draft',
+        brief: {
+          websiteUrl: 'https://brand.example',
+          businessName: 'Brand Example',
+          businessType: 'B2B SaaS',
+          approverName: 'Avery',
+          goal: 'Book walkthroughs',
+          offer: 'Proof-led launch audit',
+          competitorUrl: 'https://betterup.com',
+          channels: ['meta-ads'],
+          brandVoice: 'Grounded and direct',
+          styleVibe: 'Minimal and editorial',
+          visualReferences: [],
+          mustUseCopy: 'Book a walkthrough',
+          mustAvoidAesthetics: 'Generic stock imagery',
+          notes: 'Lead with proof points from recent launches.',
+          brandAssets: [
+            {
+              id: 'brief_asset_1',
+              name: 'Brand guidelines',
+              fileName: 'brand-guidelines.pdf',
+              contentType: 'application/pdf',
+              filePath: assetPath,
+              size: 15,
+              uploadedAt: '2026-04-04T00:00:00.000Z',
+            },
+          ],
+        },
+        stage_reviews: {
+          brand: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          strategy: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          creative: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+        },
+        creative_asset_reviews: {},
+        status_history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2),
+    );
+
+    const response = await handleGetMarketingWorkspaceAsset(
+      jobId,
+      'brief_asset_1',
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      }),
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'application/pdf');
+    assert.equal(body, 'workspace-asset');
+  });
+});
+
+test('/api/marketing/jobs/:jobId/workspace-assets/:assetId supports legacy workspace paths saved with an extra /aries-app segment', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingWorkspaceAsset } = await import('../app/api/marketing/jobs/[jobId]/workspace-assets/[assetId]/handler');
+    const jobId = 'mkt_workspace_asset_legacy_job';
+    const workspaceFile = path.join(
+      process.env.DATA_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'workspace.json',
+    );
+    const actualAssetPath = path.join(
+      process.env.CODE_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'brief-assets',
+      'brief_asset_legacy-brand-guidelines.pdf',
+    );
+    const legacySavedPath = path.join(
+      process.env.CODE_ROOT!,
+      'aries-app',
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'brief-assets',
+      'brief_asset_legacy-brand-guidelines.pdf',
+    );
+    await mkdir(path.dirname(workspaceFile), { recursive: true });
+    await mkdir(path.dirname(actualAssetPath), { recursive: true });
+    await writeFile(actualAssetPath, 'legacy-workspace-asset', 'utf8');
+    await writeFile(
+      workspaceFile,
+      JSON.stringify({
+        schema_name: 'marketing_campaign_workspace',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        tenant_id: 'tenant_real',
+        workflow_state: 'draft',
+        brief: {
+          websiteUrl: 'https://brand.example',
+          businessName: 'Brand Example',
+          businessType: 'B2B SaaS',
+          approverName: 'Avery',
+          goal: 'Book walkthroughs',
+          offer: 'Proof-led launch audit',
+          competitorUrl: 'https://betterup.com',
+          channels: ['meta-ads'],
+          brandVoice: 'Grounded and direct',
+          styleVibe: 'Minimal and editorial',
+          visualReferences: [],
+          mustUseCopy: 'Book a walkthrough',
+          mustAvoidAesthetics: 'Generic stock imagery',
+          notes: 'Lead with proof points from recent launches.',
+          brandAssets: [
+            {
+              id: 'brief_asset_legacy',
+              name: 'Brand guidelines',
+              fileName: 'brand-guidelines.pdf',
+              contentType: 'application/pdf',
+              filePath: legacySavedPath,
+              size: 22,
+              uploadedAt: '2026-04-04T00:00:00.000Z',
+            },
+          ],
+        },
+        stage_reviews: {
+          brand: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          strategy: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          creative: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+        },
+        creative_asset_reviews: {},
+        status_history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2),
+    );
+
+    const response = await handleGetMarketingWorkspaceAsset(
+      jobId,
+      'brief_asset_legacy',
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      }),
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'application/pdf');
+    assert.equal(body, 'legacy-workspace-asset');
   });
 });
 

--- a/tests/frontend-api-layer.test.ts
+++ b/tests/frontend-api-layer.test.ts
@@ -912,7 +912,7 @@ test('/api/marketing/jobs/:jobId returns stage progress and safe artifact summar
     assert.equal((body.assetPreviewCards as any[]).length, 1);
     assert.equal((body.assetPreviewCards as any[])[0].platformSlug, 'meta-ads');
     assert.equal((body.assetPreviewCards as any[])[0].mediaCount, 1);
-    assert.equal((body.assetPreviewCards as any[])[0].previewHref, `/marketing/job-approve?jobId=${jobId}&preview=platform-preview-meta-ads`);
+    assert.equal((body.assetPreviewCards as any[])[0].previewHref, `/marketing/job-approve?jobId=${jobId}&preview=platform-preview-meta-ads-1`);
     assert.equal(Array.isArray(body.calendarEvents), true);
     assert.equal((body.calendarEvents as any[]).length, 2);
     assert.equal((body.calendarEvents as any[])[0].platform, 'meta-ads');
@@ -1239,6 +1239,104 @@ test('/api/marketing/jobs/:jobId keeps same-platform publish review concepts add
 
     assert.equal(assetResponse.status, 200);
     assert.equal(await assetResponse.text(), 'preview-b');
+  });
+});
+
+test('/api/marketing/jobs/:jobId canonicalizes aliased publish review platform slugs before building preview ids', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const { handleGetMarketingJobStatus } = await import('../app/api/marketing/jobs/[jobId]/handler');
+    const jobId = 'mkt_publish_review_alias_slug';
+    const runtimeFile = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    const mediaAssetRelativePath = path.join('generated', 'draft', 'marketing-assets', 'facebook-preview.png');
+    const mediaAssetPath = path.join(dataRoot, mediaAssetRelativePath);
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await mkdir(path.dirname(mediaAssetPath), { recursive: true });
+    await writeFile(mediaAssetPath, 'facebook-preview', 'utf8');
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'marketing_job_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_real',
+        state: 'approval_required',
+        status: 'awaiting_approval',
+        current_stage: 'publish',
+        stage_order: ['research', 'strategy', 'production', 'publish'],
+        stages: {
+          research: { stage: 'research', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-r', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          strategy: { stage: 'strategy', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-s', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          production: { stage: 'production', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-p', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          publish: {
+            stage: 'publish',
+            status: 'awaiting_approval',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: 'run-publish',
+            summary: null,
+            primary_output: {
+              launch_review: {
+                review_bundle: {
+                  campaign_name: 'Sugar & Leather',
+                  summary: {},
+                  platform_previews: [
+                    {
+                      platform_slug: 'facebook',
+                      platform_name: 'Meta Ads',
+                      channel_type: 'paid-social',
+                      summary: 'Alias preview ready',
+                      media_paths: [mediaAssetRelativePath],
+                      asset_paths: {},
+                    },
+                  ],
+                },
+              },
+            },
+            outputs: {},
+            artifacts: [],
+            errors: [],
+          },
+        },
+        approvals: { current: null, history: [] },
+        publish_config: { platforms: ['meta-ads'], live_publish_platforms: [], video_render_platforms: [] },
+        brand_kit: {
+          path: path.join(process.env.DATA_ROOT!, 'generated', 'validated', 'tenant_real', 'brand-kit.json'),
+          source_url: 'https://sugarandleather.com',
+          canonical_url: 'https://sugarandleather.com',
+          brand_name: 'Sugar & Leather',
+          logo_urls: [],
+          colors: { primary: '#9c6b3e', secondary: '#f3e9dd', accent: '#3d2410', palette: ['#9c6b3e', '#f3e9dd', '#3d2410'] },
+          font_families: ['Manrope'],
+          external_links: [],
+          extracted_at: '2026-03-18T00:00:00.000Z',
+        },
+        inputs: { request: {}, brand_url: 'https://sugarandleather.com' },
+        errors: [],
+        last_error: null,
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2),
+    );
+
+    const statusResponse = await handleGetMarketingJobStatus(
+      jobId,
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      }),
+    );
+    const statusBody = (await statusResponse.json()) as Record<string, any>;
+
+    assert.equal(statusResponse.status, 200);
+    assert.equal(statusBody.assetPreviewCards[0].platformSlug, 'meta-ads');
+    assert.equal(statusBody.assetPreviewCards[0].previewHref, `/marketing/job-approve?jobId=${jobId}&preview=platform-preview-meta-ads-1`);
+    assert.equal(statusBody.reviewBundle.platformPreviews[0].id, 'platform-preview-meta-ads-1');
+    assert.equal(statusBody.reviewBundle.platformPreviews[0].mediaAssets[0].url, `/api/marketing/jobs/${jobId}/assets/platform-preview-meta-ads-1-media-1`);
   });
 });
 
@@ -4954,6 +5052,186 @@ test('/api/marketing/jobs/:jobId/workspace-assets/:assetId supports legacy works
     assert.equal(response.status, 200);
     assert.equal(response.headers.get('content-type'), 'application/pdf');
     assert.equal(body, 'legacy-workspace-asset');
+  });
+});
+
+test('/api/marketing/jobs/:jobId/workspace-assets/:assetId supports legacy workspace paths rooted at /home/node/workspace/aries-app', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingWorkspaceAsset } = await import('../app/api/marketing/jobs/[jobId]/workspace-assets/[assetId]/handler');
+    const jobId = 'mkt_workspace_asset_workspace_root_job';
+    const workspaceFile = path.join(
+      process.env.DATA_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'workspace.json',
+    );
+    const actualAssetPath = path.join(
+      process.env.CODE_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'brief-assets',
+      'brief_asset_workspace-root-brand-guidelines.pdf',
+    );
+    const legacySavedPath = actualAssetPath.replace(process.env.CODE_ROOT!, '/home/node/workspace/aries-app');
+    await mkdir(path.dirname(workspaceFile), { recursive: true });
+    await mkdir(path.dirname(actualAssetPath), { recursive: true });
+    await writeFile(actualAssetPath, 'workspace-root-legacy-asset', 'utf8');
+    await writeFile(
+      workspaceFile,
+      JSON.stringify({
+        schema_name: 'marketing_campaign_workspace',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        tenant_id: 'tenant_real',
+        workflow_state: 'draft',
+        brief: {
+          websiteUrl: 'https://brand.example',
+          businessName: 'Brand Example',
+          businessType: 'B2B SaaS',
+          approverName: 'Avery',
+          goal: 'Book walkthroughs',
+          offer: 'Proof-led launch audit',
+          competitorUrl: 'https://betterup.com',
+          channels: ['meta-ads'],
+          brandVoice: 'Grounded and direct',
+          styleVibe: 'Minimal and editorial',
+          visualReferences: [],
+          mustUseCopy: 'Book a walkthrough',
+          mustAvoidAesthetics: 'Generic stock imagery',
+          notes: 'Lead with proof points from recent launches.',
+          brandAssets: [
+            {
+              id: 'brief_asset_workspace_root',
+              name: 'Brand guidelines',
+              fileName: 'brand-guidelines.pdf',
+              contentType: 'application/pdf',
+              filePath: legacySavedPath,
+              size: 29,
+              uploadedAt: '2026-04-04T00:00:00.000Z',
+            },
+          ],
+        },
+        stage_reviews: {
+          brand: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          strategy: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          creative: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+        },
+        creative_asset_reviews: {},
+        status_history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2),
+    );
+
+    const response = await handleGetMarketingWorkspaceAsset(
+      jobId,
+      'brief_asset_workspace_root',
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      }),
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'application/pdf');
+    assert.equal(body, 'workspace-root-legacy-asset');
+  });
+});
+
+test('/api/marketing/jobs/:jobId/workspace-assets/:assetId supports legacy workspace paths rooted at /app/aries-app', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingWorkspaceAsset } = await import('../app/api/marketing/jobs/[jobId]/workspace-assets/[assetId]/handler');
+    const jobId = 'mkt_workspace_asset_app_root_job';
+    const workspaceFile = path.join(
+      process.env.DATA_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'workspace.json',
+    );
+    const actualAssetPath = path.join(
+      process.env.CODE_ROOT!,
+      'generated',
+      'draft',
+      'marketing-workspaces',
+      jobId,
+      'brief-assets',
+      'brief_asset_app-root-brand-guidelines.pdf',
+    );
+    const legacySavedPath = actualAssetPath.replace(process.env.CODE_ROOT!, '/app/aries-app');
+    await mkdir(path.dirname(workspaceFile), { recursive: true });
+    await mkdir(path.dirname(actualAssetPath), { recursive: true });
+    await writeFile(actualAssetPath, 'app-root-legacy-asset', 'utf8');
+    await writeFile(
+      workspaceFile,
+      JSON.stringify({
+        schema_name: 'marketing_campaign_workspace',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        tenant_id: 'tenant_real',
+        workflow_state: 'draft',
+        brief: {
+          websiteUrl: 'https://brand.example',
+          businessName: 'Brand Example',
+          businessType: 'B2B SaaS',
+          approverName: 'Avery',
+          goal: 'Book walkthroughs',
+          offer: 'Proof-led launch audit',
+          competitorUrl: 'https://betterup.com',
+          channels: ['meta-ads'],
+          brandVoice: 'Grounded and direct',
+          styleVibe: 'Minimal and editorial',
+          visualReferences: [],
+          mustUseCopy: 'Book a walkthrough',
+          mustAvoidAesthetics: 'Generic stock imagery',
+          notes: 'Lead with proof points from recent launches.',
+          brandAssets: [
+            {
+              id: 'brief_asset_app_root',
+              name: 'Brand guidelines',
+              fileName: 'brand-guidelines.pdf',
+              contentType: 'application/pdf',
+              filePath: legacySavedPath,
+              size: 24,
+              uploadedAt: '2026-04-04T00:00:00.000Z',
+            },
+          ],
+        },
+        stage_reviews: {
+          brand: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          strategy: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+          creative: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+        },
+        creative_asset_reviews: {},
+        status_history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2),
+    );
+
+    const response = await handleGetMarketingWorkspaceAsset(
+      jobId,
+      'brief_asset_app_root',
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin',
+      }),
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'application/pdf');
+    assert.equal(body, 'app-root-legacy-asset');
   });
 });
 


### PR DESCRIPTION
## Summary
- align publish-review asset id generation across dashboard content, job status hydration, and backend asset lookup
- preserve legacy handler lookups so existing asset URLs keep resolving while the dashboard moves to indexed preview ids
- add regression coverage for multi-concept same-platform previews so the second concept no longer 404s

## Testing
- `npx tsx --test tests/frontend-api-layer.test.ts --test-name-pattern="surfaces launch review previews|keeps same-platform publish review concepts|recovers paused-publish review previews"`
- `npm test -- --runInBand tests/frontend-api-layer.test.ts --testNamePattern="launch review previews|publish review concepts|paused-publish review previews"` *(repo still has unrelated pre-existing failures outside this slice)*