### PR TITLE
feat(marketing): surface rendered video variants as asset cards

### DIFF
--- a/backend/marketing/artifact-collector.ts
+++ b/backend/marketing/artifact-collector.ts
@@ -8,6 +8,7 @@ import {
   asStringArray,
   type MarketingStage,
   type MarketingStageArtifact,
+  type MarketingVideoStageArtifact,
   type MarketingStageSummary,
 } from './runtime-state';
 import { resolvePublishReviewBundle } from './publish-review';
@@ -119,6 +120,10 @@ function artifact(input: Omit<MarketingStageArtifact, 'details'> & { details?: s
   };
 }
 
+function videoArtifact(input: MarketingVideoStageArtifact): MarketingVideoStageArtifact {
+  return input;
+}
+
 function asRecordArray(value: unknown): Array<Record<string, unknown>> {
   return Array.isArray(value)
     ? value.filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object' && !Array.isArray(entry))
@@ -128,6 +133,104 @@ function asRecordArray(value: unknown): Array<Record<string, unknown>> {
 function detailLines(label: string, values: Array<string | null | undefined>, maxItems = 3): string[] {
   const cleaned = values.filter((value): value is string => typeof value === 'string' && value.trim().length > 0).slice(0, maxItems);
   return cleaned.length > 0 ? [`${label}: ${cleaned.join(' • ')}`] : [];
+}
+
+function numberValue(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function titleCaseSlug(value: string): string {
+  return value
+    .split(/[-_]+/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function familyTitle(value: string): string {
+  if (/^family[-_\s]/i.test(value)) {
+    return value
+      .split(/[-_\s]+/g)
+      .map((part) => (part.length === 1 ? part.toUpperCase() : part.charAt(0).toUpperCase() + part.slice(1)))
+      .join(' ');
+  }
+
+  return `Family ${value.length === 1 ? value.toUpperCase() : titleCaseSlug(value)}`;
+}
+
+function collectRenderedVideoArtifacts(params: {
+  jobId: string | null;
+  videoPayload: Record<string, unknown> | null;
+}): MarketingVideoStageArtifact[] {
+  const { jobId, videoPayload } = params;
+  if (!jobId || !videoPayload) {
+    return [];
+  }
+
+  const videoAssets = asRecord(videoPayload.video_assets) ?? {};
+  return asRecordArray(videoAssets.platform_contracts).flatMap((contract) => {
+    const platformSlug =
+      stringValue(contract.platform_slug) ||
+      stringValue(contract.canonical_platform_slug);
+    if (!platformSlug) {
+      return [];
+    }
+
+    const platformTitle =
+      stringValue(contract.platform) ||
+      stringValue(contract.platform_name) ||
+      titleCaseSlug(platformSlug);
+    const platformRequirements = asRecord(contract.platform_requirements) ?? {};
+
+    return asRecordArray(contract.rendered_video_variants).flatMap((variant) => {
+      const familyId = stringValue(variant.family_id);
+      if (!familyId) {
+        return [];
+      }
+
+      const artifactId = `video-${platformSlug}-${familyId}`;
+      const durationSeconds =
+        numberValue(variant.duration_seconds) ??
+        numberValue(platformRequirements.target_duration_seconds) ??
+        0;
+      const aspectRatio =
+        stringValue(variant.aspect_ratio) ||
+        stringValue(contract.aspect_ratio) ||
+        stringValue(platformRequirements.aspect_ratio) ||
+        'unknown';
+      const familyDisplay =
+        stringValue(variant.family_name) ||
+        stringValue(contract.family_name) ||
+        familyTitle(familyId);
+
+      return [
+        videoArtifact({
+          id: artifactId,
+          stage: 'production',
+          type: 'video',
+          title: `${platformTitle} — ${familyDisplay}`,
+          category: 'video',
+          status: 'completed',
+          summary: `${platformTitle} render for ${familyDisplay} (${aspectRatio}, ${durationSeconds}s).`,
+          details: [],
+          contentType: 'video/mp4',
+          url: `/api/marketing/jobs/${jobId}/assets/${artifactId}`,
+          posterUrl: `/api/marketing/jobs/${jobId}/assets/${artifactId}-poster`,
+          platformSlug,
+          familyId,
+          durationSeconds,
+          aspectRatio,
+        }),
+      ];
+    });
+  });
 }
 
 function resolveRunId(
@@ -324,12 +427,14 @@ export function collectProductionReviewArtifacts(
   const videoPath = videoStep?.path || (runId ? stepPayloadPath(3, runId, 'veo_video_generator') : '');
   const review = reviewStep?.payload || (reviewPath ? readJsonIfExists(reviewPath) : null);
   const video = videoStep?.payload || (videoPath ? readJsonIfExists(videoPath) : null);
+  const jobId = runtimeDoc?.job_id || stringValue(primaryOutput?.job_id) || null;
   const packet = asRecord(review?.review_packet) ?? {};
   const summaryBlock = asRecord(packet.summary) ?? {};
   const previews = asRecord(packet.asset_previews) ?? {};
   const landingDetails = readLandingPageArtifactDetails({ runtimeDoc });
   const scriptDetails = readScriptArtifactDetails({ runtimeDoc });
   const videoAssets = asRecord(video?.video_assets) ?? {};
+  const renderedVideoArtifacts = collectRenderedVideoArtifacts({ jobId, videoPayload: video });
   const summary: MarketingStageSummary | null = {
     summary:
       stringValue(summaryBlock.core_message) ||
@@ -366,20 +471,7 @@ export function collectProductionReviewArtifacts(
         path: reviewPath || null,
         preview_path: asString(asRecord(review?.artifacts)?.preview_path),
       }),
-      artifact({
-        id: 'video-contracts',
-        stage: 'production',
-        title: 'Video contract handoff',
-        category: 'contracts',
-        status: 'completed',
-        summary: `${Array.isArray(videoAssets.platform_contracts) ? videoAssets.platform_contracts.length : 0} video platform contract(s) prepared.`,
-        details: Array.isArray(videoAssets.platform_contracts)
-          ? (videoAssets.platform_contracts as Array<Record<string, unknown>>)
-              .slice(0, 4)
-              .map((entry) => stringValue(entry.platform, 'Platform'))
-          : [],
-        path: videoPath || null,
-      }),
+      ...renderedVideoArtifacts,
     ],
   };
 }

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -36,7 +36,7 @@ export type MarketingStageCard = {
   highlight?: string;
 };
 
-export type MarketingArtifactCard = {
+type MarketingArtifactCardBase = {
   id: string;
   stage: MarketingStage;
   title: string;
@@ -48,6 +48,19 @@ export type MarketingArtifactCard = {
   actionLabel?: string;
   actionHref?: string;
 };
+
+export type MarketingVideoArtifactCard = MarketingArtifactCardBase & {
+  type: 'video';
+  contentType: 'video/mp4';
+  url: string;
+  posterUrl: string;
+  platformSlug: string;
+  familyId: string;
+  durationSeconds: number;
+  aspectRatio: string;
+};
+
+export type MarketingArtifactCard = MarketingArtifactCardBase | MarketingVideoArtifactCard;
 
 export type MarketingTimelineEntry = {
   id: string;
@@ -525,6 +538,10 @@ function buildArtifacts(
   approval: MarketingApprovalSummary | null
 ): MarketingArtifactCard[] {
   const firstCheckpointCopy = firstBrandAnalysisCheckpointCopy();
+  const isVideoArtifact = (
+    entry: MarketingJobRuntimeDocument['stages'][MarketingStage]['artifacts'][number],
+  ): entry is Extract<typeof entry, { type: 'video' }> => 'type' in entry && entry.type === 'video';
+
   return Object.values(runtimeDoc.stages)
     .flatMap((stageRecord) =>
       stageRecord.artifacts.map((entry) => ({
@@ -554,6 +571,18 @@ function buildArtifacts(
           entry.id === 'launch-review' && approval?.required
             ? approval.actionHref
             : entry.action_href ?? undefined,
+        ...(isVideoArtifact(entry)
+          ? {
+              type: 'video' as const,
+              contentType: entry.contentType,
+              url: entry.url,
+              posterUrl: entry.posterUrl,
+              platformSlug: entry.platformSlug,
+              familyId: entry.familyId,
+              durationSeconds: entry.durationSeconds,
+              aspectRatio: entry.aspectRatio,
+            }
+          : {}),
       }))
     );
 }

--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -19,7 +19,7 @@ export type MarketingJobState = 'queued' | 'running' | 'approval_required' | 'co
 export type MarketingJobStatus = 'pending' | 'running' | 'awaiting_approval' | 'completed' | 'failed';
 export type MarketingStageStatus = 'not_started' | 'in_progress' | 'awaiting_approval' | 'completed' | 'failed' | 'skipped';
 
-export type MarketingStageArtifact = {
+type MarketingStageArtifactBase = {
   id: string;
   stage: MarketingStage;
   title: string;
@@ -32,6 +32,19 @@ export type MarketingStageArtifact = {
   action_label?: string | null;
   action_href?: string | null;
 };
+
+export type MarketingVideoStageArtifact = MarketingStageArtifactBase & {
+  type: 'video';
+  contentType: 'video/mp4';
+  url: string;
+  posterUrl: string;
+  platformSlug: string;
+  familyId: string;
+  durationSeconds: number;
+  aspectRatio: string;
+};
+
+export type MarketingStageArtifact = MarketingStageArtifactBase | MarketingVideoStageArtifact;
 
 export type MarketingStageSummary = {
   summary: string;

--- a/lib/api/marketing.ts
+++ b/lib/api/marketing.ts
@@ -76,7 +76,7 @@ export interface MarketingStageCard {
   highlight?: string;
 }
 
-export interface MarketingArtifactCard {
+interface MarketingArtifactCardBase {
   id: string;
   stage: MarketingStage;
   title: string;
@@ -88,6 +88,19 @@ export interface MarketingArtifactCard {
   actionLabel?: string;
   actionHref?: string;
 }
+
+export interface MarketingVideoArtifactCard extends MarketingArtifactCardBase {
+  type: 'video';
+  contentType: 'video/mp4';
+  url: string;
+  posterUrl: string;
+  platformSlug: string;
+  familyId: string;
+  durationSeconds: number;
+  aspectRatio: string;
+}
+
+export type MarketingArtifactCard = MarketingArtifactCardBase | MarketingVideoArtifactCard;
 
 export interface MarketingTimelineEntry {
   id: string;

--- a/tests/video-artifact-collector.test.ts
+++ b/tests/video-artifact-collector.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { collectProductionReviewArtifacts } from '../backend/marketing/artifact-collector';
+
+async function writeJson(filePath: string, value: unknown) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(value, null, 2), 'utf8');
+}
+
+test('collectProductionReviewArtifacts emits one video artifact per rendered variant', async () => {
+  const previousStage3CacheDir = process.env.LOBSTER_STAGE3_CACHE_DIR;
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'aries-video-artifacts-'));
+  const runId = 'run-video-artifacts';
+  const jobId = 'job-video-artifacts';
+
+  process.env.LOBSTER_STAGE3_CACHE_DIR = tempRoot;
+
+  try {
+    await writeJson(path.join(tempRoot, runId, 'veo_video_generator.json'), {
+      type: 'veo_video_generator',
+      run_id: runId,
+      video_assets: {
+        platform_contracts: [
+          {
+            platform: 'TikTok',
+            platform_slug: 'tiktok',
+            platform_requirements: {
+              target_duration_seconds: 20,
+              aspect_ratio: '9:16',
+            },
+            rendered_video_variants: [
+              {
+                family_id: 'family-a',
+                family_name: 'Family A',
+                aspect_ratio: '9:16',
+                duration_seconds: 20,
+                video_path: `/data/generated/draft/jobs/${jobId}/videos/tiktok-family-a.mp4`,
+              },
+              {
+                family_id: 'family-b',
+                family_name: 'Family B',
+                aspect_ratio: '9:16',
+                duration_seconds: 20,
+                video_path: `/data/generated/draft/jobs/${jobId}/videos/tiktok-family-b.mp4`,
+              },
+            ],
+          },
+          {
+            platform: 'YouTube Shorts',
+            platform_slug: 'youtube-shorts',
+            platform_requirements: {
+              target_duration_seconds: 30,
+              aspect_ratio: '9:16',
+            },
+            rendered_video_variants: [
+              {
+                family_id: 'family-a',
+                family_name: 'Family A',
+                aspect_ratio: '9:16',
+                duration_seconds: 30,
+                video_path: `/data/generated/draft/jobs/${jobId}/videos/youtube-shorts-family-a.mp4`,
+              },
+              {
+                family_id: 'family-b',
+                family_name: 'Family B',
+                aspect_ratio: '9:16',
+                duration_seconds: 30,
+                video_path: `/data/generated/draft/jobs/${jobId}/videos/youtube-shorts-family-b.mp4`,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const capture = collectProductionReviewArtifacts({ run_id: runId, job_id: jobId }, null);
+    const videoArtifacts = capture.artifacts.filter(
+      (artifact): artifact is Extract<(typeof capture.artifacts)[number], { type: 'video' }> =>
+        'type' in artifact && artifact.type === 'video',
+    );
+
+    assert.equal(videoArtifacts.length, 4);
+
+    const expected = new Map([
+      ['video-tiktok-family-a', { platformSlug: 'tiktok', familyId: 'family-a' }],
+      ['video-tiktok-family-b', { platformSlug: 'tiktok', familyId: 'family-b' }],
+      ['video-youtube-shorts-family-a', { platformSlug: 'youtube-shorts', familyId: 'family-a' }],
+      ['video-youtube-shorts-family-b', { platformSlug: 'youtube-shorts', familyId: 'family-b' }],
+    ]);
+
+    for (const artifact of videoArtifacts) {
+      const variant = expected.get(artifact.id);
+      assert.ok(variant, `unexpected video artifact id ${artifact.id}`);
+      assert.equal(artifact.contentType, 'video/mp4');
+      assert.equal(artifact.url, `/api/marketing/jobs/${jobId}/assets/${artifact.id}`);
+      assert.equal(artifact.posterUrl, `/api/marketing/jobs/${jobId}/assets/${artifact.id}-poster`);
+      assert.equal(artifact.platformSlug, variant.platformSlug);
+      assert.equal(artifact.familyId, variant.familyId);
+    }
+  } finally {
+    if (previousStage3CacheDir === undefined) delete process.env.LOBSTER_STAGE3_CACHE_DIR;
+    else process.env.LOBSTER_STAGE3_CACHE_DIR = previousStage3CacheDir;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- replace the single `video-contracts` production artifact with one `video` artifact per rendered variant
- preserve the new video card fields through the runtime/API artifact types and jobs-status serializer
- add a regression test covering a 2 platform x 2 family `veo_video_generator` payload

## Testing
- npm run typecheck
- npm run lint
- npm run verify
- npx tsx --test tests/video-artifact-collector.test.ts
