### PR TITLE
feat(marketing): video preview component + review bundle videos

### DIFF
--- a/frontend/components/media-preview.tsx
+++ b/frontend/components/media-preview.tsx
@@ -4,9 +4,11 @@ import { useMemo, useState } from 'react';
 import { FileImage, FileText, Globe } from 'lucide-react';
 
 import { safeHref } from '@/lib/safe-href';
+import VideoPreview from '@/frontend/components/video-preview';
 
 type MediaPreviewProps = {
   src?: string | null;
+  poster?: string | null;
   alt: string;
   contentType?: string | null;
   className?: string;
@@ -78,20 +80,12 @@ export default function MediaPreview(props: MediaPreviewProps) {
   const validatedHref = safeHref(props.href);
 
   if (mode === 'video' && props.src) {
-    // Do not wrap <video> in an anchor — the surrounding <a> swallows click
-    // events on the native controls and the play button stops working.
-    // In video mode, `props.href` is intentionally ignored; link wrapping
-    // only applies to the image/fallback rendering paths below.
     return (
       <div className={props.className}>
-        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-        <video
-          controls
-          playsInline
-          preload="metadata"
+        <VideoPreview
           src={props.src}
+          poster={props.poster}
           className={props.imageClassName || 'h-full w-full object-contain bg-black'}
-          onError={() => setFailed(true)}
         />
       </div>
     );

--- a/frontend/components/video-preview.tsx
+++ b/frontend/components/video-preview.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AlertCircle, Loader2 } from 'lucide-react';
+
+type VideoPreviewProps = {
+  src?: string | null;
+  poster?: string | null;
+  className?: string;
+};
+
+export default function VideoPreview({ src, poster, className }: VideoPreviewProps) {
+  const [loading, setLoading] = useState(Boolean(src));
+  const [failed, setFailed] = useState(false);
+
+  const fallbackLabel = useMemo(() => {
+    if (!src) {
+      return 'Preview pending';
+    }
+    return failed ? 'Preview unavailable' : null;
+  }, [failed, src]);
+
+  if (fallbackLabel) {
+    return (
+      <div className={`${className ?? ''} flex items-center justify-center bg-black/30 text-white/55`}>
+        <div className="flex flex-col items-center gap-2 px-4 text-center">
+          <AlertCircle className="h-6 w-6" />
+          <span className="text-xs font-medium uppercase tracking-[0.2em]">{fallbackLabel}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full bg-black">
+      {loading ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/30 text-white/70">
+          <div className="flex flex-col items-center gap-2 px-4 text-center">
+            <Loader2 className="h-6 w-6 animate-spin" />
+            <span className="text-xs font-medium uppercase tracking-[0.2em]">Loading preview</span>
+          </div>
+        </div>
+      ) : null}
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <video
+        controls
+        preload="metadata"
+        poster={poster ?? undefined}
+        src={src ?? undefined}
+        playsInline
+        className={className ?? 'h-full w-full object-contain bg-black'}
+        onLoadedMetadata={() => {
+          setLoading(false);
+          setFailed(false);
+        }}
+        onError={() => {
+          setLoading(false);
+          setFailed(true);
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/marketing/job-approve.tsx
+++ b/frontend/marketing/job-approve.tsx
@@ -67,6 +67,9 @@ function ArtifactPreview({ artifact }: { artifact: MarketingArtifactCard }) {
 }
 
 function ReviewPreviewCard({ preview }: { preview: MarketingReviewPreviewCard }) {
+  const imageAssets = preview.mediaAssets.filter((asset) => !asset.contentType.startsWith('video/'));
+  const videoAssets = preview.mediaAssets.filter((asset) => asset.contentType.startsWith('video/'));
+
   return (
     <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 grid gap-3">
       <div>
@@ -96,10 +99,10 @@ function ReviewPreviewCard({ preview }: { preview: MarketingReviewPreviewCard })
           ))}
         </ul>
       ) : null}
-      {preview.mediaAssets.length > 0 ? (
+      {imageAssets.length > 0 ? (
         <div className="grid gap-3">
           <div className="grid sm:grid-cols-2 gap-3">
-            {preview.mediaAssets.map((asset) => (
+            {imageAssets.map((asset) => (
               <a
                 key={asset.id}
                 href={asset.url}
@@ -118,21 +121,48 @@ function ReviewPreviewCard({ preview }: { preview: MarketingReviewPreviewCard })
               </a>
             ))}
           </div>
-          {preview.assetLinks.length > 0 ? (
-            <div className="flex flex-wrap gap-3">
-              {preview.assetLinks.map((asset) => (
-                <a
-                  key={asset.id}
-                  href={asset.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-sm text-primary hover:text-primary/80 transition-colors"
-                >
-                  {asset.label}
-                </a>
-              ))}
-            </div>
-          ) : null}
+        </div>
+      ) : null}
+      {preview.assetLinks.length > 0 ? (
+        <div className="flex flex-wrap gap-3">
+          {preview.assetLinks.map((asset) => (
+            <a
+              key={asset.id}
+              href={asset.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm text-primary hover:text-primary/80 transition-colors"
+            >
+              {asset.label}
+            </a>
+          ))}
+        </div>
+      ) : null}
+      {videoAssets.length > 0 ? (
+        <div className="grid gap-3">
+          <strong className="text-sm text-white">Rendered videos</strong>
+          <div className="grid gap-3">
+            {videoAssets.map((asset) => (
+              <a
+                key={asset.id}
+                href={asset.url}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-[1.25rem] overflow-hidden border border-white/10 bg-black/30"
+              >
+                <MediaPreview
+                  src={asset.url}
+                  poster={asset.posterUrl}
+                  alt={asset.label}
+                  contentType={asset.contentType}
+                  className="h-44 w-full"
+                  imageClassName="h-full w-full object-contain bg-black"
+                  emptyLabel="Preview pending"
+                  nonImageLabel={asset.label}
+                />
+              </a>
+            ))}
+          </div>
         </div>
       ) : null}
     </div>
@@ -217,10 +247,12 @@ function DashboardAssetPreviewCard({ asset }: { asset: MarketingDashboardAsset }
   return (
     <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 grid gap-3">
       <MediaPreview
-        src={asset.thumbnailUrl || asset.previewUrl}
+        src={asset.previewUrl || asset.thumbnailUrl}
+        poster={asset.thumbnailUrl}
         alt={asset.title}
         contentType={asset.contentType}
         className="h-44 overflow-hidden rounded-[1.1rem] border border-white/8 bg-black/20"
+        imageClassName={asset.contentType?.startsWith('video/') ? 'h-full w-full object-contain bg-black' : undefined}
         emptyLabel={`${asset.type.replace(/_/g, ' ')} pending`}
         nonImageLabel={asset.type === 'landing_page' ? 'Landing page preview available' : 'Asset preview available'}
       />
@@ -244,15 +276,18 @@ function DashboardListCard(props: {
   summary: string
   status: string
   previewUrl?: string | null
+  posterUrl?: string | null
   previewContentType?: string | null
 }) {
   return (
     <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 grid gap-3">
       <MediaPreview
         src={props.previewUrl}
+        poster={props.posterUrl}
         alt={props.title}
         contentType={props.previewContentType}
         className="h-36 overflow-hidden rounded-[1.1rem] border border-white/8 bg-black/20"
+        imageClassName={props.previewContentType?.startsWith('video/') ? 'h-full w-full object-contain bg-black' : undefined}
         emptyLabel="Preview pending"
         nonImageLabel="Preview available"
       />
@@ -271,14 +306,15 @@ function DashboardListCard(props: {
 function dashboardPreviewUrl(
   assetId: string | null | undefined,
   assetsById: Map<string, MarketingDashboardAsset>
-): { url: string | null; contentType: string | null } {
+): { url: string | null; posterUrl: string | null; contentType: string | null } {
   if (!assetId) {
-    return { url: null, contentType: null };
+    return { url: null, posterUrl: null, contentType: null };
   }
 
   const asset = assetsById.get(assetId);
   return {
-    url: asset?.thumbnailUrl || asset?.previewUrl || null,
+    url: asset?.previewUrl || asset?.thumbnailUrl || null,
+    posterUrl: asset?.thumbnailUrl || null,
     contentType: asset?.contentType || null,
   };
 }
@@ -672,6 +708,7 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
                                 summary={post.summary}
                                 status={post.status}
                                 previewUrl={preview.url}
+                                posterUrl={preview.posterUrl}
                                 previewContentType={preview.contentType}
                               />
                             );
@@ -694,6 +731,7 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
                                 summary={item.summary}
                                 status={item.status}
                                 previewUrl={preview.url}
+                                posterUrl={preview.posterUrl}
                                 previewContentType={preview.contentType}
                               />
                             );

--- a/frontend/marketing/job-status.tsx
+++ b/frontend/marketing/job-status.tsx
@@ -74,10 +74,12 @@ function DashboardAssetCard({ asset }: { asset: MarketingDashboardAsset }) {
   return (
     <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 grid gap-3">
       <MediaPreview
-        src={asset.thumbnailUrl || asset.previewUrl}
+        src={asset.previewUrl || asset.thumbnailUrl}
+        poster={asset.thumbnailUrl}
         alt={asset.title}
         contentType={asset.contentType}
         className="h-40 overflow-hidden rounded-[1rem] border border-white/8 bg-black/20"
+        imageClassName={asset.contentType?.startsWith('video/') ? 'h-full w-full object-contain bg-black' : undefined}
         emptyLabel="Preview pending"
         nonImageLabel={asset.type === 'landing_page' ? 'Landing page preview available' : 'Asset preview available'}
       />
@@ -104,10 +106,12 @@ function DashboardPostCard({
   return (
     <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 grid gap-3">
       <MediaPreview
-        src={previewAsset?.thumbnailUrl || previewAsset?.previewUrl}
+        src={previewAsset?.previewUrl || previewAsset?.thumbnailUrl}
+        poster={previewAsset?.thumbnailUrl}
         alt={post.title}
         contentType={previewAsset?.contentType}
         className="h-40 overflow-hidden rounded-[1rem] border border-white/8 bg-black/20"
+        imageClassName={previewAsset?.contentType?.startsWith('video/') ? 'h-full w-full object-contain bg-black' : undefined}
         emptyLabel="Preview pending"
         nonImageLabel="Preview available"
       />
@@ -126,34 +130,60 @@ function DashboardPostCard({
 function ReviewPreviewGallery({ previews }: { previews: MarketingReviewPreviewCard[] }) {
   return (
     <div className="grid gap-4 xl:grid-cols-2">
-      {previews.map((preview) => (
-        <div key={preview.id} className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 grid gap-3">
-          <p className="text-xs uppercase tracking-[0.22em] text-white/35">{preview.platformName}</p>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {preview.mediaAssets.length > 0 ? (
-              preview.mediaAssets.map((asset) => (
-                <a key={asset.id} href={asset.url} target="_blank" rel="noreferrer" className="rounded-[1rem] overflow-hidden border border-white/8 bg-black/20">
-                  <MediaPreview
-                    src={asset.url}
-                    alt={asset.label}
-                    contentType={asset.contentType}
-                    className="h-36 w-full"
-                    emptyLabel="Preview pending"
-                    nonImageLabel={asset.label}
-                  />
-                </a>
-              ))
-            ) : (
-              <MediaPreview
-                alt={preview.platformName}
-                className="h-36 rounded-[1rem] border border-white/8 bg-black/20"
-                emptyLabel="Preview pending"
-              />
-            )}
+      {previews.map((preview) => {
+        const imageAssets = preview.mediaAssets.filter((asset) => !asset.contentType.startsWith('video/'));
+        const videoAssets = preview.mediaAssets.filter((asset) => asset.contentType.startsWith('video/'));
+
+        return (
+          <div key={preview.id} className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 grid gap-3">
+            <p className="text-xs uppercase tracking-[0.22em] text-white/35">{preview.platformName}</p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {imageAssets.length > 0 ? (
+                imageAssets.map((asset) => (
+                  <a key={asset.id} href={asset.url} target="_blank" rel="noreferrer" className="rounded-[1rem] overflow-hidden border border-white/8 bg-black/20">
+                    <MediaPreview
+                      src={asset.url}
+                      alt={asset.label}
+                      contentType={asset.contentType}
+                      className="h-36 w-full"
+                      emptyLabel="Preview pending"
+                      nonImageLabel={asset.label}
+                    />
+                  </a>
+                ))
+              ) : (
+                <MediaPreview
+                  alt={preview.platformName}
+                  className="h-36 rounded-[1rem] border border-white/8 bg-black/20"
+                  emptyLabel="Preview pending"
+                />
+              )}
+            </div>
+            {videoAssets.length > 0 ? (
+              <div className="grid gap-3">
+                <strong className="text-sm text-white">Rendered videos</strong>
+                <div className="grid gap-3">
+                  {videoAssets.map((asset) => (
+                    <a key={asset.id} href={asset.url} target="_blank" rel="noreferrer" className="rounded-[1rem] overflow-hidden border border-white/8 bg-black/20">
+                      <MediaPreview
+                        src={asset.url}
+                        poster={asset.posterUrl}
+                        alt={asset.label}
+                        contentType={asset.contentType}
+                        className="h-36 w-full"
+                        imageClassName="h-full w-full object-contain bg-black"
+                        emptyLabel="Preview pending"
+                        nonImageLabel={asset.label}
+                      />
+                    </a>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            <p className="text-sm text-white/60">{preview.summary}</p>
           </div>
-          <p className="text-sm text-white/60">{preview.summary}</p>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/lib/api/marketing.ts
+++ b/lib/api/marketing.ts
@@ -129,6 +129,7 @@ export interface MarketingAssetLink {
   url: string;
   label: string;
   contentType: string;
+  posterUrl?: string | null;
 }
 
 export interface MarketingApprovalSummary {

--- a/tests/media-preview.test.ts
+++ b/tests/media-preview.test.ts
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import React from 'react';
 
 // Import only the pure helpers from media-preview.tsx. The default export is a
 // React component and isn't exercised here; we just verify that detection
 // ignores query/hash suffixes and covers both image and video extensions so
 // signed Lobster URLs (`...?sig=...`) still render inline.
-import { imageLike, videoLike } from '../frontend/components/media-preview';
+import MediaPreview, { imageLike, videoLike } from '../frontend/components/media-preview';
 
 test('imageLike matches common image extensions regardless of query/hash suffix', () => {
   assert.equal(imageLike('https://cdn.example/meta-ads.png'), true);
@@ -40,4 +41,68 @@ test('videoLike falls back to contentType prefix', () => {
   assert.equal(videoLike('/assets/unknown.bin', 'video/mp4'), true);
   assert.equal(videoLike('/assets/unknown.bin', 'video/quicktime'), true);
   assert.equal(videoLike('/assets/unknown.bin', 'image/png'), false);
+});
+
+test('MediaPreview renders an img for image content types', async () => {
+  const { act, create } = await import('react-test-renderer');
+  let root!: import('react-test-renderer').ReactTestRenderer;
+
+  await act(async () => {
+    root = create(
+      React.createElement(MediaPreview, {
+        src: '/api/marketing/jobs/abc/assets/image-meta-A',
+        alt: 'Meta image',
+        contentType: 'image/png',
+        className: 'h-40',
+      }),
+    );
+  });
+
+  const image = root.root.findByType('img');
+  assert.equal(image.props.src, '/api/marketing/jobs/abc/assets/image-meta-A');
+  assert.equal(image.props.alt, 'Meta image');
+  assert.equal(root.root.findAllByType('video').length, 0);
+});
+
+test('MediaPreview renders a video for video content types', async () => {
+  const { act, create } = await import('react-test-renderer');
+  let root!: import('react-test-renderer').ReactTestRenderer;
+
+  await act(async () => {
+    root = create(
+      React.createElement(MediaPreview, {
+        src: '/api/marketing/jobs/abc/assets/video-tiktok-A',
+        poster: '/api/marketing/jobs/abc/assets/video-tiktok-A-poster',
+        alt: 'TikTok video',
+        contentType: 'video/mp4',
+        className: 'h-40',
+      }),
+    );
+  });
+
+  const video = root.root.findByType('video');
+  assert.equal(video.props.src, '/api/marketing/jobs/abc/assets/video-tiktok-A');
+  assert.equal(video.props.poster, '/api/marketing/jobs/abc/assets/video-tiktok-A-poster');
+  assert.equal(root.root.findAllByType('img').length, 0);
+});
+
+test('MediaPreview keeps the existing fallback for unsupported content', async () => {
+  const { act, create } = await import('react-test-renderer');
+  let root!: import('react-test-renderer').ReactTestRenderer;
+
+  await act(async () => {
+    root = create(
+      React.createElement(MediaPreview, {
+        src: '/api/marketing/jobs/abc/assets/doc-meta-A',
+        alt: 'Meta document',
+        contentType: 'application/pdf',
+        nonImageLabel: 'Open asset preview',
+        className: 'h-40',
+      }),
+    );
+  });
+
+  assert.equal(root.root.findAllByType('img').length, 0);
+  assert.equal(root.root.findAllByType('video').length, 0);
+  assert.match(JSON.stringify(root.toJSON()), /Open asset preview/);
 });

--- a/tests/video-preview.test.ts
+++ b/tests/video-preview.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+
+import VideoPreview from '../frontend/components/video-preview';
+
+test('VideoPreview renders a video element with the expected playback props', async () => {
+  const { act, create } = await import('react-test-renderer');
+  let root!: import('react-test-renderer').ReactTestRenderer;
+
+  await act(async () => {
+    root = create(
+      React.createElement(VideoPreview, {
+        src: '/api/marketing/jobs/abc/assets/video-tiktok-A',
+        poster: '/api/marketing/jobs/abc/assets/video-tiktok-A-poster',
+        className: 'h-full w-full object-contain bg-black',
+      }),
+    );
+  });
+
+  const video = root.root.findByType('video');
+  assert.equal(video.props.src, '/api/marketing/jobs/abc/assets/video-tiktok-A');
+  assert.equal(video.props.poster, '/api/marketing/jobs/abc/assets/video-tiktok-A-poster');
+  assert.equal(video.props.controls, true);
+  assert.equal(video.props.playsInline, true);
+  assert.equal(video.props.preload, 'metadata');
+});


### PR DESCRIPTION
## Summary
- add a dedicated `VideoPreview` component and route `MediaPreview` video content through it with optional poster support
- render review bundle video assets in a separate "Rendered videos" row while keeping existing image preview behavior intact
- use dashboard asset thumbnails as video posters and add focused renderer tests for the new branching behavior

## Validation
- npm run typecheck
- npm run lint
- npm run verify
- npx tsx --test tests/media-preview.test.ts tests/video-preview.test.ts