### PR TITLE
perf(marketing): parallelize stage collectors (post-pool-sizing retry)

### DIFF
--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -25,7 +25,10 @@ import {
   explicitArtifactValue,
   normalizeArtifactText,
 } from './real-artifacts';
-import { loadValidatedMarketingProfileSnapshot } from './validated-profile-store';
+import {
+  loadValidatedMarketingProfileSnapshot,
+  type ValidatedMarketingProfileSnapshot,
+} from './validated-profile-store';
 
 type TimelineTone = 'info' | 'success' | 'warning' | 'danger';
 
@@ -200,6 +203,45 @@ type MarketingJobStatusBuilder = (
   jobId: string,
 ) => MarketingJobStatusResponse | Promise<MarketingJobStatusResponse>;
 
+type ResolvedPublishReviewBundle = Awaited<ReturnType<typeof resolvePublishReviewBundle>>;
+
+type MarketingJobStatusDependencies = {
+  buildReviewBundle: (
+    runtimeDoc: MarketingJobRuntimeDocument,
+    facts: MarketingJobFacts,
+    resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
+    assetLinksPromise?: Promise<MarketingAssetLink[]>,
+  ) => Promise<MarketingReviewBundle | null>;
+  buildCampaignWindow: (
+    runtimeDoc: MarketingJobRuntimeDocument,
+    facts: MarketingJobFacts,
+    resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
+  ) => Promise<MarketingCampaignWindow | null>;
+  buildCalendarEvents: (
+    runtimeDoc: MarketingJobRuntimeDocument,
+    facts: MarketingJobFacts,
+    resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
+  ) => Promise<MarketingCalendarEvent[]>;
+  buildPostCounts: (
+    runtimeDoc: MarketingJobRuntimeDocument,
+    facts: MarketingJobFacts,
+    reviewBundle: MarketingReviewBundle | null,
+    calendarEvents: MarketingCalendarEvent[],
+    resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
+  ) => Promise<{ plannedPostCount: number | null; createdPostCount: number | null }>;
+  loadValidatedMarketingProfileSnapshot: (
+    tenantId: string,
+    options: { currentSourceUrl?: string | null },
+  ) => Promise<ValidatedMarketingProfileSnapshot>;
+  publishReviewSource: (
+    runtimeDoc: MarketingJobRuntimeDocument,
+    facts: MarketingJobFacts,
+    resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
+  ) => Promise<'runtime' | 'merged_runtime_artifacts' | 'artifact_fallback' | 'none'>;
+  resolvePublishReviewBundle: typeof resolvePublishReviewBundle;
+  buildMarketingAssetLinks: typeof buildMarketingAssetLinks;
+};
+
 export type MarketingJobStatusCacheState = 'hit' | 'miss' | 'inflight';
 
 const STATUS_CACHE_TTL_MS = 10_000;
@@ -208,6 +250,7 @@ const statusCache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<MarketingJobStatusResponse>>();
 
 let marketingJobStatusBuilder: MarketingJobStatusBuilder = (_tenantId, jobId) => buildMarketingJobStatus(jobId);
+let marketingJobStatusDependencies: MarketingJobStatusDependencies = createDefaultMarketingJobStatusDependencies();
 
 function statusCacheKey(tenantId: string, jobId: string): string {
   return `${tenantId}:${jobId}`;
@@ -272,10 +315,20 @@ export function resetMarketingJobStatusCacheForTests(): void {
   statusCache.clear();
   inflight.clear();
   marketingJobStatusBuilder = (_tenantId, jobId) => buildMarketingJobStatus(jobId);
+  marketingJobStatusDependencies = createDefaultMarketingJobStatusDependencies();
 }
 
 export function overrideMarketingJobStatusBuilderForTests(builder: MarketingJobStatusBuilder): void {
   marketingJobStatusBuilder = builder;
+}
+
+export function overrideMarketingJobStatusDependenciesForTests(
+  overrides: Partial<MarketingJobStatusDependencies>,
+): void {
+  marketingJobStatusDependencies = {
+    ...marketingJobStatusDependencies,
+    ...overrides,
+  };
 }
 
 export function getMarketingJobStatusCacheSizeForTests(): number {
@@ -770,9 +823,14 @@ function buildTimeline(
 async function buildReviewBundle(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
+  resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
+  assetLinksPromise?: Promise<MarketingAssetLink[]>,
 ): Promise<MarketingReviewBundle | null> {
   const jobId = runtimeDoc.job_id;
-  const resolvedReview = await resolvePublishReviewBundle(runtimeDoc, facts);
+  const [resolvedReview, assetLinks] = await Promise.all([
+    resolvedReviewPromise ?? marketingJobStatusDependencies.resolvePublishReviewBundle(runtimeDoc, facts),
+    assetLinksPromise ?? marketingJobStatusDependencies.buildMarketingAssetLinks(jobId, runtimeDoc, facts),
+  ]);
   const review = resolvedReview.reviewPayload;
   const reviewBundle = resolvedReview.reviewBundle;
   if (!reviewBundle) {
@@ -783,7 +841,6 @@ async function buildReviewBundle(
   const scriptPreview = recordValue(reviewBundle.script_preview);
   const reviewPacket = recordValue(reviewBundle.review_packet);
   const artifactPaths = recordValue(reviewBundle.artifact_paths);
-  const assetLinks = await buildMarketingAssetLinks(jobId, runtimeDoc, facts);
   const linkById = new Map(assetLinks.map((asset) => [asset.id, asset] as const));
 
   return {
@@ -984,22 +1041,29 @@ function fallbackPlatformMediaAssets(assetLinks: MarketingAssetLink[], platformS
 async function rawPublishReviewBundle(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
+  resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
 ): Promise<Record<string, unknown> | null> {
-  return (await resolvePublishReviewBundle(runtimeDoc, facts)).reviewBundle;
+  return (
+    await (resolvedReviewPromise ?? marketingJobStatusDependencies.resolvePublishReviewBundle(runtimeDoc, facts))
+  ).reviewBundle;
 }
 
 async function publishReviewSource(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
+  resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
 ): Promise<'runtime' | 'merged_runtime_artifacts' | 'artifact_fallback' | 'none'> {
-  return (await resolvePublishReviewBundle(runtimeDoc, facts)).source;
+  return (
+    await (resolvedReviewPromise ?? marketingJobStatusDependencies.resolvePublishReviewBundle(runtimeDoc, facts))
+  ).source;
 }
 
 async function buildCampaignWindow(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
+  resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
 ): Promise<MarketingCampaignWindow | null> {
-  const reviewBundle = await rawPublishReviewBundle(runtimeDoc, facts);
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc, facts, resolvedReviewPromise);
   const summary = recordValue(reviewBundle?.summary);
   const campaignWindow = recordValue(summary?.campaign_window);
 
@@ -1047,8 +1111,9 @@ function buildAssetPreviewCards(jobId: string, reviewBundle: MarketingReviewBund
 async function buildCalendarEvents(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
+  resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
 ): Promise<MarketingCalendarEvent[]> {
-  const reviewBundle = await rawPublishReviewBundle(runtimeDoc, facts);
+  const reviewBundle = await rawPublishReviewBundle(runtimeDoc, facts, resolvedReviewPromise);
   const contentCalendar = recordValue(reviewBundle?.content_calendar);
   const events = recordArray(contentCalendar?.events);
 
@@ -1076,9 +1141,10 @@ async function buildPostCounts(
   runtimeDoc: MarketingJobRuntimeDocument,
   facts: MarketingJobFacts,
   reviewBundle: MarketingReviewBundle | null,
-  calendarEvents: MarketingCalendarEvent[]
+  calendarEvents: MarketingCalendarEvent[],
+  resolvedReviewPromise?: Promise<ResolvedPublishReviewBundle>,
 ): Promise<{ plannedPostCount: number | null; createdPostCount: number | null }> {
-  const rawBundle = await rawPublishReviewBundle(runtimeDoc, facts);
+  const rawBundle = await rawPublishReviewBundle(runtimeDoc, facts, resolvedReviewPromise);
   const summary = recordValue(rawBundle?.summary);
   const explicitPlanned = numberValue(summary?.planned_posts);
   const explicitCreated = numberValue(summary?.created_posts);
@@ -1139,6 +1205,8 @@ async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatu
   }
 
   const facts = createMarketingJobFacts(runtimeDoc, null);
+  const resolvedPublishReviewPromise = marketingJobStatusDependencies.resolvePublishReviewBundle(runtimeDoc, facts);
+  const assetLinksPromise = marketingJobStatusDependencies.buildMarketingAssetLinks(jobId, runtimeDoc, facts);
   const stageStatus: Record<string, string> = {
     research: responseStageStatus(runtimeDoc.stages.research),
     strategy: responseStageStatus(runtimeDoc.stages.strategy),
@@ -1147,21 +1215,38 @@ async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatu
   };
   const state = deriveState(runtimeDoc, stageStatus);
   const approval = buildApproval(jobId, runtimeDoc);
-  const reviewBundle = await buildReviewBundle(runtimeDoc, facts);
-  const campaignWindow = await buildCampaignWindow(runtimeDoc, facts);
+  const [reviewBundle, campaignWindow, calendarEvents, validatedProfile] = await Promise.all([
+    marketingJobStatusDependencies.buildReviewBundle(
+      runtimeDoc,
+      facts,
+      resolvedPublishReviewPromise,
+      assetLinksPromise,
+    ),
+    marketingJobStatusDependencies.buildCampaignWindow(runtimeDoc, facts, resolvedPublishReviewPromise),
+    marketingJobStatusDependencies.buildCalendarEvents(runtimeDoc, facts, resolvedPublishReviewPromise),
+    marketingJobStatusDependencies.loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
+      currentSourceUrl: runtimeDoc.inputs.brand_url || null,
+    }),
+  ]);
   const durationDays = buildDurationDays(campaignWindow);
   const assetPreviewCards = buildAssetPreviewCards(jobId, reviewBundle);
-  const calendarEvents = await buildCalendarEvents(runtimeDoc, facts);
-  const postCounts = await buildPostCounts(runtimeDoc, facts, reviewBundle, calendarEvents);
-  const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
-    currentSourceUrl: runtimeDoc.inputs.brand_url || null,
-  });
+  const postCounts = await marketingJobStatusDependencies.buildPostCounts(
+    runtimeDoc,
+    facts,
+    reviewBundle,
+    calendarEvents,
+    resolvedPublishReviewPromise,
+  );
   if (shouldLogMarketingJobStatus()) {
     console.info('[marketing-hydration]', {
       event: 'job-status',
       jobId,
       tenantId: runtimeDoc.tenant_id,
-      reviewBundleSource: await publishReviewSource(runtimeDoc, facts),
+      reviewBundleSource: await marketingJobStatusDependencies.publishReviewSource(
+        runtimeDoc,
+        facts,
+        resolvedPublishReviewPromise,
+      ),
       reviewBundleReason: reviewBundle ? 'hydrated' : 'no_real_publish_review_artifacts',
     });
   }
@@ -1202,4 +1287,17 @@ async function buildMarketingJobStatus(jobId: string): Promise<MarketingJobStatu
 
 export async function getMarketingJobStatus(jobId: string): Promise<MarketingJobStatusResponse> {
   return buildMarketingJobStatus(jobId);
+}
+
+function createDefaultMarketingJobStatusDependencies(): MarketingJobStatusDependencies {
+  return {
+    buildReviewBundle,
+    buildCampaignWindow,
+    buildCalendarEvents,
+    buildPostCounts,
+    loadValidatedMarketingProfileSnapshot,
+    publishReviewSource,
+    resolvePublishReviewBundle,
+    buildMarketingAssetLinks,
+  };
 }

--- a/tests/marketing-jobs-concurrency.test.ts
+++ b/tests/marketing-jobs-concurrency.test.ts
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { performance } from 'node:perf_hooks';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  getMarketingJobStatus,
+  overrideMarketingJobStatusDependenciesForTests,
+  resetMarketingJobStatusCacheForTests,
+} from '../backend/marketing/jobs-status';
+import type {
+  MarketingCampaignWindow,
+  MarketingCalendarEvent,
+  MarketingReviewBundle,
+} from '../backend/marketing/jobs-status';
+import type { MarketingBrandKitReference, MarketingJobRuntimeDocument } from '../backend/marketing/runtime-state';
+import {
+  createMarketingJobRuntimeDocument,
+  saveMarketingJobRuntime,
+} from '../backend/marketing/runtime-state';
+import type { ValidatedMarketingProfileSnapshot } from '../backend/marketing/validated-profile-store';
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function buildBrandKit(dataRoot: string): MarketingBrandKitReference {
+  return {
+    path: path.join(dataRoot, 'generated', 'validated', 'tenant-real', 'brand-kit.json'),
+    source_url: 'https://brand.example',
+    canonical_url: 'https://brand.example',
+    brand_name: 'Brand Example',
+    logo_urls: [],
+    colors: {
+      primary: '#123456',
+      secondary: '#abcdef',
+      accent: '#fedcba',
+      palette: ['#123456', '#abcdef', '#fedcba'],
+    },
+    font_families: ['Manrope'],
+    external_links: [],
+    brand_voice_summary: 'Confident and clear.',
+    offer_summary: 'Operator-led launch intensives.',
+    extracted_at: '2026-03-19T00:00:00.000Z',
+  };
+}
+
+function buildRuntimeDoc(dataRoot: string, jobId: string, tenantId: string): MarketingJobRuntimeDocument {
+  return createMarketingJobRuntimeDocument({
+    jobId,
+    tenantId,
+    payload: {
+      brandUrl: 'https://brand.example',
+      businessName: 'Brand Example',
+      channels: ['meta-ads'],
+    },
+    brandKit: buildBrandKit(dataRoot),
+    createdBy: 'user_123',
+  });
+}
+
+function buildValidatedProfileSnapshot(): ValidatedMarketingProfileSnapshot {
+  return {
+    docs: {
+      brandProfile: null,
+      websiteAnalysis: null,
+      businessProfile: null,
+      brandKit: null,
+      paths: {
+        brandProfile: null,
+        websiteAnalysis: null,
+        businessProfile: null,
+        brandKit: null,
+      },
+    },
+    brandName: 'Brand Example',
+    brandSlug: 'brand-example',
+    websiteUrl: 'https://brand.example',
+    canonicalUrl: 'https://brand.example',
+    audience: null,
+    positioning: null,
+    problemStatement: null,
+    offer: null,
+    primaryCta: null,
+    proofPoints: [],
+    brandVoice: [],
+    channelSpecificAngles: null,
+    hooks: null,
+    openingLines: null,
+    businessName: 'Brand Example',
+    businessType: null,
+    primaryGoal: null,
+    launchApproverName: null,
+    channels: ['meta-ads'],
+    competitorUrl: null,
+    brandIdentity: null,
+  };
+}
+
+async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const previousOpenClawLobsterCwd = process.env.OPENCLAW_LOBSTER_CWD;
+  const previousGatewayLobsterCwd = process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
+  const previousStage1CacheDir = process.env.LOBSTER_STAGE1_CACHE_DIR;
+  const previousStage2CacheDir = process.env.LOBSTER_STAGE2_CACHE_DIR;
+  const previousStage3CacheDir = process.env.LOBSTER_STAGE3_CACHE_DIR;
+  const previousStage4CacheDir = process.env.LOBSTER_STAGE4_CACHE_DIR;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-marketing-concurrency-'));
+
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+  process.env.OPENCLAW_LOBSTER_CWD = path.join(PROJECT_ROOT, 'lobster');
+  process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = 'lobster';
+  process.env.LOBSTER_STAGE1_CACHE_DIR = path.join(dataRoot, 'lobster-stage1-cache');
+  process.env.LOBSTER_STAGE2_CACHE_DIR = path.join(dataRoot, 'lobster-stage2-cache');
+  process.env.LOBSTER_STAGE3_CACHE_DIR = path.join(dataRoot, 'lobster-stage3-cache');
+  process.env.LOBSTER_STAGE4_CACHE_DIR = path.join(dataRoot, 'lobster-stage4-cache');
+
+  try {
+    return await run(dataRoot);
+  } finally {
+    resetMarketingJobStatusCacheForTests();
+    if (previousCodeRoot === undefined) delete process.env.CODE_ROOT;
+    else process.env.CODE_ROOT = previousCodeRoot;
+    if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previousDataRoot;
+    if (previousOpenClawLobsterCwd === undefined) delete process.env.OPENCLAW_LOBSTER_CWD;
+    else process.env.OPENCLAW_LOBSTER_CWD = previousOpenClawLobsterCwd;
+    if (previousGatewayLobsterCwd === undefined) delete process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
+    else process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = previousGatewayLobsterCwd;
+    if (previousStage1CacheDir === undefined) delete process.env.LOBSTER_STAGE1_CACHE_DIR;
+    else process.env.LOBSTER_STAGE1_CACHE_DIR = previousStage1CacheDir;
+    if (previousStage2CacheDir === undefined) delete process.env.LOBSTER_STAGE2_CACHE_DIR;
+    else process.env.LOBSTER_STAGE2_CACHE_DIR = previousStage2CacheDir;
+    if (previousStage3CacheDir === undefined) delete process.env.LOBSTER_STAGE3_CACHE_DIR;
+    else process.env.LOBSTER_STAGE3_CACHE_DIR = previousStage3CacheDir;
+    if (previousStage4CacheDir === undefined) delete process.env.LOBSTER_STAGE4_CACHE_DIR;
+    else process.env.LOBSTER_STAGE4_CACHE_DIR = previousStage4CacheDir;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+test.beforeEach(() => {
+  resetMarketingJobStatusCacheForTests();
+});
+
+test.afterEach(() => {
+  resetMarketingJobStatusCacheForTests();
+});
+
+test('buildMarketingJobStatus fans out independent collectors in parallel', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const jobId = 'job-status-concurrency';
+    saveMarketingJobRuntime(jobId, buildRuntimeDoc(dataRoot, jobId, 'tenant-real'));
+
+    const starts: number[] = [];
+    const timedDelay = async <T>(result: T): Promise<T> => {
+      starts.push(performance.now());
+      await delay(90);
+      return result;
+    };
+
+    overrideMarketingJobStatusDependenciesForTests({
+      buildReviewBundle: async () => timedDelay<MarketingReviewBundle | null>(null),
+      buildCampaignWindow: async () => timedDelay<MarketingCampaignWindow | null>(null),
+      buildCalendarEvents: async () => timedDelay<MarketingCalendarEvent[]>([]),
+      buildPostCounts: async () => ({
+        plannedPostCount: null,
+        createdPostCount: null,
+      }),
+      loadValidatedMarketingProfileSnapshot: async () => timedDelay(buildValidatedProfileSnapshot()),
+    });
+
+    const startedAt = performance.now();
+    const status = await getMarketingJobStatus(jobId);
+    const elapsedMs = performance.now() - startedAt;
+
+    assert.equal(status.jobId, jobId);
+    assert.equal(starts.length, 4);
+    assert.ok(
+      Math.max(...starts) - Math.min(...starts) < 40,
+      `expected collectors to start together, got spread ${(Math.max(...starts) - Math.min(...starts)).toFixed(1)}ms`,
+    );
+    assert.ok(elapsedMs < 170, `expected parallel execution under 170ms, got ${elapsedMs.toFixed(1)}ms`);
+  });
+});
+
+test('buildReviewBundle overlaps publish-review resolution with asset-link loading', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const jobId = 'job-review-bundle-concurrency';
+    saveMarketingJobRuntime(jobId, buildRuntimeDoc(dataRoot, jobId, 'tenant-real'));
+
+    const starts: number[] = [];
+    const markAndDelay = async <T>(result: T): Promise<T> => {
+      starts.push(performance.now());
+      await delay(90);
+      return result;
+    };
+
+    overrideMarketingJobStatusDependenciesForTests({
+      resolvePublishReviewBundle: async () =>
+        markAndDelay({
+          reviewPayload: {
+            generated_at: '2026-03-21T00:00:00.000Z',
+            approval_preview: { message: 'Ready for approval.' },
+          },
+          reviewBundle: {
+            campaign_name: 'Spring Launch',
+            approval_message: 'Ready for approval.',
+            summary: {
+              core_message: 'Launch summary',
+            },
+            platform_previews: [],
+          },
+          source: 'runtime' as const,
+        }),
+      buildMarketingAssetLinks: async () => markAndDelay([]),
+      buildCampaignWindow: async () => null,
+      buildCalendarEvents: async () => [],
+      buildPostCounts: async () => ({
+        plannedPostCount: null,
+        createdPostCount: null,
+      }),
+      loadValidatedMarketingProfileSnapshot: async () => buildValidatedProfileSnapshot(),
+    });
+
+    const startedAt = performance.now();
+    const status = await getMarketingJobStatus(jobId);
+    const elapsedMs = performance.now() - startedAt;
+
+    assert.equal(status.reviewBundle?.campaignName, 'Spring Launch');
+    assert.equal(starts.length, 2);
+    assert.ok(
+      Math.max(...starts) - Math.min(...starts) < 40,
+      `expected review bundle dependencies to start together, got spread ${(Math.max(...starts) - Math.min(...starts)).toFixed(1)}ms`,
+    );
+    assert.ok(elapsedMs < 170, `expected overlapping review bundle work under 170ms, got ${elapsedMs.toFixed(1)}ms`);
+  });
+});


### PR DESCRIPTION
References: PR #192 and PR #193, both of which were closed after 8-concurrent regressions.

This retry assumes PR #194 is merged and `DB_POOL_MAX` defaults to `20` (configurable, clamped `[5,200]`), so the pool can absorb the intended collector/query fan-out.

What changed:
- Parallelized the independent `jobs-status` collectors in `buildMarketingJobStatus` with `Promise.all(...)`.
- Narrowed `buildReviewBundle` to overlap publish-review resolution with asset-link collection.
- Added `tests/marketing-jobs-concurrency.test.ts` with delay-based wall-clock assertions for both the top-level fan-out and the narrowed review-bundle overlap.

Validation:
- `npx tsx --test tests/marketing-jobs-concurrency.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- `npm run workspace:verify` does not pass from this managed git worktree because the script only accepts the canonical checkout at `/home/node/openclaw/aries-app`.

Benchmark fixture and harness:
- Fixture job: `mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63`
- Compared `origin/master` at `CODE_ROOT=/tmp/aries-bench-master` vs this branch at the worktree root.
- Harness: direct invocation of the `/api/marketing/jobs/:id` route handler with an injected tenant context loader, in a fresh process per case.

Before (`origin/master`, post-P5) vs after (this branch) on `/api/marketing/jobs/:id`:

| Case | origin/master | this branch | Delta |
| --- | ---: | ---: | ---: |
| 1-serial wall | 1915.8 ms | 1958.8 ms | +43.0 ms |
| 8-concurrent wall | 10095.9 ms | 10903.1 ms | +807.2 ms |

Diagnostic-only measurement of `getMarketingJobStatus` itself (same fixture, fresh process):

| Case | origin/master | this branch | Delta |
| --- | ---: | ---: | ---: |
| 1-serial wall | 340.5 ms | 301.9 ms | -38.6 ms |
| 8-concurrent wall | 2140.0 ms | 1920.7 ms | -219.3 ms |

Diagnosis:
- The scoped `jobs-status` collector work does improve the status builder itself.
- The endpoint still regresses because the out-of-scope workspace/route assembly now dominates the total wall time under the same benchmark harness.
- On the 8-concurrent route benchmark, the non-`jobs-status` portion is roughly `10095.9 - 2140.0 = 7955.9 ms` on `origin/master` versus `10903.1 - 1920.7 = 8982.4 ms` on this branch, so the remaining bottleneck is outside the collector aggregation changed here.

Acceptance was not met because the route-handler benchmark is still slower than `origin/master`, so I am closing this PR rather than requesting merge.
