### PR TITLE
fix(marketing): remap host-output paths in remaining absolute asset resolvers

### DIFF
--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -49,6 +49,28 @@ function resolveExistingAbsoluteAssetPath(filePath: string): string | null {
     candidates.add(path.join(codeRoot, suffix));
   }
 
+  // Host-output → bind-mount remap. The host's Lobster pipeline writes
+  // creative images under an absolute host path (e.g. ARIES_LOBSTER_HOST_OUTPUT_DIR
+  // = /home/node/openclaw/aries-app/lobster/output) but inside this container
+  // that directory is only reachable via the read-only bind mount at
+  // ARIES_LOBSTER_HOST_OUTPUT_MOUNT (default /host-lobster-output). Without
+  // this remap, runtime_docs that pin absolute host paths (stage-3/4
+  // creative assets) fail existsSync and the dashboard collapses to
+  // creativeReviewReason='no_real_creative_assets'.
+  const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim();
+  const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
+  if (hostOutputDir && hostOutputMount) {
+    const normalizedHostDir = path.normalize(hostOutputDir);
+    const normalizedHostMount = path.normalize(hostOutputMount);
+    if (
+      normalizedPath === normalizedHostDir ||
+      normalizedPath.startsWith(`${normalizedHostDir}${path.sep}`)
+    ) {
+      const suffix = normalizedPath.slice(normalizedHostDir.length).replace(/^[\\/]+/, '');
+      candidates.add(suffix ? path.join(normalizedHostMount, suffix) : normalizedHostMount);
+    }
+  }
+
   for (const candidate of candidates) {
     if (existsSync(candidate)) {
       return candidate;

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -60,8 +60,11 @@ function resolveExistingAbsoluteAssetPath(filePath: string): string | null {
   const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim();
   const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
   if (hostOutputDir && hostOutputMount) {
-    const normalizedHostDir = path.normalize(hostOutputDir);
-    const normalizedHostMount = path.normalize(hostOutputMount);
+    // path.resolve (not path.normalize) so a trailing slash on the env var
+    // doesn't produce `/foo//` in the startsWith guard and silently no-op
+    // the remap.
+    const normalizedHostDir = path.resolve(hostOutputDir);
+    const normalizedHostMount = path.resolve(hostOutputMount);
     if (
       normalizedPath === normalizedHostDir ||
       normalizedPath.startsWith(`${normalizedHostDir}${path.sep}`)

--- a/backend/marketing/asset-read.ts
+++ b/backend/marketing/asset-read.ts
@@ -156,8 +156,11 @@ function absoluteCompatibilityCandidates(filePath: string): string[] {
   const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim();
   const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
   if (hostOutputDir && hostOutputMount) {
-    const normalizedHostDir = path.normalize(hostOutputDir);
-    const normalizedHostMount = path.normalize(hostOutputMount);
+    // path.resolve (not path.normalize) so a trailing slash on the env var
+    // doesn't produce `/foo//` in the startsWith guard and silently no-op
+    // the remap.
+    const normalizedHostDir = path.resolve(hostOutputDir);
+    const normalizedHostMount = path.resolve(hostOutputMount);
     if (
       normalized === normalizedHostDir ||
       normalized.startsWith(`${normalizedHostDir}${path.sep}`)

--- a/backend/marketing/asset-read.ts
+++ b/backend/marketing/asset-read.ts
@@ -116,6 +116,10 @@ function trustedRoots(): string[] {
         resolveCodePath('lobster'),
         process.env.OPENCLAW_LOCAL_LOBSTER_CWD?.trim(),
         process.env.OPENCLAW_LOBSTER_CWD?.trim(),
+        // Host bind-mount of the host's lobster/output tree (creative
+        // images written by the host pipeline are only reachable from
+        // inside the container via this read-only mount).
+        process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim(),
         process.env.LOBSTER_STAGE1_CACHE_DIR?.trim() || path.join(tmpdir(), 'lobster-stage1-cache'),
         process.env.LOBSTER_STAGE2_CACHE_DIR?.trim() || path.join(tmpdir(), 'lobster-stage2-cache'),
         process.env.LOBSTER_STAGE3_CACHE_DIR?.trim() || path.join(tmpdir(), 'lobster-stage3-cache'),
@@ -142,6 +146,25 @@ function absoluteCompatibilityCandidates(filePath: string): string[] {
 
     const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '');
     candidates.add(path.join(codeRoot, suffix));
+  }
+
+  // Host-output → bind-mount remap. Absolute paths that point at the
+  // host's lobster/output tree (ARIES_LOBSTER_HOST_OUTPUT_DIR) need to be
+  // rewritten onto the in-container bind-mount path
+  // (ARIES_LOBSTER_HOST_OUTPUT_MOUNT) so isWithinRoot accepts them and
+  // readFile actually finds the bytes.
+  const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim();
+  const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
+  if (hostOutputDir && hostOutputMount) {
+    const normalizedHostDir = path.normalize(hostOutputDir);
+    const normalizedHostMount = path.normalize(hostOutputMount);
+    if (
+      normalized === normalizedHostDir ||
+      normalized.startsWith(`${normalizedHostDir}${path.sep}`)
+    ) {
+      const hostSuffix = normalized.slice(normalizedHostDir.length).replace(/^[\\/]+/, '');
+      candidates.add(hostSuffix ? path.join(normalizedHostMount, hostSuffix) : normalizedHostMount);
+    }
   }
 
   return Array.from(candidates);

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -1646,6 +1646,28 @@ function resolveDashboardAssetFilePath(
       compatibilityCandidates.add(path.join(codeRoot, suffix))
     }
 
+    // Host-output → bind-mount remap. Runtime docs written by the host's
+    // Lobster pipeline pin absolute paths under ARIES_LOBSTER_HOST_OUTPUT_DIR;
+    // inside this container that tree is only reachable via the read-only
+    // bind mount at ARIES_LOBSTER_HOST_OUTPUT_MOUNT. Without this remap the
+    // dashboard drops creative image assets and falls through to
+    // creativeReviewReason='no_real_creative_assets'.
+    const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim()
+    const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim()
+    if (hostOutputDir && hostOutputMount) {
+      const normalizedHostDir = path.normalize(hostOutputDir)
+      const normalizedHostMount = path.normalize(hostOutputMount)
+      if (
+        normalized === normalizedHostDir ||
+        normalized.startsWith(`${normalizedHostDir}${path.sep}`)
+      ) {
+        const hostSuffix = normalized.slice(normalizedHostDir.length).replace(/^[\\/]+/, '')
+        compatibilityCandidates.add(
+          hostSuffix ? path.join(normalizedHostMount, hostSuffix) : normalizedHostMount,
+        )
+      }
+    }
+
     for (const compatibilityCandidate of compatibilityCandidates) {
       if (existsSync(compatibilityCandidate)) {
         return compatibilityCandidate

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -1655,8 +1655,11 @@ function resolveDashboardAssetFilePath(
     const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim()
     const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim()
     if (hostOutputDir && hostOutputMount) {
-      const normalizedHostDir = path.normalize(hostOutputDir)
-      const normalizedHostMount = path.normalize(hostOutputMount)
+      // path.resolve (not path.normalize) so a trailing slash on the env
+      // var doesn't produce `/foo//` in the startsWith guard and silently
+      // no-op the remap.
+      const normalizedHostDir = path.resolve(hostOutputDir)
+      const normalizedHostMount = path.resolve(hostOutputMount)
       if (
         normalized === normalizedHostDir ||
         normalized.startsWith(`${normalizedHostDir}${path.sep}`)


### PR DESCRIPTION
## Summary

PR #155 taught `outputRoots()` about the container's host bind-mount, but three absolute-path resolvers still didn't know about it. Runtime docs that pin absolute host paths (e.g. `/home/node/openclaw/aries-app/lobster/output/logs/<runId>/...`, the default case for creative images written by the host's stage-3/4 pipeline) still failed `existsSync` inside the container. Result: the dashboard dropped creative image assets and collapsed back to `creativeReviewReason='no_real_creative_assets'` — exactly the regression users saw return after the last deploy.

Three resolvers patched here:

- `backend/marketing/asset-library.ts::resolveExistingAbsoluteAssetPath` — primary absolute-path asset descriptor resolver.
- `backend/marketing/dashboard-content.ts::resolveDashboardAssetFilePath` — dashboard hydration path, called by `addAsset`; this was the direct feeder of `buildCreativeAssets([])` → null creative review.
- `backend/marketing/asset-read.ts::trustedRoots` + `absoluteCompatibilityCandidates` — HTTP byte-serving route; without the host mount in trusted roots, `isWithinRoot` would reject the remapped candidate even after the dashboard resolved the asset.

Each site now checks `ARIES_LOBSTER_HOST_OUTPUT_DIR` → `ARIES_LOBSTER_HOST_OUTPUT_MOUNT` and adds the remapped path to its candidate set before `existsSync` / `isWithinRoot`.

## Test plan

- [ ] `npm run typecheck` (passes with only the pre-existing `resend` module error)
- [ ] After deploy: Creative Review dashboard for Waterloo (and any campaign previously showing `no_real_creative_assets`) hydrates actual creative images instead of falling back to the shared "Frame X" placeholder.
- [ ] `/api/marketing/jobs/<jobId>/assets/<assetId>` returns 200 with real image bytes for stage-3/4 creative assets whose runtime docs pin absolute host-output paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)