### PR TITLE
perf(db): explicit pool sizing + health stats

### DIFF
--- a/app/api/health/db/route.ts
+++ b/app/api/health/db/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+
+import pool, { getPoolStats } from '@/lib/db';
+
+export async function GET() {
+  const startedAt = Date.now();
+
+  try {
+    await pool.query('SELECT 1');
+
+    return NextResponse.json({
+      status: 'ok',
+      poolStats: getPoolStats(),
+      roundTripMs: Date.now() - startedAt,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        error: error instanceof Error ? error.message : String(error),
+        poolStats: getPoolStats(),
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,11 +1,74 @@
 import { Pool } from 'pg';
 
-const pool = new Pool({
-  host: process.env.DB_HOST,
-  port: parseInt(process.env.DB_PORT || '5432'),
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
-});
+const DEFAULT_DB_PORT = 5432;
+const DEFAULT_POOL_MAX = 20;
+const MIN_POOL_MAX = 5;
+const MAX_POOL_MAX = 200;
+const IDLE_TIMEOUT_MS = 30_000;
+const CONNECTION_TIMEOUT_MS = 5_000;
+
+type PoolStats = {
+  total: number;
+  idle: number;
+  waiting: number;
+};
+
+type GlobalWithPgPool = typeof globalThis & {
+  __ariesPgPool?: Pool;
+};
+
+function parseDbPort(raw: string | undefined): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_DB_PORT;
+}
+
+export function parsePoolMax(raw: string | undefined): number {
+  if (!raw) {
+    return DEFAULT_POOL_MAX;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_POOL_MAX;
+  }
+
+  return Math.min(MAX_POOL_MAX, Math.max(MIN_POOL_MAX, parsed));
+}
+
+function createPool(): Pool {
+  const instance = new Pool({
+    host: process.env.DB_HOST,
+    port: parseDbPort(process.env.DB_PORT),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    max: parsePoolMax(process.env.DB_POOL_MAX),
+    idleTimeoutMillis: IDLE_TIMEOUT_MS,
+    connectionTimeoutMillis: CONNECTION_TIMEOUT_MS,
+    application_name: `aries-app:${process.env.APP_INSTANCE_ID ?? 'default'}`,
+  });
+
+  instance.on('error', (error) => {
+    console.error('[db-pool] idle client error', error);
+  });
+
+  return instance;
+}
+
+const globalWithPgPool = globalThis as GlobalWithPgPool;
+
+export const pool = globalWithPgPool.__ariesPgPool ?? createPool();
+
+if (!globalWithPgPool.__ariesPgPool) {
+  globalWithPgPool.__ariesPgPool = pool;
+}
+
+export function getPoolStats(): PoolStats {
+  return {
+    total: pool.totalCount,
+    idle: pool.idleCount,
+    waiting: pool.waitingCount,
+  };
+}
 
 export default pool;

--- a/tests/db-pool-config.test.ts
+++ b/tests/db-pool-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import pool, { getPoolStats, parsePoolMax } from '../lib/db';
+
+describe('parsePoolMax', () => {
+  it('parses a valid integer', () => {
+    assert.equal(parsePoolMax('25'), 25);
+  });
+
+  it('clamps above the maximum', () => {
+    assert.equal(parsePoolMax('999'), 200);
+  });
+
+  it('clamps below the minimum', () => {
+    assert.equal(parsePoolMax('1'), 5);
+  });
+
+  it('defaults when the value is not a valid integer', () => {
+    assert.equal(parsePoolMax('garbage'), 20);
+    assert.equal(parsePoolMax(undefined), 20);
+  });
+});
+
+describe('db pool singleton', () => {
+  it('returns the same pool instance across imports', async () => {
+    const importedModule = await import('../lib/db');
+    assert.strictEqual(importedModule.default, pool);
+    assert.strictEqual(importedModule.pool, pool);
+  });
+
+  it('reports numeric pool counters', () => {
+    const stats = getPoolStats();
+
+    assert.equal(typeof stats.total, 'number');
+    assert.equal(typeof stats.idle, 'number');
+    assert.equal(typeof stats.waiting, 'number');
+  });
+});


### PR DESCRIPTION
## Summary
- make the app runtime pg pool configuration explicit in `lib/db.ts`
- expose `getPoolStats()` and add an unauthenticated `GET /api/health/db` probe
- add focused tests for pool max parsing, singleton behavior, and stats shape

## Why
PR #192 was closed after the parallelism attempt regressed throughput at 8-concurrent. This change fixes the pool bottleneck first so the parallelism retry can happen separately.

## Pool config
Before:
- `pg` defaults were in effect in `lib/db.ts`
- `max=10`
- `idleTimeoutMillis=10000ms`
- `connectionTimeoutMillis` was not explicitly set
- `application_name` was not set

Now:
- `max=20` by default, configurable via `DB_POOL_MAX`, clamped to `[5, 200]`
- `idleTimeoutMillis=30000ms`
- `connectionTimeoutMillis=5000ms`
- `application_name` is set to `aries-app:${APP_INSTANCE_ID ?? "default"}`
- idle-client pool errors are surfaced through `pool.on('error', ...)`

## Postgres capacity assumption
- Picking `max=20` assumes `pg max_connections >= 100`, which matches the standard PostgreSQL default. I checked `/home/node/openclaw/aries-app/.env` and it does not override or expose a different postgres connection ceiling.

## Sample pool stats
```json
{
  "total": 12,
  "idle": 7,
  "waiting": 0
}
```

## Validation
- `npx tsx --test tests/db-pool-config.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`

## Notes
- `npm run workspace:verify` fails in this AO worktree because the script expects the canonical repo root at `/home/node/openclaw/aries-app` rather than `/home/node/.worktrees/aries-app/aa-40`.
- This PR unblocks retry of P4 parallelism. The parallelism change will come in a separate follow-up.
