### PR TITLE
fix(workspace): preserve scroll position across view pill transitions

### DIFF
--- a/frontend/aries-v1/campaign-workspace.tsx
+++ b/frontend/aries-v1/campaign-workspace.tsx
@@ -394,6 +394,7 @@ export default function AriesCampaignWorkspace(props: { campaignId: string; init
           <Link
             key={view}
             href={currentStageHref(props.campaignId, view)}
+            scroll={false}
             className={`rounded-full border px-4 py-2.5 text-sm font-medium transition ${
               activeView === view
                 ? 'border-white/20 bg-white/[0.08] text-white'

--- a/tests/campaign-workspace-tab-routing.regression-010.test.ts
+++ b/tests/campaign-workspace-tab-routing.regression-010.test.ts
@@ -64,4 +64,9 @@ test('campaign-workspace client wires the view through useSearchParams', () => {
     /resolveWorkspaceView\(/,
     'campaign-workspace.tsx must funnel the view through resolveWorkspaceView for validation',
   );
+  assert.match(
+    source,
+    /<Link[\s\S]*?href=\{currentStageHref\(props\.campaignId, view\)\}[\s\S]*?scroll=\{false\}/,
+    'campaign-workspace.tsx must disable Next Link scroll resets for view-pill navigation',
+  );
 });


### PR DESCRIPTION
## Summary
- add `scroll={false}` to the campaign workspace view-pill links so query-only App Router navigation does not force the page back to the top
- add a regression guard asserting the nav pill Link keeps the scroll override in place

## QA source
- qa-workspace ISSUE-006

## Repro
1. Sign in and open `/dashboard/campaigns/mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63?view=brand`
2. Scroll halfway down
3. Click `Launch Status` or another view pill
4. Check `window.scrollY` after the click

## Before / after
- Before on master: switching pills could reset the destination view to `window.scrollY = 0`
- After on this branch: the Link opts out of Next.js scroll resets, so the destination view keeps the browser's existing scroll position instead of forcing `0`
- Note: I could not capture exact deployed numeric `scrollY` values in this session because the demo auth environment needed for the live repro was not available locally

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx tsx --test tests/campaign-workspace-tab-routing.regression-010.test.ts`
- `npm run verify`