### PR TITLE
feat(marketing): surface rendered videos in workspace creative view

### DIFF
--- a/frontend/aries-v1/campaign-workspace.tsx
+++ b/frontend/aries-v1/campaign-workspace.tsx
@@ -9,6 +9,8 @@ import MediaPreview from '@/frontend/components/media-preview';
 import { safeHref } from '@/lib/safe-href';
 import { useMarketingJobStatus } from '@/hooks/use-marketing-job-status';
 import type {
+  MarketingArtifactCard,
+  MarketingVideoArtifactCard,
   MarketingCampaignStatusHistoryEntry,
   MarketingCreativeAssetReviewPayload,
   MarketingStageReviewPayload,
@@ -117,6 +119,90 @@ function formatDecisionTimestamp(value: string): string {
 
 function currentStageHref(campaignId: string, view: WorkspaceView): string {
   return `/dashboard/campaigns/${encodeURIComponent(campaignId)}?view=${view}`;
+}
+
+const PLATFORM_VIDEO_LABELS: Record<string, string> = {
+  tiktok: 'TikTok',
+  youtube: 'YouTube',
+  'youtube-shorts': 'YouTube Shorts',
+  instagram: 'Instagram',
+  'instagram-reels': 'Instagram Reels',
+  meta: 'Meta',
+  'meta-ads': 'Meta Ads',
+  facebook: 'Facebook',
+};
+
+function isRenderedVideoArtifact(artifact: MarketingArtifactCard): artifact is MarketingVideoArtifactCard {
+  return (
+    'type' in artifact &&
+    artifact.type === 'video' &&
+    'contentType' in artifact &&
+    artifact.contentType === 'video/mp4' &&
+    'url' in artifact &&
+    typeof artifact.url === 'string' &&
+    artifact.url.trim().length > 0
+  );
+}
+
+function humanizePlatformSlug(platformSlug: string): string {
+  const normalized = platformSlug.trim().toLowerCase();
+  if (!normalized) {
+    return 'Video';
+  }
+  if (PLATFORM_VIDEO_LABELS[normalized]) {
+    return PLATFORM_VIDEO_LABELS[normalized];
+  }
+  return normalized
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+function humanizeFamilyId(familyId: string): string {
+  const normalized = familyId.trim().replace(/[-_]+/g, ' ');
+  if (!normalized) {
+    return 'Variant';
+  }
+  const lower = normalized.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+export function RenderedVideosSection(props: { artifacts: MarketingArtifactCard[] | null | undefined }) {
+  const videoArtifacts = (props.artifacts || []).filter(isRenderedVideoArtifact);
+
+  if (videoArtifacts.length === 0) {
+    return null;
+  }
+
+  return (
+    <ShellPanel eyebrow="Creative Outputs" title="Rendered videos">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {videoArtifacts.map((artifact) => {
+          const platform = humanizePlatformSlug(artifact.platformSlug);
+          const family = humanizeFamilyId(artifact.familyId);
+
+          return (
+            <div key={artifact.id} className="space-y-3 rounded-[1.25rem] border border-white/10 bg-white/[0.03] p-4">
+              <div>
+                <p className="text-sm font-medium text-white/82">{platform} — {family}</p>
+              </div>
+              <MediaPreview
+                src={artifact.url}
+                poster={artifact.posterUrl}
+                contentType="video/mp4"
+                alt={`${platform} — ${family}`}
+                className="h-48 w-full rounded"
+                imageClassName="h-full w-full rounded object-contain bg-black"
+                emptyLabel="Rendered video pending"
+                nonImageLabel="Rendered video available"
+              />
+            </div>
+          );
+        })}
+      </div>
+    </ShellPanel>
+  );
 }
 
 export default function AriesCampaignWorkspace(props: { campaignId: string; initialView?: WorkspaceView }) {
@@ -379,6 +465,7 @@ export default function AriesCampaignWorkspace(props: { campaignId: string; init
           {generationProgress && !generationProgress.isComplete ? (
             <GenerationProgressBar progress={generationProgress} />
           ) : null}
+          <RenderedVideosSection artifacts={status.artifacts} />
           <CreativeReviewSurface
             review={status.creativeReview}
             fallback={creativeFallback}

--- a/tests/campaign-workspace-rendered-videos.test.ts
+++ b/tests/campaign-workspace-rendered-videos.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+
+import { RenderedVideosSection } from '../frontend/aries-v1/campaign-workspace';
+
+test('RenderedVideosSection renders one video card per rendered video artifact', async () => {
+  const { act, create } = await import('react-test-renderer');
+  let root!: import('react-test-renderer').ReactTestRenderer;
+
+  await act(async () => {
+    root = create(
+      React.createElement(RenderedVideosSection, {
+        artifacts: [
+          {
+            id: 'video_tiktok_offer_clarity',
+            type: 'video',
+            stage: 'production',
+            title: 'TikTok offer clarity',
+            category: 'creative',
+            status: 'ready',
+            summary: 'Rendered creative',
+            details: [],
+            contentType: 'video/mp4',
+            url: 'https://cdn.example.com/tiktok-offer-clarity.mp4',
+            posterUrl: 'https://cdn.example.com/tiktok-offer-clarity.jpg',
+            platformSlug: 'tiktok',
+            familyId: 'offer-clarity',
+            durationSeconds: 21,
+            aspectRatio: '9:16',
+          },
+          {
+            id: 'video_meta_proof_stack',
+            type: 'video',
+            stage: 'production',
+            title: 'Meta proof stack',
+            category: 'creative',
+            status: 'ready',
+            summary: 'Rendered creative',
+            details: [],
+            contentType: 'video/mp4',
+            url: 'https://cdn.example.com/meta-proof-stack.mp4',
+            posterUrl: 'https://cdn.example.com/meta-proof-stack.jpg',
+            platformSlug: 'meta-ads',
+            familyId: 'proof-stack',
+            durationSeconds: 30,
+            aspectRatio: '1:1',
+          },
+        ],
+      }),
+    );
+  });
+
+  assert.match(JSON.stringify(root.toJSON()), /Rendered videos/);
+
+  const videos = root.root.findAllByType('video');
+  assert.equal(videos.length, 2);
+  assert.deepEqual(
+    videos.map((video) => ({ src: video.props.src, poster: video.props.poster })),
+    [
+      {
+        src: 'https://cdn.example.com/tiktok-offer-clarity.mp4',
+        poster: 'https://cdn.example.com/tiktok-offer-clarity.jpg',
+      },
+      {
+        src: 'https://cdn.example.com/meta-proof-stack.mp4',
+        poster: 'https://cdn.example.com/meta-proof-stack.jpg',
+      },
+    ],
+  );
+});
+
+test('RenderedVideosSection renders nothing when no video artifacts are present', async () => {
+  const { act, create } = await import('react-test-renderer');
+  let root!: import('react-test-renderer').ReactTestRenderer;
+
+  await act(async () => {
+    root = create(
+      React.createElement(RenderedVideosSection, {
+        artifacts: [],
+      }),
+    );
+  });
+
+  assert.equal(root.toJSON(), null);
+});


### PR DESCRIPTION
## Summary
- render a dedicated rendered-videos section in the campaign workspace creative tab when video artifacts are present
- reuse MediaPreview for mp4 previews with poster support and humanized platform/family labels
- add a focused renderer test covering video src/poster output and the empty-state guard

## Validation
- npm run typecheck
- npm run lint
- npm run verify
- npx tsx --test tests/campaign-workspace-rendered-videos.test.ts