### PR TITLE
fix: preserve review deep links and recovery actions

### DIFF
--- a/app/api/marketing/reviews/[reviewId]/route.ts
+++ b/app/api/marketing/reviews/[reviewId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-import { getMarketingReviewItemForTenant } from '@/backend/marketing/runtime-views';
+import { lookupMarketingReviewItemForTenant } from '@/backend/marketing/runtime-views';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 function decodeReviewIdParam(reviewId: string): string {
@@ -21,12 +21,24 @@ export async function handleGetMarketingReviewItem(
     return tenantResult.response;
   }
 
-  const review = await getMarketingReviewItemForTenant(tenantResult.tenantContext.tenantId, decodedReviewId);
-  if (!review) {
+  const lookup = await lookupMarketingReviewItemForTenant(
+    tenantResult.tenantContext.tenantId,
+    decodedReviewId,
+  );
+  if (lookup.status === 'wrong_workspace') {
+    return NextResponse.json(
+      {
+        error: 'review_not_in_current_workspace',
+        message: 'This review belongs to a different workspace than the one currently active for your account.',
+      },
+      { status: 409 },
+    );
+  }
+  if (lookup.status !== 'ok') {
     return NextResponse.json({ error: 'review_not_found' }, { status: 404 });
   }
 
-  return NextResponse.json({ review }, { status: 200 });
+  return NextResponse.json({ review: lookup.review }, { status: 200 });
 }
 
 export async function GET(_req: Request, { params }: { params: Promise<{ reviewId: string }> }) {

--- a/app/review/[reviewId]/page.tsx
+++ b/app/review/[reviewId]/page.tsx
@@ -15,9 +15,14 @@ export default async function ReviewItemPage({
   params: Promise<{ reviewId: string }>;
 }) {
   const { reviewId } = await params;
+  const encodedReviewPath = `/review/${reviewId}`;
 
   return (
-    <AppShellLayout currentRouteId="review" skipOnboardingGate>
+    <AppShellLayout
+      currentRouteId="review"
+      skipOnboardingGate
+      loginRedirectPath={encodedReviewPath}
+    >
       <AriesReviewItemScreen reviewId={decodeReviewIdParam(reviewId)} />
     </AppShellLayout>
   );

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -3,7 +3,7 @@ import AriesReviewQueueScreen from '@/frontend/aries-v1/review-queue';
 
 export default function ReviewQueuePage() {
   return (
-    <AppShellLayout currentRouteId="review" skipOnboardingGate>
+    <AppShellLayout currentRouteId="review" skipOnboardingGate loginRedirectPath="/review">
       <AriesReviewQueueScreen />
     </AppShellLayout>
   );

--- a/backend/marketing/runtime-views.ts
+++ b/backend/marketing/runtime-views.ts
@@ -150,6 +150,11 @@ export type RuntimeReviewQueue = {
   archivedReviews: RuntimeReviewItem[];
 };
 
+export type RuntimeReviewItemLookupResult =
+  | { status: 'ok'; review: RuntimeReviewItem }
+  | { status: 'missing' }
+  | { status: 'wrong_workspace' };
+
 export type RuntimeReviewStateFile = {
   schema_name: 'marketing_review_state';
   schema_version: '1.0.0';
@@ -1542,13 +1547,30 @@ export async function listPublicMarketingReviewItems(): Promise<RuntimeReviewIte
   return items.sort((left, right) => right.scheduledFor.localeCompare(left.scheduledFor));
 }
 
-export async function getMarketingReviewItemForTenant(tenantId: string, reviewId: string): Promise<RuntimeReviewItem | null> {
+export async function lookupMarketingReviewItemForTenant(
+  tenantId: string,
+  reviewId: string,
+): Promise<RuntimeReviewItemLookupResult> {
   const { jobId } = reviewIdParts(reviewId);
   const runtimeDoc = loadMarketingJobRuntime(jobId);
-  if (!runtimeDoc || runtimeDoc.tenant_id !== tenantId) {
-    return null;
+  if (!runtimeDoc) {
+    return { status: 'missing' };
   }
-  return resolveRuntimeReviewItem(jobId, reviewId);
+  if (runtimeDoc.tenant_id !== tenantId) {
+    return { status: 'wrong_workspace' };
+  }
+
+  const review = resolveRuntimeReviewItem(jobId, reviewId);
+  if (!review) {
+    return { status: 'missing' };
+  }
+
+  return { status: 'ok', review };
+}
+
+export async function getMarketingReviewItemForTenant(tenantId: string, reviewId: string): Promise<RuntimeReviewItem | null> {
+  const lookup = await lookupMarketingReviewItemForTenant(tenantId, reviewId);
+  return lookup.status === 'ok' ? lookup.review : null;
 }
 
 export async function recordMarketingReviewDecision(input: {

--- a/components/redesign/layout/app-shell.tsx
+++ b/components/redesign/layout/app-shell.tsx
@@ -17,6 +17,7 @@ export interface RedesignAppShellProps {
   title?: string;
   subtitle?: string;
   actions?: ReactNode;
+  loginRedirectPath?: string;
   /**
    * When true, the shell skips the onboarding redirect. Use for surfaces that
    * must stay reachable for users who have not finished onboarding (for
@@ -47,6 +48,7 @@ export default async function RedesignAppShell({
   title,
   subtitle,
   actions,
+  loginRedirectPath,
   skipOnboardingGate = false,
 }: RedesignAppShellProps): Promise<JSX.Element> {
   const session = await auth();
@@ -55,7 +57,11 @@ export default async function RedesignAppShell({
     // the user to where they were trying to go (ISSUE-W2-L4).
     const h = await headers();
     const rawPath =
-      h.get('x-invoke-path') ?? h.get('x-pathname') ?? h.get('next-url') ?? null;
+      loginRedirectPath
+      ?? h.get('x-invoke-path')
+      ?? h.get('x-pathname')
+      ?? h.get('next-url')
+      ?? null;
     let pathname: string | null = rawPath;
     let search: string | null = null;
     if (!pathname) {

--- a/frontend/aries-v1/review-item.tsx
+++ b/frontend/aries-v1/review-item.tsx
@@ -8,6 +8,7 @@ import MediaPreview from '@/frontend/components/media-preview';
 import { useRuntimeReviewItem } from '@/hooks/use-runtime-review-item';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
+import { getReviewRecoveryState } from './review-recovery';
 import { isDestructiveActionBlocked } from './review-destructive-guard';
 import { EmptyStatePanel, LoadingStateGrid, ShellPanel, StatusChip } from './components';
 
@@ -64,6 +65,7 @@ function brandKitFontStyle(family: string): CSSProperties {
 export default function AriesReviewItemScreen(props: { reviewId: string }) {
   const review = useRuntimeReviewItem(props.reviewId, { autoLoad: true });
   const item = review.data?.review ?? null;
+  const recoveryState = getReviewRecoveryState(review.error);
   const [note, setNote] = useState('');
   const [activeAction, setActiveAction] = useState<DecisionActionKind>('approve');
   const [progressIndex, setProgressIndex] = useState(0);
@@ -102,6 +104,31 @@ export default function AriesReviewItemScreen(props: { reviewId: string }) {
   }
 
   if (review.error) {
+    if (recoveryState) {
+      return (
+        <EmptyStatePanel
+          title={recoveryState.title}
+          description={`${recoveryState.description} ${recoveryState.guidance}`}
+          action={
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href={recoveryState.primaryAction.href}
+                className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] transition hover:translate-y-[-1px]"
+              >
+                {recoveryState.primaryAction.label}
+              </Link>
+              <Link
+                href={recoveryState.secondaryAction.href}
+                className="inline-flex items-center gap-2 rounded-full border border-white/12 px-5 py-3 text-sm font-medium text-white/80 transition hover:border-white/20 hover:text-white"
+              >
+                {recoveryState.secondaryAction.label}
+              </Link>
+            </div>
+          }
+        />
+      );
+    }
+
     return (
       <div className="rounded-[1.5rem] border border-red-500/20 bg-red-500/10 p-5 text-red-100">
         {customerSafeUiErrorMessage(review.error.message, 'This review item is not available right now.')}

--- a/frontend/aries-v1/review-recovery.ts
+++ b/frontend/aries-v1/review-recovery.ts
@@ -1,0 +1,37 @@
+import type { ApiError } from '@/lib/api/types';
+
+export type ReviewRecoveryState = {
+  title: string;
+  description: string;
+  guidance: string;
+  primaryAction: {
+    label: string;
+    href: string;
+  };
+  secondaryAction: {
+    label: string;
+    href: string;
+  };
+};
+
+export function getReviewRecoveryState(error: ApiError | null): ReviewRecoveryState | null {
+  if (error?.code !== 'review_not_in_current_workspace') {
+    return null;
+  }
+
+  return {
+    title: 'This review belongs to a different workspace',
+    description:
+      'The link resolved to a valid review item, but the workspace currently active for your account does not own it.',
+    guidance:
+      'Open your current queue or campaigns from here. If you expected another workspace, sign out and reopen the same link with the correct account.',
+    primaryAction: {
+      label: 'Open review queue',
+      href: '/review',
+    },
+    secondaryAction: {
+      label: 'Open campaigns',
+      href: '/dashboard/campaigns',
+    },
+  };
+}

--- a/tests/frontend-api-layer.test.ts
+++ b/tests/frontend-api-layer.test.ts
@@ -5913,6 +5913,40 @@ test('/api/marketing/reviews/[reviewId] decodes encoded review ids before loadin
   });
 });
 
+test('/api/marketing/reviews/[reviewId] returns a recovery-oriented error when the review exists in another workspace', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const { handleGetMarketingReviewItem } = await import('../app/api/marketing/reviews/[reviewId]/route');
+    const jobsRoot = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs');
+    const jobId = 'mkt_review_other_workspace';
+    const runtimeDoc = makeApprovalReviewRuntimeDoc({
+      dataRoot,
+      jobId,
+      tenantId: 'tenant_expected',
+    }) as Record<string, unknown>;
+
+    await mkdir(jobsRoot, { recursive: true });
+    await writeFile(
+      path.join(jobsRoot, `${jobId}.json`),
+      JSON.stringify(runtimeDoc, null, 2),
+    );
+
+    const response = await handleGetMarketingReviewItem(
+      `${jobId}%3A%3Aapproval`,
+      async () => ({
+        userId: 'user_2',
+        tenantId: 'tenant_active',
+        tenantSlug: 'active-workspace',
+        role: 'tenant_admin',
+      }),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 409);
+    assert.equal(body.error, 'review_not_in_current_workspace');
+    assert.match(String(body.message), /different workspace/i);
+  });
+});
+
 test('/api/marketing/reviews/[reviewId]/decision decodes encoded review ids before saving the decision', async () => {
   await withRuntimeEnv(async (dataRoot) => {
     const { handlePostMarketingReviewDecision } = await import('../app/api/marketing/reviews/[reviewId]/decision/route');

--- a/tests/review-auth-redirect.test.ts
+++ b/tests/review-auth-redirect.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isValidElement } from 'react';
+
+import ReviewItemPage from '../app/review/[reviewId]/page';
+import ReviewQueuePage from '../app/review/page';
+import AppShellLayout from '../frontend/app-shell/layout';
+import { buildLoginRedirect } from '../lib/auth/callback-url';
+
+test('review queue passes an explicit login callback path into the app shell', () => {
+  const element = ReviewQueuePage();
+
+  assert.equal(isValidElement(element), true);
+  assert.equal(element.type, AppShellLayout);
+  assert.equal(element.props.loginRedirectPath, '/review');
+  assert.equal(
+    buildLoginRedirect(element.props.loginRedirectPath),
+    '/login?callbackUrl=%2Freview',
+  );
+});
+
+test('review deep links preserve the requested destination through login', async () => {
+  const element = await ReviewItemPage({
+    params: Promise.resolve({
+      reviewId: 'mkt_c3929018-5bdb-4dfc-83ab-f2ed13bdb97b%3A%3Acreative%3Aimage-proof',
+    }),
+  });
+
+  assert.equal(isValidElement(element), true);
+  assert.equal(element.type, AppShellLayout);
+  assert.equal(
+    element.props.loginRedirectPath,
+    '/review/mkt_c3929018-5bdb-4dfc-83ab-f2ed13bdb97b%3A%3Acreative%3Aimage-proof',
+  );
+  assert.equal(
+    buildLoginRedirect(element.props.loginRedirectPath),
+    '/login?callbackUrl=%2Freview%2Fmkt_c3929018-5bdb-4dfc-83ab-f2ed13bdb97b%253A%253Acreative%253Aimage-proof',
+  );
+});

--- a/tests/review-recovery.test.ts
+++ b/tests/review-recovery.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getReviewRecoveryState } from '../frontend/aries-v1/review-recovery';
+
+test('review recovery state is null for generic review errors', () => {
+  assert.equal(
+    getReviewRecoveryState({
+      status: 404,
+      code: 'review_not_found',
+      message: 'review_not_found',
+    }),
+    null,
+  );
+});
+
+test('review recovery state exposes actionable links for wrong-workspace deep links', () => {
+  const recovery = getReviewRecoveryState({
+    status: 409,
+    code: 'review_not_in_current_workspace',
+    message: 'This review belongs to a different workspace than the one currently active for your account.',
+  });
+
+  assert.ok(recovery);
+  assert.equal(recovery.title, 'This review belongs to a different workspace');
+  assert.equal(recovery.primaryAction.label, 'Open review queue');
+  assert.equal(recovery.primaryAction.href, '/review');
+  assert.equal(recovery.secondaryAction.label, 'Open campaigns');
+  assert.equal(recovery.secondaryAction.href, '/dashboard/campaigns');
+  assert.match(recovery.guidance, /sign out and reopen the same link/i);
+});

--- a/tests/review-route-access.test.ts
+++ b/tests/review-route-access.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { createMarketingJobRuntimeDocument, saveMarketingJobRuntime } from '../backend/marketing/runtime-state';
+import { saveTenantBrandKit, tenantBrandKitPath, type TenantBrandKit } from '../backend/marketing/brand-kit';
+import { handleGetMarketingReviewItem } from '../app/api/marketing/reviews/[reviewId]/route';
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+async function withRuntimeEnv<T>(run: () => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const previousOpenClawLobsterCwd = process.env.OPENCLAW_LOBSTER_CWD;
+  const previousStage1CacheDir = process.env.LOBSTER_STAGE1_CACHE_DIR;
+  const previousStage2CacheDir = process.env.LOBSTER_STAGE2_CACHE_DIR;
+  const previousStage3CacheDir = process.env.LOBSTER_STAGE3_CACHE_DIR;
+  const previousStage4CacheDir = process.env.LOBSTER_STAGE4_CACHE_DIR;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-review-route-'));
+
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+  process.env.OPENCLAW_LOBSTER_CWD = path.join(PROJECT_ROOT, 'lobster');
+  process.env.LOBSTER_STAGE1_CACHE_DIR = path.join(dataRoot, 'lobster-stage1-cache');
+  process.env.LOBSTER_STAGE2_CACHE_DIR = path.join(dataRoot, 'lobster-stage2-cache');
+  process.env.LOBSTER_STAGE3_CACHE_DIR = path.join(dataRoot, 'lobster-stage3-cache');
+  process.env.LOBSTER_STAGE4_CACHE_DIR = path.join(dataRoot, 'lobster-stage4-cache');
+
+  try {
+    return await run();
+  } finally {
+    if (previousCodeRoot === undefined) delete process.env.CODE_ROOT;
+    else process.env.CODE_ROOT = previousCodeRoot;
+    if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previousDataRoot;
+    if (previousOpenClawLobsterCwd === undefined) delete process.env.OPENCLAW_LOBSTER_CWD;
+    else process.env.OPENCLAW_LOBSTER_CWD = previousOpenClawLobsterCwd;
+    if (previousStage1CacheDir === undefined) delete process.env.LOBSTER_STAGE1_CACHE_DIR;
+    else process.env.LOBSTER_STAGE1_CACHE_DIR = previousStage1CacheDir;
+    if (previousStage2CacheDir === undefined) delete process.env.LOBSTER_STAGE2_CACHE_DIR;
+    else process.env.LOBSTER_STAGE2_CACHE_DIR = previousStage2CacheDir;
+    if (previousStage3CacheDir === undefined) delete process.env.LOBSTER_STAGE3_CACHE_DIR;
+    else process.env.LOBSTER_STAGE3_CACHE_DIR = previousStage3CacheDir;
+    if (previousStage4CacheDir === undefined) delete process.env.LOBSTER_STAGE4_CACHE_DIR;
+    else process.env.LOBSTER_STAGE4_CACHE_DIR = previousStage4CacheDir;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+function makeTenantBrandKit(tenantId: string): TenantBrandKit {
+  return {
+    tenant_id: tenantId,
+    source_url: `https://${tenantId}.example.com`,
+    canonical_url: `https://${tenantId}.example.com`,
+    brand_name: 'Brand Example',
+    logo_urls: [`https://${tenantId}.example.com/logo.png`],
+    colors: {
+      primary: '#111111',
+      secondary: '#f4f4f4',
+      accent: '#c24d2c',
+      palette: ['#111111', '#f4f4f4', '#c24d2c'],
+    },
+    font_families: ['Manrope'],
+    external_links: [],
+    extracted_at: '2026-04-23T00:00:00.000Z',
+    brand_voice_summary: 'Direct and grounded.',
+    offer_summary: 'Proof-led launch audit.',
+  };
+}
+
+test('review route returns a recovery-oriented error when the review exists in another workspace', async () => {
+  await withRuntimeEnv(async () => {
+    const tenantId = 'tenant_expected';
+    saveTenantBrandKit(tenantId, makeTenantBrandKit(tenantId));
+    const runtimeDoc = createMarketingJobRuntimeDocument({
+      jobId: 'mkt_review_wrong_workspace',
+      tenantId,
+      payload: {
+        businessName: 'Brand Example',
+        brandUrl: `https://${tenantId}.example.com`,
+      },
+      brandKit: {
+        path: tenantBrandKitPath(tenantId),
+        ...makeTenantBrandKit(tenantId),
+      },
+    });
+
+    runtimeDoc.approvals.current = {
+      stage: 'strategy',
+      status: 'awaiting_approval',
+      approval_id: 'mkta_wrong_workspace',
+      title: 'Strategy approval required',
+      message: 'Continue to strategy.',
+      requested_at: '2026-04-23T00:00:00.000Z',
+      action_label: 'Review strategy',
+    };
+
+    saveMarketingJobRuntime(runtimeDoc.job_id, runtimeDoc);
+
+    const response = await handleGetMarketingReviewItem(
+      'mkt_review_wrong_workspace%3A%3Aapproval',
+      async () => ({
+        userId: 'user_active',
+        tenantId: 'tenant_active',
+        tenantSlug: 'active',
+        role: 'tenant_admin',
+      }),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 409);
+    assert.equal(body.error, 'review_not_in_current_workspace');
+    assert.match(String(body.message), /different workspace/i);
+  });
+});

--- a/tests/runtime-pages.test.ts
+++ b/tests/runtime-pages.test.ts
@@ -56,6 +56,7 @@ import MarketingNewJobScreen from '../frontend/marketing/new-job';
 import MarketingJobStatusScreen from '../frontend/marketing/job-status';
 import MarketingJobApproveScreen from '../frontend/marketing/job-approve';
 import AppShellLayout from '../frontend/app-shell/layout';
+import { buildLoginRedirect } from '../lib/auth/callback-url';
 import { resolveProjectRoot } from './helpers/project-root';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
@@ -166,6 +167,7 @@ test('/review wraps the review queue in the app shell', () => {
   assert.equal(isValidElement(element), true);
   assert.equal(element.type, AppShellLayout);
   assert.equal(element.props.currentRouteId, 'review');
+  assert.equal(element.props.loginRedirectPath, '/review');
   assert.equal(isValidElement(element.props.children), true);
   assert.equal(element.props.children.type, AriesReviewQueueScreen);
 });
@@ -180,6 +182,10 @@ test('/review/[reviewId] preserves the review id for the review detail experienc
   assert.equal(isValidElement(element), true);
   assert.equal(element.type, AppShellLayout);
   assert.equal(element.props.currentRouteId, 'review');
+  assert.equal(
+    element.props.loginRedirectPath,
+    '/review/review_meta_launch_hero',
+  );
   assert.equal(isValidElement(element.props.children), true);
   assert.equal(element.props.children.type, AriesReviewItemScreen);
   assert.equal(element.props.children.props.reviewId, 'review_meta_launch_hero');
@@ -194,6 +200,10 @@ test('/review/[reviewId] decodes encoded review ids before rendering the detail 
 
   assert.equal(isValidElement(element), true);
   assert.equal(element.props.children.props.reviewId, 'mkt_123::approval');
+  assert.equal(
+    buildLoginRedirect(element.props.loginRedirectPath),
+    '/login?callbackUrl=%2Freview%2Fmkt_123%253A%253Aapproval',
+  );
 });
 
 test('/dashboard/calendar wraps the calendar screen in the app shell', () => {


### PR DESCRIPTION
## Summary
- preserve `/review` and `/review/[reviewId]` destinations through the login shell so protected review deep links return to the originally requested URL after auth
- return a dedicated `review_not_in_current_workspace` response when a review exists under a different tenant and render recovery actions instead of a dead-end workspace error
- add focused regressions for the auth callback path, wrong-workspace API response, and recovery-state UI

## QA scope
- MASTER-003
- MASTER-004

## Validation
- `npx tsx --test tests/review-auth-redirect.test.ts tests/review-recovery.test.ts tests/review-route-access.test.ts`
- `npm run verify`
- `npm run typecheck` *(fails on pre-existing unrelated errors in `tests/review-flow-destructive-guards.test.ts`)*
- `npm run lint` *(fails for the same pre-existing typecheck errors)*
