### PR TITLE
feat(business-profile): Add Profile CTA + live connected profiles summary

### DIFF
--- a/frontend/aries-v1/business-profile-screen.tsx
+++ b/frontend/aries-v1/business-profile-screen.tsx
@@ -108,6 +108,7 @@ export default function AriesBusinessProfileScreen() {
   const profile = business.profile.data?.profile ?? null;
   const teamProfiles = business.team.data?.profiles ?? [];
   const integrationCards = integrations.data?.status === 'ok' ? integrations.data.cards : [];
+  const integrationsUnavailable = integrations.error || integrations.data?.status === 'error';
   const connectedProfileLabels = Array.from(new Set(
     integrationCards
       .filter((card) => card.connection_state === 'connected')
@@ -115,7 +116,7 @@ export default function AriesBusinessProfileScreen() {
   ));
   const connectedProfilesSummary = integrations.isLoading
     ? 'Checking connected profiles…'
-    : integrations.error
+    : integrationsUnavailable
       ? 'Connected profile status is not available right now.'
       : connectedProfileLabels.length > 0
         ? connectedProfileLabels.join(', ')

--- a/frontend/aries-v1/business-profile-screen.tsx
+++ b/frontend/aries-v1/business-profile-screen.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 import Link from 'next/link';
 
 import { useBusinessProfile } from '@/hooks/use-business-profile';
+import { useIntegrations } from '@/hooks/use-integrations';
 import {
   hasValidationErrors,
   validateBusinessProfileForm,
@@ -44,6 +45,16 @@ const CHANNEL_OPTIONS: ChannelOption[] = [
 
 const DEFAULT_CHANNEL_IDS = ['meta-ads', 'instagram'];
 
+const CONNECTED_PROFILE_LABELS: Record<string, string> = {
+  facebook: 'Meta',
+  instagram: 'Instagram',
+  linkedin: 'LinkedIn',
+  x: 'X',
+  youtube: 'YouTube',
+  reddit: 'Reddit',
+  tiktok: 'TikTok',
+};
+
 function brandKitFontStyle(family: string): CSSProperties {
   return {
     fontFamily: `"${family}", ${family}, ui-sans-serif, system-ui, sans-serif`,
@@ -64,12 +75,20 @@ function channelLabel(channelId: string): string {
   return CHANNEL_OPTIONS.find((option) => option.id === channelId)?.label || channelId;
 }
 
-function joinedValues(values: string[]): string {
-  return values.map(channelLabel).join(', ');
+function connectedProfileLabel(platform: string, fallback: string): string {
+  return CONNECTED_PROFILE_LABELS[platform] || fallback || platform;
+}
+
+function joinedValues(values: string[], connectedProfileLabels: string[] = []): string {
+  return Array.from(new Set([
+    ...values.map(channelLabel),
+    ...connectedProfileLabels,
+  ].map((value) => value.trim()).filter(Boolean))).join(', ');
 }
 
 export default function AriesBusinessProfileScreen() {
   const business = useBusinessProfile({ autoLoad: true });
+  const integrations = useIntegrations({ autoLoad: true });
   const [businessName, setBusinessName] = useState('');
   const [websiteUrl, setWebsiteUrl] = useState('');
   const [businessType, setBusinessType] = useState('');
@@ -88,6 +107,19 @@ export default function AriesBusinessProfileScreen() {
 
   const profile = business.profile.data?.profile ?? null;
   const teamProfiles = business.team.data?.profiles ?? [];
+  const integrationCards = integrations.data?.status === 'ok' ? integrations.data.cards : [];
+  const connectedProfileLabels = Array.from(new Set(
+    integrationCards
+      .filter((card) => card.connection_state === 'connected')
+      .map((card) => connectedProfileLabel(card.platform, card.display_name)),
+  ));
+  const connectedProfilesSummary = integrations.isLoading
+    ? 'Checking connected profiles…'
+    : integrations.error
+      ? 'Connected profile status is not available right now.'
+      : connectedProfileLabels.length > 0
+        ? connectedProfileLabels.join(', ')
+        : 'No connected social profiles yet.';
   const ready = !business.profile.isLoading && !business.team.isLoading;
 
   useEffect(() => {
@@ -223,7 +255,7 @@ export default function AriesBusinessProfileScreen() {
           },
           {
             label: 'Channels',
-            value: joinedValues(selectedChannels),
+            value: joinedValues(selectedChannels, connectedProfileLabels),
             detail: profile.incomplete ? 'The profile still needs a few details before it is fully locked.' : 'These channels are ready for the next campaign.',
             tone: profile.incomplete ? 'watch' : 'good',
           },
@@ -379,6 +411,23 @@ export default function AriesBusinessProfileScreen() {
                     </button>
                   );
                 })}
+              </div>
+              <div className="rounded-[1.3rem] border border-white/8 bg-black/18 px-4 py-4 text-white">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-sm font-medium">Connected profiles</p>
+                    <p className="mt-2 text-sm leading-7 text-white/58">{connectedProfilesSummary}</p>
+                  </div>
+                  <Link
+                    href="/dashboard/settings/channel-integrations?from=business-profile"
+                    className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/15 bg-white px-4 py-2 text-sm font-semibold text-[#11161c] transition hover:bg-white/90"
+                  >
+                    Add Profile
+                  </Link>
+                </div>
+                <p className="mt-3 text-xs leading-6 text-white/42">
+                  Newly connected media portals update this Business Profile channel summary automatically.
+                </p>
               </div>
             </div>
 

--- a/tests/business-profile-screen.test.ts
+++ b/tests/business-profile-screen.test.ts
@@ -65,6 +65,16 @@ test('business profile screen offers Add Profile CTA and mirrors connected socia
     'Business Profile should derive connected social profiles from connected integration cards',
   );
   assert.equal(
+    source.includes("integrations.data?.status === 'error'"),
+    true,
+    'Business Profile should show connected profile status as unavailable when the integrations API returns an error payload with HTTP 200',
+  );
+  assert.equal(
+    source.includes('Connected profile status is not available right now.'),
+    true,
+    'Business Profile should use unavailable copy instead of the no-profiles empty state for integrations error payloads',
+  );
+  assert.equal(
     source.includes('Connected profiles'),
     true,
     'Business Profile channel section should summarize connected social profiles near the Add Profile CTA',

--- a/tests/business-profile-screen.test.ts
+++ b/tests/business-profile-screen.test.ts
@@ -42,3 +42,31 @@ test('business profile screen replaces the comma-list channel editor with curate
   assert.equal(source.includes('LinkedIn'), true);
   assert.equal(source.includes('meta-ads, instagram, linkedin'), false);
 });
+
+test('business profile screen offers Add Profile CTA and mirrors connected social profiles', () => {
+  assert.equal(
+    source.includes('Add Profile'),
+    true,
+    'Business Profile must expose an Add Profile CTA where account owners manage operating profile channels',
+  );
+  assert.equal(
+    source.includes('/dashboard/settings/channel-integrations?from=business-profile'),
+    true,
+    'Add Profile CTA should route to the existing channel integration connection page',
+  );
+  assert.equal(
+    source.includes('useIntegrations({ autoLoad: true })'),
+    true,
+    'Business Profile should load integration cards so newly connected media portals auto-update channel context',
+  );
+  assert.equal(
+    source.includes("connection_state === 'connected'"),
+    true,
+    'Business Profile should derive connected social profiles from connected integration cards',
+  );
+  assert.equal(
+    source.includes('Connected profiles'),
+    true,
+    'Business Profile channel section should summarize connected social profiles near the Add Profile CTA',
+  );
+});


### PR DESCRIPTION
## Summary

- Adds an **Add Profile** CTA button to the Business Profile screen that routes account owners to `/dashboard/settings/channel-integrations?from=business-profile` — the existing profile connection flow, no new page needed.
- Adds a **Connected profiles** card in the Business Profile channel section that pulls live data from `useIntegrations`. Only `connection_state === 'connected'` cards are surfaced, mapped to human-readable labels (Meta, Instagram, LinkedIn, X, YouTube, Reddit, TikTok).
- Channel summary (`joinedValues`) is extended to merge connected profile labels alongside the existing channel selections, so the overview always reflects the full live picture.
- Includes a helper `connectedProfileLabel()` and a `CONNECTED_PROFILE_LABELS` map.
- Source-level tests added covering: CTA presence, correct route, `useIntegrations` wiring, `connection_state` filter, and card heading.

Closes #204

## Test plan

- [x] `npx tsx --test tests/business-profile-screen.test.ts` — 4/4 pass
- [x] `npm run validate:repo-boundary` — ok (499 files checked)
- [x] `npm run validate:banned-patterns` — ok (10 patterns, 8 files)
- [x] `npm run verify` — verification suite passed
- [ ] Manual: confirm Add Profile button appears in Business Profile, tapping routes to channel-integrations, newly connected portal name surfaces in Connected profiles card

🤖 Generated with [Claude Code](https://claude.com/claude-code)