### PR TITLE
perf(marketing): convert sync file reads to async in jobs hot path

### DIFF
--- a/app/api/marketing/jobs/[jobId]/approve/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/approve/handler.ts
@@ -35,7 +35,7 @@ export async function handleApproveMarketingJob(
   }
 
   try {
-    const doc = loadMarketingJobRuntime(jobId);
+    const doc = await loadMarketingJobRuntime(jobId);
     if (!doc) {
       return NextResponse.json(
         {

--- a/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
@@ -223,7 +223,7 @@ export async function handleGetMarketingJobAsset(
       : tenantContextLoader;
   const requiresTenantContext = assetId.startsWith('video-') || !isMarketingPublicMode();
 
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     return new Response(JSON.stringify({ error: 'Marketing job not found.', reason: 'marketing_job_not_found' }), {
       status: 404,
@@ -250,7 +250,7 @@ export async function handleGetMarketingJobAsset(
     return streamVideoAsset(jobId, assetId, request);
   }
 
-  const asset = findMarketingAsset(jobId, runtimeDoc, assetId);
+  const asset = await findMarketingAsset(jobId, runtimeDoc, assetId);
   if (!asset) {
     return assetNotFoundResponse(jobId, assetId, 'asset_descriptor_missing');
   }

--- a/app/api/marketing/jobs/[jobId]/brief/route.ts
+++ b/app/api/marketing/jobs/[jobId]/brief/route.ts
@@ -93,13 +93,13 @@ export async function handlePatchMarketingJobBrief(
   }
   const tenantId = tenantResult.tenantContext.tenantId;
 
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc || runtimeDoc.tenant_id !== tenantId) {
     return NextResponse.json({ error: 'Marketing job not found.' }, { status: 404 });
   }
 
   const requestBody = await parseBriefRequest(req);
-  const record = ensureCampaignWorkspaceRecord({
+  const record = await ensureCampaignWorkspaceRecord({
     jobId,
     tenantId,
     payload: {

--- a/app/api/marketing/jobs/[jobId]/delete/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/delete/handler.ts
@@ -72,7 +72,7 @@ export async function handleDeleteMarketingJob(
     return tenantResult.response;
   }
 
-  const doc = loadMarketingJobRuntime(jobId);
+  const doc = await loadMarketingJobRuntime(jobId);
   if (!doc) {
     return NextResponse.json(
       { error: 'Campaign not found.', reason: 'marketing_job_not_found' },
@@ -107,7 +107,7 @@ export async function handleDeleteMarketingJob(
 
   const wasActive = isPipelineActive(doc);
 
-  const updated = softDeleteMarketingJob({
+  const updated = await softDeleteMarketingJob({
     jobId,
     tenantId: tenantResult.tenantContext.tenantId,
     deletedBy: tenantResult.tenantContext.userId,
@@ -155,7 +155,7 @@ export async function handleRestoreMarketingJob(
     return tenantResult.response;
   }
 
-  const doc = loadMarketingJobRuntime(jobId);
+  const doc = await loadMarketingJobRuntime(jobId);
   if (!doc) {
     return NextResponse.json(
       { error: 'Campaign not found.', reason: 'marketing_job_not_found' },
@@ -189,7 +189,7 @@ export async function handleRestoreMarketingJob(
     );
   }
 
-  const updated = restoreMarketingJob({
+  const updated = await restoreMarketingJob({
     jobId,
     tenantId: tenantResult.tenantContext.tenantId,
   });

--- a/app/api/marketing/jobs/[jobId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/handler.ts
@@ -19,8 +19,8 @@ const MARKETING_JOB_NOT_FOUND_RESPONSE = {
 
 function alignApprovalWithWorkspace(
   approval: MarketingApprovalSummary | null,
-  workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
-  publishBlockedReason: ReturnType<typeof buildCampaignWorkspaceView>['publishBlockedReason'],
+  workflowState: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['workflowState'],
+  publishBlockedReason: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['publishBlockedReason'],
 ) {
   if (!approval || workflowState !== 'revisions_requested') {
     return approval;
@@ -37,14 +37,14 @@ function alignApprovalWithWorkspace(
 
 function alignApprovalRequiredWithWorkspace(
   approvalRequired: boolean,
-  workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
+  workflowState: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['workflowState'],
 ) {
   return workflowState === 'revisions_requested' ? false : approvalRequired;
 }
 
 function alignNextStepWithWorkspace(
   nextStep: MarketingJobStatusResponse['nextStep'],
-  workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
+  workflowState: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['workflowState'],
 ) {
   return workflowState === 'revisions_requested' ? 'wait_for_completion' : nextStep;
 }
@@ -60,7 +60,7 @@ export async function handleGetMarketingJobStatus(
     return tenantResult.response;
   }
 
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc || runtimeDoc.tenant_id !== tenantResult.tenantContext.tenantId) {
     console.warn('[marketing-job-not-found]', {
       jobId,
@@ -71,7 +71,7 @@ export async function handleGetMarketingJobStatus(
 
   try {
     const { payload: result, cacheStatus } = await getMarketingJobStatusCached(tenantResult.tenantContext.tenantId, jobId);
-    const workspaceView = buildCampaignWorkspaceView(jobId);
+    const workspaceView = await buildCampaignWorkspaceView(jobId);
 
     return NextResponse.json(
       {

--- a/app/api/marketing/jobs/handler.ts
+++ b/app/api/marketing/jobs/handler.ts
@@ -147,11 +147,11 @@ function normalizeJobPayload(payload: Record<string, unknown>): Record<string, u
   return nextPayload;
 }
 
-function enrichPayloadFromBusinessProfile(
+async function enrichPayloadFromBusinessProfile(
   tenantId: string,
   payload: Record<string, unknown>,
-): Record<string, unknown> {
-  const defaults = marketingPayloadDefaultsFromBusinessProfile(tenantId);
+): Promise<Record<string, unknown>> {
+  const defaults = await marketingPayloadDefaultsFromBusinessProfile(tenantId);
   const nextPayload = { ...payload };
   const applyIfMissing = (key: string, value: unknown) => {
     if (typeof nextPayload[key] === 'string' && nextPayload[key].trim().length > 0) {
@@ -290,14 +290,14 @@ export async function handlePostMarketingJobs(
         tenantResult.tenantContext.tenantSlug,
       payload: normalizedPayload,
     });
-    const hydratedPayload = enrichPayloadFromBusinessProfile(resolvedTenantId, normalizedPayload);
+    const hydratedPayload = await enrichPayloadFromBusinessProfile(resolvedTenantId, normalizedPayload);
     const result = await startMarketingJob({
       tenantId: resolvedTenantId,
       jobType: requestBody.jobType as 'brand_campaign',
       createdBy: tenantResult.tenantContext.userId ?? null,
       payload: hydratedPayload,
     });
-    const workspace = ensureCampaignWorkspaceRecord({
+    const workspace = await ensureCampaignWorkspaceRecord({
       jobId: result.jobId,
       tenantId: resolvedTenantId,
       payload: hydratedPayload,

--- a/app/api/marketing/jobs/latest/handler.ts
+++ b/app/api/marketing/jobs/latest/handler.ts
@@ -12,9 +12,9 @@ const MARKETING_ONBOARDING_REQUIRED = {
 } as const;
 
 function alignApprovalWithWorkspace(
-  approval: ReturnType<typeof getMarketingJobStatus>['approval'],
-  workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
-  publishBlockedReason: ReturnType<typeof buildCampaignWorkspaceView>['publishBlockedReason'],
+  approval: Awaited<ReturnType<typeof getMarketingJobStatus>>['approval'],
+  workflowState: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['workflowState'],
+  publishBlockedReason: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['publishBlockedReason'],
 ) {
   if (!approval || workflowState !== 'revisions_requested') {
     return approval;
@@ -31,14 +31,14 @@ function alignApprovalWithWorkspace(
 
 function alignApprovalRequiredWithWorkspace(
   approvalRequired: boolean,
-  workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
+  workflowState: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['workflowState'],
 ) {
   return workflowState === 'revisions_requested' ? false : approvalRequired;
 }
 
 function alignNextStepWithWorkspace(
-  nextStep: ReturnType<typeof getMarketingJobStatus>['nextStep'],
-  workflowState: ReturnType<typeof buildCampaignWorkspaceView>['workflowState'],
+  nextStep: Awaited<ReturnType<typeof getMarketingJobStatus>>['nextStep'],
+  workflowState: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['workflowState'],
 ) {
   return workflowState === 'revisions_requested' ? 'wait_for_completion' : nextStep;
 }
@@ -64,7 +64,7 @@ export async function handleGetLatestMarketingJobStatus(
     );
   }
 
-  const latestJobId = findLatestMarketingJobIdForTenant(tenantId);
+  const latestJobId = await findLatestMarketingJobIdForTenant(tenantId);
   if (!latestJobId) {
     return NextResponse.json(
       {
@@ -75,8 +75,8 @@ export async function handleGetLatestMarketingJobStatus(
     );
   }
 
-  const result = getMarketingJobStatus(latestJobId);
-  const workspaceView = buildCampaignWorkspaceView(latestJobId);
+  const result = await getMarketingJobStatus(latestJobId);
+  const workspaceView = await buildCampaignWorkspaceView(latestJobId);
   return NextResponse.json(
     {
       jobId: result.jobId,

--- a/app/api/pipeline/url-preview/route.ts
+++ b/app/api/pipeline/url-preview/route.ts
@@ -53,7 +53,7 @@ export async function GET(req: NextRequest) {
   const tenantId = draftTenantId(draftId);
 
   try {
-    const storedBrandKit = loadTenantBrandKit(tenantId);
+    const storedBrandKit = await loadTenantBrandKit(tenantId);
     const sameStoredBrandKit =
       storedBrandKit &&
       (storedBrandKit.source_url === normalizedUrl || storedBrandKit.canonical_url === normalizedUrl)

--- a/app/materials/[jobId]/[assetId]/page.tsx
+++ b/app/materials/[jobId]/[assetId]/page.tsx
@@ -62,7 +62,7 @@ export default async function MaterialsViewerPage({
     notFound();
   }
 
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     notFound();
   }
@@ -81,7 +81,7 @@ export default async function MaterialsViewerPage({
     notFound();
   }
 
-  const asset = findMarketingAsset(jobId, runtimeDoc, assetId);
+  const asset = await findMarketingAsset(jobId, runtimeDoc, assetId);
   if (!asset) {
     notFound();
   }

--- a/app/onboarding/resume/page.tsx
+++ b/app/onboarding/resume/page.tsx
@@ -38,11 +38,11 @@ function businessSlugBase(input: { businessName: string; websiteUrl: string; ema
 }
 
 async function tenantIsReusable(tenantId: string): Promise<boolean> {
-  if (listMarketingJobIdsForTenant(tenantId).length > 0) {
+  if ((await listMarketingJobIdsForTenant(tenantId)).length > 0) {
     return false;
   }
 
-  if (tenantHasStoredBusinessProfileState(tenantId)) {
+  if (await tenantHasStoredBusinessProfileState(tenantId)) {
     return false;
   }
 
@@ -157,7 +157,7 @@ export default async function OnboardingResumePage(
       payload,
     });
 
-    ensureCampaignWorkspaceRecord({
+    await ensureCampaignWorkspaceRecord({
       jobId: result.jobId,
       tenantId,
       payload,

--- a/backend/marketing/artifact-collector.ts
+++ b/backend/marketing/artifact-collector.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -46,18 +47,17 @@ function stepPayloadPath(stage: 1 | 2 | 3 | 4, runId: string, stepName: string):
   return path.join(root, runId, `${stepName}.json`);
 }
 
-function readJsonIfExists(filePath: string): Record<string, unknown> | null {
-  if (!existsSync(filePath)) {
-    return null;
-  }
-
+async function readJsonIfExists(filePath: string): Promise<Record<string, unknown> | null> {
   try {
-    const raw = readFileSync(filePath, 'utf8');
+    const raw = await readFile(filePath, 'utf8');
     const parsed = JSON.parse(raw);
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : null;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
     return null;
   }
 }
@@ -233,20 +233,20 @@ function collectRenderedVideoArtifacts(params: {
   });
 }
 
-function resolveRunId(
+async function resolveRunId(
   primaryOutput: Record<string, unknown> | null,
   runtimeDoc?: MarketingJobRuntimeDocument | null,
   stage?: 1 | 2 | 3 | 4,
-): string | null {
-  return asString(primaryOutput?.run_id) || (runtimeDoc && stage ? inferMarketingStageRunId(runtimeDoc, stage) : null);
+): Promise<string | null> {
+  return asString(primaryOutput?.run_id) || (runtimeDoc && stage ? await inferMarketingStageRunId(runtimeDoc, stage) : null);
 }
 
-export function collectResearchStageArtifacts(primaryOutput: Record<string, unknown> | null): StageCapture {
-  const runId = resolveRunId(primaryOutput);
+export async function collectResearchStageArtifacts(primaryOutput: Record<string, unknown> | null): Promise<StageCapture> {
+  const runId = await resolveRunId(primaryOutput);
   const compilePath = runId ? stepPayloadPath(1, runId, 'ads_analyst_compile') : '';
   const extractorPath = runId ? stepPayloadPath(1, runId, 'meta_ads_extractor') : '';
-  const compile = compilePath ? readJsonIfExists(compilePath) : null;
-  const extractor = extractorPath ? readJsonIfExists(extractorPath) : null;
+  const compile = compilePath ? await readJsonIfExists(compilePath) : null;
+  const extractor = extractorPath ? await readJsonIfExists(extractorPath) : null;
   const executive = asRecord(compile?.executive_summary) ?? {};
   // Only treat the competitor as real if the upstream produced a non-generic value.
   // ads-analyst defaults to the literal string "competitor" when no brand was set,
@@ -290,19 +290,19 @@ export function collectResearchStageArtifacts(primaryOutput: Record<string, unkn
   };
 }
 
-export function collectStrategyReviewArtifacts(
+export async function collectStrategyReviewArtifacts(
   primaryOutput: Record<string, unknown> | null,
   runtimeDoc?: MarketingJobRuntimeDocument | null,
-): StageCapture {
+): Promise<StageCapture> {
   const sourceUrl = currentSourceUrl(runtimeDoc);
-  const validatedDocs = runtimeDoc ? loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
+  const validatedDocs = runtimeDoc ? await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
     currentSourceUrl: sourceUrl,
   }) : null;
-  const websiteStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 2, 'website_brand_analysis') : null;
-  const plannerStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 2, 'campaign_planner') : null;
-  const reviewStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 2, 'strategy_review_preview') : null;
+  const websiteStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 2, 'website_brand_analysis') : null;
+  const plannerStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 2, 'campaign_planner') : null;
+  const reviewStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 2, 'strategy_review_preview') : null;
   const runId =
-    resolveRunId(primaryOutput, runtimeDoc, 2) ||
+    await resolveRunId(primaryOutput, runtimeDoc, 2) ||
     websiteStep?.runId ||
     plannerStep?.runId ||
     reviewStep?.runId ||
@@ -318,18 +318,18 @@ export function collectStrategyReviewArtifacts(
     null;
   const plannerPath = plannerStep?.path || (runId ? stepPayloadPath(2, runId, 'campaign_planner') : '');
   const reviewPath = reviewStep?.path || (runId ? stepPayloadPath(2, runId, 'strategy_review_preview') : '');
-  const rawRunWebsite = websiteStep?.payload || (websitePath ? readJsonIfExists(websitePath) : null);
+  const rawRunWebsite = websiteStep?.payload || (websitePath ? await readJsonIfExists(websitePath) : null);
   const runWebsite = sourceMatchedRecord(
     rawRunWebsite,
     sourceUrl,
   );
   const website = runWebsite || validatedDocs?.websiteAnalysis || null;
   const brandProfile = sourceMatchedRecord(
-    validatedDocs?.brandProfile || (brandProfilePath ? readJsonIfExists(brandProfilePath) : null),
+    validatedDocs?.brandProfile || (brandProfilePath ? await readJsonIfExists(brandProfilePath) : null),
     sourceUrl,
   );
-  const plannerCandidate = plannerStep?.payload || (plannerPath ? readJsonIfExists(plannerPath) : null);
-  const reviewCandidate = reviewStep?.payload || (reviewPath ? readJsonIfExists(reviewPath) : null);
+  const plannerCandidate = plannerStep?.payload || (plannerPath ? await readJsonIfExists(plannerPath) : null);
+  const reviewCandidate = reviewStep?.payload || (reviewPath ? await readJsonIfExists(reviewPath) : null);
   const planner = strategyPayloadMatchesCurrentSource(plannerCandidate, sourceUrl, runWebsite, !!rawRunWebsite) ? plannerCandidate : null;
   const review = strategyPayloadMatchesCurrentSource(reviewCandidate, sourceUrl, runWebsite, !!rawRunWebsite) ? reviewCandidate : null;
   const brandAnalysis = asRecord(website?.brand_analysis) ?? {};
@@ -391,8 +391,8 @@ export function collectStrategyReviewArtifacts(
   };
 }
 
-export function collectStrategyFinalizeArtifacts(primaryOutput: Record<string, unknown> | null): StageCapture {
-  const runId = resolveRunId(primaryOutput);
+export async function collectStrategyFinalizeArtifacts(primaryOutput: Record<string, unknown> | null): Promise<StageCapture> {
+  const runId = await resolveRunId(primaryOutput);
   const handoff = asRecord(primaryOutput?.strategy_handoff) ?? {};
   return {
     runId,
@@ -409,15 +409,15 @@ export function collectStrategyFinalizeArtifacts(primaryOutput: Record<string, u
   };
 }
 
-export function collectProductionReviewArtifacts(
+export async function collectProductionReviewArtifacts(
   primaryOutput: Record<string, unknown> | null,
   runtimeDoc?: MarketingJobRuntimeDocument | null,
-): StageCapture {
-  const reviewStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 3, 'production_review_preview') : null;
-  const finalizeStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 3, 'creative_director_finalize') : null;
-  const videoStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 3, 'veo_video_generator') : null;
+): Promise<StageCapture> {
+  const reviewStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 3, 'production_review_preview') : null;
+  const finalizeStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 3, 'creative_director_finalize') : null;
+  const videoStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 3, 'veo_video_generator') : null;
   const runId =
-    resolveRunId(primaryOutput, runtimeDoc, 3) ||
+    await resolveRunId(primaryOutput, runtimeDoc, 3) ||
     reviewStep?.runId ||
     finalizeStep?.runId ||
     videoStep?.runId ||
@@ -425,14 +425,14 @@ export function collectProductionReviewArtifacts(
   const reviewPath = reviewStep?.path || (runId ? stepPayloadPath(3, runId, 'production_review_preview') : '');
   const finalizePath = finalizeStep?.path || (runId ? stepPayloadPath(3, runId, 'creative_director_finalize') : '');
   const videoPath = videoStep?.path || (runId ? stepPayloadPath(3, runId, 'veo_video_generator') : '');
-  const review = reviewStep?.payload || (reviewPath ? readJsonIfExists(reviewPath) : null);
-  const video = videoStep?.payload || (videoPath ? readJsonIfExists(videoPath) : null);
+  const review = reviewStep?.payload || (reviewPath ? await readJsonIfExists(reviewPath) : null);
+  const video = videoStep?.payload || (videoPath ? await readJsonIfExists(videoPath) : null);
   const jobId = runtimeDoc?.job_id || stringValue(primaryOutput?.job_id) || null;
   const packet = asRecord(review?.review_packet) ?? {};
   const summaryBlock = asRecord(packet.summary) ?? {};
   const previews = asRecord(packet.asset_previews) ?? {};
-  const landingDetails = readLandingPageArtifactDetails({ runtimeDoc });
-  const scriptDetails = readScriptArtifactDetails({ runtimeDoc });
+  const landingDetails = await readLandingPageArtifactDetails({ runtimeDoc });
+  const scriptDetails = await readScriptArtifactDetails({ runtimeDoc });
   const videoAssets = asRecord(video?.video_assets) ?? {};
   const renderedVideoArtifacts = collectRenderedVideoArtifacts({ jobId, videoPayload: video });
   const summary: MarketingStageSummary | null = {
@@ -476,8 +476,8 @@ export function collectProductionReviewArtifacts(
   };
 }
 
-export function collectProductionFinalizeArtifacts(primaryOutput: Record<string, unknown> | null): StageCapture {
-  const runId = resolveRunId(primaryOutput);
+export async function collectProductionFinalizeArtifacts(primaryOutput: Record<string, unknown> | null): Promise<StageCapture> {
+  const runId = await resolveRunId(primaryOutput);
   const handoff = asRecord(primaryOutput?.production_handoff) ?? {};
   const contractHandoffs = asRecord(handoff.contract_handoffs) ?? {};
   const staticHandoff = asRecord(contractHandoffs.static) ?? {};
@@ -497,21 +497,21 @@ export function collectProductionFinalizeArtifacts(primaryOutput: Record<string,
   };
 }
 
-export function collectPublishReviewArtifacts(
+export async function collectPublishReviewArtifacts(
   primaryOutput: Record<string, unknown> | null,
   runtimeDoc?: MarketingJobRuntimeDocument | null,
-): StageCapture {
-  const preflightStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 4, 'performance_marketer_preflight') : null;
-  const reviewStep = runtimeDoc ? readMarketingStageStepPayload(runtimeDoc, 4, 'launch_review_preview') : null;
+): Promise<StageCapture> {
+  const preflightStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 4, 'performance_marketer_preflight') : null;
+  const reviewStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 4, 'launch_review_preview') : null;
   const runId =
-    resolveRunId(primaryOutput, runtimeDoc, 4) ||
+    await resolveRunId(primaryOutput, runtimeDoc, 4) ||
     preflightStep?.runId ||
     reviewStep?.runId ||
     null;
   const preflightPath = preflightStep?.path || (runId ? stepPayloadPath(4, runId, 'performance_marketer_preflight') : '');
   const reviewPath = reviewStep?.path || (runId ? stepPayloadPath(4, runId, 'launch_review_preview') : '');
-  const preflight = preflightStep?.payload || (preflightPath ? readJsonIfExists(preflightPath) : null);
-  const resolvedPublishReview = runtimeDoc ? resolvePublishReviewBundle(runtimeDoc) : { reviewPayload: null, reviewBundle: null };
+  const preflight = preflightStep?.payload || (preflightPath ? await readJsonIfExists(preflightPath) : null);
+  const resolvedPublishReview = runtimeDoc ? await resolvePublishReviewBundle(runtimeDoc) : { reviewPayload: null, reviewBundle: null };
   // In docker setups, the lobster step cache lives on the gateway host (a different
   // filesystem) so reviewStep/reviewPath both come back null. Fall back to the
   // primaryOutput passed in by the orchestrator — that's the launch_review_preview
@@ -519,7 +519,7 @@ export function collectPublishReviewArtifacts(
   const review =
     resolvedPublishReview.reviewPayload ||
     reviewStep?.payload ||
-    (reviewPath ? readJsonIfExists(reviewPath) : null) ||
+    (reviewPath ? await readJsonIfExists(reviewPath) : null) ||
     (primaryOutput && stringValue((primaryOutput as Record<string, unknown>).type) === 'launch_review_preview'
       ? (primaryOutput as Record<string, unknown>)
       : null);
@@ -530,11 +530,11 @@ export function collectPublishReviewArtifacts(
   const landingPagePreview = asRecord(reviewBundle.landing_page_preview) ?? {};
   const scriptPreview = asRecord(reviewBundle.script_preview) ?? {};
   const platformPreviews = asRecordArray(reviewBundle.platform_previews);
-  const landingDetails = readLandingPageArtifactDetails({
+  const landingDetails = await readLandingPageArtifactDetails({
     path: stringValue(landingPagePreview.landing_page_path) || null,
     runtimeDoc: runtimeDoc || null,
   });
-  const scriptDetails = readScriptArtifactDetails({
+  const scriptDetails = await readScriptArtifactDetails({
     metaScriptPath: stringValue(scriptPreview.meta_script_path) || null,
     shortVideoScriptPath: stringValue(scriptPreview.short_video_script_path) || null,
     runtimeDoc: runtimeDoc || null,
@@ -676,10 +676,10 @@ export function collectPublishReviewArtifacts(
   };
 }
 
-export function collectPublishFinalizeArtifacts(primaryOutput: Record<string, unknown> | null): StageCapture {
-  const runId = resolveRunId(primaryOutput);
+export async function collectPublishFinalizeArtifacts(primaryOutput: Record<string, unknown> | null): Promise<StageCapture> {
+  const runId = await resolveRunId(primaryOutput);
   const summaryPath = runId ? stepPayloadPath(4, runId, 'performance_marketer_summary') : '';
-  const summaryPayload = summaryPath ? readJsonIfExists(summaryPath) : null;
+  const summaryPayload = summaryPath ? await readJsonIfExists(summaryPath) : null;
   const publisherSteps = [
     'meta_ads_publisher',
     'instagram_publisher',
@@ -689,15 +689,20 @@ export function collectPublishFinalizeArtifacts(primaryOutput: Record<string, un
     'linkedin_publisher',
     'reddit_publisher',
   ] as const;
-  const publisherPayloads = runId
-    ? publisherSteps
-        .map((stepName) => {
-          const payloadPath = stepPayloadPath(4, runId, stepName);
-          const payload = readJsonIfExists(payloadPath);
-          return payload ? { stepName, payloadPath, payload } : null;
-        })
-        .filter((entry): entry is { stepName: typeof publisherSteps[number]; payloadPath: string; payload: Record<string, unknown> } => !!entry)
-    : [];
+  const publisherPayloads: Array<{
+    stepName: typeof publisherSteps[number];
+    payloadPath: string;
+    payload: Record<string, unknown>;
+  }> = [];
+  if (runId) {
+    for (const stepName of publisherSteps) {
+      const payloadPath = stepPayloadPath(4, runId, stepName);
+      const payload = await readJsonIfExists(payloadPath);
+      if (payload) {
+        publisherPayloads.push({ stepName, payloadPath, payload });
+      }
+    }
+  }
 
   return {
     runId,

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -1,4 +1,5 @@
-import { closeSync, existsSync, openSync, readFileSync, readSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
@@ -159,81 +160,67 @@ function normalizePublishPreviewSlug(platform: Record<string, unknown>, previewI
   return canonicalizePublishReviewPlatformSlug(platform.platform_slug, `platform-${previewIndex + 1}`);
 }
 
-function sniffImageContentType(filePath: string): string | null {
+async function sniffImageContentType(filePath: string): Promise<string | null> {
   try {
-    const fd = openSync(filePath, 'r');
-    try {
-      const buffer = Buffer.alloc(12);
-      const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
-      const header = buffer.subarray(0, bytesRead);
+    const header = (await readFile(filePath)).subarray(0, 12);
 
-      if (header.length >= 3 && header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) {
-        return 'image/jpeg';
+    if (header.length >= 3 && header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff) {
+      return 'image/jpeg';
+    }
+    if (
+      header.length >= 8 &&
+      header[0] === 0x89 &&
+      header[1] === 0x50 &&
+      header[2] === 0x4e &&
+      header[3] === 0x47 &&
+      header[4] === 0x0d &&
+      header[5] === 0x0a &&
+      header[6] === 0x1a &&
+      header[7] === 0x0a
+    ) {
+      return 'image/png';
+    }
+    if (header.length >= 6) {
+      const signature = header.subarray(0, 6).toString('utf8');
+      if (signature === 'GIF87a' || signature === 'GIF89a') {
+        return 'image/gif';
       }
-      if (
-        header.length >= 8 &&
-        header[0] === 0x89 &&
-        header[1] === 0x50 &&
-        header[2] === 0x4e &&
-        header[3] === 0x47 &&
-        header[4] === 0x0d &&
-        header[5] === 0x0a &&
-        header[6] === 0x1a &&
-        header[7] === 0x0a
-      ) {
-        return 'image/png';
-      }
-      if (header.length >= 6) {
-        const signature = header.subarray(0, 6).toString('utf8');
-        if (signature === 'GIF87a' || signature === 'GIF89a') {
-          return 'image/gif';
-        }
-      }
-      if (
-        header.length >= 12 &&
-        header.subarray(0, 4).toString('ascii') === 'RIFF' &&
-        header.subarray(8, 12).toString('ascii') === 'WEBP'
-      ) {
-        return 'image/webp';
-      }
-    } finally {
-      closeSync(fd);
+    }
+    if (
+      header.length >= 12 &&
+      header.subarray(0, 4).toString('ascii') === 'RIFF' &&
+      header.subarray(8, 12).toString('ascii') === 'WEBP'
+    ) {
+      return 'image/webp';
     }
   } catch {}
 
   return null;
 }
 
-function sniffIsoBmffContentType(filePath: string): string | null {
+async function sniffIsoBmffContentType(filePath: string): Promise<string | null> {
   // ISO Base Media File Format (mp4/mov/m4v/etc.) starts with a 4-byte size
   // followed by the 'ftyp' box type. Both QuickTime (.mov) and MP4 share
   // the same outer container, so this is only safe to consult when the
   // extension already failed — otherwise we'd collapse .mov into video/mp4
   // and lose the QuickTime distinction.
   try {
-    const fd = openSync(filePath, 'r');
-    try {
-      const buffer = Buffer.alloc(8);
-      const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
-      const header = buffer.subarray(0, bytesRead);
+    const header = (await readFile(filePath)).subarray(0, 8);
 
-      if (header.length >= 8 && header.subarray(4, 8).toString('ascii') === 'ftyp') {
-        return 'video/mp4';
-      }
-    } finally {
-      closeSync(fd);
+    if (header.length >= 8 && header.subarray(4, 8).toString('ascii') === 'ftyp') {
+      return 'video/mp4';
     }
   } catch {}
 
   return null;
 }
 
-export function contentTypeForAsset(filePath: string): string {
+export async function contentTypeForAsset(filePath: string): Promise<string> {
   // Image magic bytes are unambiguous (a JPEG header can only mean JPEG, a
   // PNG signature can only mean PNG, etc.), so we let the bytes override
   // the extension when they disagree — operators routinely save sniffed
   // previews under whatever extension the source URL had.
-  const sniffedImage = sniffImageContentType(filePath);
+  const sniffedImage = await sniffImageContentType(filePath);
   if (sniffedImage) {
     return sniffedImage;
   }
@@ -278,7 +265,7 @@ export function contentTypeForAsset(filePath: string): string {
 
   // ISOBMFF (`ftyp`) sniffing is ambiguous between MP4 and QuickTime, so we
   // only run it when the extension didn't pick a winner above.
-  const sniffedIsoBmff = sniffIsoBmffContentType(filePath);
+  const sniffedIsoBmff = await sniffIsoBmffContentType(filePath);
   if (sniffedIsoBmff) {
     return sniffedIsoBmff;
   }
@@ -294,7 +281,7 @@ export function marketingAssetUrl(jobId: string, assetId: string): string {
   return `/api/marketing/jobs/${encodeURIComponent(jobId)}/assets/${encodeURIComponent(assetId)}`;
 }
 
-export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJobRuntimeDocument): MarketingAssetDescriptor[] {
+export async function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingAssetDescriptor[]> {
   const assets: MarketingAssetDescriptor[] = [];
   const assetById = new Map<string, MarketingAssetDescriptor>();
   const resolveAssetPath = (
@@ -322,7 +309,7 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
     return null;
   };
 
-  const addAsset = (
+  const addAsset = async (
     id: string,
     filePath: string | null | undefined,
     label: string,
@@ -339,21 +326,21 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
       id,
       filePath: resolvedPath,
       label,
-      contentType: contentTypeForAsset(resolvedPath),
+      contentType: await contentTypeForAsset(resolvedPath),
     });
   };
 
   const strategyOutputs = recordValue(runtimeDoc.stages.strategy.outputs);
-  const researchFallback = collectResearchStageArtifacts(
+  const researchFallback = await collectResearchStageArtifacts(
     runtimeDoc.stages.research.primary_output || { run_id: runtimeDoc.stages.research.run_id },
   );
-  const validatedProfileDocs = loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
+  const validatedProfileDocs = await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   });
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   });
-  const strategyFallback = collectStrategyReviewArtifacts(
+  const strategyFallback = await collectStrategyReviewArtifacts(
     runtimeDoc.stages.strategy.primary_output || { run_id: runtimeDoc.stages.strategy.run_id },
     runtimeDoc,
   );
@@ -378,7 +365,7 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
   if (websiteAnalysisPath) {
     try {
       const resolvedWebsiteAnalysisPath = resolveAssetPath(websiteAnalysisPath) || websiteAnalysisPath;
-      websiteAnalysis = recordValue(JSON.parse(readFileSync(resolvedWebsiteAnalysisPath, 'utf8')));
+      websiteAnalysis = recordValue(JSON.parse(await readFile(resolvedWebsiteAnalysisPath, 'utf8')));
     } catch {
       websiteAnalysis = null;
     }
@@ -405,23 +392,23 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
     })(),
   ]);
 
-  addAsset('research-summary', researchSummaryPath, 'Competitor research summary');
-  addAsset('strategy-website-analysis', websiteAnalysisPath, 'Website brand analysis');
-  addAsset(
+  await addAsset('research-summary', researchSummaryPath, 'Competitor research summary');
+  await addAsset('strategy-website-analysis', websiteAnalysisPath, 'Website brand analysis');
+  await addAsset(
     'brand-kit-json',
     runtimeDoc.brand_kit?.path || validatedProfileDocs.paths.brandKit,
     'Extracted brand kit',
     [validatedProfileDocs.paths.brandKit],
   );
-  addAsset('strategy-campaign-planner', plannerPath, 'Campaign planner');
-  addAsset('strategy-review-preview', strategyReviewPath, 'Strategy review preview');
-  addAsset(
+  await addAsset('strategy-campaign-planner', plannerPath, 'Campaign planner');
+  await addAsset('strategy-review-preview', strategyReviewPath, 'Strategy review preview');
+  await addAsset(
     'brand-bible-markdown',
     stringValue(brandArtifacts?.brand_bible_markdown_path) || null,
     'Brand bible',
     outputRoots().flatMap((outputRoot) => brandSlugCandidates.map((brandSlug) => path.join(outputRoot, `${brandSlug}-brand-bible.md`))),
   );
-  addAsset(
+  await addAsset(
     'brand-design-system',
     stringValue(brandArtifacts?.design_system_css_path) || null,
     'Design system',
@@ -429,13 +416,13 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
   );
 
   if (brandSlugCandidates.length > 0) {
-    addAsset(
+    await addAsset(
       'strategy-proposal-markdown',
       null,
       'Campaign proposal',
       outputRoots().flatMap((outputRoot) => brandSlugCandidates.map((brandSlug) => path.join(outputRoot, `${brandSlug}-campaign-proposal.md`))),
     );
-    addAsset(
+    await addAsset(
       'strategy-proposal-html',
       null,
       'Campaign proposal preview',
@@ -443,7 +430,7 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
     );
   }
 
-  const dashboardAssets = listMarketingDashboardAssetsForJob(jobId);
+  const dashboardAssets = await listMarketingDashboardAssetsForJob(jobId);
   const previewFallbacksByPlatform = new Map<string, string[]>();
   const rememberPreviewFallback = (platform: string, filePath: string) => {
     previewFallbacksByPlatform.set(platform, [
@@ -466,7 +453,7 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
     rememberPreviewFallback(asset.platform, asset.filePath);
   }
 
-  const reviewBundle = extractPublishReviewBundle(runtimeDoc);
+  const reviewBundle = await extractPublishReviewBundle(runtimeDoc);
   if (reviewBundle) {
     const artifactPaths = recordValue(reviewBundle.artifact_paths);
     const landingPage = recordValue(reviewBundle.landing_page_preview);
@@ -474,20 +461,20 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
     const reviewPacket = recordValue(reviewBundle.review_packet);
     const platformPreviews = recordArray(reviewBundle.platform_previews);
 
-    addAsset('launch-review-preview', stringValue(artifactPaths?.preview_path) || null, 'Launch review preview');
-    addAsset('landing-page-path', stringValue(landingPage?.landing_page_path) || null, 'Landing page');
-    addAsset('script-meta', stringValue(scriptPreview?.meta_script_path) || null, 'Meta script');
-    addAsset('script-video', stringValue(scriptPreview?.short_video_script_path) || null, 'Short video script');
-    addAsset('review-packet-production', stringValue(reviewPacket?.production_review_preview_path) || null, 'Production review preview');
-    addAsset('review-packet-canonical', stringValue(reviewPacket?.canonical_review_packet_path) || null, 'Canonical review packet');
+    await addAsset('launch-review-preview', stringValue(artifactPaths?.preview_path) || null, 'Launch review preview');
+    await addAsset('landing-page-path', stringValue(landingPage?.landing_page_path) || null, 'Landing page');
+    await addAsset('script-meta', stringValue(scriptPreview?.meta_script_path) || null, 'Meta script');
+    await addAsset('script-video', stringValue(scriptPreview?.short_video_script_path) || null, 'Short video script');
+    await addAsset('review-packet-production', stringValue(reviewPacket?.production_review_preview_path) || null, 'Production review preview');
+    await addAsset('review-packet-canonical', stringValue(reviewPacket?.canonical_review_packet_path) || null, 'Canonical review packet');
 
     for (const [previewIndex, platform] of platformPreviews.entries()) {
       const slug = normalizePublishPreviewSlug(platform, previewIndex);
       const platformName = stringValue(platform.platform_name, slug);
       const assetPaths = recordValue(platform.asset_paths);
 
-      stringArray(platform.media_paths).forEach((filePath, index) => {
-        addAsset(
+      for (const [index, filePath] of stringArray(platform.media_paths).entries()) {
+        await addAsset(
           publishReviewMediaAssetId({
             platformSlug: slug,
             previewIndex,
@@ -498,8 +485,8 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
           `${platformName} media ${index + 1}`,
           previewFallbacksByPlatform.get(slug) || previewFallbacksByPlatform.get('landing-page') || []
         );
-      });
-      addAsset(
+      }
+      await addAsset(
         publishReviewLinkedAssetId({
           platformSlug: slug,
           previewIndex,
@@ -509,7 +496,7 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
         stringValue(assetPaths?.contract_path) || null,
         `${platformName} contract`,
       );
-      addAsset(
+      await addAsset(
         publishReviewLinkedAssetId({
           platformSlug: slug,
           previewIndex,
@@ -519,7 +506,7 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
         stringValue(assetPaths?.brief_path) || null,
         `${platformName} brief`,
       );
-      addAsset(
+      await addAsset(
         publishReviewLinkedAssetId({
           platformSlug: slug,
           previewIndex,
@@ -536,15 +523,15 @@ export function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJ
     if (!asset.filePath) {
       continue;
     }
-    addAsset(asset.id, asset.filePath, asset.title);
+    await addAsset(asset.id, asset.filePath, asset.title);
   }
 
   assets.push(...assetById.values());
   return assets;
 }
 
-export function buildMarketingAssetLinks(jobId: string, runtimeDoc: MarketingJobRuntimeDocument): MarketingAssetLink[] {
-  return buildMarketingAssetLibrary(jobId, runtimeDoc).map((asset) => ({
+export async function buildMarketingAssetLinks(jobId: string, runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingAssetLink[]> {
+  return (await buildMarketingAssetLibrary(jobId, runtimeDoc)).map((asset) => ({
     id: asset.id,
     url: marketingAssetUrl(jobId, asset.id),
     label: asset.label,
@@ -552,18 +539,18 @@ export function buildMarketingAssetLinks(jobId: string, runtimeDoc: MarketingJob
   }));
 }
 
-export function findMarketingAsset(
+export async function findMarketingAsset(
   jobId: string,
   runtimeDoc: MarketingJobRuntimeDocument,
   assetId: string
-): MarketingAssetDescriptor | null {
-  const assets = buildMarketingAssetLibrary(jobId, runtimeDoc);
+): Promise<MarketingAssetDescriptor | null> {
+  const assets = await buildMarketingAssetLibrary(jobId, runtimeDoc);
   const directMatch = assets.find((asset) => asset.id === assetId);
   if (directMatch) {
     return directMatch;
   }
 
-  const reviewBundle = extractPublishReviewBundle(runtimeDoc);
+  const reviewBundle = await extractPublishReviewBundle(runtimeDoc);
   const platformPreviews = recordArray(reviewBundle?.platform_previews);
   const legacyToCanonical = new Map<string, string>();
 

--- a/backend/marketing/brand-kit.ts
+++ b/backend/marketing/brand-kit.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { resolveDataPath } from '@/lib/runtime-paths';
@@ -1281,15 +1282,18 @@ export function tenantBrandKitPath(tenantId: string): string {
   return resolveDataPath('generated', 'validated', tenantId, 'brand-kit.json');
 }
 
-export function loadTenantBrandKit(tenantId: string): TenantBrandKit | null {
+export async function loadTenantBrandKit(tenantId: string): Promise<TenantBrandKit | null> {
   const filePath = tenantBrandKitPath(tenantId);
-  if (!existsSync(filePath)) {
-    return null;
+  try {
+    const brandKit = normalizePersistedBrandKit(JSON.parse(await readFile(filePath, 'utf8')) as TenantBrandKit);
+    assertTenantBrandKit(brandKit);
+    return brandKit;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
   }
-
-  const brandKit = normalizePersistedBrandKit(JSON.parse(readFileSync(filePath, 'utf8')) as TenantBrandKit);
-  assertTenantBrandKit(brandKit);
-  return brandKit;
 }
 
 function isFreshBrandKit(brandKit: TenantBrandKit, brandUrl: string): boolean {
@@ -1322,7 +1326,7 @@ export async function extractAndSaveTenantBrandKit(input: {
   brandUrl: string;
   fetchImpl?: typeof fetch;
 }): Promise<{ brandKit: TenantBrandKit; filePath: string }> {
-  const existing = loadTenantBrandKit(input.tenantId);
+  const existing = await loadTenantBrandKit(input.tenantId);
   if (existing && isFreshBrandKit(existing, input.brandUrl)) {
     saveTenantBrandKit(input.tenantId, existing);
     return {

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -638,8 +638,8 @@ function statusLabel(status: MarketingDashboardItemStatus): string {
   }
 }
 
-function rawPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Record<string, unknown> | null {
-  return extractPublishReviewBundle(runtimeDoc)
+async function rawPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
+  return await extractPublishReviewBundle(runtimeDoc)
 }
 
 function envCacheRoot(stage: 1 | 2 | 3 | 4): string {
@@ -753,12 +753,12 @@ function listFiles(directoryPath: string | null | undefined, predicate?: (fileNa
   }
 }
 
-function readStageStepPayload(
+async function readStageStepPayload(
   runtimeDoc: MarketingJobRuntimeDocument,
   stage: 1 | 2 | 3 | 4,
   stepName: string,
-): Record<string, unknown> | null {
-  return readMarketingStageStepPayload(runtimeDoc, stage, stepName).payload
+): Promise<Record<string, unknown> | null> {
+  return (await readMarketingStageStepPayload(runtimeDoc, stage, stepName)).payload
 }
 
 function normalizePlatformSlug(value: string | null | undefined): string {
@@ -790,7 +790,7 @@ function extractBrandSlug(runtimeDoc: MarketingJobRuntimeDocument, planner: Prop
   return inferBrandSlug(runtimeDoc)
 }
 
-function parseProposalPlan(runtimeDoc: MarketingJobRuntimeDocument): ProposalPlan {
+async function parseProposalPlan(runtimeDoc: MarketingJobRuntimeDocument): Promise<ProposalPlan> {
   if (
     runtimeDoc.stages.strategy.status !== 'completed' &&
     runtimeDoc.stages.strategy.status !== 'failed' &&
@@ -816,10 +816,10 @@ function parseProposalPlan(runtimeDoc: MarketingJobRuntimeDocument): ProposalPla
     }
   }
 
-  const planner = readStageStepPayload(runtimeDoc, 2, 'campaign_planner')
+  const planner = await readStageStepPayload(runtimeDoc, 2, 'campaign_planner')
   const plan = recordValue(planner?.campaign_plan) ?? {}
   const brandProfiles = recordValue(planner?.brand_profiles_record) ?? {}
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   })
   return {
@@ -836,14 +836,19 @@ function parseProposalPlan(runtimeDoc: MarketingJobRuntimeDocument): ProposalPla
   }
 }
 
-function extractCampaignName(runtimeDoc: MarketingJobRuntimeDocument, status: DashboardStatusSnapshot, proposal: ProposalPlan): string {
+async function extractCampaignName(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  status: DashboardStatusSnapshot,
+  proposal: ProposalPlan,
+): Promise<string> {
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+    currentSourceUrl: runtimeDoc.inputs.brand_url || null,
+  })
   const candidates = [
     status.reviewCampaignName,
     proposal.campaignName,
     status.tenantName,
-    loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
-      currentSourceUrl: runtimeDoc.inputs.brand_url || null,
-    }).brandName,
+    validatedProfile.brandName,
     runtimeDoc.brand_kit?.brand_name,
   ]
     .map((value) => stringValue(value))
@@ -1030,12 +1035,12 @@ function publishReviewSummary(preview: Record<string, unknown>, fallback: string
   return conciseMarketingText(180, preview.caption_text, preview.summary) || fallback
 }
 
-function extractCampaignId(runtimeDoc: MarketingJobRuntimeDocument, proposal: ProposalPlan): string {
+async function extractCampaignId(runtimeDoc: MarketingJobRuntimeDocument, proposal: ProposalPlan): Promise<string> {
   if (proposal.campaignId) {
     return proposal.campaignId
   }
 
-  const publishBundle = rawPublishReviewBundle(runtimeDoc)
+  const publishBundle = await rawPublishReviewBundle(runtimeDoc)
   const reviewCampaignName = stringValue(publishBundle?.campaign_id || publishBundle?.campaign_name)
   if (reviewCampaignName) {
     return slugify(reviewCampaignName, runtimeDoc.job_id)
@@ -1138,7 +1143,7 @@ function productionArtifactsAvailable(runtimeDoc: MarketingJobRuntimeDocument): 
   )
 }
 
-function publishArtifactsAvailable(runtimeDoc: MarketingJobRuntimeDocument): boolean {
+async function publishArtifactsAvailable(runtimeDoc: MarketingJobRuntimeDocument): Promise<boolean> {
   const publish = runtimeDoc.stages.publish
   const approvalStep = approvalWorkflowStepId(runtimeDoc)
   const publishOutputs = recordValue(publish.outputs)
@@ -1151,7 +1156,7 @@ function publishArtifactsAvailable(runtimeDoc: MarketingJobRuntimeDocument): boo
     !!recordValue(publishOutputs?.review) ||
     !!recordValue(publishOutputs?.envelope) ||
     !!recordValue(primaryOutput?.launch_review) ||
-    !!extractPublishReviewBundle(runtimeDoc)
+    !!(await extractPublishReviewBundle(runtimeDoc))
   )
 }
 
@@ -1175,12 +1180,12 @@ function creativeStatus(runtimeDoc: MarketingJobRuntimeDocument): MarketingDashb
   return 'draft'
 }
 
-function publishReadyStatus(runtimeDoc: MarketingJobRuntimeDocument): MarketingDashboardItemStatus {
+async function publishReadyStatus(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingDashboardItemStatus> {
   if (approvalWorkflowStepId(runtimeDoc) === 'approve_stage_4_publish') {
     return 'ready_to_publish'
   }
   if (
-    publishArtifactsAvailable(runtimeDoc) &&
+    await publishArtifactsAvailable(runtimeDoc) &&
     (
       runtimeDoc.approvals.current?.stage === 'publish' ||
       runtimeDoc.stages.publish.status === 'awaiting_approval' ||
@@ -1335,8 +1340,8 @@ function summaryFromStatus(context: CampaignBuildContext): string {
   )
 }
 
-function buildCampaignWindowSnapshot(runtimeDoc: MarketingJobRuntimeDocument): MarketingCampaignWindow | null {
-  const reviewBundle = rawPublishReviewBundle(runtimeDoc)
+async function buildCampaignWindowSnapshot(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingCampaignWindow | null> {
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc)
   const summary = recordValue(reviewBundle?.summary)
   const campaignWindow = recordValue(summary?.campaign_window)
   const start = stringValue(campaignWindow?.start) || null
@@ -1351,11 +1356,11 @@ function approvalReviewHref(jobId: string): string {
   return `/review/${encodeURIComponent(`${jobId}::approval`)}`
 }
 
-function buildStatusSnapshot(runtimeDoc: MarketingJobRuntimeDocument, proposal: ProposalPlan): DashboardStatusSnapshot {
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+async function buildStatusSnapshot(runtimeDoc: MarketingJobRuntimeDocument, proposal: ProposalPlan): Promise<DashboardStatusSnapshot> {
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   })
-  const reviewBundle = rawPublishReviewBundle(runtimeDoc)
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc)
   const summaryHeadline =
     proposal.objective ||
     stringValue(runtimeDoc.summary?.headline) ||
@@ -1371,7 +1376,7 @@ function buildStatusSnapshot(runtimeDoc: MarketingJobRuntimeDocument, proposal: 
   return {
     tenantName: validatedProfile.brandName || runtimeDoc.brand_kit?.brand_name || null,
     brandWebsiteUrl: validatedProfile.websiteUrl || runtimeDoc.brand_kit?.source_url || runtimeDoc.inputs.brand_url || null,
-    campaignWindow: buildCampaignWindowSnapshot(runtimeDoc),
+    campaignWindow: await buildCampaignWindowSnapshot(runtimeDoc),
     currentStage: runtimeDoc.current_stage || null,
     updatedAt: runtimeDoc.updated_at || null,
     approvalRequired: !!runtimeDoc.approvals.current,
@@ -1568,11 +1573,16 @@ function campaignIdentityKey(
   ].join('::')
 }
 
-function buildCampaignContext(jobId: string, runtimeDoc: MarketingJobRuntimeDocument, options: MarketingDashboardBuildOptions): CampaignBuildContext {
-  const proposal = parseProposalPlan(runtimeDoc)
-  const status = buildStatusSnapshot(runtimeDoc, proposal)
+async function buildCampaignContext(
+  jobId: string,
+  runtimeDoc: MarketingJobRuntimeDocument,
+  options: MarketingDashboardBuildOptions,
+): Promise<CampaignBuildContext> {
+  const proposal = await parseProposalPlan(runtimeDoc)
+  const status = await buildStatusSnapshot(runtimeDoc, proposal)
   const brandSlug = extractBrandSlug(runtimeDoc, proposal)
-  const externalCampaignId = extractCampaignId(runtimeDoc, proposal)
+  const externalCampaignId = await extractCampaignId(runtimeDoc, proposal)
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc)
   return {
     jobId,
     runtimeDoc,
@@ -1581,11 +1591,11 @@ function buildCampaignContext(jobId: string, runtimeDoc: MarketingJobRuntimeDocu
     proposal,
     brandSlug,
     externalCampaignId,
-    campaignName: extractCampaignName(runtimeDoc, status, proposal),
+    campaignName: await extractCampaignName(runtimeDoc, status, proposal),
     objective: extractObjective(status, proposal),
     funnelStage: extractFunnelStage(
       proposal.objective,
-      recordValue(rawPublishReviewBundle(runtimeDoc)?.summary)?.funnel_stage,
+      recordValue(reviewBundle?.summary)?.funnel_stage,
     ),
     campaignRoot: realArtifactCampaignRootForBrand(brandSlug),
     outputRoots: lobsterOutputRoots(),
@@ -1662,7 +1672,7 @@ function resolveDashboardAssetFilePath(
   return null
 }
 
-function buildCampaignContentInternal(context: CampaignBuildContext): MarketingDashboardContentInternal {
+async function buildCampaignContentInternal(context: CampaignBuildContext): Promise<MarketingDashboardContentInternal> {
   const assetByKey = new Map<string, { priority: number; asset: MarketingDashboardAssetInternal }>()
   const postCandidates: Array<{ priority: number; post: CandidatePost }> = []
   const publishByKey = new Map<string, { priority: number; item: MarketingDashboardPublishItemInternal }>()
@@ -1676,7 +1686,7 @@ function buildCampaignContentInternal(context: CampaignBuildContext): MarketingD
   const brandUrl = context.status.brandWebsiteUrl || context.runtimeDoc.inputs.brand_url || null
   const canUseProposalArtifacts = strategyArtifactsAvailable(context.runtimeDoc)
   const canUseProductionArtifacts = productionArtifactsAvailable(context.runtimeDoc)
-  const canUsePublishArtifacts = publishArtifactsAvailable(context.runtimeDoc)
+  const canUsePublishArtifacts = await publishArtifactsAvailable(context.runtimeDoc)
 
   const addAsset = (
     candidate: CandidateAsset,
@@ -1840,7 +1850,7 @@ function buildCampaignContentInternal(context: CampaignBuildContext): MarketingD
   // aries-app container can't see the host-side lobster cache files, we can
   // still recover production_handoff from the runtime doc itself.
   const productionFinalizeOnDisk = canUseProductionArtifacts
-    ? readStageStepPayload(context.runtimeDoc, 3, 'creative_director_finalize')
+    ? await readStageStepPayload(context.runtimeDoc, 3, 'creative_director_finalize')
     : null
   const productionPrimaryOutput = recordValue(context.runtimeDoc.stages.production.primary_output)
   const productionFinalize =
@@ -2081,10 +2091,12 @@ function buildCampaignContentInternal(context: CampaignBuildContext): MarketingD
   }
 
   const publisherPayloads = canUsePublishArtifacts
-    ? PUBLISHER_STEPS.map((stepName) => {
-        const payload = readStageStepPayload(context.runtimeDoc, 4, stepName)
-        return payload ? { stepName, payload } : null
-      }).filter((entry): entry is { stepName: typeof PUBLISHER_STEPS[number]; payload: Record<string, unknown> } => !!entry)
+    ? (await Promise.all(
+        PUBLISHER_STEPS.map(async (stepName) => {
+          const payload = await readStageStepPayload(context.runtimeDoc, 4, stepName)
+          return payload ? { stepName, payload } : null
+        }),
+      )).filter((entry): entry is { stepName: typeof PUBLISHER_STEPS[number]; payload: Record<string, unknown> } => !!entry)
     : []
 
   const previewFallbackPathsByPlatform = new Map<string, string[]>()
@@ -2106,10 +2118,10 @@ function buildCampaignContentInternal(context: CampaignBuildContext): MarketingD
     rememberPreviewFallbackPath(platform, stringValue(publishPackage.fallback_svg_path))
   }
 
-  const publishBundle = canUsePublishArtifacts ? rawPublishReviewBundle(context.runtimeDoc) : null
+  const publishBundle = canUsePublishArtifacts ? await rawPublishReviewBundle(context.runtimeDoc) : null
   const platformPreviews = canUsePublishArtifacts ? recordArray(publishBundle?.platform_previews) : []
   const reviewCalendarEvents = canUsePublishArtifacts ? recordArray(recordValue(publishBundle?.content_calendar)?.events) : []
-  const publishStatus = publishReadyStatus(context.runtimeDoc)
+  const publishStatus = await publishReadyStatus(context.runtimeDoc)
 
   for (const [index, preview] of platformPreviews.entries()) {
     const platform = normalizePlatformSlug(stringValue(preview.platform_slug || preview.platform_name, 'campaign'))
@@ -2923,8 +2935,11 @@ function mergeContent(items: MarketingDashboardContentInternal[]): MarketingDash
   return merged
 }
 
-export function getMarketingDashboardContentInternal(jobId: string, options: MarketingDashboardBuildOptions = {}): MarketingDashboardContentInternal {
-  const runtimeDoc = loadMarketingJobRuntime(jobId)
+export async function getMarketingDashboardContentInternal(
+  jobId: string,
+  options: MarketingDashboardBuildOptions = {},
+): Promise<MarketingDashboardContentInternal> {
+  const runtimeDoc = await loadMarketingJobRuntime(jobId)
   if (!runtimeDoc) {
     return {
       campaigns: [],
@@ -2936,15 +2951,21 @@ export function getMarketingDashboardContentInternal(jobId: string, options: Mar
     }
   }
 
-  return buildCampaignContentInternal(buildCampaignContext(jobId, runtimeDoc, options))
+  return await buildCampaignContentInternal(await buildCampaignContext(jobId, runtimeDoc, options))
 }
 
-export function getMarketingDashboardContent(jobId: string, options: MarketingDashboardBuildOptions = {}): MarketingDashboardContent {
-  return publicFromInternal(getMarketingDashboardContentInternal(jobId, options))
+export async function getMarketingDashboardContent(
+  jobId: string,
+  options: MarketingDashboardBuildOptions = {},
+): Promise<MarketingDashboardContent> {
+  return publicFromInternal(await getMarketingDashboardContentInternal(jobId, options))
 }
 
-export function getMarketingDashboardCampaignContent(jobId: string, options: MarketingDashboardBuildOptions = {}): MarketingDashboardCampaignContent {
-  const internal = getMarketingDashboardContentInternal(jobId, options)
+export async function getMarketingDashboardCampaignContent(
+  jobId: string,
+  options: MarketingDashboardBuildOptions = {},
+): Promise<MarketingDashboardCampaignContent> {
+  const internal = await getMarketingDashboardContentInternal(jobId, options)
   return {
     campaign: internal.campaigns[0] ? sanitizeCampaign(internal.campaigns[0]) : null,
     posts: internal.posts.map(sanitizePost),
@@ -2955,15 +2976,15 @@ export function getMarketingDashboardCampaignContent(jobId: string, options: Mar
   }
 }
 
-export function getMarketingDashboardContentForTenantInternal(
+export async function getMarketingDashboardContentForTenantInternal(
   tenantId: string,
   options: MarketingDashboardBuildOptions = {},
-): MarketingDashboardContentInternal {
+): Promise<MarketingDashboardContentInternal> {
   const dedupedCampaigns: MarketingDashboardContentInternal[] = []
   const seenCampaigns = new Set<string>()
 
-  for (const jobId of listMarketingJobIdsForTenant(tenantId)) {
-    const content = getMarketingDashboardContentInternal(jobId, options)
+  for (const jobId of await listMarketingJobIdsForTenant(tenantId)) {
+    const content = await getMarketingDashboardContentInternal(jobId, options)
     const campaign = content.campaigns[0]
     const dedupeKey = campaign ? campaignIdentityKey(campaign) : `job::${jobId}`
     if (seenCampaigns.has(dedupeKey)) {
@@ -2977,15 +2998,18 @@ export function getMarketingDashboardContentForTenantInternal(
   return mergeContent(dedupedCampaigns)
 }
 
-export function getMarketingDashboardContentForTenant(
+export async function getMarketingDashboardContentForTenant(
   tenantId: string,
   options: MarketingDashboardBuildOptions = {},
-): MarketingDashboardContent {
-  return publicFromInternal(getMarketingDashboardContentForTenantInternal(tenantId, options))
+): Promise<MarketingDashboardContent> {
+  return publicFromInternal(await getMarketingDashboardContentForTenantInternal(tenantId, options))
 }
 
-export function listMarketingDashboardAssetsForJob(jobId: string, options: MarketingDashboardBuildOptions = {}): MarketingDashboardAssetInternal[] {
-  return getMarketingDashboardContentInternal(jobId, options).assets
+export async function listMarketingDashboardAssetsForJob(
+  jobId: string,
+  options: MarketingDashboardBuildOptions = {},
+): Promise<MarketingDashboardAssetInternal[]> {
+  return (await getMarketingDashboardContentInternal(jobId, options)).assets
 }
 
 export function dashboardDateRangeText(window: MarketingCampaignWindow | null): string {

--- a/backend/marketing/jobs-approve.ts
+++ b/backend/marketing/jobs-approve.ts
@@ -6,7 +6,7 @@ export type { ApproveMarketingJobRequest, ApproveMarketingJobResponse } from './
 export async function approveMarketingJob(
   input: ApproveMarketingJobRequest
 ): Promise<ApproveMarketingJobResponse> {
-  const doc = loadMarketingJobRuntime(input.jobId);
+  const doc = await loadMarketingJobRuntime(input.jobId);
   if (!doc) {
     return {
       status: 'error',

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -766,9 +766,9 @@ function buildTimeline(
   });
 }
 
-function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingReviewBundle | null {
+async function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingReviewBundle | null> {
   const jobId = runtimeDoc.job_id;
-  const resolvedReview = resolvePublishReviewBundle(runtimeDoc);
+  const resolvedReview = await resolvePublishReviewBundle(runtimeDoc);
   const review = resolvedReview.reviewPayload;
   const reviewBundle = resolvedReview.reviewBundle;
   if (!reviewBundle) {
@@ -779,7 +779,7 @@ function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): MarketingRe
   const scriptPreview = recordValue(reviewBundle.script_preview);
   const reviewPacket = recordValue(reviewBundle.review_packet);
   const artifactPaths = recordValue(reviewBundle.artifact_paths);
-  const assetLinks = buildMarketingAssetLinks(jobId, runtimeDoc);
+  const assetLinks = await buildMarketingAssetLinks(jobId, runtimeDoc);
   const linkById = new Map(assetLinks.map((asset) => [asset.id, asset] as const));
 
   return {
@@ -977,16 +977,16 @@ function fallbackPlatformMediaAssets(assetLinks: MarketingAssetLink[], platformS
   });
 }
 
-function rawPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Record<string, unknown> | null {
-  return resolvePublishReviewBundle(runtimeDoc).reviewBundle;
+async function rawPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
+  return (await resolvePublishReviewBundle(runtimeDoc)).reviewBundle;
 }
 
-function publishReviewSource(runtimeDoc: MarketingJobRuntimeDocument): 'runtime' | 'merged_runtime_artifacts' | 'artifact_fallback' | 'none' {
-  return resolvePublishReviewBundle(runtimeDoc).source;
+async function publishReviewSource(runtimeDoc: MarketingJobRuntimeDocument): Promise<'runtime' | 'merged_runtime_artifacts' | 'artifact_fallback' | 'none'> {
+  return (await resolvePublishReviewBundle(runtimeDoc)).source;
 }
 
-function buildCampaignWindow(runtimeDoc: MarketingJobRuntimeDocument): MarketingCampaignWindow | null {
-  const reviewBundle = rawPublishReviewBundle(runtimeDoc);
+async function buildCampaignWindow(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingCampaignWindow | null> {
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc);
   const summary = recordValue(reviewBundle?.summary);
   const campaignWindow = recordValue(summary?.campaign_window);
 
@@ -1031,8 +1031,8 @@ function buildAssetPreviewCards(jobId: string, reviewBundle: MarketingReviewBund
   }));
 }
 
-function buildCalendarEvents(runtimeDoc: MarketingJobRuntimeDocument): MarketingCalendarEvent[] {
-  const reviewBundle = rawPublishReviewBundle(runtimeDoc);
+async function buildCalendarEvents(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingCalendarEvent[]> {
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc);
   const contentCalendar = recordValue(reviewBundle?.content_calendar);
   const events = recordArray(contentCalendar?.events);
 
@@ -1056,12 +1056,12 @@ function buildCalendarEvents(runtimeDoc: MarketingJobRuntimeDocument): Marketing
     .filter((event): event is MarketingCalendarEvent => !!event);
 }
 
-function buildPostCounts(
+async function buildPostCounts(
   runtimeDoc: MarketingJobRuntimeDocument,
   reviewBundle: MarketingReviewBundle | null,
   calendarEvents: MarketingCalendarEvent[]
-): { plannedPostCount: number | null; createdPostCount: number | null } {
-  const rawBundle = rawPublishReviewBundle(runtimeDoc);
+): Promise<{ plannedPostCount: number | null; createdPostCount: number | null }> {
+  const rawBundle = await rawPublishReviewBundle(runtimeDoc);
   const summary = recordValue(rawBundle?.summary);
   const explicitPlanned = numberValue(summary?.planned_posts);
   const explicitCreated = numberValue(summary?.created_posts);
@@ -1079,10 +1079,10 @@ function buildPostCounts(
   };
 }
 
-function buildMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
-  assertMarketingRuntimeSchemas();
+async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatusResponse> {
+  await assertMarketingRuntimeSchemas();
 
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     return {
       jobId,
@@ -1129,13 +1129,13 @@ function buildMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
   };
   const state = deriveState(runtimeDoc, stageStatus);
   const approval = buildApproval(jobId, runtimeDoc);
-  const reviewBundle = buildReviewBundle(runtimeDoc);
-  const campaignWindow = buildCampaignWindow(runtimeDoc);
+  const reviewBundle = await buildReviewBundle(runtimeDoc);
+  const campaignWindow = await buildCampaignWindow(runtimeDoc);
   const durationDays = buildDurationDays(campaignWindow);
   const assetPreviewCards = buildAssetPreviewCards(jobId, reviewBundle);
-  const calendarEvents = buildCalendarEvents(runtimeDoc);
-  const postCounts = buildPostCounts(runtimeDoc, reviewBundle, calendarEvents);
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+  const calendarEvents = await buildCalendarEvents(runtimeDoc);
+  const postCounts = await buildPostCounts(runtimeDoc, reviewBundle, calendarEvents);
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   });
   if (shouldLogMarketingJobStatus()) {
@@ -1143,7 +1143,7 @@ function buildMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
       event: 'job-status',
       jobId,
       tenantId: runtimeDoc.tenant_id,
-      reviewBundleSource: publishReviewSource(runtimeDoc),
+      reviewBundleSource: await publishReviewSource(runtimeDoc),
       reviewBundleReason: reviewBundle ? 'hydrated' : 'no_real_publish_review_artifacts',
     });
   }
@@ -1182,6 +1182,6 @@ function buildMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
   };
 }
 
-export function getMarketingJobStatus(jobId: string): MarketingJobStatusResponse {
+export async function getMarketingJobStatus(jobId: string): Promise<MarketingJobStatusResponse> {
   return buildMarketingJobStatus(jobId);
 }

--- a/backend/marketing/orchestrator.ts
+++ b/backend/marketing/orchestrator.ts
@@ -163,7 +163,7 @@ async function ensureRuntimeBrandKit(doc: MarketingJobRuntimeDocument): Promise<
     return;
   }
 
-  const existingBrandKit = loadTenantBrandKit(doc.tenant_id);
+  const existingBrandKit = await loadTenantBrandKit(doc.tenant_id);
   if (existingBrandKit && existingBrandKit.source_url === brandUrl) {
     doc.brand_kit = runtimeBrandKitReference(existingBrandKit, tenantBrandKitPath(doc.tenant_id));
     return;
@@ -750,8 +750,8 @@ class MarketingJobCancelledError extends Error {
  * state and throws `MarketingJobCancelledError` so the caller bails without
  * starting the next stage.
  */
-function applySoftCancelIfRequested(doc: MarketingJobRuntimeDocument): void {
-  const fresh = loadMarketingJobRuntime(doc.job_id);
+async function applySoftCancelIfRequested(doc: MarketingJobRuntimeDocument): Promise<void> {
+  const fresh = await loadMarketingJobRuntime(doc.job_id);
   const armed = fresh?.soft_cancel_requested_at;
   if (!armed) {
     return;
@@ -772,7 +772,7 @@ function applySoftCancelIfRequested(doc: MarketingJobRuntimeDocument): void {
 }
 
 async function runResearchStage(doc: MarketingJobRuntimeDocument): Promise<void> {
-  applySoftCancelIfRequested(doc);
+  await applySoftCancelIfRequested(doc);
   setJobRunning(doc, 'research', 'running research stage');
   markStageInProgress(doc, 'research');
   saveMarketingJobRuntime(doc.job_id, doc);
@@ -793,7 +793,7 @@ async function runResearchStage(doc: MarketingJobRuntimeDocument): Promise<void>
 
   const envelope = await runMarketingPipeline(doc);
   const primaryOutput = primaryOutputRecord(envelope);
-  const capture = collectResearchStageArtifacts(primaryOutput);
+  const capture = await collectResearchStageArtifacts(primaryOutput);
   const summary = summarizeResearch(primaryOutput);
   const runId = capture.runId || runIdFromPrimaryOutput(primaryOutput);
   markStageCompleted(doc, 'research', {
@@ -854,7 +854,7 @@ async function finalizeStrategyAndRunProductionReview(
 
   const envelope = await resumeMarketingPipeline(resumeToken);
   const primaryOutput = primaryOutputRecord(envelope);
-  const strategyReviewCapture = collectStrategyReviewArtifacts(primaryOutput, doc);
+  const strategyReviewCapture = await collectStrategyReviewArtifacts(primaryOutput, doc);
   const strategy = summarizeStrategy(primaryOutput);
   markStageCompleted(doc, 'strategy', {
     runId: strategyReviewCapture.runId ?? runIdFromPrimaryOutput(primaryOutput) ?? getStageRecord(doc, 'research').run_id,
@@ -917,7 +917,7 @@ async function finalizeProductionAndRunPublishReview(
 
   const envelope = await resumeMarketingPipeline(resumeToken);
   const primaryOutput = primaryOutputRecord(envelope);
-  const productionReviewCapture = collectProductionReviewArtifacts(primaryOutput, doc);
+  const productionReviewCapture = await collectProductionReviewArtifacts(primaryOutput, doc);
   const production = summarizeProduction(primaryOutput);
   markStageCompleted(doc, 'production', {
     runId: productionReviewCapture.runId ?? runIdFromPrimaryOutput(primaryOutput) ?? getStageRecord(doc, 'strategy').run_id,
@@ -983,7 +983,7 @@ async function advancePublishStage(doc: MarketingJobRuntimeDocument, resumeToken
 
   const envelope = await resumeMarketingPipeline(resumeToken);
   const primaryOutput = primaryOutputRecord(envelope);
-  const publishReviewCapture = collectPublishReviewArtifacts(primaryOutput, doc);
+  const publishReviewCapture = await collectPublishReviewArtifacts(primaryOutput, doc);
   const publish = summarizePublish(primaryOutput);
   if (envelope.requiresApproval?.resumeToken) {
     const approval = publishPausedApprovalMessage(

--- a/backend/marketing/publish-review.ts
+++ b/backend/marketing/publish-review.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -61,17 +62,20 @@ function uniqueStrings(values: Array<string | null | undefined>): string[] {
   return Array.from(new Set(values.map((value) => stringValue(value)).filter(Boolean)));
 }
 
-function readJsonIfExists(filePath: string | null | undefined): Record<string, unknown> | null {
-  if (!filePath || !existsSync(filePath)) {
+async function readJsonIfExists(filePath: string | null | undefined): Promise<Record<string, unknown> | null> {
+  if (!filePath) {
     return null;
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+    const parsed = JSON.parse(await readFile(filePath, 'utf8'));
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : null;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
     return null;
   }
 }
@@ -120,15 +124,15 @@ type PublishStepPayloadCandidate = {
   mtimeMs: number;
 };
 
-function readExactPublishStepPayload(runtimeDoc: MarketingJobRuntimeDocument, stepName: string, runId: string): PublishStepPayloadCandidate | null {
+async function readExactPublishStepPayload(runtimeDoc: MarketingJobRuntimeDocument, stepName: string, runId: string): Promise<PublishStepPayloadCandidate | null> {
   const cachePath = path.join(cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache'), runId, `${stepName}.json`);
-  const cached = readJsonIfExists(cachePath);
+  const cached = await readJsonIfExists(cachePath);
   if (cached) {
     try {
       return {
         runId,
         payload: cached,
-        mtimeMs: statSync(cachePath).mtimeMs,
+        mtimeMs: (await stat(cachePath)).mtimeMs,
       };
     } catch {
       return {
@@ -141,13 +145,13 @@ function readExactPublishStepPayload(runtimeDoc: MarketingJobRuntimeDocument, st
 
   for (const outputRoot of lobsterOutputRoots()) {
     const logPath = path.join(outputRoot, 'logs', runId, 'stage-4-publish-optimize', `${stepName}.json`);
-    const logged = readJsonIfExists(logPath);
+    const logged = await readJsonIfExists(logPath);
     if (logged) {
       try {
         return {
           runId,
           payload: logged,
-          mtimeMs: statSync(logPath).mtimeMs,
+          mtimeMs: (await stat(logPath)).mtimeMs,
         };
       } catch {
         return {
@@ -209,10 +213,10 @@ function scorePublishStepPayloadCandidate(
   };
 }
 
-function collectFallbackPublishStepPayloadCandidates(
+async function collectFallbackPublishStepPayloadCandidates(
   runtimeDoc: MarketingJobRuntimeDocument,
   stepName: string
-): PublishStepPayloadCandidate[] {
+): Promise<PublishStepPayloadCandidate[]> {
   const prefix = competitorSlug(runtimeDoc);
   if (!prefix) {
     return [];
@@ -223,7 +227,7 @@ function collectFallbackPublishStepPayloadCandidates(
 
   const cacheDir = cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache');
   if (existsSync(cacheDir)) {
-    for (const entry of readdirSync(cacheDir)) {
+    for (const entry of await readdir(cacheDir)) {
       if (!entry.startsWith(`${prefix}-`)) {
         continue;
       }
@@ -231,13 +235,13 @@ function collectFallbackPublishStepPayloadCandidates(
       if (seenPaths.has(candidatePath)) {
         continue;
       }
-      const payload = readJsonIfExists(candidatePath);
+      const payload = await readJsonIfExists(candidatePath);
       if (!payload) {
         continue;
       }
       seenPaths.add(candidatePath);
       try {
-        candidates.push({ runId: entry, payload, mtimeMs: statSync(candidatePath).mtimeMs });
+        candidates.push({ runId: entry, payload, mtimeMs: (await stat(candidatePath)).mtimeMs });
       } catch {
         candidates.push({ runId: entry, payload, mtimeMs: 0 });
       }
@@ -249,7 +253,7 @@ function collectFallbackPublishStepPayloadCandidates(
     if (!existsSync(logsRoot)) {
       continue;
     }
-    for (const entry of readdirSync(logsRoot)) {
+    for (const entry of await readdir(logsRoot)) {
       if (!entry.startsWith(`${prefix}-`)) {
         continue;
       }
@@ -257,13 +261,13 @@ function collectFallbackPublishStepPayloadCandidates(
       if (seenPaths.has(candidatePath)) {
         continue;
       }
-      const payload = readJsonIfExists(candidatePath);
+      const payload = await readJsonIfExists(candidatePath);
       if (!payload) {
         continue;
       }
       seenPaths.add(candidatePath);
       try {
-        candidates.push({ runId: entry, payload, mtimeMs: statSync(candidatePath).mtimeMs });
+        candidates.push({ runId: entry, payload, mtimeMs: (await stat(candidatePath)).mtimeMs });
       } catch {
         candidates.push({ runId: entry, payload, mtimeMs: 0 });
       }
@@ -281,16 +285,16 @@ function collectFallbackPublishStepPayloadCandidates(
   });
 }
 
-function readPublishStepPayload(runtimeDoc: MarketingJobRuntimeDocument, stepName: string): Record<string, unknown> | null {
+async function readPublishStepPayload(runtimeDoc: MarketingJobRuntimeDocument, stepName: string): Promise<Record<string, unknown> | null> {
   const explicitRunId = stringValue(runtimeDoc.stages.publish.run_id);
   if (explicitRunId) {
-    const explicit = readExactPublishStepPayload(runtimeDoc, stepName, explicitRunId);
+    const explicit = await readExactPublishStepPayload(runtimeDoc, stepName, explicitRunId);
     if (explicit) {
       return explicit.payload;
     }
   }
 
-  for (const candidate of collectFallbackPublishStepPayloadCandidates(runtimeDoc, stepName)) {
+  for (const candidate of await collectFallbackPublishStepPayloadCandidates(runtimeDoc, stepName)) {
     return candidate.payload;
   }
 
@@ -644,13 +648,18 @@ function buildPublisherStepNames(): string[] {
   ];
 }
 
-function collectPublisherPayloads(runtimeDoc: MarketingJobRuntimeDocument): Array<Record<string, unknown>> {
-  return buildPublisherStepNames()
-    .map((stepName) => readPublishStepPayload(runtimeDoc, stepName))
-    .filter((payload): payload is Record<string, unknown> => !!payload);
+async function collectPublisherPayloads(runtimeDoc: MarketingJobRuntimeDocument): Promise<Array<Record<string, unknown>>> {
+  const payloads: Array<Record<string, unknown>> = [];
+  for (const stepName of buildPublisherStepNames()) {
+    const payload = await readPublishStepPayload(runtimeDoc, stepName);
+    if (payload) {
+      payloads.push(payload);
+    }
+  }
+  return payloads;
 }
 
-function reviewPackageCandidatePaths(runtimeDoc: MarketingJobRuntimeDocument, campaignName: string | null): string[] {
+async function reviewPackageCandidatePaths(runtimeDoc: MarketingJobRuntimeDocument, campaignName: string | null): Promise<string[]> {
   const brandSlug = inferBrandSlug(runtimeDoc);
   const normalizedCampaignName = stringValue(campaignName);
   const candidates = new Set<string>();
@@ -664,7 +673,7 @@ function reviewPackageCandidatePaths(runtimeDoc: MarketingJobRuntimeDocument, ca
       if (!existsSync(reviewRoot)) {
         continue;
       }
-      for (const platformEntry of readdirSync(reviewRoot)) {
+      for (const platformEntry of await readdir(reviewRoot)) {
         const filePath = path.join(reviewRoot, platformEntry, 'review-package.json');
         if (existsSync(filePath)) {
           candidates.add(filePath);
@@ -727,15 +736,15 @@ function resolvePublishArtifactBrandSlug(
   return candidates[0] || null;
 }
 
-function buildFallbackPublishReviewBundle(
+async function buildFallbackPublishReviewBundle(
   runtimeDoc: MarketingJobRuntimeDocument,
   reviewPayload: Record<string, unknown> | null,
-): Record<string, unknown> | null {
-  const preflight = readPublishStepPayload(runtimeDoc, 'performance_marketer_preflight');
+): Promise<Record<string, unknown> | null> {
+  const preflight = await readPublishStepPayload(runtimeDoc, 'performance_marketer_preflight');
   const productionHandoff = recordValue(preflight?.production_handoff);
   const productionBrief = recordValue(productionHandoff?.production_brief);
   const reviewBundle = recordValue(reviewPayload?.review_bundle);
-  const publisherPayloads = collectPublisherPayloads(runtimeDoc);
+  const publisherPayloads = await collectPublisherPayloads(runtimeDoc);
   const reviewPackagePaths = new Set<string>();
 
   for (const payload of publisherPayloads) {
@@ -751,79 +760,80 @@ function buildFallbackPublishReviewBundle(
     stringValue(reviewPayload?.campaign_name) ||
     stringValue(preflight?.campaign_name);
   const artifactBrandSlug = resolvePublishArtifactBrandSlug(runtimeDoc, campaignName || null);
-  for (const candidatePath of reviewPackageCandidatePaths(runtimeDoc, campaignName || null)) {
+  for (const candidatePath of await reviewPackageCandidatePaths(runtimeDoc, campaignName || null)) {
     const resolved = resolveMarketingArtifactPath(candidatePath);
     if (resolved) {
       reviewPackagePaths.add(resolved);
     }
   }
 
-  const landingDetails = readLandingPageArtifactDetails({
+  const landingDetails = await readLandingPageArtifactDetails({
     path: stringValue(recordValue(reviewBundle?.landing_page_preview)?.landing_page_path) || null,
     runtimeDoc,
     brandSlug: artifactBrandSlug,
   });
   const runtimeScriptPreview = recordValue(reviewBundle?.script_preview);
-  const scriptDetails = readScriptArtifactDetails({
+  const scriptDetails = await readScriptArtifactDetails({
     metaScriptPath: stringValue(runtimeScriptPreview?.meta_script_path) || null,
     shortVideoScriptPath: stringValue(runtimeScriptPreview?.short_video_script_path) || null,
     runtimeDoc,
     brandSlug: artifactBrandSlug,
   });
-  const productionReview = readMarketingStageStepPayload(runtimeDoc, 3, 'production_review_preview');
-  const platformPreviews = Array.from(reviewPackagePaths).flatMap((reviewPackagePath) => {
-      const reviewPackage = readJsonIfExists(reviewPackagePath);
-      if (!reviewPackage) {
-        return [];
-      }
-      const packageRecord = reviewPackage;
-      const rawPlatformSlug = stringValue(packageRecord.platform || path.basename(path.dirname(reviewPackagePath)));
-      const slug = platformSlug(rawPlatformSlug);
-      const publisherPayload = publisherPayloads.find((payload) =>
-        platformSlug(stringValue(payload.platform || payload.type)) === slug,
-      ) || null;
-      const publishPackage = recordValue(publisherPayload?.publish_package);
-      const packageAssetPaths = normalizeAssetPaths(packageRecord.asset_paths);
-      const copyDetails = readPublishCopyDetails(
-        stringValue(packageAssetPaths?.copy_path) ||
-          stringValue(publishPackage?.copy_path),
-      );
-      const mediaPaths = uniqueStrings([
-        resolveMarketingArtifactPath(stringValue(packageAssetPaths?.image_path)),
-        resolveMarketingArtifactPath(stringValue(packageAssetPaths?.poster_image_path)),
-        resolveMarketingArtifactPath(stringValue(publishPackage?.image_path)),
-        resolveMarketingArtifactPath(stringValue(publishPackage?.fallback_svg_path)),
-      ]);
-      return [{
-        platform_slug: slug,
-        platform_name: platformNameFromSlug(slug),
-        channel_type: channelTypeForPlatform(slug),
-        rendered_video_asset_id: firstRenderedVideoAssetIdForPlatform(runtimeDoc, slug),
-        summary:
-          preferredText(copyDetails.bodyLines[0], copyDetails.headline, stringValue(packageRecord.summary)) ||
-          ARTIFACT_UNAVAILABLE_TEXT,
-        headline: preferredText(copyDetails.headline),
-        hook:
-          slug === 'meta-ads'
-            ? preferredText(scriptDetails.metaAdHook, copyDetails.headline)
-            : slug === 'tiktok' || slug === 'youtube'
-              ? preferredText(scriptDetails.shortVideoOpeningLine, copyDetails.headline)
-              : preferredText(copyDetails.headline),
-        caption_text: preferredText(copyDetails.bodyLines[0]),
-        cta: preferredText(copyDetails.cta, landingDetails.cta),
-        media_paths: mediaPaths,
-        asset_paths: {
-          contract_path:
-            resolveMarketingArtifactPath(stringValue(packageRecord.contract_path)) ||
-            resolveMarketingArtifactPath(stringValue(publisherPayload?.contract_path)) ||
-            undefined,
-          brief_path: resolveMarketingArtifactPath(reviewPackagePath) || undefined,
-          landing_page_path: landingDetails.path || undefined,
-          copy_path: copyDetails.path || undefined,
-          image_path: mediaPaths[0] || undefined,
-        },
-      } satisfies Record<string, unknown>];
-    });
+  const productionReview = await readMarketingStageStepPayload(runtimeDoc, 3, 'production_review_preview');
+  const platformPreviews: Record<string, unknown>[] = [];
+  for (const reviewPackagePath of reviewPackagePaths) {
+    const reviewPackage = await readJsonIfExists(reviewPackagePath);
+    if (!reviewPackage) {
+      continue;
+    }
+    const packageRecord = reviewPackage;
+    const rawPlatformSlug = stringValue(packageRecord.platform || path.basename(path.dirname(reviewPackagePath)));
+    const slug = platformSlug(rawPlatformSlug);
+    const publisherPayload = publisherPayloads.find((payload) =>
+      platformSlug(stringValue(payload.platform || payload.type)) === slug,
+    ) || null;
+    const publishPackage = recordValue(publisherPayload?.publish_package);
+    const packageAssetPaths = normalizeAssetPaths(packageRecord.asset_paths);
+    const copyDetails = await readPublishCopyDetails(
+      stringValue(packageAssetPaths?.copy_path) ||
+        stringValue(publishPackage?.copy_path),
+    );
+    const mediaPaths = uniqueStrings([
+      resolveMarketingArtifactPath(stringValue(packageAssetPaths?.image_path)),
+      resolveMarketingArtifactPath(stringValue(packageAssetPaths?.poster_image_path)),
+      resolveMarketingArtifactPath(stringValue(publishPackage?.image_path)),
+      resolveMarketingArtifactPath(stringValue(publishPackage?.fallback_svg_path)),
+    ]);
+    platformPreviews.push({
+      platform_slug: slug,
+      platform_name: platformNameFromSlug(slug),
+      channel_type: channelTypeForPlatform(slug),
+      rendered_video_asset_id: firstRenderedVideoAssetIdForPlatform(runtimeDoc, slug),
+      summary:
+        preferredText(copyDetails.bodyLines[0], copyDetails.headline, stringValue(packageRecord.summary)) ||
+        ARTIFACT_UNAVAILABLE_TEXT,
+      headline: preferredText(copyDetails.headline),
+      hook:
+        slug === 'meta-ads'
+          ? preferredText(scriptDetails.metaAdHook, copyDetails.headline)
+          : slug === 'tiktok' || slug === 'youtube'
+            ? preferredText(scriptDetails.shortVideoOpeningLine, copyDetails.headline)
+            : preferredText(copyDetails.headline),
+      caption_text: preferredText(copyDetails.bodyLines[0]),
+      cta: preferredText(copyDetails.cta, landingDetails.cta),
+      media_paths: mediaPaths,
+      asset_paths: {
+        contract_path:
+          resolveMarketingArtifactPath(stringValue(packageRecord.contract_path)) ||
+          resolveMarketingArtifactPath(stringValue(publisherPayload?.contract_path)) ||
+          undefined,
+        brief_path: resolveMarketingArtifactPath(reviewPackagePath) || undefined,
+        landing_page_path: landingDetails.path || undefined,
+        copy_path: copyDetails.path || undefined,
+        image_path: mediaPaths[0] || undefined,
+      },
+    } satisfies Record<string, unknown>);
+  }
 
   const previewPath =
     resolveMarketingArtifactPath(stringValue(recordValue(reviewPayload?.artifacts)?.preview_path)) ||
@@ -835,7 +845,7 @@ function buildFallbackPublishReviewBundle(
     stringValue(runtimeDoc.inputs.request?.brandUrl) ||
     stringValue(runtimeDoc.inputs.brand_url) ||
     '';
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeSourceUrl || null,
   });
   const validatedLandingHooks = recordValue(validatedProfile.hooks)?.['landing-page'];
@@ -948,12 +958,12 @@ function runtimeDocFallbackCampaignName(
   return stringValue(primaryBundle.campaign_name || fallbackBundle.campaign_name, 'Campaign');
 }
 
-export function resolvePublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): PublishReviewBundleResolution {
-  const reviewPayload = extractPublishReviewPayload(runtimeDoc);
+export async function resolvePublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<PublishReviewBundleResolution> {
+  const reviewPayload = await extractPublishReviewPayload(runtimeDoc);
   const runtimeBundle = normalizeReviewBundle(recordValue(reviewPayload?.review_bundle));
   const fallbackBundle =
     publishStageHasRuntimeContext(runtimeDoc) || runtimeBundle
-      ? buildFallbackPublishReviewBundle(runtimeDoc, reviewPayload)
+      ? await buildFallbackPublishReviewBundle(runtimeDoc, reviewPayload)
       : null;
 
   if (runtimeBundle && !fallbackBundle) {
@@ -988,7 +998,7 @@ export function resolvePublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocume
   };
 }
 
-export function extractPublishReviewPayload(runtimeDoc: MarketingJobRuntimeDocument): Record<string, unknown> | null {
+export async function extractPublishReviewPayload(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
   const publishStage = runtimeDoc.stages.publish;
   const reviewOutput = recordValue(publishStage.outputs.review);
   if (reviewOutput) {
@@ -1002,7 +1012,7 @@ export function extractPublishReviewPayload(runtimeDoc: MarketingJobRuntimeDocum
   }
 
   const loggedReview = publishStageHasRuntimeContext(runtimeDoc)
-    ? readPublishStepPayload(runtimeDoc, 'launch_review_preview')
+    ? await readPublishStepPayload(runtimeDoc, 'launch_review_preview')
     : null;
   if (loggedReview) {
     return loggedReview;
@@ -1011,6 +1021,6 @@ export function extractPublishReviewPayload(runtimeDoc: MarketingJobRuntimeDocum
   return primaryOutput;
 }
 
-export function extractPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Record<string, unknown> | null {
-  return resolvePublishReviewBundle(runtimeDoc).reviewBundle;
+export async function extractPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
+  return (await resolvePublishReviewBundle(runtimeDoc)).reviewBundle;
 }

--- a/backend/marketing/real-artifacts.ts
+++ b/backend/marketing/real-artifacts.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
@@ -127,28 +128,28 @@ export function resolveMarketingArtifactPath(filePath: string | null | undefined
   return null;
 }
 
-export function readMarketingArtifactText(filePath: string | null | undefined): string | null {
+export async function readMarketingArtifactText(filePath: string | null | undefined): Promise<string | null> {
   const resolvedPath = resolveMarketingArtifactPath(filePath);
   if (!resolvedPath) {
     return null;
   }
 
   try {
-    const text = readFileSync(resolvedPath, 'utf8').trim();
+    const text = (await readFile(resolvedPath, 'utf8')).trim();
     return text.length > 0 ? text : null;
   } catch {
     return null;
   }
 }
 
-export function readMarketingArtifactJson(filePath: string | null | undefined): Record<string, unknown> | null {
+export async function readMarketingArtifactJson(filePath: string | null | undefined): Promise<Record<string, unknown> | null> {
   const resolvedPath = resolveMarketingArtifactPath(filePath);
   if (!resolvedPath) {
     return null;
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(resolvedPath, 'utf8'));
+    const parsed = JSON.parse(await readFile(resolvedPath, 'utf8'));
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : null;
@@ -308,14 +309,14 @@ function firstReadablePath(paths: Array<string | null | undefined>): string | nu
   return null;
 }
 
-function firstFileMatching(dirPath: string | null, matcher: (fileName: string) => boolean): string | null {
+async function firstFileMatching(dirPath: string | null, matcher: (fileName: string) => boolean): Promise<string | null> {
   const resolvedDir = resolveMarketingArtifactPath(dirPath);
   if (!resolvedDir || !existsSync(resolvedDir)) {
     return null;
   }
 
   try {
-    const fileName = readdirSync(resolvedDir)
+    const fileName = (await readdir(resolvedDir))
       .filter((entry) => matcher(entry))
       .sort()[0];
     return fileName ? path.join(resolvedDir, fileName) : null;
@@ -358,18 +359,18 @@ export type LandingPageArtifactDetails = {
   sections: string[];
 };
 
-export function readLandingPageArtifactDetails(input: {
+export async function readLandingPageArtifactDetails(input: {
   path?: string | null;
   runtimeDoc?: MarketingJobRuntimeDocument | null;
   brandSlug?: string | null;
-}): LandingPageArtifactDetails {
+}): Promise<LandingPageArtifactDetails> {
   const brandSlug = stringValue(input.brandSlug) || (input.runtimeDoc ? inferBrandSlug(input.runtimeDoc) : '');
   const campaignRoot = brandSlug ? campaignRootForBrand(brandSlug) : null;
   const resolvedPath = firstReadablePath([
     input.path,
-    firstFileMatching(campaignRoot ? path.join(campaignRoot, 'landing-pages') : null, (fileName) => fileName.endsWith('.html')),
+    await firstFileMatching(campaignRoot ? path.join(campaignRoot, 'landing-pages') : null, (fileName) => fileName.endsWith('.html')),
   ]);
-  const html = readMarketingArtifactText(resolvedPath);
+  const html = await readMarketingArtifactText(resolvedPath);
   if (!html) {
     return {
       path: resolvedPath,
@@ -419,14 +420,14 @@ function cleanMarkdownLines(value: string | null | undefined): string[] {
     .filter(Boolean);
 }
 
-function scriptPaths(brandSlug: string): { metaScriptPath: string | null; shortVideoPath: string | null } {
+async function scriptPaths(brandSlug: string): Promise<{ metaScriptPath: string | null; shortVideoPath: string | null }> {
   const campaignRoot = campaignRootForBrand(brandSlug);
   return {
-    metaScriptPath: firstFileMatching(
+    metaScriptPath: await firstFileMatching(
       campaignRoot ? path.join(campaignRoot, 'scripts') : null,
       (fileName) => /meta/i.test(fileName) && /\.(md|txt|json)$/i.test(fileName),
     ),
-    shortVideoPath: firstFileMatching(
+    shortVideoPath: await firstFileMatching(
       campaignRoot ? path.join(campaignRoot, 'scripts') : null,
       (fileName) => /(video|reel|short)/i.test(fileName) && /\.(md|txt|json)$/i.test(fileName),
     ),
@@ -442,20 +443,20 @@ export type ScriptArtifactDetails = {
   shortVideoBeats: string[];
 };
 
-export function readScriptArtifactDetails(input: {
+export async function readScriptArtifactDetails(input: {
   metaScriptPath?: string | null;
   shortVideoScriptPath?: string | null;
   runtimeDoc?: MarketingJobRuntimeDocument | null;
   brandSlug?: string | null;
-}): ScriptArtifactDetails {
+}): Promise<ScriptArtifactDetails> {
   const brandSlug = stringValue(input.brandSlug) || (input.runtimeDoc ? inferBrandSlug(input.runtimeDoc) : '');
-  const fallbackPaths = brandSlug ? scriptPaths(brandSlug) : { metaScriptPath: null, shortVideoPath: null };
+  const fallbackPaths = brandSlug ? await scriptPaths(brandSlug) : { metaScriptPath: null, shortVideoPath: null };
   const metaScriptPath = firstReadablePath([input.metaScriptPath, fallbackPaths.metaScriptPath]);
   const shortVideoScriptPath = firstReadablePath([input.shortVideoScriptPath, fallbackPaths.shortVideoPath]);
-  const metaText = readMarketingArtifactText(metaScriptPath);
-  const videoText = readMarketingArtifactText(shortVideoScriptPath);
-  const metaJson = readMarketingArtifactJson(metaScriptPath);
-  const videoJson = readMarketingArtifactJson(shortVideoScriptPath);
+  const metaText = await readMarketingArtifactText(metaScriptPath);
+  const videoText = await readMarketingArtifactText(shortVideoScriptPath);
+  const metaJson = await readMarketingArtifactJson(metaScriptPath);
+  const videoJson = await readMarketingArtifactJson(shortVideoScriptPath);
 
   const metaAdHook =
     normalizeArtifactText(stringValue(metaJson?.hook || metaJson?.headline)) ||
@@ -499,9 +500,9 @@ export type PublishCopyDetails = {
   proofPoints: string[];
 };
 
-export function readPublishCopyDetails(filePath: string | null | undefined): PublishCopyDetails {
+export async function readPublishCopyDetails(filePath: string | null | undefined): Promise<PublishCopyDetails> {
   const resolvedPath = resolveMarketingArtifactPath(filePath);
-  const payload = readMarketingArtifactJson(resolvedPath);
+  const payload = await readMarketingArtifactJson(resolvedPath);
   if (payload) {
     return {
       path: resolvedPath,
@@ -512,7 +513,7 @@ export function readPublishCopyDetails(filePath: string | null | undefined): Pub
     };
   }
 
-  const text = readMarketingArtifactText(resolvedPath);
+  const text = await readMarketingArtifactText(resolvedPath);
   if (!text) {
     return {
       path: resolvedPath,

--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { normalizeMetaLocatorUrl, normalizeMetaPageId } from '@/lib/marketing-competitor';
@@ -337,7 +338,7 @@ export function isPipelineActive(doc: MarketingJobRuntimeDocument): boolean {
   return true;
 }
 
-export function assertMarketingRuntimeSchemas(): void {
+export async function assertMarketingRuntimeSchemas(): Promise<void> {
   for (const fileName of REQUIRED_SCHEMA_FILES) {
     const resolution = describeSpecResolution(fileName);
     console.info('[marketing-runtime-schema]', {
@@ -357,7 +358,7 @@ export function assertMarketingRuntimeSchemas(): void {
     }
 
     try {
-      const raw = readFileSync(schemaPath, 'utf8');
+      const raw = await readFile(schemaPath, 'utf8');
       const parsed = JSON.parse(raw);
       if (!parsed || typeof parsed !== 'object') {
         throw new Error('schema root must be an object');
@@ -401,9 +402,9 @@ function runtimeBrandKitReferenceFromTenantBrandKit(
   };
 }
 
-function recoverLegacyRuntimeBrandKit(doc: MarketingJobRuntimeDocument): MarketingBrandKitReference | null {
+async function recoverLegacyRuntimeBrandKit(doc: MarketingJobRuntimeDocument): Promise<MarketingBrandKitReference | null> {
   try {
-    const persistedBrandKit = loadTenantBrandKit(doc.tenant_id);
+    const persistedBrandKit = await loadTenantBrandKit(doc.tenant_id);
     if (!persistedBrandKit) {
       console.warn('[marketing-runtime-state]', {
         event: 'legacy-runtime-brand-kit-missing',
@@ -453,14 +454,10 @@ function assertMarketingRuntimeDocument(doc: MarketingJobRuntimeDocument): void 
   }
 }
 
-export function loadMarketingJobRuntime(jobId: string): MarketingJobRuntimeDocument | null {
+export async function loadMarketingJobRuntime(jobId: string): Promise<MarketingJobRuntimeDocument | null> {
   const filePath = marketingRuntimePath(jobId);
-  if (!existsSync(filePath)) {
-    return null;
-  }
-
   try {
-    const raw = readFileSync(filePath, 'utf8');
+    const raw = await readFile(filePath, 'utf8');
     const parsed = JSON.parse(raw) as Record<string, unknown> | null;
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return null;
@@ -507,29 +504,36 @@ export function loadMarketingJobRuntime(jobId: string): MarketingJobRuntimeDocum
       doc.publish_config = defaultPublishConfig(doc.publish_config);
     }
     if (!doc.brand_kit) {
-      doc.brand_kit = recoverLegacyRuntimeBrandKit(doc);
+      doc.brand_kit = await recoverLegacyRuntimeBrandKit(doc);
     }
     return doc;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
     return null;
   }
 }
 
-function collectMarketingJobRefsForTenant(
+async function collectMarketingJobRefsForTenant(
   tenantId: string,
   options: { includeDeleted?: boolean; onlyDeleted?: boolean } = {},
-): Array<{ jobId: string; updatedAt: number }> {
+): Promise<Array<{ jobId: string; updatedAt: number }>> {
   const root = marketingRuntimeRoot();
-  if (!existsSync(root)) {
-    return [];
-  }
-
   const refs: Array<{ jobId: string; updatedAt: number }> = [];
-  const entries = readdirSync(root).filter((entry) => entry.endsWith('.json'));
+  let entries: string[];
+  try {
+    entries = (await readdir(root)).filter((entry) => entry.endsWith('.json'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
 
   for (const entry of entries) {
     try {
-      const raw = readFileSync(path.join(root, entry), 'utf8');
+      const raw = await readFile(path.join(root, entry), 'utf8');
       const doc = JSON.parse(raw) as Record<string, unknown>;
       if (!doc || typeof doc !== 'object' || Array.isArray(doc)) {
         continue;
@@ -583,12 +587,12 @@ function collectMarketingJobRefsForTenant(
   return refs.sort((left, right) => right.updatedAt - left.updatedAt);
 }
 
-export function listMarketingJobIdsForTenant(tenantId: string): string[] {
-  return collectMarketingJobRefsForTenant(tenantId).map((entry) => entry.jobId);
+export async function listMarketingJobIdsForTenant(tenantId: string): Promise<string[]> {
+  return (await collectMarketingJobRefsForTenant(tenantId)).map((entry) => entry.jobId);
 }
 
-export function listDeletedMarketingJobIdsForTenant(tenantId: string): string[] {
-  return collectMarketingJobRefsForTenant(tenantId, { onlyDeleted: true }).map((entry) => entry.jobId);
+export async function listDeletedMarketingJobIdsForTenant(tenantId: string): Promise<string[]> {
+  return (await collectMarketingJobRefsForTenant(tenantId, { onlyDeleted: true })).map((entry) => entry.jobId);
 }
 
 /**
@@ -613,12 +617,12 @@ export function listDeletedMarketingJobIdsForTenant(tenantId: string): string[] 
  * Returns the updated document, or `null` if the job is not found or
  * belongs to a different tenant.
  */
-export function softDeleteMarketingJob(input: {
+export async function softDeleteMarketingJob(input: {
   jobId: string;
   tenantId: string;
   deletedBy: string;
-}): MarketingJobRuntimeDocument | null {
-  const doc = loadMarketingJobRuntime(input.jobId);
+}): Promise<MarketingJobRuntimeDocument | null> {
+  const doc = await loadMarketingJobRuntime(input.jobId);
   if (!doc || doc.tenant_id !== input.tenantId) {
     return null;
   }
@@ -647,11 +651,11 @@ export function softDeleteMarketingJob(input: {
  * safe no-op. The only case that returns `null` is when the job is not
  * found at all or belongs to a different tenant.
  */
-export function restoreMarketingJob(input: {
+export async function restoreMarketingJob(input: {
   jobId: string;
   tenantId: string;
-}): MarketingJobRuntimeDocument | null {
-  const doc = loadMarketingJobRuntime(input.jobId);
+}): Promise<MarketingJobRuntimeDocument | null> {
+  const doc = await loadMarketingJobRuntime(input.jobId);
   if (!doc || doc.tenant_id !== input.tenantId) {
     return null;
   }
@@ -667,18 +671,22 @@ export function restoreMarketingJob(input: {
   return doc;
 }
 
-export function listMarketingTenantIds(): string[] {
+export async function listMarketingTenantIds(): Promise<string[]> {
   const root = marketingRuntimeRoot();
-  if (!existsSync(root)) {
-    return [];
-  }
-
-  const entries = readdirSync(root).filter((entry) => entry.endsWith('.json'));
   const tenants = new Set<string>();
+  let entries: string[];
+  try {
+    entries = (await readdir(root)).filter((entry) => entry.endsWith('.json'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
 
   for (const entry of entries) {
     try {
-      const raw = readFileSync(path.join(root, entry), 'utf8');
+      const raw = await readFile(path.join(root, entry), 'utf8');
       const doc = JSON.parse(raw) as Record<string, unknown>;
       const tenantId = typeof doc.tenant_id === 'string' ? doc.tenant_id.trim() : '';
       if (tenantId) {
@@ -692,18 +700,22 @@ export function listMarketingTenantIds(): string[] {
   return [...tenants];
 }
 
-export function findLatestMarketingTenantId(): string | null {
+export async function findLatestMarketingTenantId(): Promise<string | null> {
   const root = marketingRuntimeRoot();
-  if (!existsSync(root)) {
-    return null;
-  }
-
-  const entries = readdirSync(root).filter((entry) => entry.endsWith('.json'));
   let latest: { tenantId: string; updatedAt: number } | null = null;
+  let entries: string[];
+  try {
+    entries = (await readdir(root)).filter((entry) => entry.endsWith('.json'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
 
   for (const entry of entries) {
     try {
-      const raw = readFileSync(path.join(root, entry), 'utf8');
+      const raw = await readFile(path.join(root, entry), 'utf8');
       const doc = JSON.parse(raw) as Record<string, unknown>;
       const tenantId = typeof doc.tenant_id === 'string' ? doc.tenant_id.trim() : '';
       const updatedAt = Date.parse(typeof doc.updated_at === 'string' ? doc.updated_at : '');
@@ -721,8 +733,8 @@ export function findLatestMarketingTenantId(): string | null {
   return latest?.tenantId ?? null;
 }
 
-export function findLatestMarketingJobIdForTenant(tenantId: string): string | null {
-  return collectMarketingJobRefsForTenant(tenantId)[0]?.jobId ?? null;
+export async function findLatestMarketingJobIdForTenant(tenantId: string): Promise<string | null> {
+  return (await collectMarketingJobRefsForTenant(tenantId))[0]?.jobId ?? null;
 }
 
 export function saveMarketingJobRuntime(jobId: string, doc: MarketingJobRuntimeDocument): string {

--- a/backend/marketing/runtime-views.ts
+++ b/backend/marketing/runtime-views.ts
@@ -854,12 +854,12 @@ function viewerUrl(jobId: string, assetId: string): string {
   return `/materials/${encodeURIComponent(jobId)}/${encodeURIComponent(assetId)}`;
 }
 
-function firstCheckpointAttachments(
+async function firstCheckpointAttachments(
   view: CampaignWorkspaceView,
   runtimeDoc: MarketingJobRuntimeDocument,
-): MarketingReviewAttachment[] {
+): Promise<MarketingReviewAttachment[]> {
   const attachments: MarketingReviewAttachment[] = [];
-  const assetLinks = new Map(buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc).map((asset) => [asset.id, asset] as const));
+  const assetLinks = new Map((await buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc)).map((asset) => [asset.id, asset] as const));
   const researchSummary = assetLinks.get('research-summary');
   const brandKit = assetLinks.get('brand-kit-json');
   const brandBible = assetLinks.get('brand-bible-markdown');
@@ -1042,12 +1042,12 @@ function launchReviewApprovalSections(runtimeDoc: MarketingJobRuntimeDocument): 
   return sections;
 }
 
-function workflowApprovalItem(
+async function workflowApprovalItem(
   status: MarketingJobStatusResponse,
   view: CampaignWorkspaceView,
   runtimeDoc: MarketingJobRuntimeDocument,
   campaignNameValue: string,
-): RuntimeReviewItem | null {
+): Promise<RuntimeReviewItem | null> {
   if (!status.approval) {
     return null;
   }
@@ -1069,7 +1069,7 @@ function workflowApprovalItem(
             body: approvalSurfaceSummary(status),
           },
         ];
-  const attachments = firstCheckpoint ? firstCheckpointAttachments(view, runtimeDoc) : [];
+  const attachments = firstCheckpoint ? await firstCheckpointAttachments(view, runtimeDoc) : [];
   const summary = approvalSurfaceSummary(status);
   const title = approvalSurfaceTitle(status);
   const cta = view.workflowState === 'revisions_requested'
@@ -1222,14 +1222,14 @@ export function syncHistoryWithLastDecision(item: RuntimeReviewItem): RuntimeRev
   return { ...item, history: [...item.history, synthesized] };
 }
 
-function buildReviewItemsForJob(jobId: string): RuntimeReviewItem[] {
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+async function buildReviewItemsForJob(jobId: string): Promise<RuntimeReviewItem[]> {
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     return [];
   }
 
-  const status = getMarketingJobStatus(jobId);
-  const view = buildCampaignWorkspaceView(jobId);
+  const status = await getMarketingJobStatus(jobId);
+  const view = await buildCampaignWorkspaceView(jobId);
   const campaignNameValue = campaignName(status, view);
 
   const items: RuntimeReviewItem[] = [];
@@ -1244,7 +1244,7 @@ function buildReviewItemsForJob(jobId: string): RuntimeReviewItem[] {
   }
   items.push(...publishPreviewReviewItems(status, view, campaignNameValue));
 
-  const approvalItem = workflowApprovalItem(status, view, runtimeDoc, campaignNameValue);
+  const approvalItem = await workflowApprovalItem(status, view, runtimeDoc, campaignNameValue);
   if (approvalItem) {
     items.push(approvalItem);
   }
@@ -1252,8 +1252,8 @@ function buildReviewItemsForJob(jobId: string): RuntimeReviewItem[] {
   return mergeReviewState(jobId, runtimeDoc.tenant_id, items);
 }
 
-function resolveRuntimeReviewItem(jobId: string, reviewId: string): RuntimeReviewItem | null {
-  const items = buildReviewItemsForJob(jobId);
+async function resolveRuntimeReviewItem(jobId: string, reviewId: string): Promise<RuntimeReviewItem | null> {
+  const items = await buildReviewItemsForJob(jobId);
   const exact = items.find((item) => item.id === reviewId);
   if (exact) {
     return exact;
@@ -1267,7 +1267,7 @@ function resolveRuntimeReviewItem(jobId: string, reviewId: string): RuntimeRevie
     }
   }
 
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     return null;
   }
@@ -1377,18 +1377,18 @@ export async function listMarketingCampaignsForTenant(tenantId: string): Promise
   const campaigns: RuntimeCampaignListItem[] = [];
   const seen = new Set<string>();
 
-  for (const jobId of listMarketingJobIdsForTenant(tenantId)) {
-    const status = getMarketingJobStatus(jobId);
+  for (const jobId of await listMarketingJobIdsForTenant(tenantId)) {
+    const status = await getMarketingJobStatus(jobId);
     if (status.tenantName === null && status.brandWebsiteUrl === null && status.status === 'error') {
       continue;
     }
-    const view = buildCampaignWorkspaceView(jobId);
+    const view = await buildCampaignWorkspaceView(jobId);
     const key = view.dashboard.campaign?.externalCampaignId || view.dashboard.campaign?.name || `job::${jobId}`;
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
-    const pendingApprovals = buildReviewItemsForJob(jobId).filter((item) => item.status !== 'approved').length;
+    const pendingApprovals = (await buildReviewItemsForJob(jobId)).filter((item) => item.status !== 'approved').length;
     campaigns.push(buildCampaignListItem(status, view, pendingApprovals));
   }
 
@@ -1410,22 +1410,22 @@ export async function listDeletedMarketingCampaignsForTenant(
   const campaigns: RuntimeCampaignListItem[] = [];
   const seen = new Set<string>();
 
-  for (const jobId of listDeletedMarketingJobIdsForTenant(tenantId)) {
-    const doc = loadMarketingJobRuntime(jobId);
+  for (const jobId of await listDeletedMarketingJobIdsForTenant(tenantId)) {
+    const doc = await loadMarketingJobRuntime(jobId);
     if (!doc || doc.tenant_id !== tenantId) {
       continue;
     }
-    const status = getMarketingJobStatus(jobId);
+    const status = await getMarketingJobStatus(jobId);
     if (status.tenantName === null && status.brandWebsiteUrl === null && status.status === 'error') {
       continue;
     }
-    const view = buildCampaignWorkspaceView(jobId);
+    const view = await buildCampaignWorkspaceView(jobId);
     const key = view.dashboard.campaign?.externalCampaignId || view.dashboard.campaign?.name || `job::${jobId}`;
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
-    const pendingApprovals = buildReviewItemsForJob(jobId).filter((item) => item.status !== 'approved').length;
+    const pendingApprovals = (await buildReviewItemsForJob(jobId)).filter((item) => item.status !== 'approved').length;
     const item = buildCampaignListItem(status, view, pendingApprovals);
     item.deletedAt = doc.deleted_at ?? null;
     item.deletedBy = doc.deleted_by ?? null;
@@ -1443,7 +1443,7 @@ export async function listDeletedMarketingCampaignsForTenant(
 export async function listPublicMarketingCampaigns(): Promise<RuntimeCampaignListItem[]> {
   const byId = new Map<string, RuntimeCampaignListItem>();
 
-  for (const tenantId of listMarketingTenantIds()) {
+  for (const tenantId of await listMarketingTenantIds()) {
     const campaigns = await listMarketingCampaignsForTenant(tenantId);
     for (const campaign of campaigns) {
       if (!byId.has(campaign.id)) {
@@ -1463,21 +1463,21 @@ export async function getMarketingCampaignContentForTenant(
   tenantId: string,
   campaignId: string,
 ): Promise<MarketingDashboardCampaignContent | null> {
-  const jobIds = new Set(listMarketingJobIdsForTenant(tenantId));
+  const jobIds = new Set(await listMarketingJobIdsForTenant(tenantId));
   if (!jobIds.has(campaignId)) {
     return null;
   }
-  return buildCampaignWorkspaceView(campaignId).dashboard;
+  return (await buildCampaignWorkspaceView(campaignId)).dashboard;
 }
 
 export async function listMarketingPostsForTenant(tenantId: string): Promise<MarketingDashboardContent> {
-  return getWorkflowAwareDashboardContentForTenant(tenantId);
+  return await getWorkflowAwareDashboardContentForTenant(tenantId);
 }
 
 export async function listPublicMarketingPosts(): Promise<MarketingDashboardContent> {
-  const tenantIds = listMarketingTenantIds();
+  const tenantIds = await listMarketingTenantIds();
   const emptyTenantId = tenantIds[0] || 'public_empty';
-  const content = getWorkflowAwareDashboardContentForTenant(emptyTenantId);
+  const content = await getWorkflowAwareDashboardContentForTenant(emptyTenantId);
 
   if (tenantIds.length <= 1) {
     return content;
@@ -1501,7 +1501,7 @@ export async function listPublicMarketingPosts(): Promise<MarketingDashboardCont
   };
 
   for (const tenantId of tenantIds) {
-    const next = getWorkflowAwareDashboardContentForTenant(tenantId);
+    const next = await getWorkflowAwareDashboardContentForTenant(tenantId);
     campaigns.push(...next.campaigns);
     posts.push(...next.posts);
     assets.push(...next.assets);
@@ -1534,16 +1534,18 @@ export async function listMarketingReviewItemsForTenant(tenantId: string): Promi
 }
 
 export async function listMarketingReviewQueueForTenant(tenantId: string): Promise<RuntimeReviewQueue> {
-  const items = listMarketingJobIdsForTenant(tenantId)
-    .flatMap((jobId) => buildReviewItemsForJob(jobId))
-    .filter((item) => item.status !== 'approved');
+  const items: RuntimeReviewItem[] = [];
+  for (const jobId of await listMarketingJobIdsForTenant(tenantId)) {
+    const reviewItems = await buildReviewItemsForJob(jobId);
+    items.push(...reviewItems.filter((item) => item.status !== 'approved'));
+  }
 
   return buildRuntimeReviewQueue(items);
 }
 
 export async function listPublicMarketingReviewItems(): Promise<RuntimeReviewItem[]> {
   const items = [] as RuntimeReviewItem[];
-  for (const tenantId of listMarketingTenantIds()) {
+  for (const tenantId of await listMarketingTenantIds()) {
     items.push(...(await listMarketingReviewItemsForTenant(tenantId)));
   }
   return items.sort((left, right) => right.scheduledFor.localeCompare(left.scheduledFor));
@@ -1554,12 +1556,12 @@ export async function lookupMarketingReviewItemForTenant(
   reviewId: string,
 ): Promise<RuntimeReviewItemLookupResult> {
   const { jobId } = reviewIdParts(reviewId);
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     return { status: 'missing' };
   }
 
-  const review = resolveRuntimeReviewItem(jobId, reviewId);
+  const review = await resolveRuntimeReviewItem(jobId, reviewId);
   if (!review) {
     return { status: 'missing' };
   }
@@ -1585,18 +1587,18 @@ export async function recordMarketingReviewDecision(input: {
   approvalId?: string;
 }): Promise<RuntimeReviewItem | null> {
   const { jobId } = reviewIdParts(input.reviewId);
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc || runtimeDoc.tenant_id !== input.tenantId) {
     return null;
   }
 
-  const item = resolveRuntimeReviewItem(jobId, input.reviewId);
+  const item = await resolveRuntimeReviewItem(jobId, input.reviewId);
   if (!item) {
     return null;
   }
 
   if (isWorkflowApprovalItem(item)) {
-    const workspaceRecord = ensureCampaignWorkspaceRecord({
+    const workspaceRecord = await ensureCampaignWorkspaceRecord({
       jobId,
       tenantId: input.tenantId,
       payload: (runtimeDoc.inputs.request as Record<string, unknown>) || {},
@@ -1615,7 +1617,7 @@ export async function recordMarketingReviewDecision(input: {
         checkpoint?.approval_id &&
         input.approvalId !== checkpoint.approval_id
       ) {
-        const refreshedStale = resolveRuntimeReviewItem(jobId, item.id) || resolveRuntimeReviewItem(jobId, input.reviewId);
+        const refreshedStale = (await resolveRuntimeReviewItem(jobId, item.id)) || (await resolveRuntimeReviewItem(jobId, input.reviewId));
         return refreshedStale ?? item;
       }
       const approvalResult = await approveMarketingJob({
@@ -1661,7 +1663,7 @@ export async function recordMarketingReviewDecision(input: {
       assertDenialResult(denialResult);
     }
   } else {
-    const workspaceRecord = ensureCampaignWorkspaceRecord({
+    const workspaceRecord = await ensureCampaignWorkspaceRecord({
       jobId,
       tenantId: input.tenantId,
       payload: (runtimeDoc.inputs.request as Record<string, unknown>) || {},
@@ -1707,7 +1709,7 @@ export async function recordMarketingReviewDecision(input: {
       saveCampaignWorkspaceRecord(workspaceRecord);
 
       if (input.action === 'approve' && runtimeDoc.approvals.current?.stage === 'production') {
-        const refreshedView = buildCampaignWorkspaceView(jobId);
+        const refreshedView = await buildCampaignWorkspaceView(jobId);
         if (refreshedView.creativeReview?.approvalComplete) {
           const approvalResult = await approveMarketingJob({
             jobId,
@@ -1723,7 +1725,7 @@ export async function recordMarketingReviewDecision(input: {
   }
 
   const lastDecision = persistReviewDecision(input.tenantId, item, input.reviewId, input.action, input.actedBy, input.note);
-  const refreshed = resolveRuntimeReviewItem(jobId, item.id) || resolveRuntimeReviewItem(jobId, input.reviewId);
+  const refreshed = (await resolveRuntimeReviewItem(jobId, item.id)) || (await resolveRuntimeReviewItem(jobId, input.reviewId));
   if (!refreshed) {
     return {
       ...item,

--- a/backend/marketing/stage-artifact-resolution.ts
+++ b/backend/marketing/stage-artifact-resolution.ts
@@ -1,4 +1,5 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -88,17 +89,20 @@ function lobsterOutputRoots(): string[] {
   ]);
 }
 
-function readJsonIfExists(filePath: string | null | undefined): Record<string, unknown> | null {
-  if (!filePath || !existsSync(filePath)) {
+async function readJsonIfExists(filePath: string | null | undefined): Promise<Record<string, unknown> | null> {
+  if (!filePath) {
     return null;
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(filePath, 'utf8'));
+    const parsed = JSON.parse(await readFile(filePath, 'utf8'));
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : null;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
     return null;
   }
 }
@@ -140,10 +144,10 @@ function stageTimestamp(runtimeDoc: MarketingJobRuntimeDocument, stage: Marketin
   return candidates[0] ?? 0;
 }
 
-export function inferMarketingStageRunId(
+export async function inferMarketingStageRunId(
   runtimeDoc: MarketingJobRuntimeDocument,
   stage: MarketingArtifactStageNumber,
-): string | null {
+): Promise<string | null> {
   const currentStage = stageKey(stage);
   const explicitRunId = stringValue(runtimeDoc.stages[currentStage].run_id);
   if (explicitRunId) {
@@ -161,7 +165,7 @@ export function inferMarketingStageRunId(
 
   const stageCacheRoot = cacheRoot(stage);
   if (existsSync(stageCacheRoot)) {
-    for (const entry of readdirSync(stageCacheRoot)) {
+    for (const entry of await readdir(stageCacheRoot)) {
       if (!prefixes.some((prefix) => entry.startsWith(`${prefix}-`))) {
         continue;
       }
@@ -170,7 +174,7 @@ export function inferMarketingStageRunId(
       }
       try {
         const entryPath = path.join(stageCacheRoot, entry);
-        const stats = statSync(entryPath);
+        const stats = await stat(entryPath);
         if (!stats.isDirectory()) {
           continue;
         }
@@ -189,7 +193,7 @@ export function inferMarketingStageRunId(
     if (!existsSync(logsRoot)) {
       continue;
     }
-    for (const entry of readdirSync(logsRoot)) {
+    for (const entry of await readdir(logsRoot)) {
       if (!prefixes.some((prefix) => entry.startsWith(`${prefix}-`))) {
         continue;
       }
@@ -201,7 +205,7 @@ export function inferMarketingStageRunId(
         continue;
       }
       try {
-        const stats = statSync(stagePath);
+        const stats = await stat(stagePath);
         seenRunIds.add(entry);
         candidates.push({
           runId: entry,
@@ -217,20 +221,20 @@ export function inferMarketingStageRunId(
     ?.runId || null;
 }
 
-export function readMarketingStageStepPayload(
+export async function readMarketingStageStepPayload(
   runtimeDoc: MarketingJobRuntimeDocument,
   stage: MarketingArtifactStageNumber,
   stepName: string,
-): StepPayloadResolution {
+): Promise<StepPayloadResolution> {
   const currentStage = stageKey(stage);
   const runIds = uniqueStrings([
     stringValue(runtimeDoc.stages[currentStage].run_id),
-    inferMarketingStageRunId(runtimeDoc, stage),
+    await inferMarketingStageRunId(runtimeDoc, stage),
   ]);
 
   for (const runId of runIds) {
     const cachePath = path.join(cacheRoot(stage), runId, `${stepName}.json`);
-    const cached = readJsonIfExists(cachePath);
+    const cached = await readJsonIfExists(cachePath);
     if (cached) {
       return {
         runId,
@@ -242,7 +246,7 @@ export function readMarketingStageStepPayload(
 
     for (const outputRoot of lobsterOutputRoots()) {
       const logPath = path.join(outputRoot, 'logs', runId, stageFolder(stage), `${stepName}.json`);
-      const logged = readJsonIfExists(logPath);
+      const logged = await readJsonIfExists(logPath);
       if (logged) {
         return {
           runId,

--- a/backend/marketing/validated-profile-store.ts
+++ b/backend/marketing/validated-profile-store.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, renameSync } from 'node:fs';
+import { existsSync, renameSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 
 import type { MarketingBrandIdentity } from '@/lib/api/marketing';
 import { sanitizeLegacyCompetitorUrl } from '@/lib/marketing-competitor';
@@ -34,13 +35,13 @@ function recordValue(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function readJsonIfExists(filePath: string): Record<string, unknown> | null {
-  if (!existsSync(filePath)) {
-    return null;
-  }
+async function readJsonIfExists(filePath: string): Promise<Record<string, unknown> | null> {
   try {
-    return recordValue(JSON.parse(readFileSync(filePath, 'utf8')));
-  } catch {
+    return recordValue(JSON.parse(await readFile(filePath, 'utf8')));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
     return null;
   }
 }
@@ -127,10 +128,10 @@ export type QuarantinedValidatedProfile = {
   stalePath: string;
 };
 
-export function invalidateValidatedProfilesIfSourceChanged(
+export async function invalidateValidatedProfilesIfSourceChanged(
   tenantId: string,
   newSourceUrl: string | null | undefined,
-): { quarantined: QuarantinedValidatedProfile[] } {
+): Promise<{ quarantined: QuarantinedValidatedProfile[] }> {
   const currentFingerprint = normalizeSourceFingerprint(newSourceUrl);
   if (!currentFingerprint) {
     return { quarantined: [] };
@@ -148,7 +149,7 @@ export function invalidateValidatedProfilesIfSourceChanged(
     if (!existsSync(filePath)) {
       continue;
     }
-    const record = readJsonIfExists(filePath);
+    const record = await readJsonIfExists(filePath);
     const recordFingerprint = sourceFingerprintFromRecord(record);
     if (recordFingerprint && recordFingerprint === currentFingerprint) {
       continue;
@@ -182,18 +183,18 @@ export type ValidatedMarketingProfileLoadOptions = {
   currentSourceUrl?: string | null;
 };
 
-export function loadValidatedMarketingProfileDocs(
+export async function loadValidatedMarketingProfileDocs(
   tenantId: string,
   options: ValidatedMarketingProfileLoadOptions = {},
-): ValidatedMarketingProfileDocs {
+): Promise<ValidatedMarketingProfileDocs> {
   const brandProfilePath = tenantBrandProfilePath(tenantId);
   const websiteAnalysisPath = tenantWebsiteAnalysisPath(tenantId);
   const businessProfilePath = tenantBusinessProfilePath(tenantId);
   const brandKitPath = tenantBrandKitPath(tenantId);
-  const rawBrandProfile = readJsonIfExists(brandProfilePath);
-  const rawWebsiteAnalysis = readJsonIfExists(websiteAnalysisPath);
-  const rawBusinessProfile = readJsonIfExists(businessProfilePath);
-  const rawBrandKit = readJsonIfExists(brandKitPath);
+  const rawBrandProfile = await readJsonIfExists(brandProfilePath);
+  const rawWebsiteAnalysis = await readJsonIfExists(websiteAnalysisPath);
+  const rawBusinessProfile = await readJsonIfExists(businessProfilePath);
+  const rawBrandKit = await readJsonIfExists(brandKitPath);
   const brandProfile = recordMatchesCurrentSource(rawBrandProfile, options.currentSourceUrl) ? rawBrandProfile : null;
   const websiteAnalysis = recordMatchesCurrentSource(rawWebsiteAnalysis, options.currentSourceUrl) ? rawWebsiteAnalysis : null;
   const businessProfile = recordMatchesCurrentSource(rawBusinessProfile, options.currentSourceUrl) ? rawBusinessProfile : null;
@@ -243,11 +244,11 @@ function landingHookFromDoc(doc: Record<string, unknown> | null): string | null 
   return stringArray(creativeHandoffHooks)[0] || stringArray(analysisHooks)[0] || null;
 }
 
-export function loadValidatedMarketingProfileSnapshot(
+export async function loadValidatedMarketingProfileSnapshot(
   tenantId: string,
   options: ValidatedMarketingProfileLoadOptions = {},
-): ValidatedMarketingProfileSnapshot {
-  const docs = loadValidatedMarketingProfileDocs(tenantId, options);
+): Promise<ValidatedMarketingProfileSnapshot> {
+  const docs = await loadValidatedMarketingProfileDocs(tenantId, options);
   const brandProfile = docs.brandProfile;
   const websiteAnalysis = docs.websiteAnalysis;
   const websiteBrandAnalysis = recordValue(websiteAnalysis?.brand_analysis);

--- a/backend/marketing/workspace-store.ts
+++ b/backend/marketing/workspace-store.ts
@@ -174,11 +174,11 @@ function normalizeBrandUrlForComparison(value: string): string {
   }
 }
 
-function withBusinessProfileDefaults(
+async function withBusinessProfileDefaults(
   tenantId: string,
   payload: Record<string, unknown> = {},
-): Record<string, unknown> {
-  const defaults = marketingPayloadDefaultsFromBusinessProfile(tenantId);
+): Promise<Record<string, unknown>> {
+  const defaults = await marketingPayloadDefaultsFromBusinessProfile(tenantId);
   const nextPayload = { ...payload };
 
   const websiteUrl = coalesceStringPayload(payload.websiteUrl || payload.brandUrl, defaults.websiteUrl);
@@ -304,9 +304,9 @@ function normalizeCampaignBrief(
   };
 }
 
-export function createCampaignWorkspaceRecord(input: CreateCampaignWorkspaceInput): CampaignWorkspaceRecord {
+export async function createCampaignWorkspaceRecord(input: CreateCampaignWorkspaceInput): Promise<CampaignWorkspaceRecord> {
   const ts = nowIso();
-  const payload = withBusinessProfileDefaults(input.tenantId, input.payload || {});
+  const payload = await withBusinessProfileDefaults(input.tenantId, input.payload || {});
   return {
     schema_name: 'marketing_campaign_workspace',
     schema_version: '1.0.0',
@@ -374,8 +374,8 @@ export function saveCampaignWorkspaceRecord(record: CampaignWorkspaceRecord): st
   return filePath;
 }
 
-export function ensureCampaignWorkspaceRecord(input: CreateCampaignWorkspaceInput): CampaignWorkspaceRecord {
-  const payload = withBusinessProfileDefaults(input.tenantId, input.payload || {});
+export async function ensureCampaignWorkspaceRecord(input: CreateCampaignWorkspaceInput): Promise<CampaignWorkspaceRecord> {
+  const payload = await withBusinessProfileDefaults(input.tenantId, input.payload || {});
   const existing = loadCampaignWorkspaceRecord(input.jobId, input.tenantId);
   if (existing) {
     existing.brief = normalizeCampaignBrief(payload, existing.brief);
@@ -383,7 +383,7 @@ export function ensureCampaignWorkspaceRecord(input: CreateCampaignWorkspaceInpu
     return existing;
   }
 
-  const created = createCampaignWorkspaceRecord({ ...input, payload });
+  const created = await createCampaignWorkspaceRecord({ ...input, payload });
   saveCampaignWorkspaceRecord(created);
   return created;
 }

--- a/backend/marketing/workspace-views.ts
+++ b/backend/marketing/workspace-views.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type {
@@ -111,27 +111,33 @@ function recordArray(value: unknown): Array<Record<string, unknown>> {
     : [];
 }
 
-function readJsonIfExists(filePath: string | null | undefined): Record<string, unknown> | null {
-  if (!filePath || !existsSync(filePath)) {
+async function readJsonIfExists(filePath: string | null | undefined): Promise<Record<string, unknown> | null> {
+  if (!filePath) {
     return null;
   }
 
   try {
-    return recordValue(JSON.parse(readFileSync(filePath, 'utf8')));
-  } catch {
+    return recordValue(JSON.parse(await readFile(filePath, 'utf8')));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
     return null;
   }
 }
 
-function readTextIfExists(filePath: string | null | undefined): string | null {
-  if (!filePath || !existsSync(filePath)) {
+async function readTextIfExists(filePath: string | null | undefined): Promise<string | null> {
+  if (!filePath) {
     return null;
   }
 
   try {
-    const text = readFileSync(filePath, 'utf8').trim();
+    const text = (await readFile(filePath, 'utf8')).trim();
     return text || null;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
     return null;
   }
 }
@@ -399,18 +405,18 @@ function buildCampaignBrief(record: CampaignWorkspaceRecord): MarketingCampaignB
   };
 }
 
-function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): StagePayloadBundle {
+async function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<StagePayloadBundle> {
   const sourceUrl = currentSourceUrl(runtimeDoc);
-  const validatedDocs = loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
+  const validatedDocs = await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
     currentSourceUrl: sourceUrl,
   });
   const strategyOutputs = recordValue(runtimeDoc.stages.strategy.outputs) || {};
   const productionOutputs = recordValue(runtimeDoc.stages.production.outputs) || {};
-  const strategyFallback = collectStrategyReviewArtifacts(
+  const strategyFallback = await collectStrategyReviewArtifacts(
     runtimeDoc.stages.strategy.primary_output || { run_id: runtimeDoc.stages.strategy.run_id },
     runtimeDoc,
   );
-  const productionFallback = collectProductionReviewArtifacts(
+  const productionFallback = await collectProductionReviewArtifacts(
     runtimeDoc.stages.production.primary_output || { run_id: runtimeDoc.stages.production.run_id },
     runtimeDoc,
   );
@@ -428,14 +434,24 @@ function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): StageP
   const fallbackCampaignPlannerPath = stringValue(strategyFallback.outputs.campaign_planner_path);
   const fallbackStrategyPreviewPath = stringValue(strategyFallback.outputs.strategy_review_path);
   const fallbackProductionPreviewPath = stringValue(productionFallback.outputs.production_review_path);
+  const runtimeWebsiteAnalysisFile = await readJsonIfExists(runtimeWebsiteAnalysisPath);
+  const runtimeBrandProfileFile = await readJsonIfExists(runtimeBrandProfilePath);
+  const runtimeCampaignPlannerFile = await readJsonIfExists(runtimeCampaignPlannerPath);
+  const runtimeStrategyPreviewFile = await readJsonIfExists(runtimeStrategyPreviewPath);
+  const runtimeProductionPreviewFile = await readJsonIfExists(runtimeProductionPreviewPath);
+  const fallbackWebsiteAnalysisFile = await readJsonIfExists(fallbackWebsiteAnalysisPath);
+  const fallbackBrandProfileFile = await readJsonIfExists(fallbackBrandProfilePath);
+  const fallbackCampaignPlannerFile = await readJsonIfExists(fallbackCampaignPlannerPath);
+  const fallbackStrategyPreviewFile = await readJsonIfExists(fallbackStrategyPreviewPath);
+  const fallbackProductionPreviewFile = await readJsonIfExists(fallbackProductionPreviewPath);
 
   const rawRuntimeRunWebsiteAnalysis =
     recordValue(strategyOutputs.website) ||
-    readJsonIfExists(runtimeWebsiteAnalysisPath);
+    runtimeWebsiteAnalysisFile;
   const runtimeRunWebsiteAnalysis =
     (recordMatchesCurrentSource(recordValue(strategyOutputs.website), sourceUrl) ? recordValue(strategyOutputs.website) : null) ||
-    (recordMatchesCurrentSource(readJsonIfExists(runtimeWebsiteAnalysisPath), sourceUrl)
-      ? readJsonIfExists(runtimeWebsiteAnalysisPath)
+    (recordMatchesCurrentSource(runtimeWebsiteAnalysisFile, sourceUrl)
+      ? runtimeWebsiteAnalysisFile
       : null);
   const runtimeWebsiteAnalysis =
     runtimeRunWebsiteAnalysis ||
@@ -444,30 +460,30 @@ function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): StageP
     (recordMatchesCurrentSource(recordValue(strategyOutputs.brand_profile), sourceUrl)
       ? recordValue(strategyOutputs.brand_profile)
       : null) ||
-    (recordMatchesCurrentSource(readJsonIfExists(runtimeBrandProfilePath), sourceUrl)
-      ? readJsonIfExists(runtimeBrandProfilePath)
+    (recordMatchesCurrentSource(runtimeBrandProfileFile, sourceUrl)
+      ? runtimeBrandProfileFile
       : null);
   const runtimeCampaignPlanner = sourceMatchedStrategyPayload(
-    recordValue(strategyOutputs.planner) || readJsonIfExists(runtimeCampaignPlannerPath),
+    recordValue(strategyOutputs.planner) || runtimeCampaignPlannerFile,
     sourceUrl,
     runtimeRunWebsiteAnalysis,
     !!rawRuntimeRunWebsiteAnalysis,
   );
   const runtimeStrategyPreview = sourceMatchedStrategyPayload(
-    recordValue(strategyOutputs.review) || readJsonIfExists(runtimeStrategyPreviewPath),
+    recordValue(strategyOutputs.review) || runtimeStrategyPreviewFile,
     sourceUrl,
     runtimeRunWebsiteAnalysis,
     !!rawRuntimeRunWebsiteAnalysis,
   );
   const runtimeProductionPreview = recordValue(productionOutputs.review) ||
-    readJsonIfExists(runtimeProductionPreviewPath);
+    runtimeProductionPreviewFile;
 
   const rawFallbackRunWebsiteAnalysis =
-    readJsonIfExists(fallbackWebsiteAnalysisPath) ||
+    fallbackWebsiteAnalysisFile ||
     recordValue(strategyFallback.outputs.website);
   const fallbackRunWebsiteAnalysis =
-    (recordMatchesCurrentSource(readJsonIfExists(fallbackWebsiteAnalysisPath), sourceUrl)
-      ? readJsonIfExists(fallbackWebsiteAnalysisPath)
+    (recordMatchesCurrentSource(fallbackWebsiteAnalysisFile, sourceUrl)
+      ? fallbackWebsiteAnalysisFile
       : null) ||
     (recordMatchesCurrentSource(recordValue(strategyFallback.outputs.website), sourceUrl)
       ? recordValue(strategyFallback.outputs.website)
@@ -475,36 +491,36 @@ function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): StageP
   const websiteAnalysis = runtimeWebsiteAnalysis || fallbackRunWebsiteAnalysis;
   const brandProfile = runtimeBrandProfile ||
     validatedDocs.brandProfile ||
-    (recordMatchesCurrentSource(readJsonIfExists(fallbackBrandProfilePath), sourceUrl)
-      ? readJsonIfExists(fallbackBrandProfilePath)
+    (recordMatchesCurrentSource(fallbackBrandProfileFile, sourceUrl)
+      ? fallbackBrandProfileFile
       : null) ||
     (recordMatchesCurrentSource(recordValue(strategyFallback.outputs.brand_profile), sourceUrl)
       ? recordValue(strategyFallback.outputs.brand_profile)
       : null);
   const campaignPlanner = runtimeCampaignPlanner ||
     sourceMatchedStrategyPayload(
-      readJsonIfExists(fallbackCampaignPlannerPath) || recordValue(strategyFallback.outputs.planner),
+      fallbackCampaignPlannerFile || recordValue(strategyFallback.outputs.planner),
       sourceUrl,
       fallbackRunWebsiteAnalysis,
       !!rawFallbackRunWebsiteAnalysis,
     );
   const strategyPreview = runtimeStrategyPreview ||
     sourceMatchedStrategyPayload(
-      readJsonIfExists(fallbackStrategyPreviewPath) || recordValue(strategyFallback.outputs.review),
+      fallbackStrategyPreviewFile || recordValue(strategyFallback.outputs.review),
       sourceUrl,
       fallbackRunWebsiteAnalysis,
       !!rawFallbackRunWebsiteAnalysis,
     );
   const productionPreview = runtimeProductionPreview ||
-    readJsonIfExists(fallbackProductionPreviewPath) ||
+    fallbackProductionPreviewFile ||
     recordValue(productionFallback.outputs.review);
 
   const hasCurrentSourceBrandArtifacts = !!(websiteAnalysis || brandProfile);
   const hasCurrentSourceStrategyArtifacts = !!(campaignPlanner || strategyPreview || hasCurrentSourceBrandArtifacts);
 
-  const brandBibleAsset = findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-bible-markdown');
-  const designSystemAsset = findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-design-system');
-  const proposalMarkdownAsset = findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'strategy-proposal-markdown');
+  const brandBibleAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-bible-markdown');
+  const designSystemAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-design-system');
+  const proposalMarkdownAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'strategy-proposal-markdown');
 
   return {
     websiteAnalysis,
@@ -513,16 +529,16 @@ function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): StageP
     strategyPreview,
     productionPreview,
     brandBibleText: hasCurrentSourceBrandArtifacts
-      ? readTextIfExists(
+      ? await readTextIfExists(
           brandBibleAsset?.filePath || stringValue(recordValue(websiteAnalysis?.artifacts)?.brand_bible_markdown_path),
         )
       : null,
     designSystemCss: hasCurrentSourceBrandArtifacts
-      ? readTextIfExists(
+      ? await readTextIfExists(
           designSystemAsset?.filePath || stringValue(recordValue(websiteAnalysis?.artifacts)?.design_system_css_path),
         )
       : null,
-    proposalMarkdown: hasCurrentSourceStrategyArtifacts ? readTextIfExists(proposalMarkdownAsset?.filePath) : null,
+    proposalMarkdown: hasCurrentSourceStrategyArtifacts ? await readTextIfExists(proposalMarkdownAsset?.filePath) : null,
     sources: {
       websiteAnalysis: runtimeWebsiteAnalysis
         ? 'runtime'
@@ -643,18 +659,18 @@ function stageHistory(
     .map(campaignStatusHistoryEntry);
 }
 
-function buildBrandReview(
+async function buildBrandReview(
   runtimeDoc: MarketingJobRuntimeDocument,
   record: CampaignWorkspaceRecord,
   payloads: StagePayloadBundle,
-): MarketingStageReviewPayload | null {
+): Promise<MarketingStageReviewPayload | null> {
   const hasGeneratedBrandArtifacts = hasRealBrandArtifacts(payloads);
   const hasUploadedBrandAssets = uploadedBrandAssets(record);
   if (!hasGeneratedBrandArtifacts && !hasUploadedBrandAssets) {
     return null;
   }
 
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: currentSourceUrl(runtimeDoc) || record.brief.websiteUrl || null,
   });
   const brandProfile = payloads.brandProfile;
@@ -679,7 +695,7 @@ function buildBrandReview(
         .map((entry) => entry.trim())
     : [];
   const attachments: MarketingReviewAttachment[] = [];
-  const assetLinks = new Map(buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc).map((asset) => [asset.id, asset] as const));
+  const assetLinks = new Map((await buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc)).map((asset) => [asset.id, asset] as const));
 
   for (const asset of record.brief.brandAssets) {
     attachments.push(
@@ -865,11 +881,11 @@ function buildBrandReview(
   };
 }
 
-function buildStrategyReview(
+async function buildStrategyReview(
   runtimeDoc: MarketingJobRuntimeDocument,
   record: CampaignWorkspaceRecord,
   payloads: StagePayloadBundle,
-): MarketingStageReviewPayload | null {
+): Promise<MarketingStageReviewPayload | null> {
   const campaignPlan = recordValue(payloads.campaignPlanner?.campaign_plan);
   const reviewPacket = recordValue(payloads.strategyPreview?.review_packet);
   const productionBrief = recordValue(recordValue(payloads.productionPreview?.production_handoff)?.production_brief);
@@ -877,7 +893,7 @@ function buildStrategyReview(
     return null;
   }
   const attachments: MarketingReviewAttachment[] = [];
-  const assetLinks = new Map(buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc).map((asset) => [asset.id, asset] as const));
+  const assetLinks = new Map((await buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc)).map((asset) => [asset.id, asset] as const));
 
   for (const assetId of ['strategy-campaign-planner', 'strategy-review-preview', 'strategy-proposal-markdown', 'strategy-proposal-html'] as const) {
     const asset = assetLinks.get(assetId);
@@ -944,12 +960,12 @@ function buildStrategyReview(
   };
 }
 
-function buildCreativeAssets(
+async function buildCreativeAssets(
   runtimeDoc: MarketingJobRuntimeDocument,
   record: CampaignWorkspaceRecord,
   dashboard: MarketingDashboardCampaignContent,
   productionPreview: Record<string, unknown> | null,
-): MarketingCreativeAssetReviewPayload[] {
+): Promise<MarketingCreativeAssetReviewPayload[]> {
   const creativeAssets = dashboard.assets.filter(
     (asset) =>
       ['landing_page', 'image_ad', 'script', 'copy'].includes(asset.type) &&
@@ -957,31 +973,31 @@ function buildCreativeAssets(
   );
   const reviewPacket = recordValue(productionPreview?.review_packet);
   const assetPreviews = recordValue(reviewPacket?.asset_previews);
-  const fallbackLanding = readLandingPageArtifactDetails({ runtimeDoc });
-  const fallbackScripts = readScriptArtifactDetails({ runtimeDoc });
+  const fallbackLanding = await readLandingPageArtifactDetails({ runtimeDoc });
+  const fallbackScripts = await readScriptArtifactDetails({ runtimeDoc });
 
   let metaAdScriptsByFamily:
     | Record<string, unknown>
     | null
     | undefined;
 
-  function getMetaAdScriptsByFamily(): Record<string, unknown> | null {
+  async function getMetaAdScriptsByFamily(): Promise<Record<string, unknown> | null> {
     if (metaAdScriptsByFamily !== undefined) {
       return metaAdScriptsByFamily;
     }
-    const scriptwriterPayload = readMarketingStageStepPayload(runtimeDoc, 3, 'scriptwriter').payload;
+    const scriptwriterPayload = (await readMarketingStageStepPayload(runtimeDoc, 3, 'scriptwriter')).payload;
     metaAdScriptsByFamily = recordValue(
       recordValue(scriptwriterPayload?.script_assets)?.meta_ad_scripts_by_family,
     );
     return metaAdScriptsByFamily;
   }
 
-  function perFamilyHook(filePath: string | null): string | null {
+  async function perFamilyHook(filePath: string | null): Promise<string | null> {
     const familyId = familyIdFromImagePath(filePath);
     if (!familyId) {
       return null;
     }
-    const scriptsByFamily = getMetaAdScriptsByFamily();
+    const scriptsByFamily = await getMetaAdScriptsByFamily();
     if (!scriptsByFamily) {
       return null;
     }
@@ -989,16 +1005,16 @@ function buildCreativeAssets(
     return stringValue(entry?.hook) || null;
   }
 
-  return creativeAssets.map((asset) => {
+  return Promise.all(creativeAssets.map(async (asset) => {
     const reviewState = record.creative_asset_reviews[asset.id];
-    const resolvedAsset = findMarketingAsset(runtimeDoc.job_id, runtimeDoc, asset.id);
+    const resolvedAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, asset.id);
     const fileName = resolvedAsset?.filePath ? path.basename(resolvedAsset.filePath) : null;
     const isVideoScript = asset.platform === 'video' || /video|short/i.test(`${asset.id} ${asset.title}`);
     const scriptDetails = isVideoScript
-      ? readScriptArtifactDetails({ shortVideoScriptPath: resolvedAsset?.filePath || null, runtimeDoc })
-      : readScriptArtifactDetails({ metaScriptPath: resolvedAsset?.filePath || null, runtimeDoc });
+      ? await readScriptArtifactDetails({ shortVideoScriptPath: resolvedAsset?.filePath || null, runtimeDoc })
+      : await readScriptArtifactDetails({ metaScriptPath: resolvedAsset?.filePath || null, runtimeDoc });
     const landingDetails = asset.type === 'landing_page'
-      ? readLandingPageArtifactDetails({ path: resolvedAsset?.filePath || null, runtimeDoc })
+      ? await readLandingPageArtifactDetails({ path: resolvedAsset?.filePath || null, runtimeDoc })
       : fallbackLanding;
     const detailLines: string[] = [];
     const assetSummary =
@@ -1007,7 +1023,7 @@ function buildCreativeAssets(
           normalizeArtifactText(landingDetails.subheadline) ||
           normalizeArtifactText(stringValue(assetPreviews?.landing_page_headline))
         : asset.type === 'image_ad'
-          ? normalizeArtifactText(perFamilyHook(resolvedAsset?.filePath || null)) ||
+          ? normalizeArtifactText(await perFamilyHook(resolvedAsset?.filePath || null)) ||
             normalizeArtifactText(scriptDetails.metaAdHook) ||
             normalizeArtifactText(fallbackScripts.metaAdHook) ||
             normalizeArtifactText(stringValue(assetPreviews?.meta_ad_hook))
@@ -1033,7 +1049,7 @@ function buildCreativeAssets(
         detailLines.push(`Slug: ${landingDetails.slug}`);
       }
     } else if (asset.type === 'image_ad') {
-      detailLines.push(`Ad hook: ${perFamilyHook(resolvedAsset?.filePath || null) || scriptDetails.metaAdHook || fallbackScripts.metaAdHook || normalizeArtifactText(stringValue(assetPreviews?.meta_ad_hook)) || ARTIFACT_UNAVAILABLE_TEXT}`);
+      detailLines.push(`Ad hook: ${await perFamilyHook(resolvedAsset?.filePath || null) || scriptDetails.metaAdHook || fallbackScripts.metaAdHook || normalizeArtifactText(stringValue(assetPreviews?.meta_ad_hook)) || ARTIFACT_UNAVAILABLE_TEXT}`);
     } else if (isVideoScript) {
       detailLines.push(`Opening line: ${scriptDetails.shortVideoOpeningLine || fallbackScripts.shortVideoOpeningLine || normalizeArtifactText(stringValue(assetPreviews?.video_opening_line)) || ARTIFACT_UNAVAILABLE_TEXT}`);
       if ((scriptDetails.shortVideoBeats[0] || fallbackScripts.shortVideoBeats[0])) {
@@ -1062,7 +1078,7 @@ function buildCreativeAssets(
       latestNote: reviewState?.latestNote || null,
       history: stageHistory(record.status_history, 'creative', asset.id),
     };
-  });
+  }));
 }
 
 function creativeReviewStatus(
@@ -1080,15 +1096,15 @@ function creativeReviewStatus(
   return assets.length > 0 ? 'pending_review' : 'not_ready';
 }
 
-function buildCreativeReview(
+async function buildCreativeReview(
   runtimeDoc: MarketingJobRuntimeDocument,
   record: CampaignWorkspaceRecord,
   dashboard: MarketingDashboardCampaignContent,
   productionPreview: Record<string, unknown> | null,
   publishBlockedReason: string | null,
   counts: { approved: number; pending: number; rejected: number },
-): MarketingCreativeReviewPayload | null {
-  const assets = buildCreativeAssets(runtimeDoc, record, dashboard, productionPreview);
+): Promise<MarketingCreativeReviewPayload | null> {
+  const assets = await buildCreativeAssets(runtimeDoc, record, dashboard, productionPreview);
   if (assets.length === 0) {
     return null;
   }
@@ -1207,8 +1223,8 @@ function syncWorkspaceReviewsFromRuntime(
   return changed;
 }
 
-export function buildCampaignWorkspaceView(jobId: string): CampaignWorkspaceView {
-  const runtimeDoc = loadMarketingJobRuntime(jobId);
+export async function buildCampaignWorkspaceView(jobId: string): Promise<CampaignWorkspaceView> {
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     return {
       jobId,
@@ -1231,13 +1247,13 @@ export function buildCampaignWorkspaceView(jobId: string): CampaignWorkspaceView
     };
   }
 
-  const record = ensureCampaignWorkspaceRecord({
+  const record = await ensureCampaignWorkspaceRecord({
     jobId,
     tenantId: runtimeDoc.tenant_id,
     payload: recordValue(runtimeDoc.inputs.request) || {},
   });
-  const rawDashboard = getMarketingDashboardCampaignContent(jobId);
-  const payloads = loadStagePayloadBundle(runtimeDoc);
+  const rawDashboard = await getMarketingDashboardCampaignContent(jobId);
+  const payloads = await loadStagePayloadBundle(runtimeDoc);
   const realBrandArtifactsReady = hasRealBrandArtifacts(payloads);
   const hasUploadedBrandAssets = uploadedBrandAssets(record);
   const brandReviewRenderable = realBrandArtifactsReady || hasUploadedBrandAssets;
@@ -1297,9 +1313,9 @@ export function buildCampaignWorkspaceView(jobId: string): CampaignWorkspaceView
   });
 
   const dashboard = withGatedDashboardStatus(rawDashboard, workflowResolution.workflowState);
-  const brandReview = brandReviewRenderable ? buildBrandReview(runtimeDoc, record, payloads) : null;
-  const strategyReview = strategyReady ? buildStrategyReview(runtimeDoc, record, payloads) : null;
-  const creativeReview = buildCreativeReview(
+  const brandReview = brandReviewRenderable ? await buildBrandReview(runtimeDoc, record, payloads) : null;
+  const strategyReview = strategyReady ? await buildStrategyReview(runtimeDoc, record, payloads) : null;
+  const creativeReview = await buildCreativeReview(
     runtimeDoc,
     record,
     dashboard,
@@ -1402,12 +1418,12 @@ function campaignIdentity(campaign: MarketingDashboardCampaign | null, jobId: st
   return campaign.externalCampaignId || campaign.name || `job::${jobId}`;
 }
 
-export function getWorkflowAwareDashboardContentForTenant(tenantId: string): MarketingDashboardContent {
+export async function getWorkflowAwareDashboardContentForTenant(tenantId: string): Promise<MarketingDashboardContent> {
   const items: MarketingDashboardCampaignContent[] = [];
   const seen = new Set<string>();
 
-  for (const jobId of listMarketingJobIdsForTenant(tenantId)) {
-    const view = buildCampaignWorkspaceView(jobId);
+  for (const jobId of await listMarketingJobIdsForTenant(tenantId)) {
+    const view = await buildCampaignWorkspaceView(jobId);
     const key = campaignIdentity(view.dashboard.campaign, jobId);
     if (seen.has(key)) {
       continue;

--- a/backend/tenant/business-profile.ts
+++ b/backend/tenant/business-profile.ts
@@ -367,13 +367,13 @@ async function launchApproverName(client: PoolClient, approverUserId: string | n
   return result.rows[0].full_name || result.rows[0].email || null;
 }
 
-function runtimeBrandKitAsTenantBrandKit(tenantId: string): { brandKit: TenantBrandKit | null; latestJobId: string | null } {
-  const latestJobId = findLatestMarketingJobIdForTenant(tenantId);
+async function runtimeBrandKitAsTenantBrandKit(tenantId: string): Promise<{ brandKit: TenantBrandKit | null; latestJobId: string | null }> {
+  const latestJobId = await findLatestMarketingJobIdForTenant(tenantId);
   if (!latestJobId) {
     return { brandKit: null, latestJobId: null };
   }
 
-  const runtimeDoc = loadMarketingJobRuntime(latestJobId);
+  const runtimeDoc = await loadMarketingJobRuntime(latestJobId);
   const runtimeBrandKit = runtimeDoc?.brand_kit;
   if (!runtimeBrandKit) {
     return { brandKit: null, latestJobId };
@@ -402,12 +402,12 @@ function runtimeBrandKitAsTenantBrandKit(tenantId: string): { brandKit: TenantBr
   };
 }
 
-export function resolveBusinessProfileBrandKit(tenantId: string): {
+export async function resolveBusinessProfileBrandKit(tenantId: string): Promise<{
   brandKit: TenantBrandKit | null;
   source: BusinessProfileBrandKitSource;
   latestJobId: string | null;
-} {
-  const runtime = runtimeBrandKitAsTenantBrandKit(tenantId);
+}> {
+  const runtime = await runtimeBrandKitAsTenantBrandKit(tenantId);
   if (runtime.brandKit) {
     return {
       brandKit: runtime.brandKit,
@@ -416,7 +416,7 @@ export function resolveBusinessProfileBrandKit(tenantId: string): {
     };
   }
 
-  const persisted = loadTenantBrandKit(tenantId);
+  const persisted = await loadTenantBrandKit(tenantId);
   if (persisted) {
     return {
       brandKit: persisted,
@@ -655,8 +655,8 @@ export async function getBusinessProfileWithDiagnostics(client: PoolClient, tena
 
   const tenantRow = tenant.rows[0] as { id: number; name: string; slug: string };
   const record = loadBusinessProfileRecord(tenantId);
-  const { brandKit, source, latestJobId } = resolveBusinessProfileBrandKit(tenantId);
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(tenantId, {
+  const { brandKit, source, latestJobId } = await resolveBusinessProfileBrandKit(tenantId);
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(tenantId, {
     currentSourceUrl: record?.website_url ?? brandKit?.canonical_url ?? brandKit?.source_url ?? null,
   });
   const workspaceBrandContext = loadLatestWorkspaceBrandContext(latestJobId);
@@ -753,7 +753,7 @@ export async function updateBusinessProfileWithDiagnostics(
   return getBusinessProfileWithDiagnostics(client, input.tenantId);
 }
 
-export function tenantHasStoredBusinessProfileState(tenantId: string): boolean {
+export async function tenantHasStoredBusinessProfileState(tenantId: string): Promise<boolean> {
   const record = loadBusinessProfileRecord(tenantId);
   if (
     record &&
@@ -773,18 +773,18 @@ export function tenantHasStoredBusinessProfileState(tenantId: string): boolean {
     return true;
   }
 
-  const docs = loadValidatedMarketingProfileDocs(tenantId);
+  const docs = await loadValidatedMarketingProfileDocs(tenantId);
   return Boolean(docs.brandProfile || docs.websiteAnalysis || docs.businessProfile || docs.brandKit);
 }
 
-export function getPublicBusinessProfile(websiteUrl?: string | null): ResolvedBusinessProfile {
+export async function getPublicBusinessProfile(websiteUrl?: string | null): Promise<ResolvedBusinessProfile> {
   const normalizedWebsiteUrl = normalizeMarketingWebsiteUrl(websiteUrl);
   const tenantId =
     derivePublicMarketingTenantId(normalizedWebsiteUrl) ||
     'public_campaign';
   const record = loadBusinessProfileRecord(tenantId);
-  const { brandKit, source, latestJobId } = resolveBusinessProfileBrandKit(tenantId);
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(tenantId, {
+  const { brandKit, source, latestJobId } = await resolveBusinessProfileBrandKit(tenantId);
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(tenantId, {
     currentSourceUrl: normalizedWebsiteUrl || record?.website_url || brandKit?.canonical_url || brandKit?.source_url || null,
   });
   const tenantSlug = record?.tenant_slug || publicTenantSlug(tenantId);
@@ -818,7 +818,7 @@ export async function updatePublicBusinessProfile(input: Omit<BusinessProfileUpd
     throw new Error('invalid_website_url');
   }
 
-  const current = getPublicBusinessProfile(normalizedWebsiteUrl);
+  const current = await getPublicBusinessProfile(normalizedWebsiteUrl);
   const nextBusinessName =
     mergePersistedStringField(current.profile.businessName || null, input.businessName).value ||
     current.profile.businessName ||
@@ -856,7 +856,7 @@ export async function updatePublicBusinessProfile(input: Omit<BusinessProfileUpd
   });
 
   await persistBrandKitIfNeeded(tenantId, normalizedWebsiteUrl, current.profile.websiteUrl);
-  return getPublicBusinessProfile(normalizedWebsiteUrl);
+  return await getPublicBusinessProfile(normalizedWebsiteUrl);
 }
 
 export function persistBusinessProfileFieldsFromMarketingPayload(
@@ -984,10 +984,10 @@ export function persistBusinessProfileFieldsFromMarketingPayload(
   return nextRecord;
 }
 
-export function marketingPayloadDefaultsFromBusinessProfile(tenantId: string): PersistedMarketingProfileDefaults {
+export async function marketingPayloadDefaultsFromBusinessProfile(tenantId: string): Promise<PersistedMarketingProfileDefaults> {
   const record = loadBusinessProfileRecord(tenantId);
-  const { brandKit, latestJobId } = resolveBusinessProfileBrandKit(tenantId);
-  const validatedProfile = loadValidatedMarketingProfileSnapshot(tenantId, {
+  const { brandKit, latestJobId } = await resolveBusinessProfileBrandKit(tenantId);
+  const validatedProfile = await loadValidatedMarketingProfileSnapshot(tenantId, {
     currentSourceUrl: record?.website_url ?? brandKit?.canonical_url ?? brandKit?.source_url ?? null,
   });
   const workspaceBrandContext = loadLatestWorkspaceBrandContext(latestJobId);

--- a/lobster/bin/brand-kit-bootstrap.ts
+++ b/lobster/bin/brand-kit-bootstrap.ts
@@ -59,7 +59,7 @@ async function main(): Promise<void> {
   }
 
   const dataRoot = assertValidatedPersistenceRoot();
-  const existing = loadTenantBrandKit(tenantId);
+  const existing = await loadTenantBrandKit(tenantId);
   const existingMatches = !!existing && normalizeUrl(existing.source_url) === brandUrl;
   const { brandKit, filePath } = await extractAndSaveTenantBrandKit({
     tenantId,

--- a/tests/creative-review-per-family.test.ts
+++ b/tests/creative-review-per-family.test.ts
@@ -257,7 +257,7 @@ test('buildCampaignWorkspaceView uses per-family hooks for Meta image ad cards i
       'utf8',
     );
 
-    const view = buildCampaignWorkspaceView(jobId);
+    const view = await buildCampaignWorkspaceView(jobId);
 
     assert.notEqual(view.creativeReview, null, 'creativeReview should be populated');
 

--- a/tests/dashboard-content-adapter.test.ts
+++ b/tests/dashboard-content-adapter.test.ts
@@ -257,7 +257,7 @@ test('dashboard adapter derives proposal-backed content and calendar without liv
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
     const { listMarketingCampaignsForTenant } = await import('../backend/marketing/runtime-views');
 
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
     const campaigns = await listMarketingCampaignsForTenant('tenant_dashboard');
@@ -319,7 +319,7 @@ test('dashboard adapter recovers proposal artifacts from live Lobster logs when 
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -365,7 +365,7 @@ test('dashboard adapter uses human-readable campaign and proposal concept labels
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -423,7 +423,7 @@ test('dashboard adapter falls back to platform labels when creative contract hea
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
     const metaCreative = content.posts.find((post) => post.type === 'meta_ad');
@@ -482,7 +482,7 @@ test('dashboard adapter falls back to platform labels when creative contract cop
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
     const metaCreative = content.posts.find((post) => post.type === 'meta_ad');
@@ -529,7 +529,7 @@ test('dashboard adapter keeps proposal approval truthful and does not leak futur
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -586,7 +586,7 @@ test('dashboard adapter does not infer publish review content during strategy ap
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -609,7 +609,7 @@ test('dashboard adapter surfaces generated landing pages, image ads, scripts, an
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -655,7 +655,7 @@ test('dashboard adapter keeps campaign status in review while a live approval ch
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -713,7 +713,7 @@ test('dashboard adapter surfaces pre-publish review items as ready to publish', 
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -806,7 +806,7 @@ test('dashboard adapter recovers paused-publish review items from Stage 4 logs w
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -829,7 +829,7 @@ test('dashboard adapter surfaces paused Meta ads as published to Meta (paused)',
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -865,7 +865,7 @@ test('dashboard adapter prefers live platform schedule signals over fallback eve
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 
@@ -945,7 +945,7 @@ test('dashboard adapter surfaces rendered .mp4 video assets from veo contract fi
     await writeRuntimeDoc(jobId, doc);
 
     const { getMarketingDashboardContent } = await import('../backend/marketing/dashboard-content');
-    const content = getMarketingDashboardContent(jobId, {
+    const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
 

--- a/tests/frontend-api-layer.test.ts
+++ b/tests/frontend-api-layer.test.ts
@@ -509,7 +509,7 @@ test('/api/marketing/jobs persists present onboarding setup fields into the auth
         }),
       );
       const body = (await response.json()) as Record<string, unknown>;
-      const runtimeDoc = loadMarketingJobRuntime(String(body.jobId));
+      const runtimeDoc = await loadMarketingJobRuntime(String(body.jobId));
       const persistedRecord = JSON.parse(await readFile(businessProfilePath, 'utf8')) as Record<string, unknown>;
 
       assert.equal(response.status, 202);
@@ -743,7 +743,7 @@ test('/api/marketing/jobs/:jobId and /latest block downstream approval metadata 
       }, null, 2),
     );
 
-    const workspace = ensureCampaignWorkspaceRecord({
+    const workspace = await ensureCampaignWorkspaceRecord({
       jobId,
       tenantId,
       payload: {
@@ -2544,7 +2544,7 @@ test('/api/marketing/jobs/:jobId renders upload-only brandReview without advanci
       }, null, 2),
     );
 
-    const record = ensureCampaignWorkspaceRecord({
+    const record = await ensureCampaignWorkspaceRecord({
       jobId,
       tenantId,
       payload: {
@@ -3717,7 +3717,7 @@ test('buildCampaignWorkspaceView keeps upload-only brand review pending and reop
       }, null, 2),
     );
 
-    const record = ensureCampaignWorkspaceRecord({
+    const record = await ensureCampaignWorkspaceRecord({
       jobId,
       tenantId,
       payload: {
@@ -3736,7 +3736,7 @@ test('buildCampaignWorkspaceView keeps upload-only brand review pending and reop
       },
     ]);
 
-    const uploadOnlyView = buildCampaignWorkspaceView(jobId);
+    const uploadOnlyView = await buildCampaignWorkspaceView(jobId);
     let savedRecord = loadCampaignWorkspaceRecord(jobId, tenantId);
 
     assert.equal(uploadOnlyView.workflowState, 'draft');
@@ -3772,7 +3772,7 @@ test('buildCampaignWorkspaceView keeps upload-only brand review pending and reop
       }, null, 2),
     );
 
-    const realArtifactView = buildCampaignWorkspaceView(jobId);
+    const realArtifactView = await buildCampaignWorkspaceView(jobId);
     savedRecord = loadCampaignWorkspaceRecord(jobId, tenantId);
 
     assert.equal(realArtifactView.brandReview?.status, 'pending_review');
@@ -3874,7 +3874,7 @@ test('buildCampaignWorkspaceView backfills an empty campaign brief brand voice f
       }, null, 2),
     );
 
-    const view = buildCampaignWorkspaceView(jobId);
+    const view = await buildCampaignWorkspaceView(jobId);
     const savedRecord = loadCampaignWorkspaceRecord(jobId, tenantId);
 
     assert.equal(view.campaignBrief?.brandVoice, 'Sophisticated and Authoritative.');
@@ -4004,7 +4004,7 @@ test('polluted Stage 2 inputs do not leak into business profile or brand review'
       }, null, 2),
     );
 
-    const view = buildCampaignWorkspaceView(jobId);
+    const view = await buildCampaignWorkspaceView(jobId);
     const profile = await getBusinessProfile(
       {
         async query() {

--- a/tests/marketing-approval-persistence.test.ts
+++ b/tests/marketing-approval-persistence.test.ts
@@ -575,9 +575,9 @@ test('denying a workflow checkpoint persists a denied approval record and clears
       deniedBy: 'operator',
       approvalId,
       note: 'Not ready yet.',
-    }, loadMarketingJobRuntime(started.jobId)!);
+    }, (await loadMarketingJobRuntime(started.jobId))!);
 
-    const runtimeDoc = loadMarketingJobRuntime(started.jobId);
+    const runtimeDoc = await loadMarketingJobRuntime(started.jobId);
     const records = listMarketingApprovalRecordsForJob(started.jobId);
 
     assert.equal(denied.status, 'denied');

--- a/tests/marketing-brand-identity-parity.test.ts
+++ b/tests/marketing-brand-identity-parity.test.ts
@@ -301,7 +301,7 @@ async function seedCurrentSourceIdentity(input: {
   );
 
   const { ensureCampaignWorkspaceRecord } = await import('../backend/marketing/workspace-store');
-  ensureCampaignWorkspaceRecord({
+  await ensureCampaignWorkspaceRecord({
     jobId: input.jobId,
     tenantId: input.tenantId,
     payload: {
@@ -355,10 +355,10 @@ test('canonical brand identity stays in parity across validated snapshot, brand 
     const { buildCampaignWorkspaceView } = await import('../backend/marketing/workspace-views');
     const { getBusinessProfile } = await import('../backend/tenant/business-profile');
 
-    const snapshot = loadValidatedMarketingProfileSnapshot(tenantId, {
+    const snapshot = await loadValidatedMarketingProfileSnapshot(tenantId, {
       currentSourceUrl: fixture.websiteUrl,
     });
-    const workspaceView = buildCampaignWorkspaceView(jobId);
+    const workspaceView = await buildCampaignWorkspaceView(jobId);
     const businessProfile = await getBusinessProfile(fakeTenantClient() as never, tenantId);
 
     const strategyResult = runScript({
@@ -468,10 +468,10 @@ test('source switch prevents source A brand identity from surviving in read mode
     const { loadValidatedMarketingProfileSnapshot } = await import('../backend/marketing/validated-profile-store');
     const { buildCampaignWorkspaceView } = await import('../backend/marketing/workspace-views');
     const { getBusinessProfile } = await import('../backend/tenant/business-profile');
-    const snapshot = loadValidatedMarketingProfileSnapshot(tenantId, {
+    const snapshot = await loadValidatedMarketingProfileSnapshot(tenantId, {
       currentSourceUrl: sourceB.websiteUrl,
     });
-    const workspaceView = buildCampaignWorkspaceView(jobId);
+    const workspaceView = await buildCampaignWorkspaceView(jobId);
     const businessProfile = await getBusinessProfile(fakeTenantClient() as never, tenantId);
 
     const brandProfile = JSON.parse(

--- a/tests/marketing-brand-kit.test.ts
+++ b/tests/marketing-brand-kit.test.ts
@@ -374,7 +374,7 @@ test('normalizePersistedBrandKit sanitizes HTML markup in a cached brand_name on
       brand_voice_summary: null,
       offer_summary: null,
     });
-    const loaded = loadTenantBrandKit('nwaeventco');
+    const loaded = await loadTenantBrandKit('nwaeventco');
     assert.ok(loaded);
     assert.doesNotMatch(loaded!.brand_name, /<\/?[a-z]/i);
     assert.doesNotMatch(loaded!.brand_name, /_ngcontent-/i);

--- a/tests/marketing-flow-smoke.test.ts
+++ b/tests/marketing-flow-smoke.test.ts
@@ -176,14 +176,14 @@ test('canonical client-facing marketing smoke flow stays on the monolithic pipel
     assert.equal((startPayload as any)?.args?.pipeline, MARKETING_PIPELINE_FILE);
     assert.equal((startPayload as any)?.args?.cwd, 'lobster');
 
-    const statusBeforeApproval = getMarketingJobStatus(startResult.jobId);
+    const statusBeforeApproval = await getMarketingJobStatus(startResult.jobId);
     assert.equal(statusBeforeApproval.state, 'approval_required');
     assert.equal(statusBeforeApproval.status, 'awaiting_approval');
     assert.equal(statusBeforeApproval.currentStage, 'strategy');
     assert.equal(statusBeforeApproval.stageStatus.strategy, 'awaiting_approval');
     assert.equal(statusBeforeApproval.approvalRequired, true);
     assert.equal(statusBeforeApproval.approval?.required, true);
-    const startedDoc = loadMarketingJobRuntime(startResult.jobId)!;
+    const startedDoc = (await loadMarketingJobRuntime(startResult.jobId))!;
     assert.equal(startedDoc.approvals.current?.workflow_name, MARKETING_WORKFLOW_NAME);
     assert.equal(startedDoc.approvals.current?.workflow_step_id, 'approve_stage_2');
     assert.equal(startedDoc.stages.research.run_id, 'verify-flow-run');
@@ -194,11 +194,11 @@ test('canonical client-facing marketing smoke flow stays on the monolithic pipel
       tenantId: 'tenant_verify',
       approvedBy: 'verify-runner',
       approvedStages: ['strategy'],
-    }, loadMarketingJobRuntime(startResult.jobId)!);
+    }, (await loadMarketingJobRuntime(startResult.jobId))!);
     assert.equal(strategyApproval.status, 'resumed');
     assert.equal(strategyApproval.resumedStage, 'production');
     assert.equal(strategyApproval.completed, false);
-    const afterStrategy = loadMarketingJobRuntime(startResult.jobId)!;
+    const afterStrategy = (await loadMarketingJobRuntime(startResult.jobId))!;
     assert.equal(afterStrategy.approvals.current?.workflow_name, MARKETING_WORKFLOW_NAME);
     assert.equal(afterStrategy.approvals.current?.workflow_step_id, 'approve_stage_3');
     assert.equal(afterStrategy.stages.strategy.run_id, 'verify-flow-run');
@@ -209,11 +209,11 @@ test('canonical client-facing marketing smoke flow stays on the monolithic pipel
       tenantId: 'tenant_verify',
       approvedBy: 'verify-runner',
       approvedStages: ['production'],
-    }, loadMarketingJobRuntime(startResult.jobId)!);
+    }, (await loadMarketingJobRuntime(startResult.jobId))!);
     assert.equal(productionApproval.status, 'resumed');
     assert.equal(productionApproval.resumedStage, 'publish');
     assert.equal(productionApproval.completed, false);
-    const afterProduction = loadMarketingJobRuntime(startResult.jobId)!;
+    const afterProduction = (await loadMarketingJobRuntime(startResult.jobId))!;
     assert.equal(afterProduction.approvals.current?.workflow_name, MARKETING_WORKFLOW_NAME);
     assert.equal(afterProduction.approvals.current?.workflow_step_id, 'approve_stage_4');
     assert.equal(afterProduction.stages.production.run_id, 'verify-flow-run');
@@ -225,7 +225,7 @@ test('canonical client-facing marketing smoke flow stays on the monolithic pipel
       approvedBy: 'verify-runner',
       approvedStages: ['publish'],
       resumePublishIfNeeded: true,
-    }, loadMarketingJobRuntime(startResult.jobId)!);
+    }, (await loadMarketingJobRuntime(startResult.jobId))!);
 
 
     assert.equal(approvalResult.status, 'resumed');
@@ -234,7 +234,7 @@ test('canonical client-facing marketing smoke flow stays on the monolithic pipel
     assert.deepEqual(actions, ['run', 'resume', 'resume', 'resume']);
     assert.deepEqual(resumeTokens, ['resume_strategy', 'resume_production', 'resume_publish']);
 
-    const statusAfterApproval = getMarketingJobStatus(startResult.jobId);
+    const statusAfterApproval = await getMarketingJobStatus(startResult.jobId);
     assert.equal(statusAfterApproval.state, 'completed');
     assert.equal(statusAfterApproval.status, 'completed');
     assert.equal(statusAfterApproval.stageStatus.publish, 'completed');

--- a/tests/marketing-job-delete.test.ts
+++ b/tests/marketing-job-delete.test.ts
@@ -99,7 +99,7 @@ describe('DELETE /api/marketing/jobs/:jobId', () => {
     assert.ok(body.deletedAt);
     assert.equal(body.deletedBy, 'user_admin');
 
-    const doc = loadMarketingJobRuntime('job_admin');
+    const doc = await loadMarketingJobRuntime('job_admin');
     assert.ok(doc);
     assert.ok(doc.deleted_at);
     assert.equal(doc.deleted_by, 'user_admin');
@@ -205,7 +205,7 @@ describe('DELETE /api/marketing/jobs/:jobId', () => {
     assert.equal(secondBody.deletedAt, originalDeletedAt, 'deleted_at must not be rewritten by a repeat delete');
     assert.equal(secondBody.deletedBy, originalDeletedBy, 'deleted_by must not be rewritten by a repeat delete');
 
-    const doc = loadMarketingJobRuntime('job_idempotent');
+    const doc = await loadMarketingJobRuntime('job_idempotent');
     assert.ok(doc);
     assert.equal(doc.deleted_at, originalDeletedAt);
     assert.equal(doc.deleted_by, originalDeletedBy);
@@ -253,7 +253,7 @@ describe('POST /api/marketing/jobs/:jobId/restore', () => {
     }));
 
     assert.equal(response.status, 200);
-    const doc = loadMarketingJobRuntime('job_restore');
+    const doc = await loadMarketingJobRuntime('job_restore');
     assert.ok(doc);
     assert.equal(doc.deleted_at, null);
     assert.equal(doc.deleted_by, null);
@@ -297,7 +297,7 @@ describe('POST /api/marketing/jobs/:jobId/restore', () => {
     }));
 
     assert.equal(response.status, 200);
-    const doc = loadMarketingJobRuntime('job_restore_idempotent');
+    const doc = await loadMarketingJobRuntime('job_restore_idempotent');
     assert.ok(doc);
     assert.equal(doc.deleted_at, null);
     assert.equal(doc.deleted_by, null);

--- a/tests/marketing-job-route.smoke.test.ts
+++ b/tests/marketing-job-route.smoke.test.ts
@@ -93,7 +93,7 @@ test('/api/marketing/jobs reaches the first approval checkpoint through the real
     assert.equal((captured[0]?.args as Record<string, unknown>)?.pipeline, 'marketing-pipeline.lobster');
     assert.equal((captured[0]?.args as Record<string, unknown>)?.cwd, 'lobster');
 
-    const runtimeDoc = loadMarketingJobRuntime(String(body.jobId));
+    const runtimeDoc = await loadMarketingJobRuntime(String(body.jobId));
     assert.equal(runtimeDoc?.current_stage, 'strategy');
     assert.equal(runtimeDoc?.stages.research.run_id, 'route-smoke-run');
     assert.equal(runtimeDoc?.approvals.current?.workflow_step_id, 'approve_stage_2');

--- a/tests/marketing-validated-profile-source-leak.test.ts
+++ b/tests/marketing-validated-profile-source-leak.test.ts
@@ -79,7 +79,7 @@ test('loadValidatedMarketingProfileSnapshot hides stale tenant docs when current
       },
     });
 
-    const snapshot = loadValidatedMarketingProfileSnapshot('tenant_nwa', {
+    const snapshot = await loadValidatedMarketingProfileSnapshot('tenant_nwa', {
       currentSourceUrl: 'https://nwaeventco.com',
     });
 
@@ -109,7 +109,7 @@ test('invalidateValidatedProfilesIfSourceChanged quarantines mismatched and unfi
       },
     );
 
-    const result = invalidateValidatedProfilesIfSourceChanged('tenant_nwa', 'https://nwaeventco.com');
+    const result = await invalidateValidatedProfilesIfSourceChanged('tenant_nwa', 'https://nwaeventco.com');
 
     // The mismatched brand-profile and the unfingerprinted website-analysis must both be quarantined;
     // the matching business-profile must remain.
@@ -126,7 +126,7 @@ test('invalidateValidatedProfilesIfSourceChanged quarantines mismatched and unfi
 
     // After quarantine, loadValidatedMarketingProfileSnapshot must not see the stale content even
     // if a later caller forgets to pass currentSourceUrl.
-    const snapshot = loadValidatedMarketingProfileSnapshot('tenant_nwa');
+    const snapshot = await loadValidatedMarketingProfileSnapshot('tenant_nwa');
     assert.notEqual(snapshot.businessName, 'Mejuri', 'Mejuri data must not return after quarantine');
 
     // Sanity check: both the business-profile.json (preserved) and the new .stale- files live side by side.
@@ -143,7 +143,7 @@ test('invalidateValidatedProfilesIfSourceChanged is a no-op when no current sour
     const { brandProfilePath } = await writeValidatedDocs(dataRoot, 'tenant_nwa', {
       brandProfile: { canonical_url: 'https://anything.com/', brand_name: 'Anything' },
     });
-    const result = invalidateValidatedProfilesIfSourceChanged('tenant_nwa', null);
+    const result = await invalidateValidatedProfilesIfSourceChanged('tenant_nwa', null);
     assert.deepEqual(result.quarantined, []);
     assert.equal(existsSync(brandProfilePath), true, 'file must remain untouched when source is unknown');
   });

--- a/tests/marketing-validated-runtime.test.ts
+++ b/tests/marketing-validated-runtime.test.ts
@@ -247,7 +247,7 @@ test('validated profile snapshot reads brand/profile docs in the required preced
     );
 
     const { loadValidatedMarketingProfileSnapshot } = await import('../backend/marketing/validated-profile-store');
-    const snapshot = loadValidatedMarketingProfileSnapshot(tenantId);
+    const snapshot = await loadValidatedMarketingProfileSnapshot(tenantId);
 
     assert.equal(snapshot.brandName, 'Brand Profile Name');
     assert.equal(snapshot.websiteUrl, 'https://brand-profile.example/');

--- a/tests/runtime-views-auth-hardening.test.ts
+++ b/tests/runtime-views-auth-hardening.test.ts
@@ -653,7 +653,7 @@ test('approving a workflow approval review item resumes the marketing job', asyn
       assert.equal(approved?.status, 'approved');
       assert.equal(approved?.lastDecision?.actedBy, 'Morgan');
 
-      const runtimeDoc = loadMarketingJobRuntime(started.jobId);
+      const runtimeDoc = await loadMarketingJobRuntime(started.jobId);
       assert.equal(runtimeDoc?.current_stage, 'production');
       assert.equal(runtimeDoc?.approvals.current?.stage, 'production');
     } finally {
@@ -693,7 +693,7 @@ test('approve_stage_2 workflow reviews include research, brief, brand-kit, and u
         payload,
       });
 
-      const record = ensureCampaignWorkspaceRecord({
+      const record = await ensureCampaignWorkspaceRecord({
         jobId: started.jobId,
         tenantId: 'tenant_123',
         payload,
@@ -777,7 +777,7 @@ test('stale workflow approval ids do not advance a newer approval checkpoint', a
         approvalId: staleApprovalId,
       });
 
-      let runtimeDoc = loadMarketingJobRuntime(started.jobId);
+      let runtimeDoc = await loadMarketingJobRuntime(started.jobId);
       assert.equal(runtimeDoc?.current_stage, 'production');
       assert.equal(runtimeDoc?.approvals.current?.stage, 'production');
 
@@ -790,7 +790,7 @@ test('stale workflow approval ids do not advance a newer approval checkpoint', a
         approvalId: staleApprovalId,
       });
 
-      runtimeDoc = loadMarketingJobRuntime(started.jobId);
+      runtimeDoc = await loadMarketingJobRuntime(started.jobId);
       assert.equal(runtimeDoc?.current_stage, 'production');
       assert.equal(runtimeDoc?.approvals.current?.stage, 'production');
     } finally {

--- a/tests/tenant/business-profile.test.ts
+++ b/tests/tenant/business-profile.test.ts
@@ -181,7 +181,7 @@ test('marketingPayloadDefaultsFromBusinessProfile derives defaults from validate
       ),
     );
 
-    const defaults = marketingPayloadDefaultsFromBusinessProfile('11');
+    const defaults = await marketingPayloadDefaultsFromBusinessProfile('11');
 
     assert.equal(defaults.websiteUrl, 'https://sugarandleather.com');
     assert.equal(defaults.businessName, 'Sugar & Leather');

--- a/tests/video-artifact-collector.test.ts
+++ b/tests/video-artifact-collector.test.ts
@@ -77,7 +77,7 @@ test('collectProductionReviewArtifacts emits one video artifact per rendered var
       },
     });
 
-    const capture = collectProductionReviewArtifacts({ run_id: runId, job_id: jobId }, null);
+    const capture = await collectProductionReviewArtifacts({ run_id: runId, job_id: jobId }, null);
     const videoArtifacts = capture.artifacts.filter(
       (artifact): artifact is Extract<(typeof capture.artifacts)[number], { type: 'video' }> =>
         'type' in artifact && artifact.type === 'video',


### PR DESCRIPTION
## Summary
Converts the `/api/marketing/jobs/:id` marketing hot path from sync read-side file IO to async `node:fs/promises` reads through the plan 03 file set, then propagates the required async call chain through handlers, view builders, business-profile/default hydration, and tests.

Closes #37

## Converted Files
Read-side fs conversion in scope:
- `backend/marketing/runtime-state.ts`
- `backend/marketing/artifact-collector.ts`
- `backend/marketing/stage-artifact-resolution.ts`
- `backend/marketing/workspace-views.ts`
- `backend/marketing/publish-review.ts`
- `backend/marketing/real-artifacts.ts`
- `backend/marketing/asset-library.ts`
- `backend/marketing/jobs-status.ts`
- `backend/marketing/validated-profile-store.ts`
- `backend/marketing/brand-kit.ts`

Async propagation / consumer updates required by those conversions:
- `backend/marketing/dashboard-content.ts`
- `backend/marketing/runtime-views.ts`
- `backend/tenant/business-profile.ts`
- `app/api/marketing/jobs/[jobId]/approve/handler.ts`
- `app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts`
- `app/api/marketing/jobs/[jobId]/brief/route.ts`
- `app/api/marketing/jobs/[jobId]/delete/handler.ts`
- `app/api/marketing/jobs/[jobId]/handler.ts`
- `app/api/marketing/jobs/handler.ts`
- `app/api/marketing/jobs/latest/handler.ts`
- `app/api/pipeline/url-preview/route.ts`
- `app/materials/[jobId]/[assetId]/page.tsx`
- `app/onboarding/resume/page.tsx`
- `backend/marketing/jobs-approve.ts`
- `backend/marketing/orchestrator.ts`
- `lobster/bin/brand-kit-bootstrap.ts`
- Test updates in:
  - `tests/creative-review-per-family.test.ts`
  - `tests/dashboard-content-adapter.test.ts`
  - `tests/frontend-api-layer.test.ts`
  - `tests/marketing-approval-persistence.test.ts`
  - `tests/marketing-brand-identity-parity.test.ts`
  - `tests/marketing-brand-kit.test.ts`
  - `tests/marketing-flow-smoke.test.ts`
  - `tests/marketing-job-delete.test.ts`
  - `tests/marketing-job-route.smoke.test.ts`
  - `tests/marketing-validated-profile-source-leak.test.ts`
  - `tests/marketing-validated-runtime.test.ts`
  - `tests/runtime-views-auth-hardening.test.ts`
  - `tests/tenant/business-profile.test.ts`
  - `tests/video-artifact-collector.test.ts`

## Deliberately Left Untouched For Fs Conversion
- `backend/marketing/runtime-error-bridge.ts`: intentionally sync per plan 03 out-of-scope.
- `backend/marketing/asset-ingest.ts`: intentionally sync per plan 03 out-of-scope.
- `backend/marketing/workspace-store.ts`: no fs read conversion performed; write-side sync/atomic behavior remains unchanged. The file was only touched to propagate async business-profile default hydration through existing record constructors.
- All `writeFileSync` call sites: left unchanged per scope.
- Cheap standalone `existsSync` guards: left unchanged unless they were directly paired with a converted read path.

## Benchmark
Baseline from plan 03:
- Serial cold hit: `3.6s`
- 8 concurrent cold hits: `26.8s` tail

After this branch, measured locally against the route handler path for `mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63` with cache invalidation before each batch:
```json
{
  "jobId": "mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63",
  "serial": 1.7216847020000001,
  "concurrent8": 9.836678357999999
}
```

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
