### PR TITLE
fix(reviews): /review/{id} page resolves review payload when URL-encoded colons are used

### DIFF
--- a/app/review/[reviewId]/page.tsx
+++ b/app/review/[reviewId]/page.tsx
@@ -1,11 +1,41 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import AriesReviewItemScreen from '@/frontend/aries-v1/review-item';
+import { handleGetMarketingReviewItem } from '@/app/api/marketing/reviews/[reviewId]/route';
+import type { ReviewItemResponse } from '@/lib/api/aries-v1';
+
+type ReviewItemPageLoader = (reviewId: string) => Promise<Response>;
 
 function decodeReviewIdParam(reviewId: string): string {
   try {
     return decodeURIComponent(reviewId);
   } catch {
     return reviewId;
+  }
+}
+
+function isReviewItemResponse(value: unknown): value is ReviewItemResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'review' in value &&
+    typeof (value as { review?: { id?: unknown } }).review?.id === 'string'
+  );
+}
+
+export async function loadReviewItemPageData(
+  reviewId: string,
+  reviewItemLoader: ReviewItemPageLoader = handleGetMarketingReviewItem,
+): Promise<ReviewItemResponse | null> {
+  try {
+    const response = await reviewItemLoader(reviewId);
+    if (!response.ok) {
+      return null;
+    }
+
+    const body = await response.json() as unknown;
+    return isReviewItemResponse(body) ? body : null;
+  } catch {
+    return null;
   }
 }
 
@@ -16,6 +46,7 @@ export default async function ReviewItemPage({
 }) {
   const { reviewId } = await params;
   const encodedReviewPath = `/review/${reviewId}`;
+  const initialData = await loadReviewItemPageData(reviewId);
 
   return (
     <AppShellLayout
@@ -23,7 +54,7 @@ export default async function ReviewItemPage({
       skipOnboardingGate
       loginRedirectPath={encodedReviewPath}
     >
-      <AriesReviewItemScreen reviewId={decodeReviewIdParam(reviewId)} />
+      <AriesReviewItemScreen reviewId={decodeReviewIdParam(reviewId)} initialData={initialData} />
     </AppShellLayout>
   );
 }

--- a/frontend/aries-v1/review-item.tsx
+++ b/frontend/aries-v1/review-item.tsx
@@ -6,6 +6,7 @@ import { ArrowUpRight, CheckCircle2, LoaderCircle, MessageSquareText, XCircle } 
 
 import MediaPreview from '@/frontend/components/media-preview';
 import { useRuntimeReviewItem } from '@/hooks/use-runtime-review-item';
+import type { ReviewItemResponse } from '@/lib/api/aries-v1';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { getReviewRecoveryState } from './review-recovery';
@@ -62,9 +63,9 @@ function brandKitFontStyle(family: string): CSSProperties {
   };
 }
 
-export default function AriesReviewItemScreen(props: { reviewId: string }) {
-  const review = useRuntimeReviewItem(props.reviewId, { autoLoad: true });
-  const item = review.data?.review ?? null;
+export default function AriesReviewItemScreen(props: { reviewId: string; initialData?: ReviewItemResponse | null }) {
+  const review = useRuntimeReviewItem(props.reviewId, { autoLoad: true, initialData: props.initialData });
+  const item = review.data?.review ?? props.initialData?.review ?? null;
   const recoveryState = getReviewRecoveryState(review.error);
   const [note, setNote] = useState('');
   const [activeAction, setActiveAction] = useState<DecisionActionKind>('approve');

--- a/hooks/use-runtime-review-item.ts
+++ b/hooks/use-runtime-review-item.ts
@@ -5,7 +5,10 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { createAriesV1Api, type ReviewDecisionRequest, type ReviewItemResponse } from '@/lib/api/aries-v1';
 import { useAsyncAction, useRequestState } from './use-request-state';
 
-export function useRuntimeReviewItem(reviewId: string, options: { baseUrl?: string; autoLoad?: boolean } = {}) {
+export function useRuntimeReviewItem(
+  reviewId: string,
+  options: { baseUrl?: string; autoLoad?: boolean; initialData?: ReviewItemResponse | null } = {},
+) {
   const api = useMemo(() => createAriesV1Api(options), [options.baseUrl]);
   const state = useRequestState<ReviewItemResponse>();
   const decision = useAsyncAction<ReviewItemResponse>();
@@ -37,8 +40,9 @@ export function useRuntimeReviewItem(reviewId: string, options: { baseUrl?: stri
 
   useEffect(() => {
     if (options.autoLoad === false) return;
+    if (options.initialData?.review.id === reviewId) return;
     void load();
-  }, [load, options.autoLoad]);
+  }, [load, options.autoLoad, options.initialData?.review.id, reviewId]);
 
   return { ...state, load, decision, submitDecision };
 }

--- a/tests/runtime-pages.test.ts
+++ b/tests/runtime-pages.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
-import { isValidElement } from 'react';
+import { createElement, isValidElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import HomePage from '../app/page';
 import DashboardPage from '../app/dashboard/page';
@@ -20,7 +21,7 @@ import DashboardStrategyReviewPage from '../app/dashboard/strategy-review/page';
 import CampaignsPage from '../app/campaigns/page';
 import CampaignWorkspacePage from '../app/campaigns/[campaignId]/page';
 import ReviewQueuePage from '../app/review/page';
-import ReviewItemPage from '../app/review/[reviewId]/page';
+import ReviewItemPage, { loadReviewItemPageData } from '../app/review/[reviewId]/page';
 import ResultsPage from '../app/results/page';
 import CalendarPage from '../app/calendar/page';
 import PostsPage from '../app/posts/page';
@@ -57,6 +58,7 @@ import MarketingJobStatusScreen from '../frontend/marketing/job-status';
 import MarketingJobApproveScreen from '../frontend/marketing/job-approve';
 import AppShellLayout from '../frontend/app-shell/layout';
 import { buildLoginRedirect } from '../lib/auth/callback-url';
+import type { RuntimeReviewItem } from '../lib/api/aries-v1';
 import { resolveProjectRoot } from './helpers/project-root';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
@@ -75,6 +77,61 @@ async function expectAsyncRedirect(callable: () => Promise<unknown>, location: s
     assert.equal((error as { digest?: string }).digest, `NEXT_REDIRECT;replace;${location};307;`);
     return true;
   });
+}
+
+function makeRuntimeReviewItem(
+  id: string,
+  overrides: Partial<RuntimeReviewItem> = {},
+): RuntimeReviewItem {
+  return {
+    id,
+    jobId: id.split('::')[0] || 'mkt_review_page',
+    campaignId: 'campaign_review_page',
+    campaignName: 'Review Page Campaign',
+    reviewType: 'creative',
+    workflowState: 'creative_review_required',
+    workflowStage: 'production',
+    title: 'Review page asset',
+    channel: 'Meta Ads',
+    placement: 'Feed',
+    scheduledFor: '2026-04-24T17:00:00.000Z',
+    status: 'in_review',
+    summary: 'Review this asset before launch.',
+    currentVersion: {
+      id: 'creative:asset',
+      label: 'Current version',
+      headline: 'Review page asset',
+      supportingText: 'Asset copy.',
+      cta: 'Approve',
+      notes: [],
+    },
+    lastDecision: null,
+    previewUrl: '/api/marketing/jobs/mkt_review_page/assets/asset-preview',
+    fullPreviewUrl: '/api/marketing/jobs/mkt_review_page/assets/asset-full',
+    contentType: 'image/png',
+    destinationUrl: null,
+    sections: [],
+    attachments: [],
+    history: [],
+    ...overrides,
+  };
+}
+
+async function assertReviewPageBodyUsesLoadedReview(review: RuntimeReviewItem) {
+  const encodedReviewId = encodeURIComponent(review.id);
+  const loaded = await loadReviewItemPageData(encodedReviewId, async () => (
+    Response.json({ review })
+  ));
+
+  assert.equal(loaded?.review.id, review.id);
+
+  const body = renderToStaticMarkup(createElement(AriesReviewItemScreen, {
+    reviewId: review.id,
+    initialData: loaded,
+  }));
+
+  assert.doesNotMatch(body, /Review item not found/);
+  assert.match(body, new RegExp(review.title));
 }
 
 test('/ returns the public homepage component', () => {
@@ -204,6 +261,51 @@ test('/review/[reviewId] decodes encoded review ids before rendering the detail 
     buildLoginRedirect(element.props.loginRedirectPath),
     '/login?callbackUrl=%2Freview%2Fmkt_123%253A%253Aapproval',
   );
+});
+
+test('/review/[reviewId] seeds encoded publish-preview video review data into the rendered page body', async () => {
+  await assertReviewPageBodyUsesLoadedReview(makeRuntimeReviewItem(
+    'mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63::publish-preview:tiktok',
+    {
+      reviewType: 'workflow_approval',
+      workflowState: 'ready_to_publish',
+      workflowStage: 'publish',
+      title: 'TikTok publish preview',
+      channel: 'TikTok',
+      placement: 'Publish preview',
+      contentType: 'video/mp4',
+      previewUrl: '/api/marketing/jobs/mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63/assets/video-tiktok-portrait',
+      fullPreviewUrl: '/api/marketing/jobs/mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63/assets/video-tiktok-portrait',
+      currentVersion: {
+        id: 'approval:publish-preview:tiktok',
+        label: 'Publish preview',
+        headline: 'TikTok publish preview',
+        supportingText: 'Rendered TikTok video.',
+        cta: 'Approve',
+        notes: [],
+      },
+    },
+  ));
+});
+
+test('/review/[reviewId] seeds encoded creative image review data into the rendered page body', async () => {
+  await assertReviewPageBodyUsesLoadedReview(makeRuntimeReviewItem(
+    'mkt_c3929018-5bdb-4dfc-83ab-f2ed13bdb97b::creative:image-proof',
+    {
+      title: 'Creative image proof',
+      channel: 'Instagram',
+      placement: 'Feed image',
+      contentType: 'image/png',
+      currentVersion: {
+        id: 'creative:image-proof',
+        label: 'Image proof',
+        headline: 'Creative image proof',
+        supportingText: 'Static image creative.',
+        cta: 'Approve',
+        notes: [],
+      },
+    },
+  ));
 });
 
 test('/dashboard/calendar wraps the calendar screen in the app shell', () => {


### PR DESCRIPTION
## Summary
- Load `/review/[reviewId]` review data on the server through the same marketing review API handler used by `/api/marketing/reviews/[reviewId]`.
- Seed the review detail client screen with that payload so raw page HTML renders the found review instead of the pre-fetch fallback.
- Add regression coverage for encoded `publish-preview:tiktok` video reviews and `creative:image-proof` image reviews.

Fixes ISSUE-004.

## Before / After Curl
Before (QA reproduction on production before this fix):
```sh
REV_ID_ENC="mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63%3A%3Apublish-preview%3Atiktok"
curl -b cookies.txt -sS https://aries.sugarandleather.com/review/$REV_ID_ENC | grep -c "Review item not found"
# 1
curl -b cookies.txt -sS https://aries.sugarandleather.com/api/marketing/reviews/$REV_ID_ENC | jq '.review.id'
# "mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63::publish-preview:tiktok"
```

After (expected once this branch is deployed):
```sh
REV_ID_ENC="mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63%3A%3Apublish-preview%3Atiktok"
curl -b cookies.txt -sS https://aries.sugarandleather.com/review/$REV_ID_ENC | grep -c "Review item not found"
# 0
curl -b cookies.txt -sS https://aries.sugarandleather.com/api/marketing/reviews/$REV_ID_ENC | jq '.review.id'
# "mkt_63d45c2b-6f8e-4036-9ebf-703892f3dd63::publish-preview:tiktok"
```

I could not run the authenticated production after-curl from this undeployed worktree because no `cookies.txt` was present in the session and the branch is not live yet. The regression test renders the server-seeded page body and asserts the same fallback string is absent for both required review ID shapes.

## Validation
- `npx tsx --test tests/runtime-pages.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run verify`
- `npm run validate:repo-boundary`
- `npm run validate:banned-patterns`

Note: `npm run workspace:verify` fails in this managed worktree because the git root is `/home/node/.worktrees/aries-app/aa-47`, while the script expects canonical root `/home/node/openclaw/aries-app`.
