### PR TITLE
perf(marketing): cache + single-flight for /api/marketing/jobs/:jobId

### DIFF
--- a/app/api/marketing/jobs/[jobId]/approve/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/approve/handler.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import { approveMarketingJob } from '@/backend/marketing/orchestrator';
 import { loadMarketingJobRuntime } from '@/backend/marketing/runtime-state';
 import { OpenClawGatewayError } from '@/backend/openclaw/gateway-client';
@@ -106,6 +107,8 @@ export async function handleApproveMarketingJob(
         { status: 409 }
       );
     }
+
+    invalidateMarketingJobStatus(jobId);
 
     return NextResponse.json(
       {

--- a/app/api/marketing/jobs/[jobId]/brief/route.ts
+++ b/app/api/marketing/jobs/[jobId]/brief/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import {
   appendCampaignHistory,
   ensureCampaignWorkspaceRecord,
@@ -123,6 +124,7 @@ export async function handlePatchMarketingJobBrief(
     ...requestBody.payload,
   };
   saveMarketingJobRuntime(jobId, runtimeDoc);
+  invalidateMarketingJobStatus(jobId);
 
   return NextResponse.json({ ok: true }, { status: 200 });
 }

--- a/app/api/marketing/jobs/[jobId]/delete/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/delete/handler.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import { cancelOpenClawLobsterWorkflow } from '@/backend/openclaw/gateway-client';
 import {
   isPipelineActive,
@@ -130,6 +131,8 @@ export async function handleDeleteMarketingJob(
     await cancelOpenClawLobsterWorkflow({ correlationId: jobId }).catch(() => {});
   }
 
+  invalidateMarketingJobStatus(jobId);
+
   return NextResponse.json(
     {
       jobId,
@@ -197,6 +200,8 @@ export async function handleRestoreMarketingJob(
       { status: 404 },
     );
   }
+
+  invalidateMarketingJobStatus(jobId);
 
   return NextResponse.json(
     {

--- a/app/api/marketing/jobs/[jobId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/handler.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
-import { getMarketingJobStatus } from '@/backend/marketing/jobs-status';
+import type { MarketingApprovalSummary, MarketingJobStatusResponse } from '@/backend/marketing/jobs-status';
+import { getMarketingJobStatusCached } from '@/backend/marketing/jobs-status';
 import { buildCampaignWorkspaceView } from '@/backend/marketing/workspace-views';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
@@ -11,7 +12,7 @@ const MARKETING_ONBOARDING_REQUIRED = {
 } as const;
 
 function alignApprovalWithWorkspace(
-  approval: ReturnType<typeof getMarketingJobStatus>['approval'],
+  approval: MarketingApprovalSummary | null,
   workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
   publishBlockedReason: ReturnType<typeof buildCampaignWorkspaceView>['publishBlockedReason'],
 ) {
@@ -36,7 +37,7 @@ function alignApprovalRequiredWithWorkspace(
 }
 
 function alignNextStepWithWorkspace(
-  nextStep: ReturnType<typeof getMarketingJobStatus>['nextStep'],
+  nextStep: MarketingJobStatusResponse['nextStep'],
   workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
 ) {
   return workflowState === 'revisions_requested' ? 'wait_for_completion' : nextStep;
@@ -54,7 +55,7 @@ export async function handleGetMarketingJobStatus(
   }
 
   try {
-    const result = getMarketingJobStatus(jobId);
+    const { payload: result, cacheStatus } = await getMarketingJobStatusCached(tenantResult.tenantContext.tenantId, jobId);
     const workspaceView = buildCampaignWorkspaceView(jobId);
     if (result.tenantId && result.tenantId !== tenantResult.tenantContext.tenantId) {
       return NextResponse.json(
@@ -62,7 +63,7 @@ export async function handleGetMarketingJobStatus(
           error: 'Marketing job not found.',
           reason: 'marketing_job_not_found',
         },
-        { status: 404 }
+        { status: 404, headers: { 'x-cache': cacheStatus } }
       );
     }
 
@@ -101,7 +102,7 @@ export async function handleGetMarketingJobStatus(
         repairStatus: result.repairStatus,
         dashboard: workspaceView.dashboard,
       },
-      { status: 200 }
+      { status: 200, headers: { 'x-cache': cacheStatus } }
     );
   } catch (error) {
     return NextResponse.json(

--- a/app/api/marketing/jobs/handler.ts
+++ b/app/api/marketing/jobs/handler.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import { startMarketingJob } from '@/backend/marketing/orchestrator';
 import {
   ensureCampaignWorkspaceRecord,
@@ -304,6 +305,8 @@ export async function handlePostMarketingJobs(
     if (requestBody.uploads.length > 0) {
       saveCampaignWorkspaceAssets(workspace, requestBody.uploads);
     }
+
+    invalidateMarketingJobStatus(result.jobId);
 
     return NextResponse.json(
       {

--- a/app/api/marketing/reviews/[reviewId]/decision/route.ts
+++ b/app/api/marketing/reviews/[reviewId]/decision/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import { RuntimeReviewDecisionError, recordMarketingReviewDecision } from '@/backend/marketing/runtime-views';
 import { OpenClawGatewayError } from '@/backend/openclaw/gateway-client';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
@@ -61,6 +62,8 @@ export async function handlePostMarketingReviewDecision(
     if (!review) {
       return NextResponse.json({ error: 'review_not_found' }, { status: 404 });
     }
+
+    invalidateMarketingJobStatus(review.jobId);
 
     return NextResponse.json({ review }, { status: 200 });
   } catch (error) {

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -189,6 +189,98 @@ export type MarketingJobStatusResponse = {
   repairStatus: string;
 };
 
+type CacheEntry = {
+  payload: MarketingJobStatusResponse;
+  expiresAt: number;
+};
+
+type MarketingJobStatusBuilder = (
+  tenantId: string,
+  jobId: string,
+) => MarketingJobStatusResponse | Promise<MarketingJobStatusResponse>;
+
+export type MarketingJobStatusCacheState = 'hit' | 'miss' | 'inflight';
+
+const STATUS_CACHE_TTL_MS = 10_000;
+const STATUS_CACHE_MAX = 1_000;
+const statusCache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<MarketingJobStatusResponse>>();
+
+let marketingJobStatusBuilder: MarketingJobStatusBuilder = (_tenantId, jobId) => buildMarketingJobStatus(jobId);
+
+function statusCacheKey(tenantId: string, jobId: string): string {
+  return `${tenantId}:${jobId}`;
+}
+
+export async function getMarketingJobStatusCached(
+  tenantId: string,
+  jobId: string,
+  now: number = Date.now(),
+): Promise<{ payload: MarketingJobStatusResponse; cacheStatus: MarketingJobStatusCacheState }> {
+  const key = statusCacheKey(tenantId, jobId);
+  const cached = statusCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return { payload: cached.payload, cacheStatus: 'hit' };
+  }
+
+  const pending = inflight.get(key);
+  if (pending) {
+    return { payload: await pending, cacheStatus: 'inflight' };
+  }
+
+  const startedAt = Date.now();
+  const promise = new Promise<MarketingJobStatusResponse>((resolve, reject) => {
+    setImmediate(() => {
+      Promise.resolve(marketingJobStatusBuilder(tenantId, jobId))
+        .then((payload) => {
+          statusCache.set(key, { payload, expiresAt: now + STATUS_CACHE_TTL_MS });
+          if (statusCache.size > STATUS_CACHE_MAX) {
+            evictOldest();
+          }
+          inflight.delete(key);
+          console.log('[jobs-cache] miss key=%s cold_ms=%d', key, Date.now() - startedAt);
+          resolve(payload);
+        })
+        .catch((error: unknown) => {
+          inflight.delete(key);
+          reject(error);
+        });
+    });
+  });
+
+  inflight.set(key, promise);
+  return { payload: await promise, cacheStatus: 'miss' };
+}
+
+export function invalidateMarketingJobStatus(jobId: string): void {
+  for (const key of statusCache.keys()) {
+    if (key.endsWith(`:${jobId}`)) {
+      statusCache.delete(key);
+    }
+  }
+}
+
+export function evictOldest(): void {
+  const oldest = statusCache.keys().next().value;
+  if (oldest) {
+    statusCache.delete(oldest);
+  }
+}
+
+export function resetMarketingJobStatusCacheForTests(): void {
+  statusCache.clear();
+  inflight.clear();
+  marketingJobStatusBuilder = (_tenantId, jobId) => buildMarketingJobStatus(jobId);
+}
+
+export function overrideMarketingJobStatusBuilderForTests(builder: MarketingJobStatusBuilder): void {
+  marketingJobStatusBuilder = builder;
+}
+
+export function getMarketingJobStatusCacheSizeForTests(): number {
+  return statusCache.size;
+}
+
 function shouldLogMarketingJobStatus(): boolean {
   const raw = process.env.MARKETING_DEBUG_LOG_JOBS_STATUS?.trim().toLowerCase();
   return raw === '1' || raw === 'true';
@@ -987,7 +1079,7 @@ function buildPostCounts(
   };
 }
 
-export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
+function buildMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
   assertMarketingRuntimeSchemas();
 
   const runtimeDoc = loadMarketingJobRuntime(jobId);
@@ -1088,4 +1180,8 @@ export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse
     nextStep: state.nextStep,
     repairStatus: state.repairStatus,
   };
+}
+
+export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
+  return buildMarketingJobStatus(jobId);
 }

--- a/tests/marketing-jobs-cache.test.ts
+++ b/tests/marketing-jobs-cache.test.ts
@@ -1,0 +1,290 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  getMarketingJobStatusCached,
+  getMarketingJobStatusCacheSizeForTests,
+  invalidateMarketingJobStatus,
+  overrideMarketingJobStatusBuilderForTests,
+  resetMarketingJobStatusCacheForTests,
+  type MarketingJobStatusResponse,
+} from '../backend/marketing/jobs-status';
+import { handleGetMarketingJobStatus } from '../app/api/marketing/jobs/[jobId]/handler';
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const originalConsoleLog = console.log;
+
+function buildPayload(jobId: string, tenantId: string, sequence: number): MarketingJobStatusResponse {
+  return {
+    jobId,
+    tenantId,
+    tenantName: `${tenantId}-name`,
+    brandWebsiteUrl: null,
+    campaignWindow: null,
+    durationDays: null,
+    plannedPostCount: null,
+    createdPostCount: sequence,
+    assetPreviewCards: [],
+    calendarEvents: [],
+    state: 'running',
+    status: 'ok',
+    currentStage: 'strategy',
+    stageStatus: { research: 'completed', strategy: 'in_progress', production: 'not_started', publish: 'not_started' },
+    updatedAt: null,
+    approvalRequired: false,
+    needsAttention: false,
+    summary: {
+      headline: `headline-${sequence}`,
+      subheadline: `subheadline-${sequence}`,
+    },
+    stageCards: [],
+    artifacts: [],
+    timeline: [],
+    approval: null,
+    reviewBundle: null,
+    publishConfig: {
+      platforms: [],
+      livePublishPlatforms: [],
+      videoRenderPlatforms: [],
+    },
+    nextStep: 'wait_for_completion',
+    repairStatus: 'not_required',
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function withRuntimeEnv<T>(run: () => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const previousOpenClawLobsterCwd = process.env.OPENCLAW_LOBSTER_CWD;
+  const previousGatewayLobsterCwd = process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
+  const previousStage1CacheDir = process.env.LOBSTER_STAGE1_CACHE_DIR;
+  const previousStage2CacheDir = process.env.LOBSTER_STAGE2_CACHE_DIR;
+  const previousStage3CacheDir = process.env.LOBSTER_STAGE3_CACHE_DIR;
+  const previousStage4CacheDir = process.env.LOBSTER_STAGE4_CACHE_DIR;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-marketing-cache-'));
+
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+  process.env.OPENCLAW_LOBSTER_CWD = path.join(PROJECT_ROOT, 'lobster');
+  process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = 'lobster';
+  process.env.LOBSTER_STAGE1_CACHE_DIR = path.join(dataRoot, 'lobster-stage1-cache');
+  process.env.LOBSTER_STAGE2_CACHE_DIR = path.join(dataRoot, 'lobster-stage2-cache');
+  process.env.LOBSTER_STAGE3_CACHE_DIR = path.join(dataRoot, 'lobster-stage3-cache');
+  process.env.LOBSTER_STAGE4_CACHE_DIR = path.join(dataRoot, 'lobster-stage4-cache');
+
+  try {
+    return await run();
+  } finally {
+    resetMarketingJobStatusCacheForTests();
+    if (previousCodeRoot === undefined) delete process.env.CODE_ROOT;
+    else process.env.CODE_ROOT = previousCodeRoot;
+    if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previousDataRoot;
+    if (previousOpenClawLobsterCwd === undefined) delete process.env.OPENCLAW_LOBSTER_CWD;
+    else process.env.OPENCLAW_LOBSTER_CWD = previousOpenClawLobsterCwd;
+    if (previousGatewayLobsterCwd === undefined) delete process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
+    else process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = previousGatewayLobsterCwd;
+    if (previousStage1CacheDir === undefined) delete process.env.LOBSTER_STAGE1_CACHE_DIR;
+    else process.env.LOBSTER_STAGE1_CACHE_DIR = previousStage1CacheDir;
+    if (previousStage2CacheDir === undefined) delete process.env.LOBSTER_STAGE2_CACHE_DIR;
+    else process.env.LOBSTER_STAGE2_CACHE_DIR = previousStage2CacheDir;
+    if (previousStage3CacheDir === undefined) delete process.env.LOBSTER_STAGE3_CACHE_DIR;
+    else process.env.LOBSTER_STAGE3_CACHE_DIR = previousStage3CacheDir;
+    if (previousStage4CacheDir === undefined) delete process.env.LOBSTER_STAGE4_CACHE_DIR;
+    else process.env.LOBSTER_STAGE4_CACHE_DIR = previousStage4CacheDir;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+test.beforeEach(() => {
+  resetMarketingJobStatusCacheForTests();
+  console.log = () => {};
+});
+
+test.afterEach(() => {
+  resetMarketingJobStatusCacheForTests();
+  console.log = originalConsoleLog;
+});
+
+test('cold read returns miss and populates cache', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    await delay(50);
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  const result = await getMarketingJobStatusCached('tenant-a', 'job-1');
+
+  assert.equal(result.cacheStatus, 'miss');
+  assert.equal(result.payload.jobId, 'job-1');
+  assert.equal(calls, 1);
+});
+
+test('warm read within TTL returns hit without rebuilding', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    await delay(50);
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  const first = await getMarketingJobStatusCached('tenant-a', 'job-1', 1_000);
+  const second = await getMarketingJobStatusCached('tenant-a', 'job-1', 1_500);
+
+  assert.equal(first.cacheStatus, 'miss');
+  assert.equal(second.cacheStatus, 'hit');
+  assert.equal(second.payload.createdPostCount, 1);
+  assert.equal(calls, 1);
+});
+
+test('single-flight collapses eight parallel cold reads for the same key', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    await delay(50);
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  const results = await Promise.all(
+    Array.from({ length: 8 }, () => getMarketingJobStatusCached('tenant-a', 'job-1')),
+  );
+
+  assert.equal(calls, 1);
+  assert.equal(results.filter((entry) => entry.cacheStatus === 'miss').length, 1);
+  assert.equal(results.filter((entry) => entry.cacheStatus === 'inflight').length, 7);
+});
+
+test('parallel different keys compute independently', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    await delay(50);
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  const startedAt = performance.now();
+  const results = await Promise.all([
+    getMarketingJobStatusCached('tenant-a', 'job-a'),
+    getMarketingJobStatusCached('tenant-a', 'job-b'),
+    getMarketingJobStatusCached('tenant-a', 'job-c'),
+  ]);
+  const elapsedMs = performance.now() - startedAt;
+
+  assert.equal(calls, 3);
+  assert.deepEqual(
+    results.map((entry) => entry.payload.jobId).sort(),
+    ['job-a', 'job-b', 'job-c'],
+  );
+  assert.ok(elapsedMs < 140, `expected parallel execution under 140ms, got ${elapsedMs.toFixed(1)}ms`);
+});
+
+test('TTL expiry forces a rebuild', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  const first = await getMarketingJobStatusCached('tenant-a', 'job-1', 1_000);
+  const second = await getMarketingJobStatusCached('tenant-a', 'job-1', 11_001);
+
+  assert.equal(first.cacheStatus, 'miss');
+  assert.equal(second.cacheStatus, 'miss');
+  assert.equal(second.payload.createdPostCount, 2);
+  assert.equal(calls, 2);
+});
+
+test('invalidation clears a cached entry and returns fresh data', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  const first = await getMarketingJobStatusCached('tenant-a', 'job-1');
+  invalidateMarketingJobStatus('job-1');
+  const second = await getMarketingJobStatusCached('tenant-a', 'job-1');
+
+  assert.equal(first.cacheStatus, 'miss');
+  assert.equal(second.cacheStatus, 'miss');
+  assert.equal(second.payload.createdPostCount, 2);
+  assert.equal(calls, 2);
+});
+
+test('tenant isolation keeps same job id separate and invalidation clears both tenants', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  const tenantAFirst = await getMarketingJobStatusCached('tenant-a', 'job-1');
+  const tenantBFirst = await getMarketingJobStatusCached('tenant-b', 'job-1');
+  const tenantAHit = await getMarketingJobStatusCached('tenant-a', 'job-1');
+  const tenantBHit = await getMarketingJobStatusCached('tenant-b', 'job-1');
+
+  invalidateMarketingJobStatus('job-1');
+
+  const tenantASecond = await getMarketingJobStatusCached('tenant-a', 'job-1');
+  const tenantBSecond = await getMarketingJobStatusCached('tenant-b', 'job-1');
+
+  assert.equal(tenantAFirst.cacheStatus, 'miss');
+  assert.equal(tenantBFirst.cacheStatus, 'miss');
+  assert.equal(tenantAHit.cacheStatus, 'hit');
+  assert.equal(tenantBHit.cacheStatus, 'hit');
+  assert.equal(tenantASecond.cacheStatus, 'miss');
+  assert.equal(tenantBSecond.cacheStatus, 'miss');
+  assert.equal(calls, 4);
+});
+
+test('memory cap evicts the oldest cache entry', async () => {
+  let calls = 0;
+  overrideMarketingJobStatusBuilderForTests(async (tenantId, jobId) => {
+    calls += 1;
+    return buildPayload(jobId, tenantId, calls);
+  });
+
+  for (let index = 0; index < 1_001; index += 1) {
+    await getMarketingJobStatusCached('tenant-a', `job-${index}`, 1_000);
+  }
+
+  assert.ok(getMarketingJobStatusCacheSizeForTests() <= 1_000);
+
+  const newest = await getMarketingJobStatusCached('tenant-a', 'job-1000', 1_500);
+  const oldest = await getMarketingJobStatusCached('tenant-a', 'job-0', 1_500);
+
+  assert.equal(newest.cacheStatus, 'hit');
+  assert.equal(oldest.cacheStatus, 'miss');
+  assert.equal(calls, 1_002);
+});
+
+test('marketing job route returns x-cache miss then hit on repeat request', async () => {
+  await withRuntimeEnv(async () => {
+    const tenantContextLoader = async () => ({
+      userId: 'user-cache-test',
+      tenantId: 'tenant-cache-test',
+      tenantSlug: 'tenant-cache-test',
+      role: 'tenant_admin' as const,
+    });
+
+    const first = await handleGetMarketingJobStatus('missing-job', tenantContextLoader);
+    const second = await handleGetMarketingJobStatus('missing-job', tenantContextLoader);
+
+    assert.equal(first.status, 200);
+    assert.equal(first.headers.get('x-cache'), 'miss');
+    assert.equal(second.status, 200);
+    assert.equal(second.headers.get('x-cache'), 'hit');
+  });
+});


### PR DESCRIPTION
Closes #34

## Summary
- add a tenant-scoped in-memory TTL cache plus single-flight dedupe for `/api/marketing/jobs/:jobId`
- emit `x-cache: hit|miss|inflight` from the job status route
- invalidate cached job status from every marketing endpoint in this repo that mutates job state
- add `node:test` coverage for cold/warm reads, single-flight, TTL, invalidation, tenant isolation, memory cap, and route integration

## Mutation Endpoints Now Calling `invalidateMarketingJobStatus`
- `POST /api/marketing/jobs`
- `POST /api/marketing/jobs/:jobId/approve`
- `PATCH /api/marketing/jobs/:jobId/brief`
- `DELETE /api/marketing/jobs/:jobId`
- `POST /api/marketing/jobs/:jobId/restore`
- `POST /api/marketing/reviews/:reviewId/decision`

## `x-cache` Curl Check
```bash
curl -i \
  -H 'Cookie: next-auth.session-token=<session>' \
  http://localhost:3000/api/marketing/jobs/<jobId> | grep -i x-cache
# x-cache: miss

curl -i \
  -H 'Cookie: next-auth.session-token=<session>' \
  http://localhost:3000/api/marketing/jobs/<jobId> | grep -i x-cache
# x-cache: hit
```

## Local Benchmark
Benchmark method: local in-process benchmark against a temporary real runtime fixture, comparing the old uncached route-equivalent (`getMarketingJobStatus` + `buildCampaignWorkspaceView`) to the current cached route handler.

- Serial single request: before `12.20ms`, after cold `9.77ms`, after warm `9.78ms`
- 8 concurrent same-job requests: before `40.12ms`, after `32.05ms`
- Concurrent cached run headers: `1x miss`, `7x inflight`

Note: warm serial time remains close to cold on this local fixture because `buildCampaignWorkspaceView(jobId)` is still uncached by design in this plan.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
