### PR TITLE
chore(gstack): require gstack for AI-assisted work

### DIFF
--- a/.claude/hooks/check-gstack.sh
+++ b/.claude/hooks/check-gstack.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Block skill usage when gstack is not installed globally.
+
+if [ ! -d "$HOME/.claude/skills/gstack/bin" ]; then
+  cat >&2 <<'MSG'
+BLOCKED: gstack is not installed globally.
+
+gstack is required for AI-assisted work in this repo.
+
+Install it:
+  git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+  cd ~/.claude/skills/gstack && ./setup --team
+
+Then restart your AI coding tool.
+MSG
+  echo '{"permissionDecision":"deny","message":"gstack is required but not installed. See stderr for install instructions."}'
+  exit 0
+fi
+
+echo '{}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh\""
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-gstack.sh"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,10 @@ output/
 !.agent/workflows/
 /local/
 package-lock.json
-.claude/
+.claude/*
+!.claude/hooks/
+!.claude/hooks/**
+!.claude/settings.json
 .agent/
 skills-lock.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,27 @@ export DB_HOST=localhost DB_PORT=5432 DB_USER=aries_user DB_PASSWORD=aries_pass 
 export CODE_ROOT=/home/node/openclaw/aries-app DATA_ROOT=/tmp/aries-data NODE_ENV=development
 export APP_BASE_URL=http://localhost:3000 NEXTAUTH_URL=http://localhost:3000 AUTH_URL=http://localhost:3000 AUTH_TRUST_HOST=true
 ```
+
+## gstack (REQUIRED — global install)
+
+**Before doing ANY work, verify gstack is installed:**
+
+```bash
+test -d ~/.claude/skills/gstack/bin && echo "GSTACK_OK" || echo "GSTACK_MISSING"
+```
+
+If GSTACK_MISSING: STOP. Do not proceed. Tell the user:
+
+> gstack is required for all AI-assisted work in this repo.
+> Install it:
+> ```bash
+> git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+> cd ~/.claude/skills/gstack && ./setup --team
+> ```
+> Then restart your AI coding tool.
+
+Do not skip skills, ignore gstack errors, or work around missing gstack.
+
+Using gstack skills: After install, skills like /qa, /ship, /review, /investigate,
+and /browse are available. Use /browse for all web browsing.
+Use ~/.claude/skills/gstack/... for gstack file paths (the global path).


### PR DESCRIPTION
## Summary

Adopts [gstack](https://github.com/garrytan/gstack) as the required AI-assisted workflow toolkit for this repo. Generated by `gstack-team-init required`.

- CLAUDE.md gains a \"gstack (REQUIRED — global install)\" section that every AI session sees.
- \`.claude/hooks/check-gstack.sh\` is a PreToolUse hook that blocks the Skill tool with a clear install message when \`~/.claude/skills/gstack/bin\` is missing.
- \`.claude/settings.json\` registers that hook on the Skill matcher.
- \`.gitignore\` was switched from a blanket \`.claude/\` ignore to \`.claude/*\` with allow-rules for \`.claude/hooks/**\` and \`.claude/settings.json\`, so only the team-enforcement bits are tracked — per-developer \`.claude/\` state stays ignored.

## Contributor action required

After this lands, every contributor (human or AI) runs:

\`\`\`bash
git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
cd ~/.claude/skills/gstack && ./setup --team
\`\`\`

Without the global install, the PreToolUse hook will block Skill tool calls with the install instructions.

## Why

gstack provides \`/browse\`, \`/qa\`, \`/review\`, \`/ship\`, \`/investigate\`, \`/land-and-deploy\`, and other workflow skills we want to be the canonical path. The CLAUDE.md section specifically tells AI sessions to use \`/browse\` for all web browsing (instead of lower-level MCP Chrome tools).

## Test plan

- [ ] Merge, then on a fresh machine without gstack: open a Claude Code session in this repo → confirm Skill invocations are blocked with the install message.
- [ ] With gstack globally installed: confirm \`/browse\`, \`/qa\`, \`/review\` etc. work normally.
- [ ] Confirm \`git status\` shows no phantom \`.claude/\` files for developers who have per-session scratch there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)