### PR TITLE
perf(marketing): memoize stage payloads per request via MarketingJobFacts

### DIFF
--- a/backend/marketing/artifact-collector.ts
+++ b/backend/marketing/artifact-collector.ts
@@ -12,6 +12,7 @@ import {
   type MarketingVideoStageArtifact,
   type MarketingStageSummary,
 } from './runtime-state';
+import type { MarketingJobFacts } from './job-facts';
 import { resolvePublishReviewBundle } from './publish-review';
 import {
   ARTIFACT_UNAVAILABLE_TEXT,
@@ -241,12 +242,17 @@ async function resolveRunId(
   return asString(primaryOutput?.run_id) || (runtimeDoc && stage ? await inferMarketingStageRunId(runtimeDoc, stage) : null);
 }
 
-export async function collectResearchStageArtifacts(primaryOutput: Record<string, unknown> | null): Promise<StageCapture> {
-  const runId = await resolveRunId(primaryOutput);
+export async function collectResearchStageArtifacts(
+  facts: MarketingJobFacts,
+  primaryOutput: Record<string, unknown> | null,
+): Promise<StageCapture> {
+  const runId = (await resolveRunId(primaryOutput, facts.runtimeDoc, 1)) || facts.runId;
   const compilePath = runId ? stepPayloadPath(1, runId, 'ads_analyst_compile') : '';
   const extractorPath = runId ? stepPayloadPath(1, runId, 'meta_ads_extractor') : '';
-  const compile = compilePath ? await readJsonIfExists(compilePath) : null;
-  const extractor = extractorPath ? await readJsonIfExists(extractorPath) : null;
+  const [compile, extractor] = await Promise.all([
+    facts.stagePayload('research', 'ads_analyst_compile'),
+    facts.stagePayload('research', 'meta_ads_extractor'),
+  ]);
   const executive = asRecord(compile?.executive_summary) ?? {};
   // Only treat the competitor as real if the upstream produced a non-generic value.
   // ads-analyst defaults to the literal string "competitor" when no brand was set,
@@ -291,45 +297,42 @@ export async function collectResearchStageArtifacts(primaryOutput: Record<string
 }
 
 export async function collectStrategyReviewArtifacts(
+  facts: MarketingJobFacts,
   primaryOutput: Record<string, unknown> | null,
-  runtimeDoc?: MarketingJobRuntimeDocument | null,
 ): Promise<StageCapture> {
+  const runtimeDoc = facts.runtimeDoc;
   const sourceUrl = currentSourceUrl(runtimeDoc);
   const validatedDocs = runtimeDoc ? await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
     currentSourceUrl: sourceUrl,
   }) : null;
-  const websiteStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 2, 'website_brand_analysis') : null;
-  const plannerStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 2, 'campaign_planner') : null;
-  const reviewStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 2, 'strategy_review_preview') : null;
-  const runId =
-    await resolveRunId(primaryOutput, runtimeDoc, 2) ||
-    websiteStep?.runId ||
-    plannerStep?.runId ||
-    reviewStep?.runId ||
-    null;
+  const [websiteStep, plannerStep, reviewStep] = await Promise.all([
+    facts.stagePayload('strategy', 'website_brand_analysis'),
+    facts.stagePayload('strategy', 'campaign_planner'),
+    facts.stagePayload('strategy', 'strategy_review_preview'),
+  ]);
+  const runId = (await resolveRunId(primaryOutput, runtimeDoc, 2)) || facts.runId || null;
   const websitePath =
     stringValue(asRecord(primaryOutput)?.validated_website_analysis_path) ||
     validatedDocs?.paths.websiteAnalysis ||
-    websiteStep?.path ||
     (runId ? stepPayloadPath(2, runId, 'website_brand_analysis') : '');
   const brandProfilePath =
     stringValue(asRecord(primaryOutput)?.validated_brand_profile_path) ||
     validatedDocs?.paths.brandProfile ||
     null;
-  const plannerPath = plannerStep?.path || (runId ? stepPayloadPath(2, runId, 'campaign_planner') : '');
-  const reviewPath = reviewStep?.path || (runId ? stepPayloadPath(2, runId, 'strategy_review_preview') : '');
-  const rawRunWebsite = websiteStep?.payload || (websitePath ? await readJsonIfExists(websitePath) : null);
+  const plannerPath = runId ? stepPayloadPath(2, runId, 'campaign_planner') : '';
+  const reviewPath = runId ? stepPayloadPath(2, runId, 'strategy_review_preview') : '';
+  const rawRunWebsite = websiteStep || (websitePath ? await facts.jsonAtPath(websitePath) : null);
   const runWebsite = sourceMatchedRecord(
     rawRunWebsite,
     sourceUrl,
   );
   const website = runWebsite || validatedDocs?.websiteAnalysis || null;
   const brandProfile = sourceMatchedRecord(
-    validatedDocs?.brandProfile || (brandProfilePath ? await readJsonIfExists(brandProfilePath) : null),
+    validatedDocs?.brandProfile || (brandProfilePath ? await facts.jsonAtPath(brandProfilePath) : null),
     sourceUrl,
   );
-  const plannerCandidate = plannerStep?.payload || (plannerPath ? await readJsonIfExists(plannerPath) : null);
-  const reviewCandidate = reviewStep?.payload || (reviewPath ? await readJsonIfExists(reviewPath) : null);
+  const plannerCandidate = plannerStep || (plannerPath ? await facts.jsonAtPath(plannerPath) : null);
+  const reviewCandidate = reviewStep || (reviewPath ? await facts.jsonAtPath(reviewPath) : null);
   const planner = strategyPayloadMatchesCurrentSource(plannerCandidate, sourceUrl, runWebsite, !!rawRunWebsite) ? plannerCandidate : null;
   const review = strategyPayloadMatchesCurrentSource(reviewCandidate, sourceUrl, runWebsite, !!rawRunWebsite) ? reviewCandidate : null;
   const brandAnalysis = asRecord(website?.brand_analysis) ?? {};
@@ -410,23 +413,20 @@ export async function collectStrategyFinalizeArtifacts(primaryOutput: Record<str
 }
 
 export async function collectProductionReviewArtifacts(
+  facts: MarketingJobFacts,
   primaryOutput: Record<string, unknown> | null,
-  runtimeDoc?: MarketingJobRuntimeDocument | null,
 ): Promise<StageCapture> {
-  const reviewStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 3, 'production_review_preview') : null;
-  const finalizeStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 3, 'creative_director_finalize') : null;
-  const videoStep = runtimeDoc ? await readMarketingStageStepPayload(runtimeDoc, 3, 'veo_video_generator') : null;
-  const runId =
-    await resolveRunId(primaryOutput, runtimeDoc, 3) ||
-    reviewStep?.runId ||
-    finalizeStep?.runId ||
-    videoStep?.runId ||
-    null;
-  const reviewPath = reviewStep?.path || (runId ? stepPayloadPath(3, runId, 'production_review_preview') : '');
-  const finalizePath = finalizeStep?.path || (runId ? stepPayloadPath(3, runId, 'creative_director_finalize') : '');
-  const videoPath = videoStep?.path || (runId ? stepPayloadPath(3, runId, 'veo_video_generator') : '');
-  const review = reviewStep?.payload || (reviewPath ? await readJsonIfExists(reviewPath) : null);
-  const video = videoStep?.payload || (videoPath ? await readJsonIfExists(videoPath) : null);
+  const runtimeDoc = facts.runtimeDoc;
+  const [reviewStep, videoStep] = await Promise.all([
+    facts.stagePayload('production', 'production_review_preview'),
+    facts.stagePayload('production', 'veo_video_generator'),
+  ]);
+  const runId = (await resolveRunId(primaryOutput, runtimeDoc, 3)) || facts.runId || null;
+  const reviewPath = runId ? stepPayloadPath(3, runId, 'production_review_preview') : '';
+  const finalizePath = runId ? stepPayloadPath(3, runId, 'creative_director_finalize') : '';
+  const videoPath = runId ? stepPayloadPath(3, runId, 'veo_video_generator') : '';
+  const review = reviewStep || (reviewPath ? await facts.jsonAtPath(reviewPath) : null);
+  const video = videoStep || (videoPath ? await facts.jsonAtPath(videoPath) : null);
   const jobId = runtimeDoc?.job_id || stringValue(primaryOutput?.job_id) || null;
   const packet = asRecord(review?.review_packet) ?? {};
   const summaryBlock = asRecord(packet.summary) ?? {};

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -7,6 +7,7 @@ import { resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
 import { listMarketingDashboardAssetsForJob } from './dashboard-content';
 import { remapHostOutputToMount } from './host-output-path';
 import { collectResearchStageArtifacts, collectStrategyReviewArtifacts } from './artifact-collector';
+import { createMarketingJobFacts, type MarketingJobFacts } from './job-facts';
 import {
   canonicalizePublishReviewPlatformSlug,
   legacyPublishReviewLinkedAssetId,
@@ -281,9 +282,14 @@ export function marketingAssetUrl(jobId: string, assetId: string): string {
   return `/api/marketing/jobs/${encodeURIComponent(jobId)}/assets/${encodeURIComponent(assetId)}`;
 }
 
-export async function buildMarketingAssetLibrary(jobId: string, runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingAssetDescriptor[]> {
+export async function buildMarketingAssetLibrary(
+  jobId: string,
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts?: MarketingJobFacts,
+): Promise<MarketingAssetDescriptor[]> {
   const assets: MarketingAssetDescriptor[] = [];
   const assetById = new Map<string, MarketingAssetDescriptor>();
+  const resolvedFacts = facts ?? createMarketingJobFacts(runtimeDoc, null);
   const resolveAssetPath = (
     filePath: string | null | undefined,
     fallbackPaths: Array<string | null | undefined> = []
@@ -332,6 +338,7 @@ export async function buildMarketingAssetLibrary(jobId: string, runtimeDoc: Mark
 
   const strategyOutputs = recordValue(runtimeDoc.stages.strategy.outputs);
   const researchFallback = await collectResearchStageArtifacts(
+    resolvedFacts,
     runtimeDoc.stages.research.primary_output || { run_id: runtimeDoc.stages.research.run_id },
   );
   const validatedProfileDocs = await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
@@ -341,8 +348,8 @@ export async function buildMarketingAssetLibrary(jobId: string, runtimeDoc: Mark
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   });
   const strategyFallback = await collectStrategyReviewArtifacts(
+    resolvedFacts,
     runtimeDoc.stages.strategy.primary_output || { run_id: runtimeDoc.stages.strategy.run_id },
-    runtimeDoc,
   );
   const researchSummaryPath =
     stringValue(researchFallback.outputs.compile_path) ||
@@ -453,7 +460,7 @@ export async function buildMarketingAssetLibrary(jobId: string, runtimeDoc: Mark
     rememberPreviewFallback(asset.platform, asset.filePath);
   }
 
-  const reviewBundle = await extractPublishReviewBundle(runtimeDoc);
+  const reviewBundle = await extractPublishReviewBundle(runtimeDoc, resolvedFacts);
   if (reviewBundle) {
     const artifactPaths = recordValue(reviewBundle.artifact_paths);
     const landingPage = recordValue(reviewBundle.landing_page_preview);
@@ -530,8 +537,12 @@ export async function buildMarketingAssetLibrary(jobId: string, runtimeDoc: Mark
   return assets;
 }
 
-export async function buildMarketingAssetLinks(jobId: string, runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingAssetLink[]> {
-  return (await buildMarketingAssetLibrary(jobId, runtimeDoc)).map((asset) => ({
+export async function buildMarketingAssetLinks(
+  jobId: string,
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts?: MarketingJobFacts,
+): Promise<MarketingAssetLink[]> {
+  return (await buildMarketingAssetLibrary(jobId, runtimeDoc, facts)).map((asset) => ({
     id: asset.id,
     url: marketingAssetUrl(jobId, asset.id),
     label: asset.label,
@@ -542,15 +553,17 @@ export async function buildMarketingAssetLinks(jobId: string, runtimeDoc: Market
 export async function findMarketingAsset(
   jobId: string,
   runtimeDoc: MarketingJobRuntimeDocument,
-  assetId: string
+  assetId: string,
+  facts?: MarketingJobFacts,
 ): Promise<MarketingAssetDescriptor | null> {
-  const assets = await buildMarketingAssetLibrary(jobId, runtimeDoc);
+  const resolvedFacts = facts ?? createMarketingJobFacts(runtimeDoc, null);
+  const assets = await buildMarketingAssetLibrary(jobId, runtimeDoc, resolvedFacts);
   const directMatch = assets.find((asset) => asset.id === assetId);
   if (directMatch) {
     return directMatch;
   }
 
-  const reviewBundle = await extractPublishReviewBundle(runtimeDoc);
+  const reviewBundle = await extractPublishReviewBundle(runtimeDoc, resolvedFacts);
   const platformPreviews = recordArray(reviewBundle?.platform_previews);
   const legacyToCanonical = new Map<string, string>();
 

--- a/backend/marketing/job-facts.ts
+++ b/backend/marketing/job-facts.ts
@@ -1,0 +1,102 @@
+import { readFile } from 'node:fs/promises';
+
+import type { MarketingJobRuntimeDocument, MarketingStage } from './runtime-state';
+import {
+  readMarketingStageStepPayload,
+  type MarketingArtifactStageNumber,
+  type StepPayloadResolution,
+} from './stage-artifact-resolution';
+
+type JsonRecord = Record<string, unknown>;
+
+type MarketingJobFactsDependencies = {
+  readJsonAtPath?: (absolutePath: string) => Promise<JsonRecord | null>;
+  readStageStepPayload?: (
+    runtimeDoc: MarketingJobRuntimeDocument,
+    stage: MarketingArtifactStageNumber,
+    stepName: string,
+    preferredRunId?: string | null,
+  ) => Promise<StepPayloadResolution>;
+};
+
+export interface MarketingJobFacts {
+  runtimeDoc: MarketingJobRuntimeDocument;
+  runId: string | null;
+  stagePayload(stage: MarketingStage, stepName: string): Promise<JsonRecord | null>;
+  jsonAtPath(absolutePath: string): Promise<JsonRecord | null>;
+}
+
+function stageNumber(stage: MarketingStage): MarketingArtifactStageNumber {
+  if (stage === 'research') {
+    return 1;
+  }
+  if (stage === 'strategy') {
+    return 2;
+  }
+  if (stage === 'production') {
+    return 3;
+  }
+  return 4;
+}
+
+async function defaultReadJsonAtPath(absolutePath: string): Promise<JsonRecord | null> {
+  try {
+    const parsed = JSON.parse(await readFile(absolutePath, 'utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonRecord)
+      : null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return null;
+    }
+    return null;
+  }
+}
+
+export function createMarketingJobFacts(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  runId: string | null,
+  dependencies: MarketingJobFactsDependencies = {},
+): MarketingJobFacts {
+  const readJsonAtPath = dependencies.readJsonAtPath ?? defaultReadJsonAtPath;
+  const readStageStepPayload = dependencies.readStageStepPayload ?? readMarketingStageStepPayload;
+  const pathCache = new Map<string, Promise<JsonRecord | null>>();
+  const stageCache = new Map<string, Promise<StepPayloadResolution>>();
+
+  return {
+    runtimeDoc,
+    runId,
+    async stagePayload(stage, stepName) {
+      const cacheKey = `${stage}:${stepName}`;
+      const existing = stageCache.get(cacheKey);
+      if (existing) {
+        return (await existing).payload;
+      }
+
+      const pending = readStageStepPayload(
+        runtimeDoc,
+        stageNumber(stage),
+        stepName,
+        runId,
+      ).then((resolution) => {
+        if (resolution.path && !pathCache.has(resolution.path)) {
+          pathCache.set(resolution.path, Promise.resolve(resolution.payload));
+        }
+        return resolution;
+      });
+
+      stageCache.set(cacheKey, pending);
+      return (await pending).payload;
+    },
+    jsonAtPath(absolutePath) {
+      const existing = pathCache.get(absolutePath);
+      if (existing) {
+        return existing;
+      }
+
+      const pending = readJsonAtPath(absolutePath);
+      pathCache.set(absolutePath, pending);
+      return pending;
+    },
+  };
+}

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -11,6 +11,7 @@ import {
   type MarketingStage,
 } from './runtime-state';
 import { buildMarketingAssetLinks, marketingAssetUrl, type MarketingAssetLink } from './asset-library';
+import { createMarketingJobFacts, type MarketingJobFacts } from './job-facts';
 import { resolvePublishReviewBundle } from './publish-review';
 import {
   canonicalizePublishReviewPlatformSlug,
@@ -766,9 +767,12 @@ function buildTimeline(
   });
 }
 
-async function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingReviewBundle | null> {
+async function buildReviewBundle(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts: MarketingJobFacts,
+): Promise<MarketingReviewBundle | null> {
   const jobId = runtimeDoc.job_id;
-  const resolvedReview = await resolvePublishReviewBundle(runtimeDoc);
+  const resolvedReview = await resolvePublishReviewBundle(runtimeDoc, facts);
   const review = resolvedReview.reviewPayload;
   const reviewBundle = resolvedReview.reviewBundle;
   if (!reviewBundle) {
@@ -779,7 +783,7 @@ async function buildReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promi
   const scriptPreview = recordValue(reviewBundle.script_preview);
   const reviewPacket = recordValue(reviewBundle.review_packet);
   const artifactPaths = recordValue(reviewBundle.artifact_paths);
-  const assetLinks = await buildMarketingAssetLinks(jobId, runtimeDoc);
+  const assetLinks = await buildMarketingAssetLinks(jobId, runtimeDoc, facts);
   const linkById = new Map(assetLinks.map((asset) => [asset.id, asset] as const));
 
   return {
@@ -977,16 +981,25 @@ function fallbackPlatformMediaAssets(assetLinks: MarketingAssetLink[], platformS
   });
 }
 
-async function rawPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
-  return (await resolvePublishReviewBundle(runtimeDoc)).reviewBundle;
+async function rawPublishReviewBundle(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts: MarketingJobFacts,
+): Promise<Record<string, unknown> | null> {
+  return (await resolvePublishReviewBundle(runtimeDoc, facts)).reviewBundle;
 }
 
-async function publishReviewSource(runtimeDoc: MarketingJobRuntimeDocument): Promise<'runtime' | 'merged_runtime_artifacts' | 'artifact_fallback' | 'none'> {
-  return (await resolvePublishReviewBundle(runtimeDoc)).source;
+async function publishReviewSource(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts: MarketingJobFacts,
+): Promise<'runtime' | 'merged_runtime_artifacts' | 'artifact_fallback' | 'none'> {
+  return (await resolvePublishReviewBundle(runtimeDoc, facts)).source;
 }
 
-async function buildCampaignWindow(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingCampaignWindow | null> {
-  const reviewBundle = await rawPublishReviewBundle(runtimeDoc);
+async function buildCampaignWindow(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts: MarketingJobFacts,
+): Promise<MarketingCampaignWindow | null> {
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc, facts);
   const summary = recordValue(reviewBundle?.summary);
   const campaignWindow = recordValue(summary?.campaign_window);
 
@@ -1031,8 +1044,11 @@ function buildAssetPreviewCards(jobId: string, reviewBundle: MarketingReviewBund
   }));
 }
 
-async function buildCalendarEvents(runtimeDoc: MarketingJobRuntimeDocument): Promise<MarketingCalendarEvent[]> {
-  const reviewBundle = await rawPublishReviewBundle(runtimeDoc);
+async function buildCalendarEvents(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts: MarketingJobFacts,
+): Promise<MarketingCalendarEvent[]> {
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc, facts);
   const contentCalendar = recordValue(reviewBundle?.content_calendar);
   const events = recordArray(contentCalendar?.events);
 
@@ -1058,10 +1074,11 @@ async function buildCalendarEvents(runtimeDoc: MarketingJobRuntimeDocument): Pro
 
 async function buildPostCounts(
   runtimeDoc: MarketingJobRuntimeDocument,
+  facts: MarketingJobFacts,
   reviewBundle: MarketingReviewBundle | null,
   calendarEvents: MarketingCalendarEvent[]
 ): Promise<{ plannedPostCount: number | null; createdPostCount: number | null }> {
-  const rawBundle = await rawPublishReviewBundle(runtimeDoc);
+  const rawBundle = await rawPublishReviewBundle(runtimeDoc, facts);
   const summary = recordValue(rawBundle?.summary);
   const explicitPlanned = numberValue(summary?.planned_posts);
   const explicitCreated = numberValue(summary?.created_posts);
@@ -1121,6 +1138,7 @@ async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatu
     };
   }
 
+  const facts = createMarketingJobFacts(runtimeDoc, null);
   const stageStatus: Record<string, string> = {
     research: responseStageStatus(runtimeDoc.stages.research),
     strategy: responseStageStatus(runtimeDoc.stages.strategy),
@@ -1129,12 +1147,12 @@ async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatu
   };
   const state = deriveState(runtimeDoc, stageStatus);
   const approval = buildApproval(jobId, runtimeDoc);
-  const reviewBundle = await buildReviewBundle(runtimeDoc);
-  const campaignWindow = await buildCampaignWindow(runtimeDoc);
+  const reviewBundle = await buildReviewBundle(runtimeDoc, facts);
+  const campaignWindow = await buildCampaignWindow(runtimeDoc, facts);
   const durationDays = buildDurationDays(campaignWindow);
   const assetPreviewCards = buildAssetPreviewCards(jobId, reviewBundle);
-  const calendarEvents = await buildCalendarEvents(runtimeDoc);
-  const postCounts = await buildPostCounts(runtimeDoc, reviewBundle, calendarEvents);
+  const calendarEvents = await buildCalendarEvents(runtimeDoc, facts);
+  const postCounts = await buildPostCounts(runtimeDoc, facts, reviewBundle, calendarEvents);
   const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   });
@@ -1143,7 +1161,7 @@ async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatu
       event: 'job-status',
       jobId,
       tenantId: runtimeDoc.tenant_id,
-      reviewBundleSource: await publishReviewSource(runtimeDoc),
+      reviewBundleSource: await publishReviewSource(runtimeDoc, facts),
       reviewBundleReason: reviewBundle ? 'hydrated' : 'no_real_publish_review_artifacts',
     });
   }

--- a/backend/marketing/orchestrator.ts
+++ b/backend/marketing/orchestrator.ts
@@ -36,6 +36,7 @@ import {
   collectResearchStageArtifacts,
   collectStrategyReviewArtifacts,
 } from './artifact-collector';
+import { createMarketingJobFacts } from './job-facts';
 import {
   appendHistory,
   assertMarketingRuntimeSchemas,
@@ -793,7 +794,10 @@ async function runResearchStage(doc: MarketingJobRuntimeDocument): Promise<void>
 
   const envelope = await runMarketingPipeline(doc);
   const primaryOutput = primaryOutputRecord(envelope);
-  const capture = await collectResearchStageArtifacts(primaryOutput);
+  const capture = await collectResearchStageArtifacts(
+    createMarketingJobFacts(doc, runIdFromPrimaryOutput(primaryOutput)),
+    primaryOutput,
+  );
   const summary = summarizeResearch(primaryOutput);
   const runId = capture.runId || runIdFromPrimaryOutput(primaryOutput);
   markStageCompleted(doc, 'research', {
@@ -854,7 +858,10 @@ async function finalizeStrategyAndRunProductionReview(
 
   const envelope = await resumeMarketingPipeline(resumeToken);
   const primaryOutput = primaryOutputRecord(envelope);
-  const strategyReviewCapture = await collectStrategyReviewArtifacts(primaryOutput, doc);
+  const strategyReviewCapture = await collectStrategyReviewArtifacts(
+    createMarketingJobFacts(doc, runIdFromPrimaryOutput(primaryOutput)),
+    primaryOutput,
+  );
   const strategy = summarizeStrategy(primaryOutput);
   markStageCompleted(doc, 'strategy', {
     runId: strategyReviewCapture.runId ?? runIdFromPrimaryOutput(primaryOutput) ?? getStageRecord(doc, 'research').run_id,
@@ -917,7 +924,10 @@ async function finalizeProductionAndRunPublishReview(
 
   const envelope = await resumeMarketingPipeline(resumeToken);
   const primaryOutput = primaryOutputRecord(envelope);
-  const productionReviewCapture = await collectProductionReviewArtifacts(primaryOutput, doc);
+  const productionReviewCapture = await collectProductionReviewArtifacts(
+    createMarketingJobFacts(doc, runIdFromPrimaryOutput(primaryOutput)),
+    primaryOutput,
+  );
   const production = summarizeProduction(primaryOutput);
   markStageCompleted(doc, 'production', {
     runId: productionReviewCapture.runId ?? runIdFromPrimaryOutput(primaryOutput) ?? getStageRecord(doc, 'strategy').run_id,

--- a/backend/marketing/publish-review.ts
+++ b/backend/marketing/publish-review.ts
@@ -3,6 +3,7 @@ import { readdir, readFile, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import type { MarketingJobFacts } from './job-facts';
 import type { MarketingJobRuntimeDocument, MarketingVideoStageArtifact } from './runtime-state';
 import { readMarketingStageStepPayload } from './stage-artifact-resolution';
 import {
@@ -739,6 +740,7 @@ function resolvePublishArtifactBrandSlug(
 async function buildFallbackPublishReviewBundle(
   runtimeDoc: MarketingJobRuntimeDocument,
   reviewPayload: Record<string, unknown> | null,
+  facts?: MarketingJobFacts,
 ): Promise<Record<string, unknown> | null> {
   const preflight = await readPublishStepPayload(runtimeDoc, 'performance_marketer_preflight');
   const productionHandoff = recordValue(preflight?.production_handoff);
@@ -779,7 +781,12 @@ async function buildFallbackPublishReviewBundle(
     runtimeDoc,
     brandSlug: artifactBrandSlug,
   });
-  const productionReview = await readMarketingStageStepPayload(runtimeDoc, 3, 'production_review_preview');
+  const productionReview = facts
+    ? await facts.stagePayload('production', 'production_review_preview')
+    : (await readMarketingStageStepPayload(runtimeDoc, 3, 'production_review_preview')).payload;
+  const productionReviewPath =
+    stringValue(recordValue(runtimeDoc.stages.production.outputs)?.production_review_path) ||
+    null;
   const platformPreviews: Record<string, unknown>[] = [];
   for (const reviewPackagePath of reviewPackagePaths) {
     const reviewPackage = await readJsonIfExists(reviewPackagePath);
@@ -898,9 +905,9 @@ async function buildFallbackPublishReviewBundle(
             short_video_script_path: scriptDetails.shortVideoScriptPath || undefined,
           }
         : null,
-    review_packet: productionReview.path
+    review_packet: productionReviewPath
       ? {
-          production_review_preview_path: resolveMarketingArtifactPath(productionReview.path) || productionReview.path,
+          production_review_preview_path: resolveMarketingArtifactPath(productionReviewPath) || productionReviewPath,
         }
       : null,
     platform_previews: platformPreviews,
@@ -958,12 +965,15 @@ function runtimeDocFallbackCampaignName(
   return stringValue(primaryBundle.campaign_name || fallbackBundle.campaign_name, 'Campaign');
 }
 
-export async function resolvePublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<PublishReviewBundleResolution> {
-  const reviewPayload = await extractPublishReviewPayload(runtimeDoc);
+export async function resolvePublishReviewBundle(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts?: MarketingJobFacts,
+): Promise<PublishReviewBundleResolution> {
+  const reviewPayload = await extractPublishReviewPayload(runtimeDoc, facts);
   const runtimeBundle = normalizeReviewBundle(recordValue(reviewPayload?.review_bundle));
   const fallbackBundle =
     publishStageHasRuntimeContext(runtimeDoc) || runtimeBundle
-      ? await buildFallbackPublishReviewBundle(runtimeDoc, reviewPayload)
+      ? await buildFallbackPublishReviewBundle(runtimeDoc, reviewPayload, facts)
       : null;
 
   if (runtimeBundle && !fallbackBundle) {
@@ -998,7 +1008,10 @@ export async function resolvePublishReviewBundle(runtimeDoc: MarketingJobRuntime
   };
 }
 
-export async function extractPublishReviewPayload(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
+export async function extractPublishReviewPayload(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts?: MarketingJobFacts,
+): Promise<Record<string, unknown> | null> {
   const publishStage = runtimeDoc.stages.publish;
   const reviewOutput = recordValue(publishStage.outputs.review);
   if (reviewOutput) {
@@ -1012,7 +1025,9 @@ export async function extractPublishReviewPayload(runtimeDoc: MarketingJobRuntim
   }
 
   const loggedReview = publishStageHasRuntimeContext(runtimeDoc)
-    ? await readPublishStepPayload(runtimeDoc, 'launch_review_preview')
+    ? facts
+      ? await facts.stagePayload('publish', 'launch_review_preview')
+      : await readPublishStepPayload(runtimeDoc, 'launch_review_preview')
     : null;
   if (loggedReview) {
     return loggedReview;
@@ -1021,6 +1036,9 @@ export async function extractPublishReviewPayload(runtimeDoc: MarketingJobRuntim
   return primaryOutput;
 }
 
-export async function extractPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
-  return (await resolvePublishReviewBundle(runtimeDoc)).reviewBundle;
+export async function extractPublishReviewBundle(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts?: MarketingJobFacts,
+): Promise<Record<string, unknown> | null> {
+  return (await resolvePublishReviewBundle(runtimeDoc, facts)).reviewBundle;
 }

--- a/backend/marketing/stage-artifact-resolution.ts
+++ b/backend/marketing/stage-artifact-resolution.ts
@@ -9,7 +9,7 @@ import type { MarketingJobRuntimeDocument, MarketingStage } from './runtime-stat
 
 export type MarketingArtifactStageNumber = 1 | 2 | 3 | 4;
 
-type StepPayloadResolution = {
+export type StepPayloadResolution = {
   runId: string | null;
   path: string | null;
   payload: Record<string, unknown> | null;
@@ -225,9 +225,11 @@ export async function readMarketingStageStepPayload(
   runtimeDoc: MarketingJobRuntimeDocument,
   stage: MarketingArtifactStageNumber,
   stepName: string,
+  preferredRunId?: string | null,
 ): Promise<StepPayloadResolution> {
   const currentStage = stageKey(stage);
   const runIds = uniqueStrings([
+    preferredRunId,
     stringValue(runtimeDoc.stages[currentStage].run_id),
     await inferMarketingStageRunId(runtimeDoc, stage),
   ]);

--- a/backend/marketing/workspace-views.ts
+++ b/backend/marketing/workspace-views.ts
@@ -21,6 +21,7 @@ import {
   collectProductionReviewArtifacts,
   collectStrategyReviewArtifacts,
 } from './artifact-collector';
+import { createMarketingJobFacts, type MarketingJobFacts } from './job-facts';
 import { recordMatchesCurrentSource, sourceFingerprintFromRecord } from './brand-identity';
 import { sanitizeBrandKitSummaryText } from './brand-kit';
 import { getMarketingDashboardCampaignContent } from './dashboard-content';
@@ -32,7 +33,6 @@ import {
   readLandingPageArtifactDetails,
   readScriptArtifactDetails,
 } from './real-artifacts';
-import { readMarketingStageStepPayload } from './stage-artifact-resolution';
 import {
   ensureCampaignWorkspaceRecord,
   marketingWorkspaceAssetUrl,
@@ -405,7 +405,10 @@ function buildCampaignBrief(record: CampaignWorkspaceRecord): MarketingCampaignB
   };
 }
 
-async function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<StagePayloadBundle> {
+async function loadStagePayloadBundle(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  facts: MarketingJobFacts,
+): Promise<StagePayloadBundle> {
   const sourceUrl = currentSourceUrl(runtimeDoc);
   const validatedDocs = await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
     currentSourceUrl: sourceUrl,
@@ -413,12 +416,12 @@ async function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): 
   const strategyOutputs = recordValue(runtimeDoc.stages.strategy.outputs) || {};
   const productionOutputs = recordValue(runtimeDoc.stages.production.outputs) || {};
   const strategyFallback = await collectStrategyReviewArtifacts(
+    facts,
     runtimeDoc.stages.strategy.primary_output || { run_id: runtimeDoc.stages.strategy.run_id },
-    runtimeDoc,
   );
   const productionFallback = await collectProductionReviewArtifacts(
+    facts,
     runtimeDoc.stages.production.primary_output || { run_id: runtimeDoc.stages.production.run_id },
-    runtimeDoc,
   );
 
   const runtimeWebsiteAnalysisPath = stringValue(strategyOutputs.validated_website_analysis_path) || stringValue(strategyOutputs.website_brand_analysis_path);
@@ -518,9 +521,9 @@ async function loadStagePayloadBundle(runtimeDoc: MarketingJobRuntimeDocument): 
   const hasCurrentSourceBrandArtifacts = !!(websiteAnalysis || brandProfile);
   const hasCurrentSourceStrategyArtifacts = !!(campaignPlanner || strategyPreview || hasCurrentSourceBrandArtifacts);
 
-  const brandBibleAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-bible-markdown');
-  const designSystemAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-design-system');
-  const proposalMarkdownAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'strategy-proposal-markdown');
+  const brandBibleAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-bible-markdown', facts);
+  const designSystemAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'brand-design-system', facts);
+  const proposalMarkdownAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, 'strategy-proposal-markdown', facts);
 
   return {
     websiteAnalysis,
@@ -663,6 +666,7 @@ async function buildBrandReview(
   runtimeDoc: MarketingJobRuntimeDocument,
   record: CampaignWorkspaceRecord,
   payloads: StagePayloadBundle,
+  facts: MarketingJobFacts,
 ): Promise<MarketingStageReviewPayload | null> {
   const hasGeneratedBrandArtifacts = hasRealBrandArtifacts(payloads);
   const hasUploadedBrandAssets = uploadedBrandAssets(record);
@@ -695,7 +699,7 @@ async function buildBrandReview(
         .map((entry) => entry.trim())
     : [];
   const attachments: MarketingReviewAttachment[] = [];
-  const assetLinks = new Map((await buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc)).map((asset) => [asset.id, asset] as const));
+  const assetLinks = new Map((await buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc, facts)).map((asset) => [asset.id, asset] as const));
 
   for (const asset of record.brief.brandAssets) {
     attachments.push(
@@ -885,6 +889,7 @@ async function buildStrategyReview(
   runtimeDoc: MarketingJobRuntimeDocument,
   record: CampaignWorkspaceRecord,
   payloads: StagePayloadBundle,
+  facts: MarketingJobFacts,
 ): Promise<MarketingStageReviewPayload | null> {
   const campaignPlan = recordValue(payloads.campaignPlanner?.campaign_plan);
   const reviewPacket = recordValue(payloads.strategyPreview?.review_packet);
@@ -893,7 +898,7 @@ async function buildStrategyReview(
     return null;
   }
   const attachments: MarketingReviewAttachment[] = [];
-  const assetLinks = new Map((await buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc)).map((asset) => [asset.id, asset] as const));
+  const assetLinks = new Map((await buildMarketingAssetLinks(runtimeDoc.job_id, runtimeDoc, facts)).map((asset) => [asset.id, asset] as const));
 
   for (const assetId of ['strategy-campaign-planner', 'strategy-review-preview', 'strategy-proposal-markdown', 'strategy-proposal-html'] as const) {
     const asset = assetLinks.get(assetId);
@@ -965,6 +970,7 @@ async function buildCreativeAssets(
   record: CampaignWorkspaceRecord,
   dashboard: MarketingDashboardCampaignContent,
   productionPreview: Record<string, unknown> | null,
+  facts: MarketingJobFacts,
 ): Promise<MarketingCreativeAssetReviewPayload[]> {
   const creativeAssets = dashboard.assets.filter(
     (asset) =>
@@ -985,7 +991,7 @@ async function buildCreativeAssets(
     if (metaAdScriptsByFamily !== undefined) {
       return metaAdScriptsByFamily;
     }
-    const scriptwriterPayload = (await readMarketingStageStepPayload(runtimeDoc, 3, 'scriptwriter')).payload;
+    const scriptwriterPayload = await facts.stagePayload('production', 'scriptwriter');
     metaAdScriptsByFamily = recordValue(
       recordValue(scriptwriterPayload?.script_assets)?.meta_ad_scripts_by_family,
     );
@@ -1007,7 +1013,7 @@ async function buildCreativeAssets(
 
   return Promise.all(creativeAssets.map(async (asset) => {
     const reviewState = record.creative_asset_reviews[asset.id];
-    const resolvedAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, asset.id);
+    const resolvedAsset = await findMarketingAsset(runtimeDoc.job_id, runtimeDoc, asset.id, facts);
     const fileName = resolvedAsset?.filePath ? path.basename(resolvedAsset.filePath) : null;
     const isVideoScript = asset.platform === 'video' || /video|short/i.test(`${asset.id} ${asset.title}`);
     const scriptDetails = isVideoScript
@@ -1103,8 +1109,9 @@ async function buildCreativeReview(
   productionPreview: Record<string, unknown> | null,
   publishBlockedReason: string | null,
   counts: { approved: number; pending: number; rejected: number },
+  facts: MarketingJobFacts,
 ): Promise<MarketingCreativeReviewPayload | null> {
-  const assets = await buildCreativeAssets(runtimeDoc, record, dashboard, productionPreview);
+  const assets = await buildCreativeAssets(runtimeDoc, record, dashboard, productionPreview, facts);
   if (assets.length === 0) {
     return null;
   }
@@ -1252,8 +1259,9 @@ export async function buildCampaignWorkspaceView(jobId: string): Promise<Campaig
     tenantId: runtimeDoc.tenant_id,
     payload: recordValue(runtimeDoc.inputs.request) || {},
   });
+  const facts = createMarketingJobFacts(runtimeDoc, null);
   const rawDashboard = await getMarketingDashboardCampaignContent(jobId);
-  const payloads = await loadStagePayloadBundle(runtimeDoc);
+  const payloads = await loadStagePayloadBundle(runtimeDoc, facts);
   const realBrandArtifactsReady = hasRealBrandArtifacts(payloads);
   const hasUploadedBrandAssets = uploadedBrandAssets(record);
   const brandReviewRenderable = realBrandArtifactsReady || hasUploadedBrandAssets;
@@ -1313,8 +1321,8 @@ export async function buildCampaignWorkspaceView(jobId: string): Promise<Campaig
   });
 
   const dashboard = withGatedDashboardStatus(rawDashboard, workflowResolution.workflowState);
-  const brandReview = brandReviewRenderable ? await buildBrandReview(runtimeDoc, record, payloads) : null;
-  const strategyReview = strategyReady ? await buildStrategyReview(runtimeDoc, record, payloads) : null;
+  const brandReview = brandReviewRenderable ? await buildBrandReview(runtimeDoc, record, payloads, facts) : null;
+  const strategyReview = strategyReady ? await buildStrategyReview(runtimeDoc, record, payloads, facts) : null;
   const creativeReview = await buildCreativeReview(
     runtimeDoc,
     record,
@@ -1326,6 +1334,7 @@ export async function buildCampaignWorkspaceView(jobId: string): Promise<Campaig
       pending: workflowResolution.creativePendingCount,
       rejected: workflowResolution.creativeRejectedCount,
     },
+    facts,
   );
 
   console.info('[marketing-hydration]', {

--- a/tests/marketing-job-facts.test.ts
+++ b/tests/marketing-job-facts.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectProductionReviewArtifacts,
+  collectResearchStageArtifacts,
+  collectStrategyReviewArtifacts,
+} from '../backend/marketing/artifact-collector';
+import { createMarketingJobFacts } from '../backend/marketing/job-facts';
+import { createMarketingJobRuntimeDocument } from '../backend/marketing/runtime-state';
+import type { MarketingArtifactStageNumber, StepPayloadResolution } from '../backend/marketing/stage-artifact-resolution';
+
+function makeRuntimeDoc() {
+  const runtimeDoc = createMarketingJobRuntimeDocument({
+    jobId: 'mkt_job_facts',
+    tenantId: 'tenant_job_facts',
+      payload: {
+        brandUrl: 'https://brand.example.com',
+        websiteUrl: 'https://brand.example.com',
+      },
+      brandKit: {
+        path: '/tmp/tenant_job_facts.brand-kit.json',
+        source_url: 'https://brand.example.com',
+        canonical_url: 'https://brand.example.com',
+        brand_name: 'Brand Example',
+      logo_urls: [],
+      colors: {
+        primary: '#111111',
+        secondary: '#f4f4f4',
+        accent: '#c24d2c',
+        palette: ['#111111', '#f4f4f4', '#c24d2c'],
+      },
+      font_families: ['Manrope'],
+      external_links: [],
+      extracted_at: '2026-04-24T00:00:00.000Z',
+      brand_voice_summary: 'Direct and grounded.',
+      offer_summary: 'Proof-led launch audit.',
+    },
+  });
+
+  runtimeDoc.stages.research.run_id = 'run-research';
+  runtimeDoc.stages.strategy.run_id = 'run-strategy';
+  runtimeDoc.stages.production.run_id = 'run-production';
+  runtimeDoc.stages.publish.run_id = 'run-publish';
+
+  return runtimeDoc;
+}
+
+function resolvedPayload(
+  runId: string,
+  payload: Record<string, unknown>,
+  filePath = `/tmp/${runId}.json`,
+): StepPayloadResolution {
+  return {
+    runId,
+    path: filePath,
+    payload,
+    source: 'cache',
+  };
+}
+
+test('stagePayload loads the same step once', async () => {
+  const runtimeDoc = makeRuntimeDoc();
+  let reads = 0;
+  const facts = createMarketingJobFacts(runtimeDoc, null, {
+    readStageStepPayload: async () => {
+      reads += 1;
+      return resolvedPayload('run-production', { ok: true });
+    },
+  });
+
+  const first = await facts.stagePayload('production', 'veo_video_generator');
+  const second = await facts.stagePayload('production', 'veo_video_generator');
+
+  assert.deepEqual(first, { ok: true });
+  assert.deepEqual(second, { ok: true });
+  assert.equal(reads, 1);
+});
+
+test('concurrent stagePayload lookups dedupe the in-flight read', async () => {
+  const runtimeDoc = makeRuntimeDoc();
+  let reads = 0;
+  const facts = createMarketingJobFacts(runtimeDoc, null, {
+    readStageStepPayload: async () => {
+      reads += 1;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return resolvedPayload('run-production', { ok: true });
+    },
+  });
+
+  const [first, second] = await Promise.all([
+    facts.stagePayload('production', 'veo_video_generator'),
+    facts.stagePayload('production', 'veo_video_generator'),
+  ]);
+
+  assert.deepEqual(first, { ok: true });
+  assert.deepEqual(second, { ok: true });
+  assert.equal(reads, 1);
+});
+
+test('different stage keys do not collide', async () => {
+  const runtimeDoc = makeRuntimeDoc();
+  const seenKeys: string[] = [];
+  const facts = createMarketingJobFacts(runtimeDoc, null, {
+    readStageStepPayload: async (_runtimeDoc, stage, stepName) => {
+      seenKeys.push(`${stage}:${stepName}`);
+      return resolvedPayload(`run-${stage}`, { stage, stepName });
+    },
+  });
+
+  const [research, strategy] = await Promise.all([
+    facts.stagePayload('research', 'shared_step'),
+    facts.stagePayload('strategy', 'shared_step'),
+  ]);
+
+  assert.deepEqual(research, { stage: 1, stepName: 'shared_step' });
+  assert.deepEqual(strategy, { stage: 2, stepName: 'shared_step' });
+  assert.deepEqual(seenKeys.sort(), ['1:shared_step', '2:shared_step']);
+});
+
+test('jsonAtPath memoizes repeated path reads', async () => {
+  const runtimeDoc = makeRuntimeDoc();
+  let reads = 0;
+  const facts = createMarketingJobFacts(runtimeDoc, null, {
+    readJsonAtPath: async () => {
+      reads += 1;
+      return { ok: true };
+    },
+  });
+
+  const [first, second] = await Promise.all([
+    facts.jsonAtPath('/tmp/reused.json'),
+    facts.jsonAtPath('/tmp/reused.json'),
+  ]);
+
+  assert.deepEqual(first, { ok: true });
+  assert.deepEqual(second, { ok: true });
+  assert.equal(reads, 1);
+});
+
+test('jsonAtPath caches missing files as null', async () => {
+  const runtimeDoc = makeRuntimeDoc();
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'aries-job-facts-missing-'));
+  const missingPath = path.join(tempRoot, 'missing.json');
+
+  try {
+    const facts = createMarketingJobFacts(runtimeDoc, null);
+    const first = facts.jsonAtPath(missingPath);
+    const second = facts.jsonAtPath(missingPath);
+
+    assert.strictEqual(first, second);
+    assert.equal(await first, null);
+    assert.strictEqual(facts.jsonAtPath(missingPath), first);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('jsonAtPath caches malformed JSON as null', async () => {
+  const runtimeDoc = makeRuntimeDoc();
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'aries-job-facts-malformed-'));
+  const malformedPath = path.join(tempRoot, 'broken.json');
+
+  try {
+    await mkdir(path.dirname(malformedPath), { recursive: true });
+    await writeFile(malformedPath, '{not-json', 'utf8');
+
+    const facts = createMarketingJobFacts(runtimeDoc, null);
+    const first = facts.jsonAtPath(malformedPath);
+    const second = facts.jsonAtPath(malformedPath);
+
+    assert.strictEqual(first, second);
+    assert.equal(await first, null);
+    assert.strictEqual(facts.jsonAtPath(malformedPath), first);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('shared facts dedupe stage payload reads across collector invocations', async () => {
+  const runtimeDoc = makeRuntimeDoc();
+  const readCounts = new Map<string, number>();
+
+  const stagePayloads = new Map<string, Record<string, unknown>>([
+    ['1:ads_analyst_compile', { executive_summary: { market_positioning: 'Research ready' } }],
+    ['1:meta_ads_extractor', { competitor: 'Competitor Example' }],
+    ['2:website_brand_analysis', {
+      brand_slug: 'brand-example',
+      brand_analysis: { brand_promise: 'Clear value' },
+    }],
+    ['2:campaign_planner', { campaign_plan: { core_message: 'Planner ready', primary_cta: 'Book now' } }],
+    ['2:strategy_review_preview', { review_packet: { objective: 'Review strategy', channels_in_scope: ['meta-ads'] } }],
+    ['3:production_review_preview', { review_packet: { summary: { core_message: 'Production ready' }, asset_previews: {} } }],
+    ['3:veo_video_generator', { video_assets: { platform_contracts: [] } }],
+  ]);
+
+  const facts = createMarketingJobFacts(runtimeDoc, null, {
+    readStageStepPayload: async (_runtimeDoc, stage: MarketingArtifactStageNumber, stepName: string) => {
+      const key = `${stage}:${stepName}`;
+      readCounts.set(key, (readCounts.get(key) ?? 0) + 1);
+      return resolvedPayload(`run-${stage}`, stagePayloads.get(key) ?? {}, `/tmp/${key}.json`);
+    },
+    readJsonAtPath: async () => null,
+  });
+
+  await Promise.all([
+    collectResearchStageArtifacts(facts, runtimeDoc.stages.research.primary_output),
+    collectStrategyReviewArtifacts(facts, runtimeDoc.stages.strategy.primary_output),
+    collectProductionReviewArtifacts(facts, { job_id: runtimeDoc.job_id }),
+    collectResearchStageArtifacts(facts, runtimeDoc.stages.research.primary_output),
+    collectStrategyReviewArtifacts(facts, runtimeDoc.stages.strategy.primary_output),
+    collectProductionReviewArtifacts(facts, { job_id: runtimeDoc.job_id }),
+  ]);
+
+  assert.deepEqual(
+    Array.from(readCounts.entries()).sort(([left], [right]) => left.localeCompare(right)),
+    [
+      ['1:ads_analyst_compile', 1],
+      ['1:meta_ads_extractor', 1],
+      ['2:campaign_planner', 1],
+      ['2:strategy_review_preview', 1],
+      ['2:website_brand_analysis', 1],
+      ['3:production_review_preview', 1],
+      ['3:veo_video_generator', 1],
+    ],
+  );
+});

--- a/tests/video-artifact-collector.test.ts
+++ b/tests/video-artifact-collector.test.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { collectProductionReviewArtifacts } from '../backend/marketing/artifact-collector';
+import { createMarketingJobFacts } from '../backend/marketing/job-facts';
+import { createMarketingJobRuntimeDocument } from '../backend/marketing/runtime-state';
 
 async function writeJson(filePath: string, value: unknown) {
   await mkdir(path.dirname(filePath), { recursive: true });
@@ -20,6 +22,33 @@ test('collectProductionReviewArtifacts emits one video artifact per rendered var
   process.env.LOBSTER_STAGE3_CACHE_DIR = tempRoot;
 
   try {
+    const runtimeDoc = createMarketingJobRuntimeDocument({
+      jobId,
+      tenantId: 'tenant-video-artifacts',
+      payload: {
+        brandUrl: 'https://brand.example.com',
+      },
+      brandKit: {
+        path: path.join(tempRoot, 'brand-kit.json'),
+        source_url: 'https://brand.example.com',
+        canonical_url: 'https://brand.example.com',
+        brand_name: 'Brand Example',
+        logo_urls: [],
+        colors: {
+          primary: '#111111',
+          secondary: '#f4f4f4',
+          accent: '#c24d2c',
+          palette: ['#111111', '#f4f4f4', '#c24d2c'],
+        },
+        font_families: ['Manrope'],
+        external_links: [],
+        extracted_at: '2026-04-24T00:00:00.000Z',
+        brand_voice_summary: 'Direct and grounded.',
+        offer_summary: 'Proof-led launch audit.',
+      },
+    });
+    runtimeDoc.stages.production.run_id = runId;
+
     await writeJson(path.join(tempRoot, runId, 'veo_video_generator.json'), {
       type: 'veo_video_generator',
       run_id: runId,
@@ -77,7 +106,10 @@ test('collectProductionReviewArtifacts emits one video artifact per rendered var
       },
     });
 
-    const capture = await collectProductionReviewArtifacts({ run_id: runId, job_id: jobId }, null);
+    const capture = await collectProductionReviewArtifacts(
+      createMarketingJobFacts(runtimeDoc, runId),
+      { run_id: runId, job_id: jobId },
+    );
     const videoArtifacts = capture.artifacts.filter(
       (artifact): artifact is Extract<(typeof capture.artifacts)[number], { type: 'video' }> =>
         'type' in artifact && artifact.type === 'video',


### PR DESCRIPTION
## Summary
- add `backend/marketing/job-facts.ts` with promise-backed per-request memoization for logical stage payload lookups and raw JSON path reads
- refactor the research, strategy, and production collectors to read through shared `MarketingJobFacts` instead of loading the same stage JSON directly
- thread a fresh facts instance through `buildMarketingJobStatus`, `publish-review`, and the request-local workspace/asset helper paths; add dedicated memoization coverage in `tests/marketing-job-facts.test.ts`

## Benchmarks
Target job: `/api/marketing/jobs/mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63`

Full endpoint benchmark with the jobs-status cache reset before each run:

| Scenario | PR #190 baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| 1 serial | 1.72s | 1.76s (`1756ms`) | +0.04s |
| 8 concurrent | 9.83s | 9.93s (`9932ms`) | +0.10s |

Isolated `jobs-status` cold-miss benchmark against the same job (same cache reset, bypassing the route wrapper):

| Scenario | This PR |
| --- | ---: |
| 1 serial | 0.35s (`349ms`) |
| 8 concurrent | 0.31s (`308ms`) |

The isolated numbers show the facts layer removing duplicate parse work inside `buildMarketingJobStatus`. The remaining full-route latency is still dominated by the separate `buildCampaignWorkspaceView` path that executes after the cached status payload is produced.

## Collector Sanity Check
`sed -n '245,468p' backend/marketing/artifact-collector.ts | rg -n "readMarketingStageStepPayload|readJsonIfExists"` returns no matches, so the three target collectors no longer do direct stage reads.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- `npx tsx --test tests/marketing-job-facts.test.ts tests/video-artifact-collector.test.ts`

Closes #38
