### PR TITLE
chore(infra): add companion postgres service + pin aries-app to local DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,10 @@ services:
       OPENCLAW_GATEWAY_URL: ${OPENCLAW_GATEWAY_URL}
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       OPENCLAW_SESSION_KEY: ${OPENCLAW_SESSION_KEY:-main}
-      DB_HOST: ${DB_HOST}
-      DB_PORT: ${DB_PORT:-5432}
+      # DB_HOST points at the companion postgres service below, not at ${DB_HOST}
+      # from .env. Compose owns service discovery; .env only holds credentials.
+      DB_HOST: postgres
+      DB_PORT: 5432
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
@@ -82,6 +84,29 @@ services:
       start_period: 30s
     networks:
       - docker_stack
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    volumes:
+      - aries_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+      - docker_stack
 
 networks:
   docker_stack:
@@ -92,4 +117,6 @@ volumes:
   gh_config:
     name: aries-app_gh_config
     external: true
+  aries_pg_data:
+    name: aries_pg_data
     


### PR DESCRIPTION
## Summary
Eliminates the Tailscale dependency for DB connectivity. The aries-app container now connects to an in-stack `postgres:16-alpine` service over the docker_stack network instead of `100.65.234.31:5432`.

## Changes
- New `postgres` service in `docker-compose.yml` (PG 16.x to match remote PG 16.13 for dump/restore compat)
- Persistent volume `aries_pg_data`
- `pg_isready` healthcheck + `depends_on` gate on aries-app
- `DB_HOST: postgres` hardcoded in the aries-app compose block — service discovery belongs in compose, not in `.env`

## Data migration (already executed locally)
- `pg_dump --format=custom` of remote `aries_auth` database
- `pg_restore` into the new volume
- Preserved: 10 tables, 19 users, 59 organizations, all test accounts + campaign runtime rows

## Deploy validation
- `postgres` container healthy via `pg_isready`
- `aries-app` container rebuilt and healthy on the new `DB_HOST=postgres`
- Public homepage returns HTTP 200 @ 134ms
- Test account `qa-video-1777014617@aries-test.local` survived the migration

## Test plan
- [x] Container healthy post-migration
- [x] Test user row survives in restored DB
- [x] Public homepage responds 200
- [ ] Credentials sign-in end-to-end (next session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)