### PR TITLE
feat(marketing): default Veo to veo-3.1-fast-generate-preview

### DIFF
--- a/lobster/bin/_stage4_common.py
+++ b/lobster/bin/_stage4_common.py
@@ -416,7 +416,7 @@ def run_nano_banana(prompt: str, destination: Path, aspect_ratio: str) -> dict:
         }
 
 
-VEO_MODEL_DEFAULT = "veo-3.1-generate-preview"
+VEO_MODEL_DEFAULT = "veo-3.1-fast-generate-preview"
 VEO_POLL_INTERVAL_SECONDS = 10
 VEO_POLL_TIMEOUT_SECONDS = 600
 VEO_MAX_ATTEMPTS = 2

--- a/lobster/bin/veo-video-generator
+++ b/lobster/bin/veo-video-generator
@@ -340,7 +340,7 @@ def main() -> int:
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--brand-slug", default="client-brand")
     parser.add_argument("--research-model", default="gemini/gemini-3-flash-preview")
-    parser.add_argument("--video-model", default="veo-3.0-generate-001")
+    parser.add_argument("--video-model", default="veo-3.1-fast-generate-preview")
     parser.add_argument("--campaign-id", default="")
     parser.add_argument("--concept-id", default="")
     parser.add_argument("--job-id", default="")


### PR DESCRIPTION
## Summary
- update the CLI fallback video model to veo-3.1-fast-generate-preview
- align the stage 4 shared Veo default with the same fallback model
- keep env-based overrides unchanged by only changing the default constant

## Validation
- python3 -c "import ast; ast.parse(open('lobster/bin/_stage4_common.py').read())"
- npm run typecheck
- npm run lint
- npm run verify
