### PR TITLE
refactor(marketing): extract host-output remap into shared helper

### DIFF
--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
 
 import { listMarketingDashboardAssetsForJob } from './dashboard-content';
+import { remapHostOutputToMount } from './host-output-path';
 import { collectResearchStageArtifacts, collectStrategyReviewArtifacts } from './artifact-collector';
 import {
   canonicalizePublishReviewPlatformSlug,
@@ -49,29 +50,9 @@ function resolveExistingAbsoluteAssetPath(filePath: string): string | null {
     candidates.add(path.join(codeRoot, suffix));
   }
 
-  // Host-output → bind-mount remap. The host's Lobster pipeline writes
-  // creative images under an absolute host path (e.g. ARIES_LOBSTER_HOST_OUTPUT_DIR
-  // = /home/node/openclaw/aries-app/lobster/output) but inside this container
-  // that directory is only reachable via the read-only bind mount at
-  // ARIES_LOBSTER_HOST_OUTPUT_MOUNT (default /host-lobster-output). Without
-  // this remap, runtime_docs that pin absolute host paths (stage-3/4
-  // creative assets) fail existsSync and the dashboard collapses to
-  // creativeReviewReason='no_real_creative_assets'.
-  const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim();
-  const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
-  if (hostOutputDir && hostOutputMount) {
-    // path.resolve (not path.normalize) so a trailing slash on the env var
-    // doesn't produce `/foo//` in the startsWith guard and silently no-op
-    // the remap.
-    const normalizedHostDir = path.resolve(hostOutputDir);
-    const normalizedHostMount = path.resolve(hostOutputMount);
-    if (
-      normalizedPath === normalizedHostDir ||
-      normalizedPath.startsWith(`${normalizedHostDir}${path.sep}`)
-    ) {
-      const suffix = normalizedPath.slice(normalizedHostDir.length).replace(/^[\\/]+/, '');
-      candidates.add(suffix ? path.join(normalizedHostMount, suffix) : normalizedHostMount);
-    }
+  const hostMountCandidate = remapHostOutputToMount(normalizedPath);
+  if (hostMountCandidate) {
+    candidates.add(hostMountCandidate);
   }
 
   for (const candidate of candidates) {

--- a/backend/marketing/asset-read.ts
+++ b/backend/marketing/asset-read.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
 
+import { remapHostOutputToMount } from './host-output-path';
+
 /**
  * Safe reader for files referenced by the marketing runtime documents.
  *
@@ -148,26 +150,9 @@ function absoluteCompatibilityCandidates(filePath: string): string[] {
     candidates.add(path.join(codeRoot, suffix));
   }
 
-  // Host-output → bind-mount remap. Absolute paths that point at the
-  // host's lobster/output tree (ARIES_LOBSTER_HOST_OUTPUT_DIR) need to be
-  // rewritten onto the in-container bind-mount path
-  // (ARIES_LOBSTER_HOST_OUTPUT_MOUNT) so isWithinRoot accepts them and
-  // readFile actually finds the bytes.
-  const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim();
-  const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
-  if (hostOutputDir && hostOutputMount) {
-    // path.resolve (not path.normalize) so a trailing slash on the env var
-    // doesn't produce `/foo//` in the startsWith guard and silently no-op
-    // the remap.
-    const normalizedHostDir = path.resolve(hostOutputDir);
-    const normalizedHostMount = path.resolve(hostOutputMount);
-    if (
-      normalized === normalizedHostDir ||
-      normalized.startsWith(`${normalizedHostDir}${path.sep}`)
-    ) {
-      const hostSuffix = normalized.slice(normalizedHostDir.length).replace(/^[\\/]+/, '');
-      candidates.add(hostSuffix ? path.join(normalizedHostMount, hostSuffix) : normalizedHostMount);
-    }
+  const hostMountCandidate = remapHostOutputToMount(normalized);
+  if (hostMountCandidate) {
+    candidates.add(hostMountCandidate);
   }
 
   return Array.from(candidates);

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths'
 
+import { remapHostOutputToMount } from './host-output-path'
 import type { MarketingCampaignWindow } from './jobs-status'
 import { extractPublishReviewBundle } from './publish-review'
 import { publishReviewLinkedAssetId, publishReviewMediaAssetId } from './publish-review-asset-ids'
@@ -1646,29 +1647,9 @@ function resolveDashboardAssetFilePath(
       compatibilityCandidates.add(path.join(codeRoot, suffix))
     }
 
-    // Host-output → bind-mount remap. Runtime docs written by the host's
-    // Lobster pipeline pin absolute paths under ARIES_LOBSTER_HOST_OUTPUT_DIR;
-    // inside this container that tree is only reachable via the read-only
-    // bind mount at ARIES_LOBSTER_HOST_OUTPUT_MOUNT. Without this remap the
-    // dashboard drops creative image assets and falls through to
-    // creativeReviewReason='no_real_creative_assets'.
-    const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim()
-    const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim()
-    if (hostOutputDir && hostOutputMount) {
-      // path.resolve (not path.normalize) so a trailing slash on the env
-      // var doesn't produce `/foo//` in the startsWith guard and silently
-      // no-op the remap.
-      const normalizedHostDir = path.resolve(hostOutputDir)
-      const normalizedHostMount = path.resolve(hostOutputMount)
-      if (
-        normalized === normalizedHostDir ||
-        normalized.startsWith(`${normalizedHostDir}${path.sep}`)
-      ) {
-        const hostSuffix = normalized.slice(normalizedHostDir.length).replace(/^[\\/]+/, '')
-        compatibilityCandidates.add(
-          hostSuffix ? path.join(normalizedHostMount, hostSuffix) : normalizedHostMount,
-        )
-      }
+    const hostMountCandidate = remapHostOutputToMount(normalized)
+    if (hostMountCandidate) {
+      compatibilityCandidates.add(hostMountCandidate)
     }
 
     for (const compatibilityCandidate of compatibilityCandidates) {

--- a/backend/marketing/host-output-path.ts
+++ b/backend/marketing/host-output-path.ts
@@ -1,0 +1,37 @@
+import path from 'node:path';
+
+/**
+ * Remap an absolute host-output path onto the in-container bind mount.
+ *
+ * The host's Lobster pipeline writes creative images and other artifacts
+ * under an absolute host path (ARIES_LOBSTER_HOST_OUTPUT_DIR), but inside
+ * this container that tree is only reachable via the read-only bind mount
+ * at ARIES_LOBSTER_HOST_OUTPUT_MOUNT. Runtime docs routinely pin absolute
+ * host paths (stage-3/4 creative assets especially), so every asset
+ * resolver that does an absolute-path existsSync / isWithinRoot check
+ * needs to add the remapped candidate before giving up. Without this
+ * the dashboard drops creative assets and collapses to
+ * creativeReviewReason='no_real_creative_assets'.
+ *
+ * Returns the remapped absolute path when `absolutePath` is under the
+ * configured host output dir, otherwise null (including when either env
+ * var is unset). path.resolve is used on the env-var-derived paths so a
+ * trailing slash on the env var doesn't break the startsWith guard.
+ */
+export function remapHostOutputToMount(absolutePath: string): string | null {
+  const hostOutputDir = process.env.ARIES_LOBSTER_HOST_OUTPUT_DIR?.trim();
+  const hostOutputMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
+  if (!hostOutputDir || !hostOutputMount) {
+    return null;
+  }
+
+  const normalized = path.normalize(absolutePath);
+  const hostDir = path.resolve(hostOutputDir);
+  const hostMount = path.resolve(hostOutputMount);
+  if (normalized !== hostDir && !normalized.startsWith(`${hostDir}${path.sep}`)) {
+    return null;
+  }
+
+  const suffix = normalized.slice(hostDir.length).replace(/^[\\/]+/, '');
+  return suffix ? path.join(hostMount, suffix) : hostMount;
+}

--- a/tests/host-output-path.test.ts
+++ b/tests/host-output-path.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+
+import { remapHostOutputToMount } from '../backend/marketing/host-output-path';
+
+async function withEnv<T>(
+  overrides: Record<string, string | undefined>,
+  run: () => Promise<T> | T,
+): Promise<T> {
+  const prior: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(overrides)) {
+    prior[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [k, v] of Object.entries(prior)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+test('remapHostOutputToMount returns null when env vars are unset', async () => {
+  await withEnv(
+    { ARIES_LOBSTER_HOST_OUTPUT_DIR: undefined, ARIES_LOBSTER_HOST_OUTPUT_MOUNT: undefined },
+    () => {
+      assert.equal(remapHostOutputToMount('/anything'), null);
+    },
+  );
+});
+
+test('remapHostOutputToMount returns null when only one env var is set', async () => {
+  await withEnv(
+    { ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out', ARIES_LOBSTER_HOST_OUTPUT_MOUNT: undefined },
+    () => {
+      assert.equal(remapHostOutputToMount('/host/out/file'), null);
+    },
+  );
+  await withEnv(
+    { ARIES_LOBSTER_HOST_OUTPUT_DIR: undefined, ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt' },
+    () => {
+      assert.equal(remapHostOutputToMount('/host/out/file'), null);
+    },
+  );
+});
+
+test('remapHostOutputToMount rewrites paths under host-output-dir onto the mount', async () => {
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/home/node/openclaw/aries-app/lobster/output',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/host-lobster-output',
+    },
+    () => {
+      const input = '/home/node/openclaw/aries-app/lobster/output/27-campaign/landing-pages/index.html';
+      assert.equal(
+        remapHostOutputToMount(input),
+        '/host-lobster-output/27-campaign/landing-pages/index.html',
+      );
+    },
+  );
+});
+
+test('remapHostOutputToMount returns the mount itself when input equals host-output-dir', async () => {
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt',
+    },
+    () => {
+      assert.equal(remapHostOutputToMount('/host/out'), '/mnt');
+    },
+  );
+});
+
+test('remapHostOutputToMount returns null for paths outside host-output-dir', async () => {
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt',
+    },
+    () => {
+      assert.equal(remapHostOutputToMount('/host/outside/file'), null);
+      assert.equal(remapHostOutputToMount('/different/root/file'), null);
+      assert.equal(remapHostOutputToMount('/host'), null);
+    },
+  );
+});
+
+test('remapHostOutputToMount handles trailing slashes on env vars without breaking prefix match', async () => {
+  // The footgun Copilot flagged: path.normalize preserves trailing slashes,
+  // which would make the `${hostDir}${path.sep}` startsWith guard never match.
+  // path.resolve strips them, so this must still work.
+  const input = '/host/out/campaign/image.png';
+  const expected = '/mnt/campaign/image.png';
+
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out/',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt',
+    },
+    () => {
+      assert.equal(remapHostOutputToMount(input), expected);
+    },
+  );
+
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt/',
+    },
+    () => {
+      assert.equal(remapHostOutputToMount(input), expected);
+    },
+  );
+
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out/',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt/',
+    },
+    () => {
+      assert.equal(remapHostOutputToMount(input), expected);
+    },
+  );
+
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out///',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt///',
+    },
+    () => {
+      assert.equal(remapHostOutputToMount(input), expected);
+    },
+  );
+});
+
+test('remapHostOutputToMount normalizes the input path', async () => {
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt',
+    },
+    () => {
+      // Redundant separators and current-dir segments collapse before the prefix match.
+      assert.equal(
+        remapHostOutputToMount('/host/out//sub/./file.png'),
+        path.join('/mnt', 'sub', 'file.png'),
+      );
+    },
+  );
+});
+
+test('remapHostOutputToMount does not match partial directory-name prefixes', async () => {
+  // /host/output must NOT match /host/out — that's why we require the separator.
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: '/host/out',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt',
+    },
+    () => {
+      assert.equal(remapHostOutputToMount('/host/output/file.png'), null);
+      assert.equal(remapHostOutputToMount('/host/out-sibling/file.png'), null);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Cleanup follow-up to #156. The regression fix in #156 added the same ~25-line host-mount remap block to three absolute-path resolvers. This pulls it into one helper so the trust boundary lives in a single file.

- New \`backend/marketing/host-output-path.ts\` with \`remapHostOutputToMount(absolutePath) -> string | null\`.
- Uses \`path.resolve()\` on the env-var paths so a trailing slash on \`ARIES_LOBSTER_HOST_OUTPUT_DIR\` or \`ARIES_LOBSTER_HOST_OUTPUT_MOUNT\` can't break the \`startsWith(\`\${hostDir}\${path.sep}\`)\` guard (Copilot comment from #156, already applied there, now enforced by test).
- Three callers (\`asset-library.ts\`, \`dashboard-content.ts\`, \`asset-read.ts\`) drop their inline blocks and call the helper.
- New \`tests/host-output-path.test.ts\` covers: unset env vars, one-side-only, normal remap, equal-to-root, outside-dir, trailing slashes on either/both env vars, input path normalization, and partial-prefix rejection (\`/host/out\` must not match \`/host/output\`).

Net: -53 lines across callers, +37 in the helper, +8 new unit tests.

## Test plan

- [x] \`APP_BASE_URL=https://aries.example.com tsx --test tests/host-output-path.test.ts\` — 8/8 pass
- [x] \`APP_BASE_URL=https://aries.example.com tsx --test tests/asset-ingest.test.ts\` — 8/8 pass (existing integration tests still green)
- [x] \`APP_BASE_URL=https://aries.example.com tsx --test tests/dashboard-content-adapter.test.ts tests/asset-library-content-type.test.ts\` — 20/20 pass
- [x] \`npm run typecheck\` — only pre-existing \`resend\` error unchanged by this PR
- [ ] Confirm dashboard creative assets still resolve in prod after deploy (no behavior change expected; pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)