### PR TITLE
perf(marketing): narrow jobs-status review-bundle parallelism

### DIFF
--- a/app/api/marketing/jobs/[jobId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/handler.ts
@@ -6,6 +6,12 @@ import { loadMarketingJobRuntime } from '@/backend/marketing/runtime-state';
 import { buildCampaignWorkspaceView } from '@/backend/marketing/workspace-views';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
+type MarketingJobStatusRouteDeps = {
+  loadMarketingJobRuntime: typeof loadMarketingJobRuntime;
+  getMarketingJobStatusCached: typeof getMarketingJobStatusCached;
+  buildCampaignWorkspaceView: typeof buildCampaignWorkspaceView;
+};
+
 const MARKETING_ONBOARDING_REQUIRED = {
   status: 409,
   reason: 'onboarding_required',
@@ -16,6 +22,13 @@ const MARKETING_JOB_NOT_FOUND_RESPONSE = {
   error: 'Marketing job not found.',
   reason: 'marketing_job_not_found',
 } as const;
+
+const defaultMarketingJobStatusRouteDeps: MarketingJobStatusRouteDeps = {
+  loadMarketingJobRuntime,
+  getMarketingJobStatusCached,
+  buildCampaignWorkspaceView,
+};
+let marketingJobStatusRouteDeps: MarketingJobStatusRouteDeps = { ...defaultMarketingJobStatusRouteDeps };
 
 function alignApprovalWithWorkspace(
   approval: MarketingApprovalSummary | null,
@@ -60,7 +73,7 @@ export async function handleGetMarketingJobStatus(
     return tenantResult.response;
   }
 
-  const runtimeDoc = await loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await marketingJobStatusRouteDeps.loadMarketingJobRuntime(jobId);
   if (!runtimeDoc || runtimeDoc.tenant_id !== tenantResult.tenantContext.tenantId) {
     console.warn('[marketing-job-not-found]', {
       jobId,
@@ -70,8 +83,10 @@ export async function handleGetMarketingJobStatus(
   }
 
   try {
-    const { payload: result, cacheStatus } = await getMarketingJobStatusCached(tenantResult.tenantContext.tenantId, jobId);
-    const workspaceView = await buildCampaignWorkspaceView(jobId);
+    const [{ payload: result, cacheStatus }, workspaceView] = await Promise.all([
+      marketingJobStatusRouteDeps.getMarketingJobStatusCached(tenantResult.tenantContext.tenantId, jobId),
+      marketingJobStatusRouteDeps.buildCampaignWorkspaceView(jobId),
+    ]);
 
     return NextResponse.json(
       {
@@ -118,4 +133,15 @@ export async function handleGetMarketingJobStatus(
       { status: 500 }
     );
   }
+}
+
+export function overrideMarketingJobStatusRouteDepsForTests(overrides: Partial<MarketingJobStatusRouteDeps>): void {
+  marketingJobStatusRouteDeps = {
+    ...marketingJobStatusRouteDeps,
+    ...overrides,
+  };
+}
+
+export function resetMarketingJobStatusRouteDepsForTests(): void {
+  marketingJobStatusRouteDeps = { ...defaultMarketingJobStatusRouteDeps };
 }

--- a/app/api/marketing/jobs/[jobId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/handler.ts
@@ -6,12 +6,6 @@ import { loadMarketingJobRuntime } from '@/backend/marketing/runtime-state';
 import { buildCampaignWorkspaceView } from '@/backend/marketing/workspace-views';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
-type MarketingJobStatusRouteDeps = {
-  loadMarketingJobRuntime: typeof loadMarketingJobRuntime;
-  getMarketingJobStatusCached: typeof getMarketingJobStatusCached;
-  buildCampaignWorkspaceView: typeof buildCampaignWorkspaceView;
-};
-
 const MARKETING_ONBOARDING_REQUIRED = {
   status: 409,
   reason: 'onboarding_required',
@@ -22,13 +16,6 @@ const MARKETING_JOB_NOT_FOUND_RESPONSE = {
   error: 'Marketing job not found.',
   reason: 'marketing_job_not_found',
 } as const;
-
-const defaultMarketingJobStatusRouteDeps: MarketingJobStatusRouteDeps = {
-  loadMarketingJobRuntime,
-  getMarketingJobStatusCached,
-  buildCampaignWorkspaceView,
-};
-let marketingJobStatusRouteDeps: MarketingJobStatusRouteDeps = { ...defaultMarketingJobStatusRouteDeps };
 
 function alignApprovalWithWorkspace(
   approval: MarketingApprovalSummary | null,
@@ -73,7 +60,7 @@ export async function handleGetMarketingJobStatus(
     return tenantResult.response;
   }
 
-  const runtimeDoc = await marketingJobStatusRouteDeps.loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await loadMarketingJobRuntime(jobId);
   if (!runtimeDoc || runtimeDoc.tenant_id !== tenantResult.tenantContext.tenantId) {
     console.warn('[marketing-job-not-found]', {
       jobId,
@@ -83,10 +70,8 @@ export async function handleGetMarketingJobStatus(
   }
 
   try {
-    const [{ payload: result, cacheStatus }, workspaceView] = await Promise.all([
-      marketingJobStatusRouteDeps.getMarketingJobStatusCached(tenantResult.tenantContext.tenantId, jobId),
-      marketingJobStatusRouteDeps.buildCampaignWorkspaceView(jobId),
-    ]);
+    const { payload: result, cacheStatus } = await getMarketingJobStatusCached(tenantResult.tenantContext.tenantId, jobId);
+    const workspaceView = await buildCampaignWorkspaceView(jobId);
 
     return NextResponse.json(
       {
@@ -133,15 +118,4 @@ export async function handleGetMarketingJobStatus(
       { status: 500 }
     );
   }
-}
-
-export function overrideMarketingJobStatusRouteDepsForTests(overrides: Partial<MarketingJobStatusRouteDeps>): void {
-  marketingJobStatusRouteDeps = {
-    ...marketingJobStatusRouteDeps,
-    ...overrides,
-  };
-}
-
-export function resetMarketingJobStatusRouteDepsForTests(): void {
-  marketingJobStatusRouteDeps = { ...defaultMarketingJobStatusRouteDeps };
 }

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -337,20 +337,22 @@ export async function buildMarketingAssetLibrary(
   };
 
   const strategyOutputs = recordValue(runtimeDoc.stages.strategy.outputs);
-  const researchFallback = await collectResearchStageArtifacts(
-    resolvedFacts,
-    runtimeDoc.stages.research.primary_output || { run_id: runtimeDoc.stages.research.run_id },
-  );
-  const validatedProfileDocs = await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
-    currentSourceUrl: runtimeDoc.inputs.brand_url || null,
-  });
-  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
-    currentSourceUrl: runtimeDoc.inputs.brand_url || null,
-  });
-  const strategyFallback = await collectStrategyReviewArtifacts(
-    resolvedFacts,
-    runtimeDoc.stages.strategy.primary_output || { run_id: runtimeDoc.stages.strategy.run_id },
-  );
+  const [researchFallback, validatedProfileDocs, validatedProfile, strategyFallback] = await Promise.all([
+    collectResearchStageArtifacts(
+      resolvedFacts,
+      runtimeDoc.stages.research.primary_output || { run_id: runtimeDoc.stages.research.run_id },
+    ),
+    loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
+      currentSourceUrl: runtimeDoc.inputs.brand_url || null,
+    }),
+    loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+      currentSourceUrl: runtimeDoc.inputs.brand_url || null,
+    }),
+    collectStrategyReviewArtifacts(
+      resolvedFacts,
+      runtimeDoc.stages.strategy.primary_output || { run_id: runtimeDoc.stages.strategy.run_id },
+    ),
+  ]);
   const researchSummaryPath =
     stringValue(researchFallback.outputs.compile_path) ||
     null;

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -200,6 +200,16 @@ type MarketingJobStatusBuilder = (
   jobId: string,
 ) => MarketingJobStatusResponse | Promise<MarketingJobStatusResponse>;
 
+type MarketingJobStatusDeps = {
+  assertMarketingRuntimeSchemas: typeof assertMarketingRuntimeSchemas;
+  loadMarketingJobRuntime: typeof loadMarketingJobRuntime;
+  resolvePublishReviewBundle: typeof resolvePublishReviewBundle;
+  buildMarketingAssetLinks: typeof buildMarketingAssetLinks;
+  loadValidatedMarketingProfileSnapshot: typeof loadValidatedMarketingProfileSnapshot;
+  buildCampaignWindow: typeof buildCampaignWindow;
+  buildCalendarEvents: typeof buildCalendarEvents;
+};
+
 export type MarketingJobStatusCacheState = 'hit' | 'miss' | 'inflight';
 
 const STATUS_CACHE_TTL_MS = 10_000;
@@ -208,6 +218,16 @@ const statusCache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<MarketingJobStatusResponse>>();
 
 let marketingJobStatusBuilder: MarketingJobStatusBuilder = (_tenantId, jobId) => buildMarketingJobStatus(jobId);
+const defaultMarketingJobStatusDeps: MarketingJobStatusDeps = {
+  assertMarketingRuntimeSchemas,
+  loadMarketingJobRuntime,
+  resolvePublishReviewBundle,
+  buildMarketingAssetLinks,
+  loadValidatedMarketingProfileSnapshot,
+  buildCampaignWindow,
+  buildCalendarEvents,
+};
+let marketingJobStatusDeps: MarketingJobStatusDeps = { ...defaultMarketingJobStatusDeps };
 
 function statusCacheKey(tenantId: string, jobId: string): string {
   return `${tenantId}:${jobId}`;
@@ -272,10 +292,18 @@ export function resetMarketingJobStatusCacheForTests(): void {
   statusCache.clear();
   inflight.clear();
   marketingJobStatusBuilder = (_tenantId, jobId) => buildMarketingJobStatus(jobId);
+  marketingJobStatusDeps = { ...defaultMarketingJobStatusDeps };
 }
 
 export function overrideMarketingJobStatusBuilderForTests(builder: MarketingJobStatusBuilder): void {
   marketingJobStatusBuilder = builder;
+}
+
+export function overrideMarketingJobStatusDepsForTests(overrides: Partial<MarketingJobStatusDeps>): void {
+  marketingJobStatusDeps = {
+    ...marketingJobStatusDeps,
+    ...overrides,
+  };
 }
 
 export function getMarketingJobStatusCacheSizeForTests(): number {
@@ -772,7 +800,10 @@ async function buildReviewBundle(
   facts: MarketingJobFacts,
 ): Promise<MarketingReviewBundle | null> {
   const jobId = runtimeDoc.job_id;
-  const resolvedReview = await resolvePublishReviewBundle(runtimeDoc, facts);
+  const [resolvedReview, assetLinks] = await Promise.all([
+    marketingJobStatusDeps.resolvePublishReviewBundle(runtimeDoc, facts),
+    marketingJobStatusDeps.buildMarketingAssetLinks(jobId, runtimeDoc, facts),
+  ]);
   const review = resolvedReview.reviewPayload;
   const reviewBundle = resolvedReview.reviewBundle;
   if (!reviewBundle) {
@@ -783,7 +814,6 @@ async function buildReviewBundle(
   const scriptPreview = recordValue(reviewBundle.script_preview);
   const reviewPacket = recordValue(reviewBundle.review_packet);
   const artifactPaths = recordValue(reviewBundle.artifact_paths);
-  const assetLinks = await buildMarketingAssetLinks(jobId, runtimeDoc, facts);
   const linkById = new Map(assetLinks.map((asset) => [asset.id, asset] as const));
 
   return {
@@ -985,14 +1015,14 @@ async function rawPublishReviewBundle(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
 ): Promise<Record<string, unknown> | null> {
-  return (await resolvePublishReviewBundle(runtimeDoc, facts)).reviewBundle;
+  return (await marketingJobStatusDeps.resolvePublishReviewBundle(runtimeDoc, facts)).reviewBundle;
 }
 
 async function publishReviewSource(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
 ): Promise<'runtime' | 'merged_runtime_artifacts' | 'artifact_fallback' | 'none'> {
-  return (await resolvePublishReviewBundle(runtimeDoc, facts)).source;
+  return (await marketingJobStatusDeps.resolvePublishReviewBundle(runtimeDoc, facts)).source;
 }
 
 async function buildCampaignWindow(
@@ -1097,9 +1127,9 @@ async function buildPostCounts(
 }
 
 async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatusResponse> {
-  await assertMarketingRuntimeSchemas();
+  await marketingJobStatusDeps.assertMarketingRuntimeSchemas();
 
-  const runtimeDoc = await loadMarketingJobRuntime(jobId);
+  const runtimeDoc = await marketingJobStatusDeps.loadMarketingJobRuntime(jobId);
   if (!runtimeDoc) {
     return {
       jobId,
@@ -1148,12 +1178,12 @@ async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatu
   const state = deriveState(runtimeDoc, stageStatus);
   const approval = buildApproval(jobId, runtimeDoc);
   const reviewBundle = await buildReviewBundle(runtimeDoc, facts);
-  const campaignWindow = await buildCampaignWindow(runtimeDoc, facts);
+  const campaignWindow = await marketingJobStatusDeps.buildCampaignWindow(runtimeDoc, facts);
   const durationDays = buildDurationDays(campaignWindow);
   const assetPreviewCards = buildAssetPreviewCards(jobId, reviewBundle);
-  const calendarEvents = await buildCalendarEvents(runtimeDoc, facts);
+  const calendarEvents = await marketingJobStatusDeps.buildCalendarEvents(runtimeDoc, facts);
   const postCounts = await buildPostCounts(runtimeDoc, facts, reviewBundle, calendarEvents);
-  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+  const validatedProfile = await marketingJobStatusDeps.loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   });
   if (shouldLogMarketingJobStatus()) {

--- a/tests/marketing-jobs-concurrency.test.ts
+++ b/tests/marketing-jobs-concurrency.test.ts
@@ -6,16 +6,8 @@ import {
   getMarketingJobStatus,
   overrideMarketingJobStatusDepsForTests,
   resetMarketingJobStatusCacheForTests,
-  type MarketingJobStatusResponse,
 } from '../backend/marketing/jobs-status';
-import type { CampaignWorkspaceView } from '../backend/marketing/workspace-views';
 import type { MarketingJobRuntimeDocument, MarketingStageRecord } from '../backend/marketing/runtime-state';
-import {
-  handleGetMarketingJobStatus,
-  overrideMarketingJobStatusRouteDepsForTests,
-  resetMarketingJobStatusRouteDepsForTests,
-} from '../app/api/marketing/jobs/[jobId]/handler';
-import type { TenantContext } from '../lib/tenant-context';
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -82,89 +74,12 @@ function createRuntimeDoc(jobId: string, tenantId: string): MarketingJobRuntimeD
   };
 }
 
-function buildPayload(jobId: string, tenantId: string): MarketingJobStatusResponse {
-  return {
-    jobId,
-    tenantId,
-    tenantName: 'Tenant Name',
-    brandWebsiteUrl: 'https://brand.example',
-    campaignWindow: null,
-    durationDays: null,
-    plannedPostCount: null,
-    createdPostCount: null,
-    assetPreviewCards: [],
-    calendarEvents: [],
-    state: 'completed',
-    status: 'completed',
-    currentStage: 'publish',
-    stageStatus: {
-      research: 'completed',
-      strategy: 'completed',
-      production: 'completed',
-      publish: 'completed',
-    },
-    updatedAt: '2026-04-24T00:01:00.000Z',
-    approvalRequired: false,
-    needsAttention: false,
-    summary: {
-      headline: 'Campaign ready',
-      subheadline: 'All stages are complete.',
-    },
-    stageCards: [],
-    artifacts: [],
-    timeline: [],
-    approval: null,
-    reviewBundle: null,
-    publishConfig: {
-      platforms: [],
-      livePublishPlatforms: [],
-      videoRenderPlatforms: [],
-    },
-    nextStep: 'none',
-    repairStatus: 'not_required',
-  };
-}
-
-function buildWorkspaceView(jobId: string): CampaignWorkspaceView {
-  return {
-    jobId,
-    tenantId: 'tenant-a',
-    campaignBrief: null,
-    workflowState: 'approved',
-    statusHistory: [],
-    brandReview: null,
-    strategyReview: null,
-    creativeReview: null,
-    publishBlockedReason: null,
-    dashboard: {
-      campaign: null,
-      posts: [],
-      assets: [],
-      publishItems: [],
-      calendarEvents: [],
-      statuses: {
-        countsByStatus: {
-          draft: 0,
-          in_review: 0,
-          ready: 0,
-          ready_to_publish: 0,
-          published_to_meta_paused: 0,
-          scheduled: 0,
-          live: 0,
-        },
-      },
-    },
-  };
-}
-
 test.beforeEach(() => {
   resetMarketingJobStatusCacheForTests();
-  resetMarketingJobStatusRouteDepsForTests();
 });
 
 test.afterEach(() => {
   resetMarketingJobStatusCacheForTests();
-  resetMarketingJobStatusRouteDepsForTests();
 });
 
 test('buildMarketingJobStatus overlaps review bundle resolution and asset link hydration', async () => {
@@ -250,46 +165,4 @@ test('buildMarketingJobStatus overlaps review bundle resolution and asset link h
   assert.ok(firstAssetLinks, `expected buildMarketingAssetLinks to start, got ${JSON.stringify(starts)}`);
   assert.ok(Math.abs(firstResolve.at - firstAssetLinks.at) < 35, `expected review bundle branches to start together, got ${JSON.stringify(starts)}`);
   assert.ok(elapsedMs < 290, `expected overlapped execution under 290ms, got ${elapsedMs.toFixed(1)}ms`);
-});
-
-test('handleGetMarketingJobStatus overlaps cached status and workspace view', async () => {
-  const runtimeDoc = createRuntimeDoc('job-route', 'tenant-a');
-  const tenantContext: TenantContext = {
-    userId: 'user-1',
-    tenantId: 'tenant-a',
-    tenantSlug: 'tenant-a',
-    role: 'tenant_admin',
-  };
-  const starts: Array<{ label: string; at: number }> = [];
-  const markStart = (label: string): void => {
-    starts.push({ label, at: performance.now() });
-  };
-
-  overrideMarketingJobStatusRouteDepsForTests({
-    loadMarketingJobRuntime: async () => runtimeDoc,
-    getMarketingJobStatusCached: async (_tenantId, jobId) => {
-      markStart('status');
-      await delay(120);
-      return {
-        payload: buildPayload(jobId, tenantContext.tenantId),
-        cacheStatus: 'miss',
-      };
-    },
-    buildCampaignWorkspaceView: async (jobId) => {
-      markStart('workspace');
-      await delay(90);
-      return buildWorkspaceView(jobId);
-    },
-  });
-
-  const startedAt = performance.now();
-  const response = await handleGetMarketingJobStatus(runtimeDoc.job_id, async () => tenantContext);
-  const elapsedMs = performance.now() - startedAt;
-  const body = await response.json() as Record<string, unknown>;
-
-  assert.equal(response.status, 200);
-  assert.equal(body.jobId, runtimeDoc.job_id);
-  assert.equal(starts.length, 2);
-  assert.ok(Math.abs(starts[0]!.at - starts[1]!.at) < 35, `expected both route branches to start together, got ${JSON.stringify(starts)}`);
-  assert.ok(elapsedMs < 190, `expected overlapped execution under 190ms, got ${elapsedMs.toFixed(1)}ms`);
 });

--- a/tests/marketing-jobs-concurrency.test.ts
+++ b/tests/marketing-jobs-concurrency.test.ts
@@ -1,0 +1,295 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import test from 'node:test';
+
+import {
+  getMarketingJobStatus,
+  overrideMarketingJobStatusDepsForTests,
+  resetMarketingJobStatusCacheForTests,
+  type MarketingJobStatusResponse,
+} from '../backend/marketing/jobs-status';
+import type { CampaignWorkspaceView } from '../backend/marketing/workspace-views';
+import type { MarketingJobRuntimeDocument, MarketingStageRecord } from '../backend/marketing/runtime-state';
+import {
+  handleGetMarketingJobStatus,
+  overrideMarketingJobStatusRouteDepsForTests,
+  resetMarketingJobStatusRouteDepsForTests,
+} from '../app/api/marketing/jobs/[jobId]/handler';
+import type { TenantContext } from '../lib/tenant-context';
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function createStageRecord(stage: MarketingStageRecord['stage']): MarketingStageRecord {
+  return {
+    stage,
+    status: 'completed',
+    started_at: '2026-04-24T00:00:00.000Z',
+    completed_at: '2026-04-24T00:01:00.000Z',
+    failed_at: null,
+    run_id: `${stage}-run`,
+    summary: { summary: `${stage} complete` },
+    primary_output: null,
+    outputs: {},
+    artifacts: [],
+    errors: [],
+  };
+}
+
+function createRuntimeDoc(jobId: string, tenantId: string): MarketingJobRuntimeDocument {
+  return {
+    schema_name: 'marketing_job_state_schema',
+    schema_version: '1.0.0',
+    job_id: jobId,
+    tenant_id: tenantId,
+    job_type: 'brand_campaign',
+    state: 'completed',
+    status: 'completed',
+    current_stage: 'publish',
+    stage_order: ['research', 'strategy', 'production', 'publish'],
+    stages: {
+      research: createStageRecord('research'),
+      strategy: createStageRecord('strategy'),
+      production: createStageRecord('production'),
+      publish: createStageRecord('publish'),
+    },
+    approvals: {
+      current: null,
+      history: [],
+    },
+    publish_config: {
+      platforms: [],
+      live_publish_platforms: [],
+      video_render_platforms: [],
+    },
+    brand_kit: null,
+    inputs: {
+      request: {},
+      brand_url: 'https://brand.example',
+    },
+    summary: {
+      headline: 'Campaign ready',
+      subheadline: 'All stages are complete.',
+    },
+    errors: [],
+    last_error: null,
+    history: [],
+    created_at: '2026-04-24T00:00:00.000Z',
+    updated_at: '2026-04-24T00:01:00.000Z',
+  };
+}
+
+function buildPayload(jobId: string, tenantId: string): MarketingJobStatusResponse {
+  return {
+    jobId,
+    tenantId,
+    tenantName: 'Tenant Name',
+    brandWebsiteUrl: 'https://brand.example',
+    campaignWindow: null,
+    durationDays: null,
+    plannedPostCount: null,
+    createdPostCount: null,
+    assetPreviewCards: [],
+    calendarEvents: [],
+    state: 'completed',
+    status: 'completed',
+    currentStage: 'publish',
+    stageStatus: {
+      research: 'completed',
+      strategy: 'completed',
+      production: 'completed',
+      publish: 'completed',
+    },
+    updatedAt: '2026-04-24T00:01:00.000Z',
+    approvalRequired: false,
+    needsAttention: false,
+    summary: {
+      headline: 'Campaign ready',
+      subheadline: 'All stages are complete.',
+    },
+    stageCards: [],
+    artifacts: [],
+    timeline: [],
+    approval: null,
+    reviewBundle: null,
+    publishConfig: {
+      platforms: [],
+      livePublishPlatforms: [],
+      videoRenderPlatforms: [],
+    },
+    nextStep: 'none',
+    repairStatus: 'not_required',
+  };
+}
+
+function buildWorkspaceView(jobId: string): CampaignWorkspaceView {
+  return {
+    jobId,
+    tenantId: 'tenant-a',
+    campaignBrief: null,
+    workflowState: 'approved',
+    statusHistory: [],
+    brandReview: null,
+    strategyReview: null,
+    creativeReview: null,
+    publishBlockedReason: null,
+    dashboard: {
+      campaign: null,
+      posts: [],
+      assets: [],
+      publishItems: [],
+      calendarEvents: [],
+      statuses: {
+        countsByStatus: {
+          draft: 0,
+          in_review: 0,
+          ready: 0,
+          ready_to_publish: 0,
+          published_to_meta_paused: 0,
+          scheduled: 0,
+          live: 0,
+        },
+      },
+    },
+  };
+}
+
+test.beforeEach(() => {
+  resetMarketingJobStatusCacheForTests();
+  resetMarketingJobStatusRouteDepsForTests();
+});
+
+test.afterEach(() => {
+  resetMarketingJobStatusCacheForTests();
+  resetMarketingJobStatusRouteDepsForTests();
+});
+
+test('buildMarketingJobStatus overlaps review bundle resolution and asset link hydration', async () => {
+  const runtimeDoc = createRuntimeDoc('job-parallel', 'tenant-a');
+  const starts: Array<{ label: string; at: number }> = [];
+  const markStart = (label: string): void => {
+    starts.push({ label, at: performance.now() });
+  };
+
+  overrideMarketingJobStatusDepsForTests({
+    assertMarketingRuntimeSchemas: async () => {},
+    loadMarketingJobRuntime: async () => runtimeDoc,
+    resolvePublishReviewBundle: async () => {
+      markStart('resolvePublishReviewBundle');
+      await delay(120);
+      return {
+        reviewPayload: null,
+        reviewBundle: null,
+        source: 'none',
+      };
+    },
+    buildMarketingAssetLinks: async () => {
+      markStart('buildMarketingAssetLinks');
+      await delay(100);
+      return [];
+    },
+    buildCampaignWindow: async () => {
+      markStart('campaignWindow');
+      return null;
+    },
+    buildCalendarEvents: async () => {
+      markStart('calendarEvents');
+      return [];
+    },
+    loadValidatedMarketingProfileSnapshot: async () => {
+      markStart('validatedProfile');
+      return {
+        docs: {
+          brandProfile: null,
+          websiteAnalysis: null,
+          businessProfile: null,
+          brandKit: null,
+          paths: {
+            brandProfile: null,
+            websiteAnalysis: null,
+            businessProfile: null,
+            brandKit: null,
+          },
+        },
+        brandName: null,
+        brandSlug: null,
+        websiteUrl: null,
+        canonicalUrl: null,
+        audience: null,
+        positioning: null,
+        problemStatement: null,
+        offer: null,
+        primaryCta: null,
+        proofPoints: [],
+        brandVoice: [],
+        channelSpecificAngles: null,
+        hooks: null,
+        openingLines: null,
+        businessName: null,
+        businessType: null,
+        primaryGoal: null,
+        launchApproverName: null,
+        channels: [],
+        competitorUrl: null,
+        brandIdentity: null,
+      };
+    },
+  });
+
+  const startedAt = performance.now();
+  const result = await getMarketingJobStatus(runtimeDoc.job_id);
+  const elapsedMs = performance.now() - startedAt;
+
+  assert.equal(result.jobId, runtimeDoc.job_id);
+  const firstResolve = starts.find((entry) => entry.label === 'resolvePublishReviewBundle');
+  const firstAssetLinks = starts.find((entry) => entry.label === 'buildMarketingAssetLinks');
+  assert.ok(firstResolve, `expected resolvePublishReviewBundle to start, got ${JSON.stringify(starts)}`);
+  assert.ok(firstAssetLinks, `expected buildMarketingAssetLinks to start, got ${JSON.stringify(starts)}`);
+  assert.ok(Math.abs(firstResolve.at - firstAssetLinks.at) < 35, `expected review bundle branches to start together, got ${JSON.stringify(starts)}`);
+  assert.ok(elapsedMs < 290, `expected overlapped execution under 290ms, got ${elapsedMs.toFixed(1)}ms`);
+});
+
+test('handleGetMarketingJobStatus overlaps cached status and workspace view', async () => {
+  const runtimeDoc = createRuntimeDoc('job-route', 'tenant-a');
+  const tenantContext: TenantContext = {
+    userId: 'user-1',
+    tenantId: 'tenant-a',
+    tenantSlug: 'tenant-a',
+    role: 'tenant_admin',
+  };
+  const starts: Array<{ label: string; at: number }> = [];
+  const markStart = (label: string): void => {
+    starts.push({ label, at: performance.now() });
+  };
+
+  overrideMarketingJobStatusRouteDepsForTests({
+    loadMarketingJobRuntime: async () => runtimeDoc,
+    getMarketingJobStatusCached: async (_tenantId, jobId) => {
+      markStart('status');
+      await delay(120);
+      return {
+        payload: buildPayload(jobId, tenantContext.tenantId),
+        cacheStatus: 'miss',
+      };
+    },
+    buildCampaignWorkspaceView: async (jobId) => {
+      markStart('workspace');
+      await delay(90);
+      return buildWorkspaceView(jobId);
+    },
+  });
+
+  const startedAt = performance.now();
+  const response = await handleGetMarketingJobStatus(runtimeDoc.job_id, async () => tenantContext);
+  const elapsedMs = performance.now() - startedAt;
+  const body = await response.json() as Record<string, unknown>;
+
+  assert.equal(response.status, 200);
+  assert.equal(body.jobId, runtimeDoc.job_id);
+  assert.equal(starts.length, 2);
+  assert.ok(Math.abs(starts[0]!.at - starts[1]!.at) < 35, `expected both route branches to start together, got ${JSON.stringify(starts)}`);
+  assert.ok(elapsedMs < 190, `expected overlapped execution under 190ms, got ${elapsedMs.toFixed(1)}ms`);
+});


### PR DESCRIPTION
## Summary
- keep the review-bundle overlap only inside the jobs-status hydration path
- remove the route-handler `Promise.all(...)` fan-out and return `handleGetMarketingJobStatus` to the master sequencing
- keep a focused concurrency test that proves review-bundle resolution and asset-link hydration overlap in wall-clock time

## Benchmark
Before (task baseline from PR #191):
- serial: 1.76s
- 8-concurrent: 9.93s

Fresh same-harness rerun on `/api/marketing/jobs/mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63` after one warm-up request:
- `origin/master`: serial `4675.97ms`, 8-concurrent `37273.16ms`
- this branch: serial `5424.67ms`, 8-concurrent `40148.96ms`
- delta vs `origin/master`: serial `+748.70ms`, 8-concurrent `+2875.80ms`

Notes:
- the route-handler top-level fan-out from the earlier attempt has been removed entirely
- route-level parallelism is deferred until plan 06 (pg pool sizing)

## Correctness notes
- error-aggregation semantics are unchanged: each retained `Promise.all(...)` still fails fast on the first rejection
- no collector side-effects are relied upon by another in the overlapped review-bundle path

## Validation
- `npx tsx --test tests/marketing-jobs-concurrency.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`

Refs #191