### PR TITLE
fix(docker): publish aries-app port from base compose

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -22,6 +22,8 @@ The GitHub Actions deploy workflow expects `ghcr.io/delicioushouse/aries-app:<sh
 docker compose -f docker-compose.yml -f docker-compose.local.yml build
 ```
 
+`docker-compose.yml` now owns the host port publish for `aries-app`, so deploys and production-style runs work even when only the base file is used. `docker-compose.local.yml` remains a merged override for localhost defaults and the optional `aries-app-dev` helper service.
+
 ## Required environment
 - `APP_BASE_URL`
 - `ARIES_APP_IMAGE` (optional image/tag override, default: `aries-app:local`)
@@ -61,6 +63,7 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml down
 - Production should not bind mount the repository into `/app`.
 - Keep real secrets out of git.
 - The runtime contract remains `CODE_ROOT=/app` and `DATA_ROOT=/data`.
+- The main `aries-app` service publishes `${PORT:-3000}` from the base compose file; the local override merges into that same service instead of launching a duplicate production instance.
 - Workflow execution is delegated through OpenClaw.
 
 ## Lobster stage cache directories

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ cp .env.example .env
 docker network create docker-stack || true
 ```
 
-3. Start the app with the local overrides file so port `3000` is published and `host.docker.internal` is available for host-based OpenClaw access:
+3. Start the app with the local overrides file so localhost-oriented URL defaults and `host.docker.internal` are applied for host-based OpenClaw access. The base compose file now owns the production port publish, so this override does not create a second app instance:
 
 ```bash
 docker compose --env-file .env -f docker-compose.yml -f docker-compose.local.yml up --build -d aries-app
@@ -227,7 +227,8 @@ docker compose --env-file .env -f docker-compose.yml -f docker-compose.local.yml
 ### Docker-specific notes
 
 - The app container stores generated runtime artifacts under `/data`, which is a bind mount from `${ARIES_SHARED_DATA_ROOT:-/home/node/data}` on the host. Using a bind mount (not a Docker-managed named volume) is intentional: it lets host-side OpenClaw/Lobster and the Aries container read and write the same files at the same absolute paths.
-- `docker-compose.local.yml` defaults `OPENCLAW_GATEWAY_URL` to `http://host.docker.internal:3456` so the container can talk to an OpenClaw process running on the host.
+- `docker-compose.yml` now publishes `${PORT:-3000}` for the main `aries-app` service because both deploys and local production-style runs depend on that host port existing.
+- `docker-compose.local.yml` only layers in localhost-friendly URL defaults plus `OPENCLAW_GATEWAY_URL=http://host.docker.internal:3456`; it merges into the same `aries-app` service rather than creating a second production container.
 - The Compose setup expects an external PostgreSQL instance; it does not include a Postgres service.
 - For production-style Compose runs, `NODE_ENV` is set to `production` and the container starts with `npm run start`.
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,11 +1,10 @@
 services:
   aries-app:
-    # The aries-app service runs the baked production image (`npm run start`).
-    # Do NOT bind-mount the source tree onto /app here — it would shadow the
-    # image's built `.next`, production `node_modules`, and compiled output
-    # and break the runtime. For a live-reload dev loop, use `aries-app-dev`
-    # (the dev profile below) which runs `npm run dev` against the mounted
-    # source at /app.
+    # This block is a local-only override for the main aries-app service.
+    # It does NOT create a second instance; Compose merges these fields into
+    # the base aries-app definition from docker-compose.yml. Keep local URL
+    # defaults here, while the production port publish stays in the base file
+    # so deploys work even when only docker-compose.yml is used.
     environment:
       PORT: ${PORT:-3000}
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:3000}
@@ -13,10 +12,6 @@ services:
       AUTH_URL: ${AUTH_URL:-http://localhost:3000}
       OPENCLAW_GATEWAY_URL: ${OPENCLAW_GATEWAY_URL:-http://host.docker.internal:3456}
       OPENCLAW_SESSION_KEY: ${OPENCLAW_SESSION_KEY:-main}
-    ports:
-      - "${PORT:-3000}:${PORT:-3000}"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
 
   aries-app-dev:
     profiles: ["dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       # the bind mount below so asset-ingest can remap host paths.
       ARIES_LOBSTER_HOST_OUTPUT_DIR: ${ARIES_LOBSTER_HOST_OUTPUT_DIR:-/home/node/openclaw/aries-app/lobster/output}
       ARIES_LOBSTER_HOST_OUTPUT_MOUNT: ${ARIES_LOBSTER_HOST_OUTPUT_MOUNT:-/host-lobster-output}
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/tests/production-compose-port-publish.regression-016.test.ts
+++ b/tests/production-compose-port-publish.regression-016.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+const baseCompose = readFileSync(
+  path.join(PROJECT_ROOT, 'docker-compose.yml'),
+  'utf8',
+);
+
+const localCompose = readFileSync(
+  path.join(PROJECT_ROOT, 'docker-compose.local.yml'),
+  'utf8',
+);
+
+// Regression: deploy uses the base compose file on the host. The production
+// port publish therefore has to live in docker-compose.yml rather than only in
+// the local override file, or the external reverse proxy loses its upstream.
+test('base compose owns the production aries-app port publish', () => {
+  const baseAriesApp = baseCompose.match(/services:\n  aries-app:\n[\s\S]*?(?=\nnetworks:|\nvolumes:|$)/);
+  assert.ok(baseAriesApp, 'expected to find the base aries-app service definition');
+  assert.match(
+    baseAriesApp![0],
+    /ports:\n\s+- "\$\{PORT:-3000\}:\$\{PORT:-3000\}"/,
+    'docker-compose.yml should publish the app port for production deploys',
+  );
+
+  const localAriesApp = localCompose.match(/services:\n  aries-app:\n[\s\S]*?(?=\n  aries-app-dev:|$)/);
+  assert.ok(localAriesApp, 'expected to find the local override aries-app service block');
+  assert.doesNotMatch(
+    localAriesApp![0],
+    /\n\s+ports:\n/,
+    'docker-compose.local.yml should no longer be the only place the production aries-app port is exposed',
+  );
+
+  assert.match(
+    localCompose,
+    /  aries-app-dev:\n[\s\S]*?\n\s+ports:\n\s+- "\$\{PORT:-3000\}:\$\{PORT:-3000\}"/,
+    'the optional dev container can still publish the port inside the local override',
+  );
+});


### PR DESCRIPTION
## Summary
- move the production `aries-app` port publish into `docker-compose.yml`
- keep `docker-compose.local.yml` as a local/dev override instead of the only place the prod port is exposed
- add a regression test and docs clarifying that the two compose files merge into one service definition rather than launching duplicate prod instances

## Why
Deploy currently runs against the base compose file on the host. When the port publish lived only in `docker-compose.local.yml`, production deploys could leave the container healthy but unreachable from the external Caddy proxy, causing `aries.sugarandleather.com` to return 502.

## Test Plan
- [x] `npx tsx --test tests/deploy-workflow-self-hosted.regression-015.test.ts tests/production-compose-port-publish.regression-016.test.ts`
- [x] `docker compose -f docker-compose.yml config`
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`

## Live note
I also used the updated base compose locally on the deploy host to republish port 3000 and restore `aries.sugarandleather.com` while this PR is under review.
