### PR TITLE
feat(marketing): attach mp4 videos to publish-preview reviews

### DIFF
--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -29,6 +29,7 @@ export type MarketingAssetLink = {
   url: string;
   label: string;
   contentType: string;
+  posterUrl?: string | null;
 };
 
 function resolveExistingAbsoluteAssetPath(filePath: string): string | null {

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -750,6 +750,12 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
           ),
         )
         .filter((asset): asset is MarketingAssetLink => !!asset);
+      const renderedVideoAsset = resolveRenderedVideoAssetLink(
+        runtimeDoc,
+        platformSlug,
+        stringValue(entry.rendered_video_asset_id) || null,
+        platformName,
+      );
       const previewId = publishReviewPreviewAssetPrefix({
         platformSlug,
         previewIndex: index,
@@ -773,7 +779,10 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
           ...stringArray(entry.proof_points),
           ...stringArray(recordValue(entry.format) ? Object.values(recordValue(entry.format) as Record<string, unknown>) : []),
         ],
-        mediaAssets: directMediaAssets.length > 0 ? directMediaAssets : fallbackPlatformMediaAssets(assetLinks, platformSlug),
+        mediaAssets: mergePreviewMediaAssets(
+          directMediaAssets.length > 0 ? directMediaAssets : fallbackPlatformMediaAssets(assetLinks, platformSlug),
+          renderedVideoAsset,
+        ),
         assetLinks: [
           linkById.get(
             publishReviewLinkedAssetId({
@@ -803,6 +812,61 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
       };
     }),
   };
+}
+
+function isVideoArtifact(
+  artifact: MarketingJobRuntimeDocument['stages'][MarketingStage]['artifacts'][number],
+): artifact is Extract<MarketingJobRuntimeDocument['stages'][MarketingStage]['artifacts'][number], { type: 'video' }> {
+  return 'type' in artifact && artifact.type === 'video';
+}
+
+function renderedVideoLabel(
+  platformName: string,
+  artifact: Extract<MarketingJobRuntimeDocument['stages'][MarketingStage]['artifacts'][number], { type: 'video' }>,
+): string {
+  const [, familyDisplay = artifact.familyId] = artifact.title.split(' — ');
+  return `${platformName} video — ${familyDisplay}`;
+}
+
+function resolveRenderedVideoAssetLink(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  platformSlug: string,
+  explicitAssetId: string | null,
+  platformName: string,
+): MarketingAssetLink | null {
+  let matchingArtifact: Extract<MarketingJobRuntimeDocument['stages'][MarketingStage]['artifacts'][number], { type: 'video' }> | null = null;
+  for (const artifact of runtimeDoc.stages.production.artifacts) {
+    if (!isVideoArtifact(artifact)) {
+      continue;
+    }
+    if (artifact.id === explicitAssetId || (!explicitAssetId && artifact.platformSlug === platformSlug)) {
+      matchingArtifact = artifact;
+      break;
+    }
+  }
+
+  if (!matchingArtifact) {
+    return null;
+  }
+
+  return {
+    id: matchingArtifact.id,
+    label: renderedVideoLabel(platformName, matchingArtifact),
+    url: matchingArtifact.url,
+    contentType: matchingArtifact.contentType,
+    posterUrl: matchingArtifact.posterUrl,
+  };
+}
+
+function mergePreviewMediaAssets(
+  assets: MarketingAssetLink[],
+  renderedVideoAsset: MarketingAssetLink | null,
+): MarketingAssetLink[] {
+  if (!renderedVideoAsset) {
+    return assets;
+  }
+
+  return [renderedVideoAsset, ...assets.filter((asset) => asset.id !== renderedVideoAsset.id)];
 }
 
 function fallbackPlatformMediaAssets(assetLinks: MarketingAssetLink[], platformSlug: string): MarketingAssetLink[] {

--- a/backend/marketing/publish-review.ts
+++ b/backend/marketing/publish-review.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import type { MarketingJobRuntimeDocument } from './runtime-state';
+import type { MarketingJobRuntimeDocument, MarketingVideoStageArtifact } from './runtime-state';
 import { readMarketingStageStepPayload } from './stage-artifact-resolution';
 import {
   ARTIFACT_INCOMPLETE_TEXT,
@@ -386,6 +386,23 @@ function normalizePlatformPreview(value: Record<string, unknown>): Record<string
       .filter(Boolean),
     asset_paths: normalizeAssetPaths(value.asset_paths),
   };
+}
+
+function isVideoStageArtifact(
+  artifact: MarketingJobRuntimeDocument['stages']['production']['artifacts'][number],
+): artifact is MarketingVideoStageArtifact {
+  return 'type' in artifact && artifact.type === 'video';
+}
+
+function firstRenderedVideoAssetIdForPlatform(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  platformSlugValue: string,
+): string | undefined {
+  const match = runtimeDoc.stages.production.artifacts.find((artifact) => (
+    isVideoStageArtifact(artifact) && artifact.platformSlug === platformSlugValue
+  ));
+
+  return match?.id;
 }
 
 function normalizeLandingPagePreview(value: unknown): Record<string, unknown> | null {
@@ -781,6 +798,7 @@ function buildFallbackPublishReviewBundle(
         platform_slug: slug,
         platform_name: platformNameFromSlug(slug),
         channel_type: channelTypeForPlatform(slug),
+        rendered_video_asset_id: firstRenderedVideoAssetIdForPlatform(runtimeDoc, slug),
         summary:
           preferredText(copyDetails.bodyLines[0], copyDetails.headline, stringValue(packageRecord.summary)) ||
           ARTIFACT_UNAVAILABLE_TEXT,

--- a/backend/marketing/runtime-views.ts
+++ b/backend/marketing/runtime-views.ts
@@ -713,7 +713,8 @@ function publishPreviewReviewItems(
           label: asset.label,
           url: asset.url,
           contentType: asset.contentType,
-          kind: asset.contentType.startsWith('image/') ? ('preview' as const) : ('artifact' as const),
+          kind: /^(image|video)\//.test(asset.contentType) ? ('preview' as const) : ('artifact' as const),
+          posterUrl: asset.posterUrl ?? null,
         })),
         ...preview.assetLinks.map((asset) => ({
           id: asset.id,
@@ -721,6 +722,7 @@ function publishPreviewReviewItems(
           url: asset.url,
           contentType: asset.contentType,
           kind: asset.contentType.startsWith('image/') ? ('preview' as const) : ('artifact' as const),
+          posterUrl: asset.posterUrl ?? null,
         })),
       ],
       history: [],

--- a/lib/api/marketing.ts
+++ b/lib/api/marketing.ts
@@ -281,6 +281,7 @@ export interface MarketingReviewAttachment {
   url: string;
   contentType: string;
   kind: 'brand_asset' | 'document' | 'preview' | 'artifact';
+  posterUrl?: string | null;
 }
 
 export interface MarketingStageReviewPayload {

--- a/tests/runtime-views-auth-hardening.test.ts
+++ b/tests/runtime-views-auth-hardening.test.ts
@@ -179,23 +179,47 @@ function makeAwaitingPublishApprovalRuntimeDoc(input: {
   tenantId: string;
   launchPreviewPath: string;
   platformSlug?: string | null;
+  platformPreviews?: Array<{
+    platformSlug: string;
+    platformName: string;
+    channelType?: string;
+  }>;
+  renderedVideos?: Array<{
+    platformSlug: string;
+    familyId: string;
+    title?: string;
+    posterUrl?: string;
+    url?: string;
+  }>;
   updatedAt?: string;
 }) {
   const updatedAt = input.updatedAt ?? '2026-03-20T00:10:00.000Z';
-  const platformPreviews = input.platformSlug
-    ? [
-        {
-          platform_slug: input.platformSlug,
-          platform_name: 'Meta Ads',
-          channel_type: 'paid-social',
-          summary: 'Carousel preview ready for launch.',
-          headline: 'April collection launch',
-          caption_text: 'Meet the April collection.',
-          cta: 'Shop the drop',
-          media_paths: [],
-        },
-      ]
-    : [];
+  const platformPreviews = input.platformPreviews
+    ? input.platformPreviews.map((preview) => ({
+        platform_slug: preview.platformSlug,
+        platform_name: preview.platformName,
+        channel_type: preview.channelType ?? 'paid-social',
+        summary: `${preview.platformName} preview ready for launch.`,
+        headline: 'April collection launch',
+        caption_text: 'Meet the April collection.',
+        cta: 'Shop the drop',
+        media_paths: [],
+      }))
+    : input.platformSlug
+      ? [
+          {
+            platform_slug: input.platformSlug,
+            platform_name: 'Meta Ads',
+            channel_type: 'paid-social',
+            summary: 'Carousel preview ready for launch.',
+            headline: 'April collection launch',
+            caption_text: 'Meet the April collection.',
+            cta: 'Shop the drop',
+            media_paths: [],
+          },
+        ]
+      : [];
+  const renderedVideos = input.renderedVideos ?? [];
 
   return {
     schema_name: 'marketing_job_state_schema',
@@ -210,7 +234,35 @@ function makeAwaitingPublishApprovalRuntimeDoc(input: {
     stages: {
       research: { stage: 'research', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-r', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
       strategy: { stage: 'strategy', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-s', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
-      production: { stage: 'production', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-p', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      production: {
+        stage: 'production',
+        status: 'completed',
+        started_at: null,
+        completed_at: null,
+        failed_at: null,
+        run_id: 'run-p',
+        summary: null,
+        primary_output: null,
+        outputs: {},
+        artifacts: renderedVideos.map((video) => ({
+          id: `video-${video.platformSlug}-${video.familyId}`,
+          stage: 'production',
+          type: 'video',
+          title: video.title ?? `${video.platformSlug} — ${video.familyId}`,
+          category: 'video',
+          status: 'completed',
+          summary: `${video.platformSlug} render for ${video.familyId}.`,
+          details: [],
+          contentType: 'video/mp4',
+          url: video.url ?? `/api/marketing/jobs/${input.jobId}/assets/video-${video.platformSlug}-${video.familyId}`,
+          posterUrl: video.posterUrl ?? `/api/marketing/jobs/${input.jobId}/assets/video-${video.platformSlug}-${video.familyId}-poster`,
+          platformSlug: video.platformSlug,
+          familyId: video.familyId,
+          durationSeconds: 15,
+          aspectRatio: '9:16',
+        })),
+        errors: [],
+      },
       publish: {
         stage: 'publish',
         status: 'awaiting_approval',
@@ -921,5 +973,50 @@ test('publish approvals still surface a workflow review item when the bundle has
     assert.equal(campaigns[0].approvalActionHref, undefined);
     assert.equal(workspace?.workflow_state, 'revisions_requested');
     assert.equal(workspace?.stage_reviews.creative.status, 'changes_requested');
+  });
+});
+
+test('publish-preview review items attach rendered mp4 previews for video platforms', async () => {
+  await withMarketingRuntimeEnv(async (dataRoot) => {
+    const jobsRoot = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs');
+    const jobId = 'publish-preview-video-attachments';
+    const runtimeFile = path.join(jobsRoot, `${jobId}.json`);
+    const launchPreviewPath = path.join(dataRoot, 'launch-review-preview.txt');
+    await mkdir(jobsRoot, { recursive: true });
+    await writeFile(launchPreviewPath, 'Launch review packet', 'utf8');
+    await writeFile(
+      runtimeFile,
+      JSON.stringify(makeAwaitingPublishApprovalRuntimeDoc({
+        dataRoot,
+        jobId,
+        tenantId: 'tenant_review',
+        launchPreviewPath,
+        platformPreviews: [
+          { platformSlug: 'tiktok', platformName: 'TikTok', channelType: 'video' },
+          { platformSlug: 'youtube', platformName: 'YouTube', channelType: 'video' },
+        ],
+        renderedVideos: [
+          { platformSlug: 'tiktok', familyId: 'portrait', title: 'TikTok — Portrait' },
+          { platformSlug: 'youtube', familyId: 'shorts', title: 'YouTube — Shorts' },
+        ],
+      }), null, 2),
+    );
+
+    const views = await import('../backend/marketing/runtime-views');
+    const reviews = await views.listMarketingReviewItemsForTenant('tenant_review');
+    const publishPreviewReviews = reviews.filter((item) => item.id.startsWith(`${jobId}::publish-preview:`));
+
+    assert.equal(publishPreviewReviews.length, 2);
+
+    for (const [platformSlug, familyId] of [['tiktok', 'portrait'], ['youtube', 'shorts']] as const) {
+      const review = publishPreviewReviews.find((item) => item.id === `${jobId}::publish-preview:${platformSlug}`);
+      assert.ok(review, `expected publish preview review for ${platformSlug}`);
+
+      const videoAttachment = review.attachments.find((attachment) => attachment.contentType === 'video/mp4');
+      assert.ok(videoAttachment, `expected video attachment for ${platformSlug}`);
+      assert.equal(videoAttachment?.id, `video-${platformSlug}-${familyId}`);
+      assert.equal(videoAttachment?.kind, 'preview');
+      assert.equal(videoAttachment?.posterUrl, `/api/marketing/jobs/${jobId}/assets/video-${platformSlug}-${familyId}-poster`);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- carry the selected production video asset id through publish-review fallback bundles
- resolve publish-preview review media from the production-stage video artifacts so review items expose `video/mp4` attachments with poster URLs
- add a regression test covering multi-platform publish-preview video attachments

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- `npx tsx --test tests/runtime-views-auth-hardening.test.ts --test-name-pattern "publish-preview review items attach rendered mp4 previews for video platforms"`
