### PR TITLE
fix: close QA metadata and contact regressions

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -6,6 +6,9 @@ export const metadata = {
   title: 'Contact — Aries AI',
 };
 
+const SUPPORT_EMAIL = 'support@sugarandleather.com';
+const SUPPORT_MAILTO = `mailto:${SUPPORT_EMAIL}?subject=Aries%20support%20request`;
+
 export default function ContactPage() {
   return (
     <MarketingLayout>
@@ -19,19 +22,29 @@ export default function ContactPage() {
               Get in touch with the <span className="text-gradient">Aries team</span>
             </h1>
             <p className="text-xl text-white/60 mb-8">
-              Contact intake is not available yet. In the meantime, the best way to get started is to set up your business directly in the app.
+              Reach the team directly at{' '}
+              <a href={SUPPORT_MAILTO} className="underline decoration-primary/60 underline-offset-4 hover:text-white">
+                {SUPPORT_EMAIL}
+              </a>
+              . Include your business name, goal, and the best reply address so we can route your request quickly.
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4">
+              <a
+                href={SUPPORT_MAILTO}
+                className="px-8 py-4 rounded-full bg-gradient-to-r from-primary to-secondary text-white font-semibold shadow-xl shadow-primary/20 text-center"
+              >
+                Email support
+              </a>
               <Link
                 href="/onboarding/start"
-                className="px-8 py-4 rounded-full bg-gradient-to-r from-primary to-secondary text-white font-semibold shadow-xl shadow-primary/20"
+                className="px-8 py-4 rounded-full bg-white/5 border border-white/10 text-white font-semibold hover:bg-white/10 transition-all text-center"
               >
                 Start with your business
               </Link>
               <Link
                 href="/login"
-                className="px-8 py-4 rounded-full bg-white/5 border border-white/10 text-white font-semibold hover:bg-white/10 transition-all"
+                className="px-8 py-4 rounded-full bg-white/5 border border-white/10 text-white font-semibold hover:bg-white/10 transition-all text-center"
               >
                 Sign in
               </Link>

--- a/app/dashboard/campaigns/new/page.tsx
+++ b/app/dashboard/campaigns/new/page.tsx
@@ -1,6 +1,10 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import MarketingNewJobScreen from '@/frontend/marketing/new-job';
 
+export const metadata = {
+  title: 'New Campaign · Aries AI',
+};
+
 export default function DashboardNewCampaignPage() {
   return (
     <AppShellLayout currentRouteId="newCampaign">

--- a/app/dashboard/campaigns/page.tsx
+++ b/app/dashboard/campaigns/page.tsx
@@ -1,6 +1,10 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import AriesCampaignListScreen from '@/frontend/aries-v1/campaign-list';
 
+export const metadata = {
+  title: 'Campaigns · Aries AI',
+};
+
 export default function DashboardCampaignsPage() {
   return (
     <AppShellLayout currentRouteId="campaigns">

--- a/app/dashboard/publish-status/page.tsx
+++ b/app/dashboard/publish-status/page.tsx
@@ -1,6 +1,10 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import AriesLatestCampaignView from '@/frontend/aries-v1/latest-campaign-view';
 
+export const metadata = {
+  title: 'Publish Status · Aries AI',
+};
+
 export default function DashboardPublishStatusPage() {
   return (
     <AppShellLayout currentRouteId="publishStatus">

--- a/app/marketing/job-approve/page.tsx
+++ b/app/marketing/job-approve/page.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import MarketingJobApproveScreen from '../../../frontend/marketing/job-approve';
 
+export const metadata = {
+  title: 'Campaign Approval · Aries AI',
+};
+
 export default async function MarketingJobApprovePage({
   searchParams
 }: {

--- a/app/marketing/job-status/page.tsx
+++ b/app/marketing/job-status/page.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import MarketingJobStatusScreen from '../../../frontend/marketing/job-status';
 
+export const metadata = {
+  title: 'Campaign Status · Aries AI',
+};
+
 export default async function MarketingJobStatusPage({
   searchParams
 }: {

--- a/app/marketing/new-job/page.tsx
+++ b/app/marketing/new-job/page.tsx
@@ -1,7 +1,8 @@
-'use client';
-
-import React from 'react';
 import MarketingNewJobScreen from '../../../frontend/marketing/new-job';
+
+export const metadata = {
+  title: 'New Campaign · Aries AI',
+};
 
 export default function MarketingNewJobPage() {
   return <MarketingNewJobScreen />;

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -1,6 +1,10 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import AriesReviewQueueScreen from '@/frontend/aries-v1/review-queue';
 
+export const metadata = {
+  title: 'Review · Aries AI',
+};
+
 export default function ReviewQueuePage() {
   return (
     <AppShellLayout currentRouteId="review" skipOnboardingGate>

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -1,5 +1,9 @@
 import MarketingLayout from '@/frontend/marketing/MarketingLayout';
 
+export const metadata = {
+  title: 'Sitemap · Aries AI',
+};
+
 const ROUTE_GROUPS: Array<{ title: string; routes: Array<{ href: string; label: string }> }> = [
   {
     title: 'Public',

--- a/frontend/documentation/Docs.tsx
+++ b/frontend/documentation/Docs.tsx
@@ -21,6 +21,9 @@ const sections = [
   { id: 'security', title: 'Security', icon: ShieldCheck },
 ];
 
+export const SECTION_ANCHOR_CLASS = 'scroll-mt-32 md:scroll-mt-36';
+export const DIVIDED_SECTION_ANCHOR_CLASS = `${SECTION_ANCHOR_CLASS} pt-12 border-t border-white/5`;
+
 export default function Docs() {
   const [activeSection, setActiveSection] = useState('overview');
   const sectionRefs = useRef<{ [key: string]: HTMLElement | null }>({});
@@ -136,7 +139,7 @@ export default function Docs() {
               <section
                 id="overview"
                 ref={(el) => { sectionRefs.current['overview'] = el; }}
-                className="scroll-mt-24"
+                className={SECTION_ANCHOR_CLASS}
               >
                 <div className="flex items-center gap-4 mb-8">
                   <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center border border-white/10">
@@ -159,7 +162,7 @@ export default function Docs() {
               <section
                 id="quick-start"
                 ref={(el) => { sectionRefs.current['quick-start'] = el; }}
-                className="scroll-mt-24 pt-12 border-t border-white/5"
+                className={DIVIDED_SECTION_ANCHOR_CLASS}
               >
                 <div className="flex items-center gap-4 mb-8">
                   <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center border border-white/10">
@@ -188,7 +191,7 @@ export default function Docs() {
               <section
                 id="architecture"
                 ref={(el) => { sectionRefs.current['architecture'] = el; }}
-                className="scroll-mt-24 pt-12 border-t border-white/5"
+                className={DIVIDED_SECTION_ANCHOR_CLASS}
               >
                 <div className="flex items-center gap-4 mb-8">
                   <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center border border-white/10">
@@ -211,7 +214,7 @@ export default function Docs() {
               <section
                 id="campaigns"
                 ref={(el) => { sectionRefs.current['campaigns'] = el; }}
-                className="scroll-mt-24 pt-12 border-t border-white/5"
+                className={DIVIDED_SECTION_ANCHOR_CLASS}
               >
                 <div className="flex items-center gap-4 mb-8">
                   <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center border border-white/10">
@@ -247,7 +250,7 @@ export default function Docs() {
               <section
                 id="integrations"
                 ref={(el) => { sectionRefs.current['integrations'] = el; }}
-                className="scroll-mt-24 pt-12 border-t border-white/5"
+                className={DIVIDED_SECTION_ANCHOR_CLASS}
               >
                 <div className="flex items-center gap-4 mb-8">
                   <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center border border-white/10">
@@ -286,7 +289,7 @@ export default function Docs() {
               <section
                 id="security"
                 ref={(el) => { sectionRefs.current['security'] = el; }}
-                className="scroll-mt-24 pt-12 border-t border-white/5"
+                className={DIVIDED_SECTION_ANCHOR_CLASS}
               >
                 <div className="flex items-center gap-4 mb-8">
                   <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center border border-white/10">
@@ -325,6 +328,6 @@ export default function Docs() {
   );
 }
 
-function cn(...classes: any[]) {
+function cn(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(' ');
 }

--- a/tests/public-marketing-pages.test.ts
+++ b/tests/public-marketing-pages.test.ts
@@ -101,11 +101,13 @@ test('public marketing pages return valid elements with expected route shells an
     assert.equal(isValidElement(contactElement), true);
     assert.equal(contactElement.type, MarketingLayout);
     const contactText = normalizeWhitespace(collectText(contactElement.props.children));
-    assert.match(contactText, /Contact intake is not available yet/);
+    assert.match(contactText, /support@sugarandleather\.com/);
+    assert.match(contactText, /Email support/);
     assert.match(contactText, /Start with your business/);
     const contactSource = readRepoFile('app/contact/page.tsx');
+    assert.match(contactSource, /const SUPPORT_EMAIL = 'support@sugarandleather\.com';/);
+    assert.match(contactSource, /const SUPPORT_MAILTO = `mailto:\$\{SUPPORT_EMAIL\}\?subject=Aries%20support%20request`;/);
     assert.match(contactSource, /\/onboarding\/start/);
-    assert.doesNotMatch(contactSource, /\/onboarding\/pipeline-intake/);
 
     const apiDocsElement = ApiDocsPage();
     assert.equal(isValidElement(apiDocsElement), true);

--- a/tests/review-flow-destructive-guards.test.ts
+++ b/tests/review-flow-destructive-guards.test.ts
@@ -51,7 +51,7 @@ function baseReviewItem(overrides: Partial<RuntimeReviewItem> = {}): RuntimeRevi
     campaignId: 'job_x',
     campaignName: 'Demo',
     reviewType: 'workflow_approval',
-    workflowState: 'in_review',
+    workflowState: 'strategy_review_required',
     workflowStage: 'strategy',
     title: 'Approve strategy',
     channel: 'Campaign',
@@ -60,6 +60,7 @@ function baseReviewItem(overrides: Partial<RuntimeReviewItem> = {}): RuntimeRevi
     status: 'changes_requested',
     summary: '',
     currentVersion: { id: 'approval:abc', label: '', headline: '', supportingText: '', cta: '', notes: [] },
+    lastDecision: null,
     sections: [],
     attachments: [],
     history: [],
@@ -116,7 +117,7 @@ test('M4: workflow_approval items stay as stage_review (they have no assetId)', 
 });
 
 test('M4: no lastDecision => history is untouched', () => {
-  const item = baseReviewItem({ lastDecision: undefined });
+  const item = baseReviewItem({ lastDecision: null });
   const out = syncHistoryWithLastDecision(item);
   assert.equal(out.history.length, 0);
   assert.strictEqual(out, item);
@@ -133,7 +134,7 @@ test('M4: already-recorded decision is not duplicated', () => {
         at,
         actor: 'Client reviewer',
         type: 'stage_review',
-        workflowState: 'in_review',
+        workflowState: 'strategy_review_required',
         action: 'approve',
         note: null,
         status: 'approved',

--- a/tests/route-metadata-and-docs-anchors.regression-015.test.ts
+++ b/tests/route-metadata-and-docs-anchors.regression-015.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { metadata as sitemapMetadata } from '../app/sitemap/page';
+import { metadata as reviewMetadata } from '../app/review/page';
+import { metadata as publishStatusMetadata } from '../app/dashboard/publish-status/page';
+import { metadata as dashboardCampaignsMetadata } from '../app/dashboard/campaigns/page';
+import { metadata as dashboardNewCampaignMetadata } from '../app/dashboard/campaigns/new/page';
+import { metadata as marketingNewJobMetadata } from '../app/marketing/new-job/page';
+import { metadata as marketingJobStatusMetadata } from '../app/marketing/job-status/page';
+import { metadata as marketingJobApproveMetadata } from '../app/marketing/job-approve/page';
+import {
+  DIVIDED_SECTION_ANCHOR_CLASS,
+  SECTION_ANCHOR_CLASS,
+} from '../frontend/documentation/Docs';
+
+test('route-level metadata stays specific for QA-regressed pages', () => {
+  assert.equal(sitemapMetadata.title, 'Sitemap · Aries AI');
+  assert.equal(reviewMetadata.title, 'Review · Aries AI');
+  assert.equal(publishStatusMetadata.title, 'Publish Status · Aries AI');
+  assert.equal(dashboardCampaignsMetadata.title, 'Campaigns · Aries AI');
+  assert.equal(dashboardNewCampaignMetadata.title, 'New Campaign · Aries AI');
+  assert.equal(marketingNewJobMetadata.title, 'New Campaign · Aries AI');
+  assert.equal(marketingJobStatusMetadata.title, 'Campaign Status · Aries AI');
+  assert.equal(marketingJobApproveMetadata.title, 'Campaign Approval · Aries AI');
+});
+
+test('documentation anchors keep a top offset for clean in-page navigation', () => {
+  assert.match(SECTION_ANCHOR_CLASS, /\bscroll-mt-32\b/);
+  assert.match(DIVIDED_SECTION_ANCHOR_CLASS, /\bscroll-mt-32\b/);
+  assert.match(DIVIDED_SECTION_ANCHOR_CLASS, /\bmd:scroll-mt-36\b/);
+});


### PR DESCRIPTION
## Summary\n- add route-specific metadata titles for the QA-listed pages\n- replace the /contact placeholder with the existing support email channel\n- tighten documentation section anchor offsets and add regression coverage\n- refresh the stale destructive-review test fixture so typecheck matches the current workflow-state contract\n\n## QA\n- Addresses MASTER-013\n- Addresses MASTER-014\n- Addresses MASTER-015\n\n## Validation\n- npm run typecheck\n- npm run lint\n- npm run verify\n- npx tsx --test tests/route-metadata-and-docs-anchors.regression-015.test.ts tests/public-marketing-pages.test.ts tests/runtime-pages.test.ts