### PR TITLE
fix: add shared inline form validation across auth and onboarding flows

### DIFF
--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -23,6 +23,10 @@ import {
 
 import { useBusinessProfile } from '@/hooks/use-business-profile';
 import { createAriesV1Api, type UrlPreviewBrandKitPreview, type UrlPreviewResponse } from '@/lib/api/aries-v1';
+import {
+  getRequiredFieldError,
+  useDisabledUntilValid,
+} from '@/lib/form-validation';
 import { validateCanonicalCompetitorUrl } from '@/lib/marketing-competitor';
 import { VISUAL_BOARD_EMPTY_STATE_COPY } from './onboarding-flow.copy';
 
@@ -269,6 +273,7 @@ function stepReady(stepKey: StepKey, values: {
   selectedChannels: string[];
   goal: string;
   customGoal: string;
+  offer: string;
 }): boolean {
   if (stepKey === 'business') {
     return values.businessName.trim().length > 0 && values.businessType.trim().length > 0;
@@ -281,9 +286,9 @@ function stepReady(stepKey: StepKey, values: {
   }
   if (stepKey === 'goal') {
     if (values.goal === 'Other') {
-      return values.customGoal.trim().length > 0;
+      return values.customGoal.trim().length > 0 && values.offer.trim().length > 0;
     }
-    return values.goal.trim().length > 0;
+    return values.goal.trim().length > 0 && values.offer.trim().length > 0;
   }
   return true;
 }
@@ -291,6 +296,8 @@ function stepReady(stepKey: StepKey, values: {
 function stepValidationMessage(stepKey: StepKey, values?: {
   businessName: string;
   businessType: string;
+  goal: string;
+  offer: string;
 }): string | null {
   if (stepKey === 'business') {
     if (values) {
@@ -314,7 +321,13 @@ function stepValidationMessage(stepKey: StepKey, values?: {
     return 'Select at least one channel before continuing.';
   }
   if (stepKey === 'goal') {
-    return 'Choose a business outcome before continuing.';
+    if (!values?.goal.trim()) {
+      return 'Choose a business outcome before continuing.';
+    }
+    if (!values.offer.trim()) {
+      return 'Describe what your business offers before continuing.';
+    }
+    return null;
   }
   return 'Complete the current step before continuing.';
 }
@@ -452,6 +465,7 @@ function offerPlaceholderForBusinessType(businessType: string): string {
 type TouchedFields = {
   businessName: boolean;
   businessType: boolean;
+  goal: boolean;
   approverName: boolean;
   websiteUrl: boolean;
   offer: boolean;
@@ -516,6 +530,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   const [touched, setTouched] = useState<TouchedFields>({
     businessName: false,
     businessType: false,
+    goal: false,
     approverName: false,
     websiteUrl: false,
     offer: false,
@@ -569,8 +584,20 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       selectedChannels,
       goal,
       customGoal,
+      offer,
     }),
   );
+  const currentStepIsReady = stepReady(currentStep.key, {
+    businessName,
+    businessType,
+    websiteUrl,
+    selectedChannels,
+    goal,
+    customGoal,
+    offer,
+  });
+  const continueDisabled = useDisabledUntilValid(currentStepIsReady, submitting || creatingDraft);
+  const finishDisabled = useDisabledUntilValid(canFinish, submitting || creatingDraft);
   const fieldInputClassName =
     'w-full rounded-[1rem] border border-white/12 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] px-4 py-3 text-white outline-none transition duration-200 placeholder:text-white/24 focus:border-[#b36cff] focus:shadow-[0_0_0_1px_rgba(179,108,255,0.24),0_0_24px_rgba(179,108,255,0.14)]';
 
@@ -963,8 +990,25 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   }
 
   function handleContinue() {
-    if (!stepReady(currentStep.key, { businessName, businessType, websiteUrl, selectedChannels, goal, customGoal })) {
-      setError(stepValidationMessage(currentStep.key, { businessName, businessType }) ?? 'Complete the current step before continuing.');
+    if (!currentStepIsReady) {
+      if (currentStep.key === 'business') {
+        markTouched('businessName');
+        markTouched('businessType');
+      }
+      if (currentStep.key === 'website' || currentStep.key === 'brand') {
+        markTouched('websiteUrl');
+      }
+      if (currentStep.key === 'goal') {
+        markTouched('goal');
+        markTouched('offer');
+        if (goal === 'Other') {
+          markTouched('customGoal');
+        }
+      }
+      setError(
+        stepValidationMessage(currentStep.key, { businessName, businessType, goal, offer }) ??
+          'Complete the current step before continuing.',
+      );
       return;
     }
     setError(null);
@@ -973,7 +1017,10 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
 
   async function handleFinish() {
     if (!canFinish) {
-      setError(stepValidationMessage(currentStep.key, { businessName, businessType }) ?? 'Complete the current step before continuing.');
+      setError(
+        stepValidationMessage(currentStep.key, { businessName, businessType, goal, offer }) ??
+          'Complete the current step before continuing.',
+      );
       return;
     }
 
@@ -1085,7 +1132,15 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       : isValidHttpsUrl(competitorUrl)
         ? 'valid'
         : 'invalid';
-  const offerValidity: FieldValidity = touched.offer && offer.trim().length > 0 ? 'valid' : 'untouched';
+  const goalError = touched.goal && !goal.trim()
+    ? 'Choose a business outcome before continuing.'
+    : null;
+  const offerError = touched.offer ? getRequiredFieldError(offer, 'what your business offers') : null;
+  const offerValidity: FieldValidity = !touched.offer
+    ? 'untouched'
+    : offer.trim().length > 0
+      ? 'valid'
+      : 'invalid';
   const customGoalValidity: FieldValidity = !touched.customGoal
     ? 'untouched'
     : customGoal.trim().length > 0
@@ -1109,6 +1164,8 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         return businessName.trim() ? null : 'Add a business name.';
       case 'businessType':
         return businessType.trim() ? null : 'Describe the business in plain language.';
+      case 'goal':
+        return goal.trim() ? null : 'Choose a business outcome before continuing.';
       case 'websiteUrl': {
         if (!websiteUrl.trim()) return 'Enter a website so Aries can analyze it.';
         return isValidHttpsUrl(websiteUrl) ? null : 'Enter a valid HTTPS URL (e.g. https://yourbusiness.com).';
@@ -1120,6 +1177,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       case 'customGoal':
         return customGoal.trim() ? null : 'Describe the business outcome you want.';
       case 'offer':
+        return getRequiredFieldError(offer, 'what your business offers');
       case 'approverName':
       default:
         return null;
@@ -1632,7 +1690,13 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                 <div className="grid gap-6 lg:grid-cols-[0.95fr_1.05fr]">
                   <div className="space-y-4">
                     <p className="text-sm leading-7 text-white/65">What should Aries help your business achieve first?</p>
-                    <div className="grid gap-3" role="radiogroup" aria-label="Campaign goal">
+                    <div
+                      className="grid gap-3"
+                      role="radiogroup"
+                      aria-label="Campaign goal"
+                      aria-invalid={goalError ? true : undefined}
+                      aria-describedby={goalError ? 'onboarding-goal-error' : undefined}
+                    >
                       {GOAL_OPTIONS.map((option) => {
                         const active = goal === option.label;
                         return (
@@ -1644,6 +1708,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                             tabIndex={0}
                             onClick={() => {
                               setGoal(option.label);
+                              markTouched('goal');
                               if (option.label !== 'Other') {
                                 setCustomGoal('');
                               }
@@ -1652,6 +1717,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                               if (event.key === 'Enter' || event.key === ' ') {
                                 event.preventDefault();
                                 setGoal(option.label);
+                                markTouched('goal');
                                 if (option.label !== 'Other') {
                                   setCustomGoal('');
                                 }
@@ -1680,11 +1746,18 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                             autoFocus
                           />
                           {fieldErrorMessage('customGoal') ? (
-                            <p className="text-xs text-red-400">{fieldErrorMessage('customGoal')}</p>
+                            <p id="onboarding-custom-goal-error" role="alert" className="text-xs text-red-400">
+                              {fieldErrorMessage('customGoal')}
+                            </p>
                           ) : null}
                         </div>
                       ) : null}
                     </div>
+                    {goalError ? (
+                      <p id="onboarding-goal-error" role="alert" className="text-sm text-red-300">
+                        {goalError}
+                      </p>
+                    ) : null}
                   </div>
 
                   <div className="grid gap-5">
@@ -1723,7 +1796,14 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                             : 'border-[#a96cff]/30',
                         )}
                         placeholder={offerPlaceholderForBusinessType(businessType)}
+                        aria-invalid={offerError ? true : undefined}
+                        aria-describedby={offerError ? 'onboarding-offer-error' : undefined}
                       />
+                      {offerError ? (
+                        <p id="onboarding-offer-error" role="alert" className="text-sm text-red-300">
+                          {offerError}
+                        </p>
+                      ) : null}
                     </div>
 
                     <Field
@@ -1771,7 +1851,8 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                   <button
                     type="button"
                     onClick={handleContinue}
-                    className="inline-flex items-center gap-2 rounded-full border border-[#a96cff]/40 bg-[linear-gradient(90deg,#5c2e96,#7a41c2,#a96cff)] px-6 py-3 text-sm font-semibold text-white shadow-[0_0_24px_rgba(169,108,255,0.2)] transition hover:translate-y-[-1px]"
+                    disabled={continueDisabled}
+                    className="inline-flex items-center gap-2 rounded-full border border-[#a96cff]/40 bg-[linear-gradient(90deg,#5c2e96,#7a41c2,#a96cff)] px-6 py-3 text-sm font-semibold text-white shadow-[0_0_24px_rgba(169,108,255,0.2)] transition hover:translate-y-[-1px] disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     Continue
                     <ArrowRight className="h-4 w-4" />
@@ -1780,7 +1861,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                   <button
                     type="button"
                     onClick={() => void handleFinish()}
-                    disabled={submitting || !canFinish || creatingDraft}
+                    disabled={finishDisabled}
                     className="inline-flex items-center gap-2 rounded-full border border-[#a96cff]/40 bg-[linear-gradient(90deg,#5c2e96,#7a41c2,#a96cff)] px-6 py-3 text-sm font-semibold text-white shadow-[0_0_24px_rgba(169,108,255,0.2)] transition hover:translate-y-[-1px] disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     {submitting
@@ -1833,7 +1914,7 @@ function Field(props: {
       </span>
       {props.children}
       {props.error ? (
-        <p className="text-xs text-red-400">{props.error}</p>
+        <p role="alert" className="text-xs text-red-400">{props.error}</p>
       ) : props.hint ? (
         <p className="text-sm leading-7 text-white/46">{props.hint}</p>
       ) : null}

--- a/frontend/auth/ForgotPasswordForm.tsx
+++ b/frontend/auth/ForgotPasswordForm.tsx
@@ -3,6 +3,11 @@
 import React, { useState } from 'react';
 import { AuthView } from '../types';
 import { AriesMark } from '@/frontend/donor/ui';
+import {
+  getEmailFieldError,
+  isValidEmailAddress,
+  useDisabledUntilValid,
+} from '@/lib/form-validation';
 
 
 interface ForgotPasswordFormProps {
@@ -16,11 +21,18 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
   const [email, setEmail] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [emailTouched, setEmailTouched] = useState(false);
 
+  const emailError = emailTouched ? getEmailFieldError(email, 'your account email') : null;
+  const submitDisabled = useDisabledUntilValid(
+    isValidEmailAddress(email),
+    isLoading || parentLoading,
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email) return;
+    setEmailTouched(true);
+    if (submitDisabled) return;
 
 
     setIsLoading(true);
@@ -42,7 +54,7 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
       }
 
       onSubmit(email);
-    } catch (err: any) {
+    } catch {
       setError("An unexpected error occurred. Please try again.");
     } finally {
       setIsLoading(false);
@@ -79,15 +91,24 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <label className="block text-sm font-medium text-white/80 mb-1.5">Account Email</label>
+            <label htmlFor="forgot-password-email" className="block text-sm font-medium text-white/80 mb-1.5">Account Email</label>
             <input
+              id="forgot-password-email"
               type="email"
               required
               className="block w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/30 focus:outline-none transition-all"
               placeholder="name@company.com"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
+              onBlur={() => setEmailTouched(true)}
+              aria-invalid={emailError ? true : undefined}
+              aria-describedby={emailError ? 'forgot-password-email-error' : undefined}
             />
+            {emailError ? (
+              <p id="forgot-password-email-error" role="alert" className="mt-2 text-sm text-red-300">
+                {emailError}
+              </p>
+            ) : null}
           </div>
 
 
@@ -100,7 +121,7 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
 
           <button
             type="submit"
-            disabled={isLoading || parentLoading || !email}
+            disabled={submitDisabled}
             className="w-full py-3 px-4 bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-white font-medium rounded-xl transition-all shadow-[0_0_20px_rgba(124,58,237,0.3)] hover:shadow-[0_0_30px_rgba(124,58,237,0.5)] flex items-center justify-center gap-2 disabled:opacity-60"
           >
             {isLoading || parentLoading ? 'Sending Code...' : 'Send Recovery Code'}
@@ -113,6 +134,5 @@ const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({ onNavigate, onS
 
 
 export default ForgotPasswordForm;
-
 
 

--- a/frontend/auth/login-form.tsx
+++ b/frontend/auth/login-form.tsx
@@ -3,6 +3,12 @@ import Link from 'next/link';
 import { ArrowLeft, ArrowRight, Lock, Mail } from 'lucide-react';
 
 import { AriesMark } from '@/frontend/donor/ui';
+import {
+  getEmailFieldError,
+  getRequiredFieldError,
+  isValidEmailAddress,
+  useDisabledUntilValid,
+} from '@/lib/form-validation';
 
 interface LoginFormProps {
   defaultEmail?: string;
@@ -26,10 +32,17 @@ const LoginForm: React.FC<LoginFormProps> = ({
   const [email, setEmail] = useState(defaultEmail || '');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [emailTouched, setEmailTouched] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
 
   useEffect(() => {
     setEmail(defaultEmail || '');
   }, [defaultEmail]);
+
+  const emailError = emailTouched ? getEmailFieldError(email) : null;
+  const passwordError = passwordTouched ? getRequiredFieldError(password, 'your password') : null;
+  const credentialsAreValid = isValidEmailAddress(email) && password.trim().length > 0;
+  const submitDisabled = useDisabledUntilValid(credentialsAreValid, isLoading);
 
   return (
     <div className="max-w-md mx-auto">
@@ -60,30 +73,44 @@ const LoginForm: React.FC<LoginFormProps> = ({
           className="space-y-5"
           onSubmit={(event) => {
             event.preventDefault();
+            setEmailTouched(true);
+            setPasswordTouched(true);
+            if (submitDisabled) {
+              return;
+            }
             onCredentialsSubmit(email, password);
           }}
         >
           <div>
-            <label className="block text-sm font-medium text-white/80 mb-1.5">Email Address</label>
+            <label htmlFor="login-email" className="block text-sm font-medium text-white/80 mb-1.5">Email Address</label>
             <div className="relative">
               <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                 <Mail className="h-5 w-5 text-white/40" />
               </div>
               <input
+                id="login-email"
                 type="email"
                 className="block w-full pl-10 pr-3 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/30 focus:outline-none transition-all disabled:opacity-60"
                 placeholder="you@example.com"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
+                onBlur={() => setEmailTouched(true)}
                 autoComplete="email"
                 disabled={isLoading}
+                aria-invalid={emailError ? true : undefined}
+                aria-describedby={emailError ? 'login-email-error' : undefined}
               />
             </div>
+            {emailError ? (
+              <p id="login-email-error" role="alert" className="mt-2 text-sm text-red-300">
+                {emailError}
+              </p>
+            ) : null}
           </div>
 
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <label className="block text-sm font-medium text-white/80">Password</label>
+              <label htmlFor="login-password" className="block text-sm font-medium text-white/80">Password</label>
               <Link href="/forgot-password" className="text-sm text-white/60 hover:text-white transition-colors">
                 Forgot password?
               </Link>
@@ -93,13 +120,17 @@ const LoginForm: React.FC<LoginFormProps> = ({
                 <Lock className="h-5 w-5 text-white/40" />
               </div>
               <input
+                id="login-password"
                 type={showPassword ? 'text' : 'password'}
                 className="block w-full pl-10 pr-12 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/30 focus:outline-none transition-all disabled:opacity-60"
                 placeholder="••••••••"
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
+                onBlur={() => setPasswordTouched(true)}
                 autoComplete="current-password"
                 disabled={isLoading}
+                aria-invalid={passwordError ? true : undefined}
+                aria-describedby={passwordError ? 'login-password-error' : undefined}
               />
               <button
                 type="button"
@@ -109,11 +140,16 @@ const LoginForm: React.FC<LoginFormProps> = ({
                 {showPassword ? 'Hide' : 'Show'}
               </button>
             </div>
+            {passwordError ? (
+              <p id="login-password-error" role="alert" className="mt-2 text-sm text-red-300">
+                {passwordError}
+              </p>
+            ) : null}
           </div>
 
           <button
             type="submit"
-            disabled={isLoading || !email || !password}
+            disabled={submitDisabled}
             className="w-full py-3 px-4 bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-white font-medium rounded-xl transition-all shadow-[0_0_20px_rgba(124,58,237,0.3)] hover:shadow-[0_0_30px_rgba(124,58,237,0.5)] flex items-center justify-center gap-2 disabled:opacity-60"
           >
             <Lock className="w-4 h-4" />

--- a/frontend/auth/sign-up-form.tsx
+++ b/frontend/auth/sign-up-form.tsx
@@ -5,8 +5,12 @@ import { AuthView } from '../types';
 import { registerUserAction } from '@/app/actions/auth';
 import { getInvitationByToken } from '../services/supabase';
 import { AriesMark } from '@/frontend/donor/ui';
-
-
+import {
+  getEmailFieldError,
+  getRequiredFieldError,
+  isValidEmailAddress,
+  useDisabledUntilValid,
+} from '@/lib/form-validation';
 
 interface SignUpFormProps {
   onNavigate: (view: AuthView, email?: string) => void;
@@ -19,6 +23,15 @@ interface SignUpFormProps {
 }
 
 const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/;
+const PASSWORD_POLICY_MESSAGE =
+  'Password must be at least 8 characters long and include an uppercase letter, a number, and a special character.';
+
+type InvitationData = {
+  email: string;
+  organizations?: {
+    name?: string;
+  } | null;
+};
 
 const SignUpForm: React.FC<SignUpFormProps> = ({
   onNavigate,
@@ -35,8 +48,11 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
   const [orgNameInput, setOrgNameInput] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorLocal, setErrorLocal] = useState<string | null>(null);
-  const [invitationData, setInvitationData] = useState<Record<string, any> | null>(null);
+  const [invitationData, setInvitationData] = useState<InvitationData | null>(null);
   const [showPassword, setShowPassword] = useState(false);
+  const [fullNameTouched, setFullNameTouched] = useState(false);
+  const [emailTouched, setEmailTouched] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
 
 
   useEffect(() => {
@@ -50,13 +66,14 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
     const emailParam = params.get('email');
     if (token) {
       getInvitationByToken(token).then(data => {
-        if (data) {
-          setInvitationData(data);
-          setOrgNameInput(data.organizations?.name || '');
-          setEmail(data.email);
+        const invitation = data as InvitationData | null;
+        if (invitation) {
+          setInvitationData(invitation);
+          setOrgNameInput(invitation.organizations?.name || '');
+          setEmail(invitation.email);
 
 
-          const namePart = data.email.split('@')[0];
+          const namePart = invitation.email.split('@')[0];
           const firstName = namePart.split(/[._+-]/)[0];
           setFullName(firstName.charAt(0).toUpperCase() + firstName.slice(1));
         }
@@ -81,18 +98,31 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
 
 
   const passwordMeetsPolicy = PASSWORD_POLICY_REGEX.test(password);
-  const emailIsValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+  const emailIsValid = isValidEmailAddress(email);
   const fullNameIsValid = fullName.trim().length > 0;
-  const canSubmit = fullNameIsValid && emailIsValid && passwordMeetsPolicy && !isLoading && !isSubmitting;
+  const fullNameError = fullNameTouched ? getRequiredFieldError(fullName, 'your full name') : null;
+  const emailError = emailTouched ? getEmailFieldError(email) : null;
+  const passwordError = !passwordTouched
+    ? null
+    : !password.trim()
+      ? getRequiredFieldError(password, 'your password')
+      : passwordMeetsPolicy
+        ? null
+        : PASSWORD_POLICY_MESSAGE;
+  const canSubmit = fullNameIsValid && emailIsValid && passwordMeetsPolicy;
+  const submitDisabled = useDisabledUntilValid(canSubmit, isLoading || isSubmitting);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isLoading || isSubmitting) return;
-    if (!fullNameIsValid || !emailIsValid) return;
+    setFullNameTouched(true);
+    setEmailTouched(true);
+    setPasswordTouched(true);
+    if (!fullNameIsValid || !emailIsValid || !password.trim()) return;
 
     // Password Validation
     if (!PASSWORD_POLICY_REGEX.test(password)) {
-      setErrorLocal("Password must be at least 8 characters long and include an uppercase letter, a number, and a special character.");
+      setErrorLocal(null);
       return;
     }
 
@@ -116,14 +146,11 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
       if (!submitResult.success) {
         setIsSubmitting(false);
       }
-    } catch (err: any) {
-      setErrorLocal(err.message || "Signup failed.");
+    } catch (error: unknown) {
+      setErrorLocal(error instanceof Error ? error.message : "Signup failed.");
       setIsSubmitting(false);
     }
   };
-
-
-  const inputStyle = "w-full px-[16px] py-[10px] rounded-xl border border-white/20 bg-black/10 text-white placeholder-[#851028] placeholder:font-medium placeholder:text-[15px] focus:outline-none focus:border-white/40 transition-all text-[15px] shadow-inner";
 
 
   return (
@@ -135,7 +162,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
           <span className="text-2xl font-bold tracking-tight text-white -mt-4">Aries AI</span>
         </div>
         <h1 className="text-3xl font-bold mb-2 text-white">
-          {invitationData ? `Joining ${invitationData.organizations.name}` : "Create Account"}
+          {invitationData ? `Joining ${invitationData.organizations?.name || 'your organization'}` : "Create Account"}
         </h1>
         <p className="text-white/60">
           Plan, approve, and launch campaigns from one workspace.
@@ -165,15 +192,24 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
 
         <form onSubmit={handleSubmit} className="space-y-5">
           <div>
-            <label className="block text-sm font-medium text-white/80 mb-1.5">Full Name</label>
+            <label htmlFor="signup-full-name" className="block text-sm font-medium text-white/80 mb-1.5">Full Name</label>
             <input 
+              id="signup-full-name"
               type="text" 
               required 
               className="block w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/30 focus:outline-none transition-all" 
               placeholder="John Doe" 
               value={fullName} 
-              onChange={(e) => setFullName(e.target.value)} 
+              onChange={(e) => setFullName(e.target.value)}
+              onBlur={() => setFullNameTouched(true)}
+              aria-invalid={fullNameError ? true : undefined}
+              aria-describedby={fullNameError ? 'signup-full-name-error' : undefined}
             />
+            {fullNameError ? (
+              <p id="signup-full-name-error" role="alert" className="mt-2 text-sm text-red-300">
+                {fullNameError}
+              </p>
+            ) : null}
           </div>
 
 
@@ -191,29 +227,42 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
 
 
           <div>
-            <label className="block text-sm font-medium text-white/80 mb-1.5">Email Address</label>
+            <label htmlFor="signup-email" className="block text-sm font-medium text-white/80 mb-1.5">Email Address</label>
             <input 
+              id="signup-email"
               type="email" 
               required 
               className="block w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/30 focus:outline-none transition-all disabled:opacity-60" 
               placeholder="name@company.com" 
               value={email} 
-              onChange={(e) => setEmail(e.target.value)} 
+              onChange={(e) => setEmail(e.target.value)}
+              onBlur={() => setEmailTouched(true)}
               disabled={!!invitationData} 
+              aria-invalid={emailError ? true : undefined}
+              aria-describedby={emailError ? 'signup-email-error' : undefined}
             />
+            {emailError ? (
+              <p id="signup-email-error" role="alert" className="mt-2 text-sm text-red-300">
+                {emailError}
+              </p>
+            ) : null}
           </div>
 
 
           <div>
-            <label className="block text-sm font-medium text-white/80 mb-1.5">Password</label>
+            <label htmlFor="signup-password" className="block text-sm font-medium text-white/80 mb-1.5">Password</label>
             <div className="relative">
               <input 
+                id="signup-password"
                 type={showPassword ? 'text' : 'password'} 
                 required 
                 className="block w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/30 focus:outline-none transition-all" 
                 placeholder="••••••••" 
                 value={password} 
-                onChange={(e) => setPassword(e.target.value)} 
+                onChange={(e) => setPassword(e.target.value)}
+                onBlur={() => setPasswordTouched(true)}
+                aria-invalid={passwordError ? true : undefined}
+                aria-describedby={passwordError ? 'signup-password-error' : undefined}
               />
               <button
                 type="button"
@@ -232,12 +281,17 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
                 )}
               </button>
             </div>
+            {passwordError ? (
+              <p id="signup-password-error" role="alert" className="mt-2 text-sm text-red-300">
+                {passwordError}
+              </p>
+            ) : null}
           </div>
 
 
           <button
             type="submit"
-            disabled={!canSubmit}
+            disabled={submitDisabled}
             className="w-full py-3 px-4 bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-white font-medium rounded-xl transition-all shadow-[0_0_20px_rgba(124,58,237,0.3)] hover:shadow-[0_0_30px_rgba(124,58,237,0.5)] flex items-center justify-center gap-2 disabled:opacity-60"
           >
             {isSubmitting ? 'Creating account…' : 'Create account'}

--- a/frontend/auth/sign-up-form.tsx
+++ b/frontend/auth/sign-up-form.tsx
@@ -119,6 +119,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
     setEmailTouched(true);
     setPasswordTouched(true);
     if (!fullNameIsValid || !emailIsValid || !password.trim()) return;
+    const normalizedEmail = email.trim();
 
     // Password Validation
     if (!PASSWORD_POLICY_REGEX.test(password)) {
@@ -130,7 +131,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
     setErrorLocal(null);
     try {
       const result = await registerUserAction({
-        email,
+        email: normalizedEmail,
         password,
         fullName,
         orgName: orgNameInput
@@ -142,7 +143,7 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
         return;
       }
 
-      const submitResult = await onSubmit(email, password);
+      const submitResult = await onSubmit(normalizedEmail, password);
       if (!submitResult.success) {
         setIsSubmitting(false);
       }

--- a/frontend/donor/marketing/home-page.tsx
+++ b/frontend/donor/marketing/home-page.tsx
@@ -86,7 +86,7 @@ function EarlyAccessCopy({
   );
 }
 
-function EarlyAccessForm({
+export function EarlyAccessForm({
   source,
   emailInputId,
   className,
@@ -103,6 +103,7 @@ function EarlyAccessForm({
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState<string | null>(null);
   const [emailTouched, setEmailTouched] = useState(false);
+  const submittingRef = useRef(false);
   const emailError = emailTouched ? getEmailFieldError(email, 'your email') : null;
   const submitDisabled = useDisabledUntilValid(isValidEmailAddress(email), status === 'loading');
 
@@ -121,15 +122,20 @@ function EarlyAccessForm({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    setEmailTouched(true);
-
-    const trimmedEmail = email.trim();
-    if (submitDisabled) {
-      setStatus('error');
-      setMessage(emailError);
+    if (status === 'loading' || submittingRef.current) {
       return;
     }
 
+    const trimmedEmail = email.trim();
+    const nextError = getEmailFieldError(trimmedEmail, 'your email');
+    setEmailTouched(true);
+    if (nextError) {
+      setStatus('error');
+      setMessage(nextError);
+      return;
+    }
+
+    submittingRef.current = true;
     setStatus('loading');
     setMessage(null);
 
@@ -156,6 +162,8 @@ function EarlyAccessForm({
     } catch (error) {
       setStatus('error');
       setMessage(error instanceof Error ? error.message : 'We could not save your email right now.');
+    } finally {
+      submittingRef.current = false;
     }
   }
 

--- a/frontend/donor/marketing/home-page.tsx
+++ b/frontend/donor/marketing/home-page.tsx
@@ -32,6 +32,11 @@ import { motion, useScroll, useSpring, useTransform, type MotionValue } from 'mo
 import { cn } from '../lib/utils';
 import { AriesMark } from '../ui';
 import { DonorMarketingShell } from './chrome';
+import {
+  getEmailFieldError,
+  isValidEmailAddress,
+  useDisabledUntilValid,
+} from '@/lib/form-validation';
 
 const EARLY_ACCESS_STEPS = [
   ['01', ['Beta invite']],
@@ -97,6 +102,9 @@ function EarlyAccessForm({
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState<string | null>(null);
+  const [emailTouched, setEmailTouched] = useState(false);
+  const emailError = emailTouched ? getEmailFieldError(email, 'your email') : null;
+  const submitDisabled = useDisabledUntilValid(isValidEmailAddress(email), status === 'loading');
 
   useEffect(() => {
     if (variant !== 'hero' || status !== 'success' || !message) {
@@ -113,11 +121,12 @@ function EarlyAccessForm({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    setEmailTouched(true);
 
     const trimmedEmail = email.trim();
-    if (!trimmedEmail) {
+    if (submitDisabled) {
       setStatus('error');
-      setMessage('Enter your email to request early access.');
+      setMessage(emailError);
       return;
     }
 
@@ -172,10 +181,13 @@ function EarlyAccessForm({
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
+            onBlur={() => setEmailTouched(true)}
             placeholder="Enter email address"
             className="w-full sm:w-[300px] md:w-[340px] rounded-full bg-white/6 px-6 py-4 text-base text-white outline-none transition placeholder:text-white/30 focus:border-primary/50 shadow-xl shadow-black/20"
             style={{ border: '1px solid #fff3' }}
             disabled={status === 'loading'}
+            aria-invalid={emailError ? true : undefined}
+            aria-describedby={emailError ? `${emailInputId}-error` : undefined}
           />
         ) : (
           <input
@@ -183,14 +195,17 @@ function EarlyAccessForm({
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
+            onBlur={() => setEmailTouched(true)}
             placeholder="you@company.com"
             className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-3 text-white outline-none transition placeholder:text-white/30 focus:border-primary/50"
             disabled={status === 'loading'}
+            aria-invalid={emailError ? true : undefined}
+            aria-describedby={emailError ? `${emailInputId}-error` : undefined}
           />
         )}
         <button
           type="submit"
-          disabled={status === 'loading'}
+          disabled={submitDisabled}
           className={cn(
             'bg-gradient-to-r from-primary to-secondary font-bold text-white shadow-lg shadow-primary/20 transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60',
             isHeroVariant
@@ -201,6 +216,15 @@ function EarlyAccessForm({
           {status === 'loading' ? 'Saving...' : buttonLabel}
         </button>
       </div>
+      {emailError ? (
+        <p
+          id={`${emailInputId}-error`}
+          role="alert"
+          className={cn('mt-4 text-sm text-red-100', isHeroVariant ? 'text-center' : '')}
+        >
+          {emailError}
+        </p>
+      ) : null}
       {message ? (
         <p
           className={cn(

--- a/lib/form-validation.ts
+++ b/lib/form-validation.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+export const EMAIL_ADDRESS_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+
+export function isValidEmailAddress(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.length > 0 && EMAIL_ADDRESS_REGEX.test(trimmed);
+}
+
+export function getRequiredFieldError(value: string, label: string): string | null {
+  return value.trim().length > 0 ? null : `Enter ${label}.`;
+}
+
+export function getEmailFieldError(value: string, label = 'your email address'): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return `Enter ${label}.`;
+  }
+  return isValidEmailAddress(trimmed) ? null : 'Enter a valid email address.';
+}
+
+export function useDisabledUntilValid(isValid: boolean, isBusy = false): boolean {
+  return useMemo(() => isBusy || !isValid, [isBusy, isValid]);
+}

--- a/tests/forgot-password-form-validation.regression-011.test.ts
+++ b/tests/forgot-password-form-validation.regression-011.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'auth', 'ForgotPasswordForm.tsx'),
+  'utf8',
+);
+
+test('forgot-password form blocks invalid emails and renders inline alerts', () => {
+  assert.match(
+    source,
+    /const emailError = emailTouched \? getEmailFieldError\(email, 'your account email'\) : null;/,
+    'forgot-password should reuse the shared email validator',
+  );
+  assert.match(
+    source,
+    /const submitDisabled = useDisabledUntilValid\(\s*isValidEmailAddress\(email\),\s*isLoading \|\| parentLoading,\s*\);/,
+    'forgot-password should disable submit until the email is valid',
+  );
+  assert.match(
+    source,
+    /<p id="forgot-password-email-error" role="alert"/,
+    'forgot-password should show inline email validation feedback',
+  );
+  assert.match(
+    source,
+    /disabled=\{submitDisabled\}/,
+    'Send Recovery Code must stay disabled until the form is valid',
+  );
+});

--- a/tests/form-validation.test.ts
+++ b/tests/form-validation.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EMAIL_ADDRESS_REGEX,
+  getEmailFieldError,
+  getRequiredFieldError,
+  isValidEmailAddress,
+} from '../lib/form-validation';
+
+test('EMAIL_ADDRESS_REGEX accepts browser-style valid email addresses', () => {
+  assert.match('name@example.com', EMAIL_ADDRESS_REGEX);
+  assert.match("o'hara+sales@example.co.uk", EMAIL_ADDRESS_REGEX);
+  assert.match('team.member@subdomain.example.io', EMAIL_ADDRESS_REGEX);
+});
+
+test('isValidEmailAddress trims and rejects syntactically invalid emails', () => {
+  assert.equal(isValidEmailAddress(' valid@example.com '), true);
+  assert.equal(isValidEmailAddress('missing-at.example.com'), false);
+  assert.equal(isValidEmailAddress('missing-domain@'), false);
+  assert.equal(isValidEmailAddress(''), false);
+});
+
+test('shared field validation messages stay consistent across forms', () => {
+  assert.equal(getRequiredFieldError('', 'your full name'), 'Enter your full name.');
+  assert.equal(getRequiredFieldError('Brendan', 'your full name'), null);
+  assert.equal(getEmailFieldError('', 'your work email'), 'Enter your work email.');
+  assert.equal(getEmailFieldError('not-an-email'), 'Enter a valid email address.');
+  assert.equal(getEmailFieldError('founder@example.com'), null);
+});

--- a/tests/homepage-request-access-loading.regression-016.test.ts
+++ b/tests/homepage-request-access-loading.regression-016.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import React from 'react';
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function textContent(node: unknown): string {
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node.map(textContent).join('');
+  }
+  if (!node || typeof node !== 'object') {
+    return '';
+  }
+  const props = (node as { props?: { children?: unknown } }).props;
+  return textContent(props?.children);
+}
+
+test('request-access form does not flip to validation error on a second submit while loading', async () => {
+  const previousFetch = globalThis.fetch;
+  let resolveFetch: ((value: Response) => void) | null = null;
+  let fetchCalls = 0;
+
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    return await new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+  }) as typeof fetch;
+
+  try {
+    const { act, create } = await import('react-test-renderer');
+    const { EarlyAccessForm } = await import('../frontend/donor/marketing/home-page');
+
+    let root!: import('react-test-renderer').ReactTestRenderer;
+    await act(async () => {
+      root = create(
+        React.createElement(EarlyAccessForm, {
+          source: 'test',
+          emailInputId: 'test-email',
+        }),
+      );
+    });
+
+    const input = root.root.findByType('input');
+    await act(async () => {
+      input.props.onChange({ target: { value: 'founder@example.com' } });
+    });
+
+    const form = root.root.findByType('form');
+    await act(async () => {
+      const submitEvent = { preventDefault() {} };
+      const firstSubmit = form.props.onSubmit(submitEvent);
+      form.props.onSubmit(submitEvent);
+      await flushMicrotasks();
+      assert.equal(fetchCalls, 1);
+      assert.equal(root.root.findByType('button').props.disabled, true);
+      assert.equal(
+        root.root.findAll((node) => node.props?.role === 'alert').length,
+        0,
+      );
+      resolveFetch?.(
+        new Response(JSON.stringify({ message: "You're on the early access list." }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      await firstSubmit;
+      await flushMicrotasks();
+    });
+
+    const alertTexts = root.root
+      .findAll((node) => node.props?.role === 'alert')
+      .map((node) => textContent(node.props.children));
+    assert.equal(alertTexts.some((text) => text.includes('Enter a valid email address.')), false);
+    const paragraphs = root.root.findAllByType('p').map((node) => textContent(node.props.children));
+    assert.equal(paragraphs.some((text) => text.includes("You're on the early access list.")), true);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});

--- a/tests/homepage-request-access-validation.regression-013.test.ts
+++ b/tests/homepage-request-access-validation.regression-013.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'donor', 'marketing', 'home-page.tsx'),
+  'utf8',
+);
+
+test('homepage request-access form disables submit until the email is valid and shows an inline alert', () => {
+  assert.match(
+    source,
+    /const emailError = emailTouched \? getEmailFieldError\(email, 'your email'\) : null;/,
+    'request-access should reuse the shared email validation helper',
+  );
+  assert.match(
+    source,
+    /const submitDisabled = useDisabledUntilValid\(isValidEmailAddress\(email\), status === 'loading'\);/,
+    'request-access should keep its CTA disabled until the email is valid',
+  );
+  assert.match(
+    source,
+    /role="alert"/,
+    'request-access should render inline validation feedback as an alert',
+  );
+  assert.match(
+    source,
+    /disabled=\{submitDisabled\}/,
+    'Request access must stay disabled until the form is valid',
+  );
+});

--- a/tests/login-form-validation.regression-010.test.ts
+++ b/tests/login-form-validation.regression-010.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'auth', 'login-form.tsx'),
+  'utf8',
+);
+
+test('login form keeps Sign in disabled until credentials are valid and exposes inline alerts', () => {
+  assert.match(
+    source,
+    /const emailError = emailTouched \? getEmailFieldError\(email\) : null;/,
+    'login should derive its email error from the shared helper',
+  );
+  assert.match(
+    source,
+    /const credentialsAreValid = isValidEmailAddress\(email\) && password\.trim\(\)\.length > 0;/,
+    'login should require a syntactically valid email and non-empty password before enabling submit',
+  );
+  assert.match(
+    source,
+    /const submitDisabled = useDisabledUntilValid\(credentialsAreValid, isLoading\);/,
+    'login should use the shared disabled-until-valid helper',
+  );
+  assert.match(
+    source,
+    /<p id="login-email-error" role="alert"/,
+    'login should render inline email validation feedback as an alert',
+  );
+  assert.match(
+    source,
+    /disabled=\{submitDisabled\}/,
+    'Sign in must stay disabled until the login form is valid',
+  );
+});

--- a/tests/onboarding-step-one-validation.regression-012.test.ts
+++ b/tests/onboarding-step-one-validation.regression-012.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'onboarding-flow.tsx'),
+  'utf8',
+);
+
+test('onboarding step one keeps Continue disabled until goal and offer are valid with inline alerts', () => {
+  assert.match(
+    source,
+    /return values\.goal\.trim\(\)\.length > 0 && values\.offer\.trim\(\)\.length > 0;/,
+    'step-one validity should require both a selected goal and a non-empty offer summary',
+  );
+  assert.match(
+    source,
+    /const continueDisabled = useDisabledUntilValid\(currentStepIsReady, submitting \|\| creatingDraft\);/,
+    'onboarding should use the shared disabled-until-valid helper for Continue',
+  );
+  assert.match(
+    source,
+    /<p id="onboarding-goal-error" role="alert"/,
+    'onboarding should render an inline goal validation alert',
+  );
+  assert.match(
+    source,
+    /<p id="onboarding-offer-error" role="alert"/,
+    'onboarding should render an inline offer validation alert',
+  );
+  assert.match(
+    source,
+    /disabled=\{continueDisabled\}/,
+    'Continue should stay disabled until the current onboarding step is valid',
+  );
+});

--- a/tests/sign-up-form-submit-validity.regression-001.test.ts
+++ b/tests/sign-up-form-submit-validity.regression-001.test.ts
@@ -28,7 +28,7 @@ test('signup submit CTA depends on real form validity, not just loading state', 
   );
   assert.match(
     source,
-    /const emailIsValid = .*test\(email\.trim\(\)\);/,
+    /const emailIsValid = isValidEmailAddress\(email\);/,
     'signup form should derive email validity before enabling submit',
   );
   assert.match(
@@ -38,12 +38,17 @@ test('signup submit CTA depends on real form validity, not just loading state', 
   );
   assert.match(
     source,
-    /const canSubmit = fullNameIsValid && emailIsValid && passwordMeetsPolicy && !isLoading && !isSubmitting;/,
-    'signup form should gate submit on required fields, valid email, and password policy',
+    /const canSubmit = fullNameIsValid && emailIsValid && passwordMeetsPolicy;/,
+    'signup form should derive validity from required fields, valid email, and password policy',
   );
   assert.match(
     source,
-    /disabled=\{!canSubmit\}/,
+    /const submitDisabled = useDisabledUntilValid\(canSubmit, isLoading \|\| isSubmitting\);/,
+    'signup should gate the submit button through the shared disabled-until-valid helper',
+  );
+  assert.match(
+    source,
+    /disabled=\{submitDisabled\}/,
     'Create account button should stay disabled until the form is actually valid',
   );
   assert.match(
@@ -53,12 +58,17 @@ test('signup submit CTA depends on real form validity, not just loading state', 
   );
   assert.match(
     source,
-    /if \(!fullNameIsValid \|\| !emailIsValid\) return;/,
+    /if \(!fullNameIsValid \|\| !emailIsValid \|\| !password\.trim\(\)\) return;/,
     'handleSubmit should still short-circuit if a caller bypasses the disabled button state with missing required fields',
   );
   assert.match(
     source,
-    /if \(!PASSWORD_POLICY_REGEX\.test\(password\)\) \{[\s\S]*?Password must be at least 8 characters long and include an uppercase letter, a number, and a special character\./,
-    'submit-time password validation should reuse the shared policy regex and preserve the explanatory error message',
+    /<p id="signup-email-error" role="alert"/,
+    'signup should render inline email validation feedback',
+  );
+  assert.match(
+    source,
+    /<p id="signup-password-error" role="alert"/,
+    'signup should render inline password validation feedback',
   );
 });

--- a/tests/signup-email-normalization.regression-017.test.ts
+++ b/tests/signup-email-normalization.regression-017.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'auth', 'sign-up-form.tsx'),
+  'utf8',
+);
+
+test('signup submit trims the validated email before registration and auth handoff', () => {
+  assert.match(
+    source,
+    /const normalizedEmail = email\.trim\(\);/,
+    'signup should normalize the email once at submit time',
+  );
+  assert.match(
+    source,
+    /await registerUserAction\(\{\s*email: normalizedEmail,/s,
+    'signup should register with the trimmed email value',
+  );
+  assert.match(
+    source,
+    /const submitResult = await onSubmit\(normalizedEmail, password\);/,
+    'signup should pass the trimmed email into the follow-on auth submit',
+  );
+});


### PR DESCRIPTION
## Summary
- add a shared form validation helper for email syntax, required-field messaging, and disabled-until-valid button gating
- apply inline validation and submit gating to login, forgot-password, signup, onboarding Step 1, and the homepage request-access form
- add regression coverage for the shared helper and each scoped form flow

## QA scope
- MASTER-007
- MASTER-009
- MASTER-010
- MASTER-011
- MASTER-012

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- `npm test` (fails on unrelated pre-existing tests: tenant-access local-dev auto-assignment, multiple oauth/integrations tenant-context tests, review/public surface assertions, `/api/contact` copy expectation, business-profile default-copy expectation, and `workspace:verify` canonical-root assumptions in a worktree)