### PR TITLE
fix: address live QA Ralph findings

### DIFF
--- a/.ralph/log.md
+++ b/.ralph/log.md
@@ -1,0 +1,49 @@
+# Ralph loop log — live QA 2026-04-27
+
+## Baseline deploy
+
+- PR #207 merged: https://github.com/DeliciousHouse/aries-app/pull/207
+- Master SHA: `880e4dccaac4aa89c21c4cd68bb2027e9999d62d`
+- Published image: `ghcr.io/delicioushouse/aries-app:880e4dccaac4aa89c21c4cd68bb2027e9999d62d`
+- GHCR digest: `sha256:53593def30704d8a85fbdd24635168e95d773df797785706dcb43f6e6e192d01`
+- Deploy workflow run: https://github.com/DeliciousHouse/aries-app/actions/runs/24972531636
+
+## Discovery waves
+
+### Public marketing/auth
+
+Routes tested: `/`, `/features`, `/documentation`, `/api-docs`, `/terms`, `/privacy`, `/sitemap`, `/contact`, `/login`, `/signup`, `/forgot-password`, `/reset-password`.
+
+Findings:
+- Reset-password backend failures are silent after HTTP 400.
+- Reset-password submit enables before confirm/password-policy validation passes.
+- Reset-password inputs lack useful accessible names.
+- Signup password visibility button is unnamed, and Organization uses placeholder as accessible name.
+- Global Features links go to `/#features` while `/features` is a standalone sitemap route.
+- Auth pages have no `main`; documentation has nested `main` landmarks.
+
+### Onboarding/review/marketing job
+
+Routes tested: `/onboarding/start`, `/onboarding`, `/onboarding/resume`, `/onboarding/status`, `/marketing/new-job`, `/marketing/job-status`, `/marketing/job-approve`, `/publish-status`, `/review`, invalid `/review/:id`, invalid `/materials/:job/:asset`.
+
+Findings:
+- Onboarding competitor field accepts Facebook URL at step 1, then blocks only on final submit.
+- Job approval CTA remains enabled after unauthenticated/failed status load.
+- Approve API checks job runtime before tenant/auth context, unlike status API.
+- Publish status unauthenticated redirect loses callback URL.
+- Invalid onboarding tenant displays top-level `onboarding_status OK` despite not-found provisioning state.
+
+### Protected routes
+
+Routes tested: dashboard routes and legacy aliases while unauthenticated.
+
+Result: no route-breaking findings. Protected routes and aliases ultimately land on `/login` with HTTP 200 and no console errors.
+
+## Story plan
+
+- ISSUE-001: Reset password error handling, validation, and labels.
+- ISSUE-002: Signup form accessible names.
+- ISSUE-003: Public nav canonical Features link and landmark structure.
+- ISSUE-004: Onboarding competitor validation and not-found status copy.
+- ISSUE-005: Marketing job approval gating and approve API auth-order consistency.
+- ISSUE-006: Publish-status login callback preservation.

--- a/.ralph/log.md
+++ b/.ralph/log.md
@@ -39,11 +39,39 @@ Routes tested: dashboard routes and legacy aliases while unauthenticated.
 
 Result: no route-breaking findings. Protected routes and aliases ultimately land on `/login` with HTTP 200 and no console errors.
 
-## Story plan
+## Story plan and resolution
 
-- ISSUE-001: Reset password error handling, validation, and labels.
-- ISSUE-002: Signup form accessible names.
-- ISSUE-003: Public nav canonical Features link and landmark structure.
-- ISSUE-004: Onboarding competitor validation and not-found status copy.
-- ISSUE-005: Marketing job approval gating and approve API auth-order consistency.
-- ISSUE-006: Publish-status login callback preservation.
+- ISSUE-001: Reset password error handling, validation, and labels. PASS. Commits: `5ec2cb9`, `e23f0de`.
+- ISSUE-002: Signup form accessible names. PASS. Commit: `8f2e518`.
+- ISSUE-003: Public nav canonical Features link and landmark structure. PASS. Commits: `fe9beac`, `45dc5b1`.
+- ISSUE-004: Onboarding competitor validation and not-found status copy. PASS. Commits: `5a0ae9d`, `84d9fb8`.
+- ISSUE-005: Marketing job approval gating and approve API auth-order consistency. PASS. Commit: `fc595c0`.
+- ISSUE-006: Publish-status login callback preservation. PASS. Commit: `435ef83`.
+
+## Review loop
+
+- ISSUE-001 initial review requested behavioral tests and safer non-string failed-response parsing. Fixed in `e23f0de`; re-review approved.
+- ISSUE-002 approved with non-blocking source-test caveat.
+- ISSUE-003 initial review requested labeled navigation landmarks. Fixed in `45dc5b1`; re-review approved.
+- ISSUE-004 initial review requested behavioral/source-imported tests. Fixed in `84d9fb8`; re-review approved.
+- ISSUE-005 approved.
+- ISSUE-006 approved.
+
+## Integration validation
+
+Canonical checkout: `/home/node/openclaw/aries-app`.
+
+Passed:
+- `npm run workspace:verify`
+- `npm run typecheck`
+- Targeted 87-test QA regression suite covering reset password, signup, publish-status redirects, public nav/landmarks, onboarding validation/status, marketing approval gating, and core route pages.
+- `git diff --check origin/master...HEAD`
+- `npm run validate:repo-boundary`
+- `npm run validate:banned-patterns`
+- `npm run verify`
+
+## Remaining caveats
+
+- Browser vision analysis failed in this Hermes/Codex session due unsupported configured vision model, so discovery used browser snapshots, console, DOM checks, route status checks, and source lookup.
+- Authenticated dashboard behavior was limited to unauthenticated redirects because no private credentials were available in the session.
+- Broader `tests/frontend-api-layer.test.ts` has unrelated known marketing workspace/hydration failures when run as a full file, but the ISSUE-004 and ISSUE-005 targeted paths pass and `npm run verify` passes.

--- a/.ralph/log.md
+++ b/.ralph/log.md
@@ -72,6 +72,6 @@ Passed:
 
 ## Remaining caveats
 
-- Browser vision analysis failed in this Hermes/Codex session due unsupported configured vision model, so discovery used browser snapshots, console, DOM checks, route status checks, and source lookup.
+- Browser vision analysis failed in this Hermes/Codex session due to unsupported configured vision model, so discovery used browser snapshots, console, DOM checks, route status checks, and source lookup.
 - Authenticated dashboard behavior was limited to unauthenticated redirects because no private credentials were available in the session.
 - Broader `tests/frontend-api-layer.test.ts` has unrelated known marketing workspace/hydration failures when run as a full file, but the ISSUE-004 and ISSUE-005 targeted paths pass and `npm run verify` passes.

--- a/.ralph/prompt.md
+++ b/.ralph/prompt.md
@@ -1,0 +1,27 @@
+# Ralph loop driver — live QA 2026-04-27
+
+Live site: https://aries.sugarandleather.com
+Baseline deployed SHA: 880e4dccaac4aa89c21c4cd68bb2027e9999d62d
+Branch: qa/live-20260427-ralph-loop
+
+## Rules
+
+- Fix the issues documented under `.ralph/user-stories/`.
+- Use targeted regression tests for each fix where practical.
+- Stage only files owned by your assigned story. Never use `git add -A`, `git add .`, or `git commit -a`.
+- If the working tree contains sibling-agent edits, leave them alone.
+- Do not push during development.
+- Keep commits atomic by story.
+- Prefer real Aries/Sugar & Leather context over synthetic QA examples. Do not hardcode fake business/person/media examples.
+- For any fix with a primary path and fallback/error path, explicitly verify the fallback behavior.
+- After each story, run the narrowest targeted test, then report files changed and commit SHA.
+
+## Mandatory reviewer prompts
+
+Quality reviewers must answer:
+
+1. What does the fallback path return when the primary path is empty or failed?
+2. Can lower-quality/error-state candidates crowd out higher-quality/valid candidates?
+3. Is source-priority/auth-ordering applied before lookup/score-based behavior?
+4. If the same fix pattern appears in two sibling functions, do they stay in sync?
+5. Does the fix add accessible names/status text that match visible labels?

--- a/.ralph/user-stories/ISSUE-001-reset-password.json
+++ b/.ralph/user-stories/ISSUE-001-reset-password.json
@@ -3,7 +3,7 @@
   "title": "Reset password form shows failed reset errors, validates before submit, and exposes accessible labels",
   "severity": "high",
   "category": "functional/accessibility",
-  "passes": false,
+  "passes": true,
   "blocked": false,
   "page": "https://aries.sugarandleather.com/reset-password?email=qa.invalid%40example.com",
   "symptom": "Invalid reset requests return HTTP 400 but the form silently returns to an enabled state. The submit button enables before confirm/password-policy validation passes, and inputs are named by current values/placeholders instead of visible labels.",

--- a/.ralph/user-stories/ISSUE-001-reset-password.json
+++ b/.ralph/user-stories/ISSUE-001-reset-password.json
@@ -1,0 +1,23 @@
+{
+  "id": "ISSUE-001",
+  "title": "Reset password form shows failed reset errors, validates before submit, and exposes accessible labels",
+  "severity": "high",
+  "category": "functional/accessibility",
+  "passes": false,
+  "blocked": false,
+  "page": "https://aries.sugarandleather.com/reset-password?email=qa.invalid%40example.com",
+  "symptom": "Invalid reset requests return HTTP 400 but the form silently returns to an enabled state. The submit button enables before confirm/password-policy validation passes, and inputs are named by current values/placeholders instead of visible labels.",
+  "acceptance_criteria": [
+    "When /api/auth/reset-password returns non-2xx, the form shows a visible accessible error explaining the code is invalid/expired or reset failed.",
+    "Update Password is disabled or blocked until code is valid, password satisfies policy, and confirmation matches.",
+    "Mismatched or weak passwords show inline validation before the backend request.",
+    "Recovery Code, New Password, and Confirm Password inputs have accessible names matching their visible labels.",
+    "Add regression tests covering failed reset error display, invalid submit gating, and labels."
+  ],
+  "suspected_files": [
+    "frontend/auth/reset-password-form.tsx",
+    "app/reset-password/page-client.tsx",
+    "tests"
+  ],
+  "notes": "Discovery evidence: POST /api/auth/reset-password responseStatus 400 produced no visible error. Source hint: reset-password-form disables only on isLoading || !password || !code and labels lack htmlFor/id."
+}

--- a/.ralph/user-stories/ISSUE-002-signup-accessibility.json
+++ b/.ralph/user-stories/ISSUE-002-signup-accessibility.json
@@ -3,7 +3,7 @@
   "title": "Signup form controls have useful accessible names",
   "severity": "medium",
   "category": "accessibility",
-  "passes": false,
+  "passes": true,
   "blocked": false,
   "page": "https://aries.sugarandleather.com/signup",
   "symptom": "The signup password visibility toggle is an unnamed icon-only button, and Organization is named from placeholder text instead of its visible label.",

--- a/.ralph/user-stories/ISSUE-002-signup-accessibility.json
+++ b/.ralph/user-stories/ISSUE-002-signup-accessibility.json
@@ -1,0 +1,22 @@
+{
+  "id": "ISSUE-002",
+  "title": "Signup form controls have useful accessible names",
+  "severity": "medium",
+  "category": "accessibility",
+  "passes": false,
+  "blocked": false,
+  "page": "https://aries.sugarandleather.com/signup",
+  "symptom": "The signup password visibility toggle is an unnamed icon-only button, and Organization is named from placeholder text instead of its visible label.",
+  "acceptance_criteria": [
+    "Password visibility toggle has an accessible name such as Show password / Hide password and updates when toggled.",
+    "The toggle exposes pressed state if appropriate.",
+    "Organization input is associated with its visible Organization (Optional) label via htmlFor/id or aria-labelledby.",
+    "No signup interactive control appears as an unnamed button in the accessibility tree.",
+    "Add a regression test for these accessible names."
+  ],
+  "suspected_files": [
+    "frontend/auth/sign-up-form.tsx",
+    "tests"
+  ],
+  "notes": "Discovery evidence: accessibility snapshot exposed an unnamed button next to Password, and Organization textbox was named e.g. Acme Corp."
+}

--- a/.ralph/user-stories/ISSUE-003-nav-landmarks.json
+++ b/.ralph/user-stories/ISSUE-003-nav-landmarks.json
@@ -1,0 +1,25 @@
+{
+  "id": "ISSUE-003",
+  "title": "Public navigation has a canonical Features destination and one main landmark per page",
+  "severity": "medium",
+  "category": "ux/accessibility",
+  "passes": false,
+  "blocked": false,
+  "page": "https://aries.sugarandleather.com/features and https://aries.sugarandleather.com/documentation",
+  "symptom": "Global Features links route to /#features while /features exists as a standalone sitemap route. Auth pages have no main landmark, and documentation renders nested main landmarks.",
+  "acceptance_criteria": [
+    "Header/footer Features links consistently navigate to the canonical /features route, or the duplicate /features route is deliberately removed from sitemap/navigation. Prefer /features for this fix.",
+    "Auth pages expose exactly one primary main landmark.",
+    "Documentation page avoids nested main landmarks under the marketing shell.",
+    "Add regression tests for canonical feature links and landmark counts where practical."
+  ],
+  "suspected_files": [
+    "frontend/donor/marketing/chrome.tsx",
+    "frontend/auth/auth-layout.tsx",
+    "frontend/documentation/Docs.tsx",
+    "app/features/page.tsx",
+    "app/sitemap/page.tsx",
+    "tests"
+  ],
+  "notes": "Discovery evidence: clicking Features from /terms lands on /#features, while direct /features exists. DOM: auth pages mainCount=0; /documentation mainCount=2."
+}

--- a/.ralph/user-stories/ISSUE-003-nav-landmarks.json
+++ b/.ralph/user-stories/ISSUE-003-nav-landmarks.json
@@ -3,7 +3,7 @@
   "title": "Public navigation has a canonical Features destination and one main landmark per page",
   "severity": "medium",
   "category": "ux/accessibility",
-  "passes": false,
+  "passes": true,
   "blocked": false,
   "page": "https://aries.sugarandleather.com/features and https://aries.sugarandleather.com/documentation",
   "symptom": "Global Features links route to /#features while /features exists as a standalone sitemap route. Auth pages have no main landmark, and documentation renders nested main landmarks.",

--- a/.ralph/user-stories/ISSUE-004-onboarding-validation-status.json
+++ b/.ralph/user-stories/ISSUE-004-onboarding-validation-status.json
@@ -3,7 +3,7 @@
   "title": "Onboarding validates competitor URLs at entry time and labels not-found tenant status clearly",
   "severity": "medium",
   "category": "validation/content",
-  "passes": false,
+  "passes": true,
   "blocked": false,
   "page": "https://aries.sugarandleather.com/onboarding/start and /onboarding/status?tenant_id=obviously-invalid-tenant&signup_event_id=bad",
   "symptom": "Onboarding accepts a Facebook competitor URL on step 1 and blocks only at final submit. Invalid tenant status displays onboarding_status OK even though provisioning_status is NOT FOUND.",

--- a/.ralph/user-stories/ISSUE-004-onboarding-validation-status.json
+++ b/.ralph/user-stories/ISSUE-004-onboarding-validation-status.json
@@ -1,0 +1,23 @@
+{
+  "id": "ISSUE-004",
+  "title": "Onboarding validates competitor URLs at entry time and labels not-found tenant status clearly",
+  "severity": "medium",
+  "category": "validation/content",
+  "passes": false,
+  "blocked": false,
+  "page": "https://aries.sugarandleather.com/onboarding/start and /onboarding/status?tenant_id=obviously-invalid-tenant&signup_event_id=bad",
+  "symptom": "Onboarding accepts a Facebook competitor URL on step 1 and blocks only at final submit. Invalid tenant status displays onboarding_status OK even though provisioning_status is NOT FOUND.",
+  "acceptance_criteria": [
+    "Competitor URL entry uses the same canonical validation as final submit before leaving step 1.",
+    "Facebook, Meta Ad Library, and unsupported competitor URLs show inline field errors at step 1 and block Continue while present.",
+    "Nonexistent tenant status copy clearly distinguishes request success from tenant existence, avoiding a top-level OK label for not-found tenants.",
+    "Add regression tests for competitor URL step gating and not-found status copy/API mapping."
+  ],
+  "suspected_files": [
+    "frontend/aries-v1/onboarding-flow.tsx",
+    "frontend/onboarding/status.tsx",
+    "app/api/onboarding/status/[tenantId]/route.ts",
+    "tests"
+  ],
+  "notes": "Discovery evidence: step 1 allowed https://facebook.com/sugarandleather, then final page displayed competitor_url must be competitor website. Invalid tenant displayed onboarding_status OK + provisioning_status NOT FOUND."
+}

--- a/.ralph/user-stories/ISSUE-005-job-approval-auth-gating.json
+++ b/.ralph/user-stories/ISSUE-005-job-approval-auth-gating.json
@@ -1,0 +1,24 @@
+{
+  "id": "ISSUE-005",
+  "title": "Marketing job approval requires loaded approval state and authenticates before job lookup",
+  "severity": "medium",
+  "category": "security/approval-gating",
+  "passes": false,
+  "blocked": false,
+  "page": "https://aries.sugarandleather.com/marketing/job-approve?jobId=obviously-invalid-job",
+  "symptom": "Approve and Resume remains enabled after status load fails with Authentication required. The approve API returns Marketing job not found to unauthenticated users because it checks runtime job existence before tenant/auth context, unlike the status API.",
+  "acceptance_criteria": [
+    "Approve and Resume remains disabled until status load succeeds and returns an active approval requirement/checkpoint.",
+    "Status-load failures never leave the approval/resume CTA enabled.",
+    "Approve API resolves/authenticates tenant context before checking runtime job existence.",
+    "GET status and POST approve produce consistent unauthenticated behavior, so job existence is not distinguishable to unauthenticated users.",
+    "Add regression tests for UI gating and API auth-order consistency."
+  ],
+  "suspected_files": [
+    "frontend/marketing/job-approve.tsx",
+    "app/api/marketing/jobs/[jobId]/approve/handler.ts",
+    "app/api/marketing/jobs/[jobId]/handler.ts",
+    "tests"
+  ],
+  "notes": "Discovery evidence: status surface displayed Authentication required but Approve and Resume was enabled. POST approve on invalid job displayed Marketing job not found."
+}

--- a/.ralph/user-stories/ISSUE-005-job-approval-auth-gating.json
+++ b/.ralph/user-stories/ISSUE-005-job-approval-auth-gating.json
@@ -3,7 +3,7 @@
   "title": "Marketing job approval requires loaded approval state and authenticates before job lookup",
   "severity": "medium",
   "category": "security/approval-gating",
-  "passes": false,
+  "passes": true,
   "blocked": false,
   "page": "https://aries.sugarandleather.com/marketing/job-approve?jobId=obviously-invalid-job",
   "symptom": "Approve and Resume remains enabled after status load fails with Authentication required. The approve API returns Marketing job not found to unauthenticated users because it checks runtime job existence before tenant/auth context, unlike the status API.",

--- a/.ralph/user-stories/ISSUE-006-publish-status-callback.json
+++ b/.ralph/user-stories/ISSUE-006-publish-status-callback.json
@@ -3,7 +3,7 @@
   "title": "Publish status login redirects preserve callback URL",
   "severity": "medium",
   "category": "auth-redirect",
-  "passes": false,
+  "passes": true,
   "blocked": false,
   "page": "https://aries.sugarandleather.com/publish-status and /dashboard/publish-status",
   "symptom": "Unauthenticated publish-status access redirects to /login without callbackUrl, unlike /review surfaces.",

--- a/.ralph/user-stories/ISSUE-006-publish-status-callback.json
+++ b/.ralph/user-stories/ISSUE-006-publish-status-callback.json
@@ -1,0 +1,23 @@
+{
+  "id": "ISSUE-006",
+  "title": "Publish status login redirects preserve callback URL",
+  "severity": "medium",
+  "category": "auth-redirect",
+  "passes": false,
+  "blocked": false,
+  "page": "https://aries.sugarandleather.com/publish-status and /dashboard/publish-status",
+  "symptom": "Unauthenticated publish-status access redirects to /login without callbackUrl, unlike /review surfaces.",
+  "acceptance_criteria": [
+    "Unauthenticated /publish-status redirects to login with callbackUrl preserving /publish-status or /dashboard/publish-status.",
+    "Direct /dashboard/publish-status also preserves callbackUrl.",
+    "Behavior matches protected review/dashboard redirect patterns.",
+    "Add regression tests for both redirect paths."
+  ],
+  "suspected_files": [
+    "app/publish-status/page.tsx",
+    "app/dashboard/publish-status/page.tsx",
+    "components/redesign/layout/app-shell.tsx",
+    "tests"
+  ],
+  "notes": "Discovery evidence: /publish-status and /dashboard/publish-status both landed on https://aries.sugarandleather.com/login with no callbackUrl. /review preserves callbackUrl."
+}

--- a/app/api/marketing/jobs/[jobId]/approve/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/approve/handler.ts
@@ -35,6 +35,14 @@ export async function handleApproveMarketingJob(
   }
 
   try {
+    const tenantResult = await loadTenantContextOrResponse(tenantContextLoader, {
+      missingMembershipResponse: MARKETING_ONBOARDING_REQUIRED,
+    });
+    if ('response' in tenantResult) {
+      return tenantResult.response;
+    }
+    const resolvedTenantId = tenantResult.tenantContext.tenantId;
+
     const doc = await loadMarketingJobRuntime(jobId);
     if (!doc) {
       return NextResponse.json(
@@ -45,13 +53,6 @@ export async function handleApproveMarketingJob(
         { status: 404 }
       );
     }
-    const tenantResult = await loadTenantContextOrResponse(tenantContextLoader, {
-      missingMembershipResponse: MARKETING_ONBOARDING_REQUIRED,
-    });
-    if ('response' in tenantResult) {
-      return tenantResult.response;
-    }
-    const resolvedTenantId = tenantResult.tenantContext.tenantId;
     const result = await approveMarketingJob({
       jobId,
       tenantId: resolvedTenantId,

--- a/app/api/onboarding/status/[tenantId]/route.ts
+++ b/app/api/onboarding/status/[tenantId]/route.ts
@@ -32,6 +32,7 @@ export async function GET(
   if (result.status === 'ok') {
     return NextResponse.json(
       {
+        request_status: 'ok',
         onboarding_status: 'ok',
         tenant_id: result.tenant_id,
         signup_event_id: result.signup_event_id,

--- a/app/dashboard/publish-status/page.tsx
+++ b/app/dashboard/publish-status/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
 
 export default function DashboardPublishStatusPage() {
   return (
-    <AppShellLayout currentRouteId="publishStatus">
+    <AppShellLayout currentRouteId="publishStatus" loginRedirectPath="/dashboard/publish-status">
       <AriesLatestCampaignView
         view="publish"
         title="No publish status yet"

--- a/app/reset-password/page-client.tsx
+++ b/app/reset-password/page-client.tsx
@@ -53,7 +53,10 @@ export default function ResetPasswordPageClient() {
 
       if (!response.ok) {
         const data = (await response.json().catch(() => ({}))) as { error?: string };
-        throw new Error(data.error || 'Failed to update password. Try again.');
+        const fallbackMessage = response.status === 400
+          ? 'Your recovery code is invalid or expired. Request a new code and try again.'
+          : 'Failed to update password. Try again.';
+        throw new Error(data.error?.trim() || fallbackMessage);
       }
 
       router.push('/login?reset=success');

--- a/app/reset-password/page-client.tsx
+++ b/app/reset-password/page-client.tsx
@@ -52,11 +52,12 @@ export default function ResetPasswordPageClient() {
       });
 
       if (!response.ok) {
-        const data = (await response.json().catch(() => ({}))) as { error?: string };
+        const data = (await response.json().catch(() => null)) as { error?: unknown } | null;
         const fallbackMessage = response.status === 400
           ? 'Your recovery code is invalid or expired. Request a new code and try again.'
           : 'Failed to update password. Try again.';
-        throw new Error(data.error?.trim() || fallbackMessage);
+        const responseMessage = typeof data?.error === 'string' ? data.error.trim() : '';
+        throw new Error(responseMessage || fallbackMessage);
       }
 
       router.push('/login?reset=success');

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -276,7 +276,7 @@ function brandPreviewSummary(
   );
 }
 
-function stepReady(stepKey: StepKey, values: {
+export function stepReady(stepKey: StepKey, values: {
   businessName: string;
   businessType: string;
   websiteUrl: string;
@@ -308,7 +308,7 @@ function stepReady(stepKey: StepKey, values: {
   return true;
 }
 
-function stepValidationMessage(stepKey: StepKey, values?: {
+export function stepValidationMessage(stepKey: StepKey, values?: {
   businessName: string;
   businessType: string;
   goal: string;

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -284,6 +284,7 @@ function stepReady(stepKey: StepKey, values: {
   goal: string;
   customGoal: string;
   offer: string;
+  competitorUrl?: string;
 }): boolean {
   if (stepKey === 'business') {
     return values.businessName.trim().length > 0 && values.businessType.trim().length > 0;
@@ -295,6 +296,10 @@ function stepReady(stepKey: StepKey, values: {
     return values.selectedChannels.length > 0;
   }
   if (stepKey === 'goal') {
+    const competitorValidation = validateCanonicalCompetitorUrl(values.competitorUrl ?? '');
+    if (competitorValidation.error) {
+      return false;
+    }
     if (values.goal === 'Other') {
       return values.customGoal.trim().length > 0 && values.offer.trim().length > 0;
     }
@@ -308,6 +313,7 @@ function stepValidationMessage(stepKey: StepKey, values?: {
   businessType: string;
   goal: string;
   offer: string;
+  competitorUrl?: string;
 }): string | null {
   if (stepKey === 'business') {
     if (values) {
@@ -336,6 +342,10 @@ function stepValidationMessage(stepKey: StepKey, values?: {
     }
     if (!values.offer.trim()) {
       return 'Describe what your business offers before continuing.';
+    }
+    const competitorValidation = validateCanonicalCompetitorUrl(values.competitorUrl ?? '');
+    if (competitorValidation.error) {
+      return competitorValidation.error;
     }
     return null;
   }
@@ -630,6 +640,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       goal,
       customGoal,
       offer,
+      competitorUrl,
     }),
   );
   const currentStepIsReady = stepReady(currentStep.key, {
@@ -640,6 +651,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
     goal,
     customGoal,
     offer,
+    competitorUrl,
   });
   const continueDisabled = useDisabledUntilValid(currentStepIsReady, submitting || creatingDraft);
   const finishDisabled = useDisabledUntilValid(canFinish, submitting || creatingDraft);
@@ -1062,12 +1074,15 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       if (currentStep.key === 'goal') {
         markTouched('goal');
         markTouched('offer');
+        if (validateCanonicalCompetitorUrl(competitorUrl).error) {
+          markTouched('competitorUrl');
+        }
         if (goal === 'Other') {
           markTouched('customGoal');
         }
       }
       setError(
-        stepValidationMessage(currentStep.key, { businessName, businessType, goal, offer }) ??
+        stepValidationMessage(currentStep.key, { businessName, businessType, goal, offer, competitorUrl }) ??
           'Complete the current step before continuing.',
       );
       return;
@@ -1086,7 +1101,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   async function handleFinish() {
     if (!canFinish) {
       setError(
-        stepValidationMessage(currentStep.key, { businessName, businessType, goal, offer }) ??
+        stepValidationMessage(currentStep.key, { businessName, businessType, goal, offer, competitorUrl }) ??
           'Complete the current step before continuing.',
       );
       return;
@@ -1111,11 +1126,13 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
 
     try {
       const trimmedCompetitorUrl = competitorUrl.trim();
+      let canonicalCompetitorUrl: string | null = null;
       if (trimmedCompetitorUrl) {
         const competitorValidation = validateCanonicalCompetitorUrl(trimmedCompetitorUrl);
         if (competitorValidation.error) {
           throw new Error(competitorValidation.error);
         }
+        canonicalCompetitorUrl = competitorValidation.normalized ?? trimmedCompetitorUrl;
       }
 
       const resolvedGoal = goal === 'Other' ? customGoal.trim() : goal;
@@ -1128,7 +1145,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         channels: selectedChannels,
         goal: resolvedGoal,
         offer,
-        competitorUrl: trimmedCompetitorUrl || null,
+        competitorUrl: canonicalCompetitorUrl,
         preview: urlPreview,
         provenance: {
           source_url: websiteUrl,
@@ -1193,13 +1210,18 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       : isValidHttpsUrl(websiteUrl)
         ? 'valid'
         : 'invalid';
-  const competitorUrlValidity: FieldValidity = !touched.competitorUrl
+  const competitorUrlValidation = validateCanonicalCompetitorUrl(competitorUrl);
+  const competitorUrlError = competitorUrl.trim() ? competitorUrlValidation.error : null;
+  const competitorUrlFieldError = competitorUrlError && (touched.competitorUrl || currentStep.key === 'goal')
+    ? competitorUrlError
+    : null;
+  const competitorUrlValidity: FieldValidity = !touched.competitorUrl && !competitorUrlError
     ? 'untouched'
     : competitorUrl.trim().length === 0
       ? 'valid' // optional field
-      : isValidHttpsUrl(competitorUrl)
-        ? 'valid'
-        : 'invalid';
+      : competitorUrlError
+        ? 'invalid'
+        : 'valid';
   const goalError = touched.goal && !goal.trim()
     ? 'Choose a business outcome before continuing.'
     : null;
@@ -1240,7 +1262,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       }
       case 'competitorUrl': {
         if (!competitorUrl.trim()) return null; // optional
-        return isValidHttpsUrl(competitorUrl) ? null : 'Enter a valid HTTPS URL for the competitor.';
+        return validateCanonicalCompetitorUrl(competitorUrl).error;
       }
       case 'customGoal':
         return customGoal.trim() ? null : 'Describe the business outcome you want.';
@@ -1876,10 +1898,10 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
 
                     <Field
                       label="Competitor website"
-                      hint="Add one strong comparison site if you want Aries to account for market positioning."
+                      hint="Add one strong comparison site if you want Aries to account for market positioning. Do not paste Facebook, Instagram, or Meta Ad Library URLs."
                       optional
                       validity={competitorUrlValidity}
-                      error={fieldErrorMessage('competitorUrl')}
+                      error={competitorUrlFieldError}
                     >
                       <input
                         value={competitorUrl}

--- a/frontend/auth/auth-layout.tsx
+++ b/frontend/auth/auth-layout.tsx
@@ -23,9 +23,9 @@ const AuthLayout: React.FC<AuthLayoutProps> = ({ children }) => {
         />
       </div>
 
-      <div className="container mx-auto px-6 relative z-10">
+      <main className="container mx-auto px-6 relative z-10">
         {children}
-      </div>
+      </main>
     </div>
   );
 };

--- a/frontend/auth/reset-password-form.tsx
+++ b/frontend/auth/reset-password-form.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { AuthView } from '../types';
 import { BrandLogo } from '@/components/redesign/brand/logo';
+import { getRequiredFieldError, useDisabledUntilValid } from '@/lib/form-validation';
 
 
 interface ResetPasswordFormProps {
@@ -11,49 +12,62 @@ interface ResetPasswordFormProps {
   isLoading: boolean;
 }
 
+const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/;
+const PASSWORD_POLICY_MESSAGE =
+  'Password must be at least 8 characters long and include an uppercase letter, a number, and a special character.';
+
 
 const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, onNavigate, onSubmit, isLoading }) => {
   const [code, setCode] = useState(otpCode ?? '');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [codeTouched, setCodeTouched] = useState(false);
+  const [passwordTouched, setPasswordTouched] = useState(false);
+  const [confirmPasswordTouched, setConfirmPasswordTouched] = useState(false);
 
+  const normalizedCode = code.trim();
+  const codeIsValid = /^\d{6}$/.test(normalizedCode);
+  const passwordMeetsPolicy = PASSWORD_POLICY_REGEX.test(password);
+  const passwordsMatch = confirmPassword.length > 0 && password === confirmPassword;
+  const canSubmit = codeIsValid && passwordMeetsPolicy && passwordsMatch;
+  const submitDisabled = useDisabledUntilValid(canSubmit, isLoading);
 
-  useEffect(() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        setError(null);
-      }, 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [error]);
-
+  const showCodeError = codeTouched || code.length > 0;
+  const showPasswordError = passwordTouched || password.length > 0;
+  const showConfirmPasswordError = confirmPasswordTouched || confirmPassword.length > 0;
+  const codeError = showCodeError && !codeIsValid ? 'Enter the 6-digit code from your email.' : null;
+  const passwordError = !showPasswordError
+    ? null
+    : !password.trim()
+      ? getRequiredFieldError(password, 'your new password')
+      : passwordMeetsPolicy
+        ? null
+        : PASSWORD_POLICY_MESSAGE;
+  const confirmPasswordError = !showConfirmPasswordError
+    ? null
+    : !confirmPassword.trim()
+      ? getRequiredFieldError(confirmPassword, 'your confirmation password')
+      : passwordsMatch
+        ? null
+        : 'Passwords do not match.';
 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isLoading) return;
+    setCodeTouched(true);
+    setPasswordTouched(true);
+    setConfirmPasswordTouched(true);
     setError(null);
 
-
-    if (!/^\d{6}$/.test(code.trim())) {
-      setError("Enter the 6-digit code from your email.");
-      return;
-    }
-
-    if (password !== confirmPassword) {
-      setError("Passwords do not match.");
-      return;
-    }
-
-    const passwordRegex = /^(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&]).{8,}$/;
-    if (!passwordRegex.test(password)) {
-      setError("Password must be at least 8 characters long and include an uppercase letter, a number, and a special character.");
+    if (!canSubmit) {
       return;
     }
 
 
     try {
-      await onSubmit(email, code.trim(), password);
+      await onSubmit(email, normalizedCode, password);
     } catch (err: any) {
       setError(err?.message || "Failed to update password. Try again.");
     }
@@ -76,8 +90,9 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
       <div className="auth-card animate-in fade-in zoom-in-95 duration-500">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <label className="auth-label">Recovery Code</label>
+            <label htmlFor="reset-password-code" className="auth-label">Recovery Code</label>
             <input
+              id="reset-password-code"
               type="text"
               inputMode="numeric"
               autoComplete="one-time-code"
@@ -87,21 +102,73 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
               className="auth-input tracking-[0.4em] text-center"
               placeholder="123456"
               value={code}
-              onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+              onChange={(e) => {
+                setCode(e.target.value.replace(/\D/g, '').slice(0, 6));
+                setError(null);
+              }}
+              onBlur={() => setCodeTouched(true)}
+              aria-invalid={codeError ? true : undefined}
+              aria-describedby={codeError ? 'reset-password-code-error' : undefined}
             />
+            {codeError ? (
+              <p id="reset-password-code-error" role="alert" className="text-sm text-red-300">
+                {codeError}
+              </p>
+            ) : null}
           </div>
           <div className="space-y-2">
-            <label className="auth-label">New Password</label>
-            <input type="password" required className="auth-input" placeholder="••••••••" value={password} onChange={(e) => setPassword(e.target.value)} />
+            <label htmlFor="reset-password-new-password" className="auth-label">New Password</label>
+            <input
+              id="reset-password-new-password"
+              type="password"
+              required
+              className="auth-input"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setError(null);
+              }}
+              onBlur={() => setPasswordTouched(true)}
+              autoComplete="new-password"
+              aria-invalid={passwordError ? true : undefined}
+              aria-describedby={passwordError ? 'reset-password-new-password-error' : undefined}
+            />
+            {passwordError ? (
+              <p id="reset-password-new-password-error" role="alert" className="text-sm text-red-300">
+                {passwordError}
+              </p>
+            ) : null}
           </div>
           <div className="space-y-2">
-            <label className="auth-label">Confirm Password</label>
-            <input type="password" required className="auth-input" placeholder="••••••••" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
+            <label htmlFor="reset-password-confirm-password" className="auth-label">Confirm Password</label>
+            <input
+              id="reset-password-confirm-password"
+              type="password"
+              required
+              className="auth-input"
+              placeholder="••••••••"
+              value={confirmPassword}
+              onChange={(e) => {
+                setConfirmPassword(e.target.value);
+                setError(null);
+              }}
+              onBlur={() => setConfirmPasswordTouched(true)}
+              autoComplete="new-password"
+              aria-invalid={confirmPasswordError ? true : undefined}
+              aria-describedby={confirmPasswordError ? 'reset-password-confirm-password-error' : undefined}
+            />
+            {confirmPasswordError ? (
+              <p id="reset-password-confirm-password-error" role="alert" className="text-sm text-red-300">
+                {confirmPasswordError}
+              </p>
+            ) : null}
           </div>
 
 
           {error && (
             <div className="rounded-xl border border-red-500/20 bg-gradient-to-r from-red-500/15 via-red-500/5 to-transparent backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.3)] flex items-center gap-3 animate-in fade-in slide-in-from-top-3 duration-500"
+                 role="alert"
                  style={{
                    padding: '16px',
                    marginBottom: '32px',
@@ -127,7 +194,7 @@ const ResetPasswordForm: React.FC<ResetPasswordFormProps> = ({ email, otpCode, o
 
           <button
             type="submit"
-            disabled={isLoading || !password || !code}
+            disabled={submitDisabled}
             className="auth-primary-button"
           >
             {isLoading ? 'Updating...' : 'UPDATE PASSWORD'}

--- a/frontend/auth/sign-up-form.tsx
+++ b/frontend/auth/sign-up-form.tsx
@@ -215,8 +215,9 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
 
 
           <div>
-            <label className="block text-sm font-medium text-white/80 mb-1.5">Organization {!invitationData && "(Optional)"}</label>
+            <label htmlFor="signup-organization" className="block text-sm font-medium text-white/80 mb-1.5">Organization {!invitationData && "(Optional)"}</label>
             <input 
+              id="signup-organization"
               type="text" 
               className="block w-full px-4 py-2.5 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/30 focus:outline-none transition-all disabled:opacity-60" 
               placeholder="e.g. Acme Corp" 
@@ -267,15 +268,18 @@ const SignUpForm: React.FC<SignUpFormProps> = ({
               />
               <button
                 type="button"
-                onClick={() => setShowPassword(!showPassword)}
+                onClick={() => setShowPassword((value) => !value)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                aria-pressed={showPassword}
+                aria-controls="signup-password"
                 className={`absolute right-4 top-1/2 -translate-y-1/2 ${showPassword ? 'text-white' : 'text-white/40'} hover:text-white transition-colors`}
               >
                 {showPassword ? (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                  <svg aria-hidden="true" focusable="false" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.892 7.892L21 21m-2.228-2.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
                   </svg>
                 ) : (
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                  <svg aria-hidden="true" focusable="false" className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.644C3.399 8.049 7.21 5 12 5c4.79 0 8.601 3.049 9.964 6.678.114.303.114.626 0 .93C20.601 15.951 16.79 19 12 19c-4.479 0-8.268-2.943-9.543-7z" />
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                   </svg>

--- a/frontend/documentation/Docs.tsx
+++ b/frontend/documentation/Docs.tsx
@@ -97,7 +97,10 @@ export default function Docs() {
             {/* Sidebar */}
             <aside className="lg:w-64 flex-shrink-0">
               <div className="lg:sticky lg:top-24 space-y-2">
-                <nav className="flex lg:flex-col overflow-x-auto lg:overflow-visible pb-4 lg:pb-0 gap-2 scrollbar-hide">
+                <nav
+                  aria-label="Documentation sections"
+                  className="flex lg:flex-col overflow-x-auto lg:overflow-visible pb-4 lg:pb-0 gap-2 scrollbar-hide"
+                >
                   {sections.map((section) => {
                     const Icon = section.icon;
                     return (

--- a/frontend/documentation/Docs.tsx
+++ b/frontend/documentation/Docs.tsx
@@ -61,7 +61,7 @@ export default function Docs() {
 
   return (
     <div className="min-h-screen bg-[#050505] text-white selection:bg-primary/30">
-      <main className="relative z-10 pt-32 pb-20">
+      <div className="relative z-10 pt-32 pb-20">
         <div className="container mx-auto px-6 max-w-7xl">
           {/* Header */}
           <div className="text-center mb-16">
@@ -323,7 +323,7 @@ export default function Docs() {
             </div>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   );
 }

--- a/frontend/donor/marketing/chrome.tsx
+++ b/frontend/donor/marketing/chrome.tsx
@@ -73,6 +73,7 @@ export function DonorNavbar({ heroMode = false }: { heroMode?: boolean }) {
 
   return (
     <nav
+      aria-label="Primary"
       className={cn(
         'fixed top-0 left-0 right-0 z-50 transition-all duration-300 px-6',
         isScrolled && (!heroMode || !isHome || scrollProgress > 0.95)

--- a/frontend/donor/marketing/chrome.tsx
+++ b/frontend/donor/marketing/chrome.tsx
@@ -17,7 +17,7 @@ export interface DonorMarketingShellProps {
 
 const NAV_ITEMS = [
   { name: 'How it works', href: '/#how-it-works' },
-  { name: 'Features', href: '/#features' },
+  { name: 'Features', href: '/features' },
   { name: 'Documentation', href: '/documentation' },
 ] as const;
 
@@ -185,7 +185,7 @@ export function DonorFooter() {
             </p>
             <div className="flex gap-4 text-sm text-white/60">
               <a href="/#how-it-works" className="hover:text-white transition-colors">How it works</a>
-              <a href="/#features" className="hover:text-white transition-colors">Features</a>
+              <a href="/features" className="hover:text-white transition-colors">Features</a>
               <a href="/documentation" className="hover:text-white transition-colors">Documentation</a>
             </div>
           </div>

--- a/frontend/marketing/job-approve.tsx
+++ b/frontend/marketing/job-approve.tsx
@@ -356,11 +356,21 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
   const [loadingStatus, setLoadingStatus] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [jobStatus, setJobStatus] = useState<JobStatusResult | null>(null);
+  const [loadedStatusJobId, setLoadedStatusJobId] = useState<string | null>(null);
   const [approveResult, setApproveResult] = useState<ApproveResult | null>(null);
 
+  const statusSuccess = jobStatus && !isErrorResult(jobStatus) ? jobStatus : null;
+  const activeApprovalCheckpoint =
+    !!statusSuccess?.approval?.required &&
+    statusSuccess.approval.status === 'awaiting_approval' &&
+    !!statusSuccess.marketing_stage;
+  const normalizedJobId = jobId.trim();
   const canSubmit =
-    jobId.trim().length > 0 &&
+    normalizedJobId.length > 0 &&
+    loadedStatusJobId === normalizedJobId &&
+    activeApprovalCheckpoint &&
     approvedBy.trim().length > 0 &&
+    !loadingStatus &&
     !submitting;
 
   useEffect(() => {
@@ -373,14 +383,18 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
   }, [props.defaultJobId]);
 
   async function handleLoadStatus() {
-    if (!jobId.trim()) return;
+    const requestedJobId = jobId.trim();
+    if (!requestedJobId) return;
     setLoadingStatus(true);
+    setLoadedStatusJobId(null);
+    setJobStatus(null);
     setApproveResult(null);
     try {
       marketingStatus.reset();
-      const result = await marketingStatus.load(jobId.trim());
+      const result = await marketingStatus.load(requestedJobId);
       setJobStatus(result);
       if (result && !isErrorResult(result) && result.marketing_stage) {
+        setLoadedStatusJobId(requestedJobId);
         setApprovedStages([result.marketing_stage as MarketingStage]);
         setPlatforms(result.publishConfig.platforms);
         setLivePublishPlatforms(result.publishConfig.livePublishPlatforms);
@@ -389,6 +403,14 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
     } finally {
       setLoadingStatus(false);
     }
+  }
+
+  function handleJobIdChange(value: string) {
+    setJobId(value);
+    setLoadedStatusJobId(null);
+    setJobStatus(null);
+    setApproveResult(null);
+    marketingStatus.reset();
   }
 
   function toggleValue(value: string, setter: Dispatch<SetStateAction<string[]>>) {
@@ -450,7 +472,6 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
     return { tone: 'danger', text: `Approval failed: ${approveResult.approval_status}` };
   })();
 
-  const statusSuccess = jobStatus && !isErrorResult(jobStatus) ? jobStatus : null;
   const approveSuccess = approveResult && !isErrorResult(approveResult) ? approveResult : null;
   const pendingStage = statusSuccess?.approval ? statusSuccess.marketing_stage : null;
   const loadOrActionFailed = !!(
@@ -498,7 +519,7 @@ export function MarketingJobApproveScreen(props: MarketingJobApproveScreenProps)
             <Field label="Job ID" hint="Use the current campaign identifier.">
               <input
                 value={jobId}
-                onChange={(event) => setJobId(event.target.value)}
+                onChange={(event) => handleJobIdChange(event.target.value)}
                 placeholder="mkt_..."
                 className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
               />

--- a/frontend/onboarding/status.tsx
+++ b/frontend/onboarding/status.tsx
@@ -67,6 +67,7 @@ export default function OnboardingStatusScreen({
 
   const isStatusError = response?.onboarding_status === 'error';
   const success = !isStatusError && response ? (response as OnboardingStatusSuccess) : null;
+  const tenantNotFound = success?.provisioning_status === 'not_found';
 
   return (
     <div className="min-h-screen bg-background px-6 py-10 md:px-8 lg:px-10">
@@ -152,15 +153,34 @@ export default function OnboardingStatusScreen({
           </div>
         ) : (
           <div className="space-y-5">
+            {tenantNotFound ? (
+              <div className="rounded-2xl border border-amber-400/25 bg-amber-400/10 p-4 text-amber-100">
+                <strong className="block text-white">Tenant not found</strong>
+                <p className="mt-1 text-sm text-amber-100/80">
+                  The status request succeeded, but Aries could not find onboarding artifacts for this tenant ID yet.
+                </p>
+              </div>
+            ) : null}
             <div className="space-y-3">
               <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-5 py-4 flex items-center justify-between gap-4">
                 <strong>tenant_id</strong>
                 <span className="text-white/70 break-all text-right">{success.tenant_id}</span>
               </div>
               <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-5 py-4 flex items-center justify-between gap-4">
-                <strong>onboarding_status</strong>
-                <StatusBadge status={success.onboarding_status} />
+                <strong>request_status</strong>
+                <span className="text-white/70 text-right">Request succeeded</span>
               </div>
+              {tenantNotFound ? (
+                <div className="rounded-[1.5rem] border border-amber-400/20 bg-amber-400/10 px-5 py-4 flex items-center justify-between gap-4">
+                  <strong>tenant_status</strong>
+                  <StatusBadge status="not_found" />
+                </div>
+              ) : (
+                <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-5 py-4 flex items-center justify-between gap-4">
+                  <strong>onboarding_status</strong>
+                  <StatusBadge status={success.onboarding_status} />
+                </div>
+              )}
               <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-5 py-4 flex items-center justify-between gap-4">
                 <strong>provisioning_status</strong>
                 <StatusBadge status={success.provisioning_status} />

--- a/lib/api/onboarding.ts
+++ b/lib/api/onboarding.ts
@@ -65,6 +65,8 @@ export interface OnboardingStatusQuery {
 }
 
 export interface OnboardingStatusSuccess {
+  /** Transport/request outcome. Tenant existence is represented by provisioning_status. */
+  request_status: 'ok';
   onboarding_status: 'ok';
   tenant_id: string;
   signup_event_id?: string;

--- a/specs/onboarding_response_shapes.v1.json
+++ b/specs/onboarding_response_shapes.v1.json
@@ -174,6 +174,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "request_status": {
+          "const": "ok"
+        },
         "tenant_id": {
           "type": "string"
         },
@@ -218,6 +221,7 @@
         }
       },
       "required": [
+        "request_status",
         "onboarding_status",
         "tenant_id",
         "provisioning_status",

--- a/tests/frontend-api-layer.test.ts
+++ b/tests/frontend-api-layer.test.ts
@@ -346,6 +346,7 @@ test('/api/onboarding/status exposes artifact booleans instead of runtime paths'
   const body = (await response.json()) as Record<string, unknown>;
 
   assert.equal(response.status, 200);
+  assert.equal(body.request_status, 'ok');
   assert.equal(body.onboarding_status, 'ok');
   assert.equal(body.tenant_id, 'tenant_123');
   assert.equal('artifacts' in body, true);

--- a/tests/marketing-job-approval-qa.test.ts
+++ b/tests/marketing-job-approval-qa.test.ts
@@ -1,0 +1,374 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import React from 'react';
+
+import { MarketingJobApproveScreen } from '../frontend/marketing/job-approve';
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-marketing-approval-qa-'));
+
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+
+  try {
+    return await run(dataRoot);
+  } finally {
+    if (previousCodeRoot === undefined) {
+      delete process.env.CODE_ROOT;
+    } else {
+      process.env.CODE_ROOT = previousCodeRoot;
+    }
+    if (previousDataRoot === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = previousDataRoot;
+    }
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+function authRequiredLoader(): never {
+  throw new Error('Authentication required.');
+}
+
+async function writeRuntimeDoc(jobId: string, tenantId = 'tenant_auth_order') {
+  const jobsRoot = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs');
+  await mkdir(jobsRoot, { recursive: true });
+  await writeFile(
+    path.join(jobsRoot, `${jobId}.json`),
+    JSON.stringify(
+      {
+        schema_name: 'marketing_job_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        tenant_id: tenantId,
+        job_type: 'brand_campaign',
+        state: 'running',
+        status: 'awaiting_approval',
+        current_stage: 'strategy',
+        stage_order: ['research', 'strategy', 'production', 'publish'],
+        stages: {
+          strategy: {
+            stage: 'strategy',
+            status: 'awaiting_approval',
+            started_at: null,
+            completed_at: null,
+            failed_at: null,
+            run_id: null,
+            summary: null,
+            primary_output: null,
+            outputs: {},
+            artifacts: [],
+            errors: [],
+          },
+        },
+        approvals: {
+          current: {
+            stage: 'strategy',
+            status: 'awaiting_approval',
+            approval_id: 'mkta_auth_order',
+            workflow_step_id: 'approve_stage_2',
+            requested_at: '2026-04-27T00:00:00.000Z',
+            title: 'Strategy approval required',
+            message: 'Approve strategy before continuing.',
+            action_label: 'Review strategy',
+          },
+          history: [],
+        },
+        publish_config: {
+          platforms: [],
+          live_publish_platforms: [],
+          video_render_platforms: [],
+        },
+        brand_kit: {
+          source_url: 'https://brand.example',
+          extracted_at: '2026-04-27T00:00:00.000Z',
+        },
+        inputs: {
+          request: { brandUrl: 'https://brand.example' },
+          brand_url: 'https://brand.example',
+          competitor_url: 'https://competitor.example',
+        },
+        errors: [],
+        last_error: null,
+        history: [],
+        created_at: '2026-04-27T00:00:00.000Z',
+        updated_at: '2026-04-27T00:00:00.000Z',
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function baseStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    jobId: 'mkt_ui_gate',
+    tenantName: 'Tenant',
+    brandWebsiteUrl: 'https://brand.example',
+    campaignWindow: null,
+    durationDays: 14,
+    plannedPostCount: 0,
+    createdPostCount: 0,
+    assetPreviewCards: [],
+    calendarEvents: [],
+    marketing_job_state: 'approval_required',
+    marketing_job_status: 'awaiting_approval',
+    marketing_stage: 'strategy',
+    marketing_stage_status: { strategy: 'awaiting_approval' },
+    updatedAt: '2026-04-27T00:00:00.000Z',
+    needs_attention: true,
+    approvalRequired: true,
+    summary: { headline: 'Approval required', subheadline: 'Review strategy', trustNote: 'Approval is required.' },
+    stageCards: [],
+    artifacts: [],
+    timeline: [],
+    approval: {
+      required: true,
+      status: 'awaiting_approval',
+      approvalId: 'mkta_ui_gate',
+      workflowStepId: 'approve_stage_2',
+      title: 'Strategy approval required',
+      message: 'Review strategy before continuing.',
+      actionLabel: 'Review strategy',
+      actionHref: '/marketing/reviews/mkt_ui_gate%3A%3Aapproval',
+    },
+    reviewBundle: null,
+    campaignBrief: null,
+    workflowState: 'waiting_on_approval',
+    statusHistory: [],
+    brandReview: null,
+    strategyReview: null,
+    creativeReview: null,
+    publishConfig: {
+      platforms: [],
+      livePublishPlatforms: [],
+      videoRenderPlatforms: [],
+    },
+    nextStep: 'submit_approval',
+    repairStatus: 'not_required',
+    dashboard: {
+      assets: [],
+      posts: [],
+      publishItems: [],
+    },
+    ...overrides,
+  };
+}
+
+function findApproveButton(root: import('react-test-renderer').ReactTestRenderer) {
+  const buttons = root.root.findAllByType('button');
+  const button = buttons.find((entry) => JSON.stringify(entry.props.children).includes('Approve and Resume'));
+  assert.ok(button, 'Approve and Resume button should render');
+  return button;
+}
+
+test('MarketingJobApproveScreen keeps Approve and Resume disabled after status auth failure', async () => {
+  const previousFetch = globalThis.fetch;
+  const globalWithWindow = globalThis as Record<string, unknown>;
+  const previousWindow = globalWithWindow.window;
+  let postCalls = 0;
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const method = init?.method || 'GET';
+    if (method === 'POST') {
+      postCalls += 1;
+      return new Response(JSON.stringify({ approval_status: 'resumed' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({ reason: 'tenant_context_required', message: 'Authentication required.' }), {
+      status: 403,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  globalWithWindow.window = globalThis;
+
+  try {
+    const { act, create } = await import('react-test-renderer');
+    let root!: import('react-test-renderer').ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(MarketingJobApproveScreen, {
+          baseUrl: 'http://localhost',
+          defaultJobId: 'mkt_ui_gate',
+          defaultApprovedBy: 'Reviewer',
+        }),
+      );
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    const approveButton = findApproveButton(root);
+    assert.equal(approveButton.props.disabled, true);
+    assert.match(JSON.stringify(root.toJSON()), /Authentication required/);
+
+    await act(async () => {
+      await approveButton.props.onClick();
+      await flushMicrotasks();
+    });
+    assert.equal(postCalls, 0, 'status failure must not allow a POST approval request');
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousWindow === undefined) {
+      delete globalWithWindow.window;
+    } else {
+      globalWithWindow.window = previousWindow;
+    }
+  }
+});
+
+test('MarketingJobApproveScreen enables approval only for the loaded job with an active checkpoint', async () => {
+  const previousFetch = globalThis.fetch;
+  const globalWithWindow = globalThis as Record<string, unknown>;
+  const previousWindow = globalWithWindow.window;
+
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(baseStatus()), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+  globalWithWindow.window = globalThis;
+
+  try {
+    const { act, create } = await import('react-test-renderer');
+    let root!: import('react-test-renderer').ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(MarketingJobApproveScreen, {
+          baseUrl: 'http://localhost',
+          defaultJobId: 'mkt_ui_gate',
+          defaultApprovedBy: 'Reviewer',
+        }),
+      );
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    assert.equal(findApproveButton(root).props.disabled, false);
+
+    const jobIdInput = root.root.findByProps({ placeholder: 'mkt_...' });
+    await act(async () => {
+      jobIdInput.props.onChange({ target: { value: 'mkt_other_job' } });
+      await flushMicrotasks();
+    });
+
+    assert.equal(findApproveButton(root).props.disabled, true, 'changing the job id must clear the loaded approval gate');
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousWindow === undefined) {
+      delete globalWithWindow.window;
+    } else {
+      globalWithWindow.window = previousWindow;
+    }
+  }
+});
+
+test('MarketingJobApproveScreen keeps approval disabled when loaded status has no active approval checkpoint', async () => {
+  const previousFetch = globalThis.fetch;
+  const globalWithWindow = globalThis as Record<string, unknown>;
+  const previousWindow = globalWithWindow.window;
+
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify(baseStatus({
+        approvalRequired: false,
+        approval: null,
+        marketing_job_state: 'running',
+        marketing_job_status: 'running',
+        needs_attention: false,
+      })),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    )) as typeof fetch;
+  globalWithWindow.window = globalThis;
+
+  try {
+    const { act, create } = await import('react-test-renderer');
+    let root!: import('react-test-renderer').ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(MarketingJobApproveScreen, {
+          baseUrl: 'http://localhost',
+          defaultJobId: 'mkt_ui_gate',
+          defaultApprovedBy: 'Reviewer',
+        }),
+      );
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    assert.equal(findApproveButton(root).props.disabled, true);
+    assert.match(JSON.stringify(root.toJSON()), /No approval required/);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousWindow === undefined) {
+      delete globalWithWindow.window;
+    } else {
+      globalWithWindow.window = previousWindow;
+    }
+  }
+});
+
+test('/api/marketing/jobs/:jobId/approve authenticates before revealing runtime job existence', async () => {
+  await withRuntimeEnv(async () => {
+    const { handleGetMarketingJobStatus } = await import('../app/api/marketing/jobs/[jobId]/handler');
+    const { handleApproveMarketingJob } = await import('../app/api/marketing/jobs/[jobId]/approve/handler');
+    const existingJobId = 'mkt_auth_order_existing';
+    const missingJobId = 'mkt_auth_order_missing';
+    await writeRuntimeDoc(existingJobId);
+
+    const getMissing = await handleGetMarketingJobStatus(missingJobId, authRequiredLoader);
+    const postMissing = await handleApproveMarketingJob(
+      missingJobId,
+      new Request(`http://localhost/api/marketing/jobs/${missingJobId}/approve`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ approvedBy: 'Reviewer', approvedStages: ['strategy'] }),
+      }),
+      authRequiredLoader,
+    );
+    const postExisting = await handleApproveMarketingJob(
+      existingJobId,
+      new Request(`http://localhost/api/marketing/jobs/${existingJobId}/approve`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ approvedBy: 'Reviewer', approvedStages: ['strategy'] }),
+      }),
+      authRequiredLoader,
+    );
+
+    const getMissingBody = (await getMissing.json()) as Record<string, unknown>;
+    const postMissingBody = (await postMissing.json()) as Record<string, unknown>;
+    const postExistingBody = (await postExisting.json()) as Record<string, unknown>;
+
+    assert.equal(getMissing.status, 403);
+    assert.equal(postMissing.status, getMissing.status);
+    assert.equal(postExisting.status, getMissing.status);
+    assert.equal(getMissingBody.message, 'Authentication required.');
+    assert.equal(postMissingBody.message, getMissingBody.message);
+    assert.equal(postExistingBody.message, getMissingBody.message);
+    assert.equal(postMissingBody.reason, getMissingBody.reason);
+    assert.equal(postExistingBody.reason, getMissingBody.reason);
+    assert.notEqual(postMissingBody.reason, 'marketing_job_not_found');
+  });
+});

--- a/tests/onboarding-marketing-contracts.test.ts
+++ b/tests/onboarding-marketing-contracts.test.ts
@@ -27,6 +27,7 @@ test('createOnboardingClient.status appends signup_event_id when provided', asyn
       requests.push(url);
       return new Response(
         JSON.stringify({
+          request_status: 'ok',
           onboarding_status: 'ok',
           tenant_id: 'tenant_backend',
           signup_event_id: 'signup_backend',

--- a/tests/onboarding-status-not-found.regression-004.test.ts
+++ b/tests/onboarding-status-not-found.regression-004.test.ts
@@ -1,21 +1,50 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { GET as getOnboardingStatus } from '../app/api/onboarding/status/[tenantId]/route';
-import { resolveProjectRoot } from './helpers/project-root';
+import React from 'react';
 
-const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
-const statusScreenSource = readFileSync(
-  path.join(PROJECT_ROOT, 'frontend', 'onboarding', 'status.tsx'),
-  'utf8',
-);
-const statusRouteSource = readFileSync(
-  path.join(PROJECT_ROOT, 'app', 'api', 'onboarding', 'status', '[tenantId]', 'route.ts'),
-  'utf8',
-);
+import { GET as getOnboardingStatus } from '../app/api/onboarding/status/[tenantId]/route';
+import OnboardingStatusScreen from '../frontend/onboarding/status';
+import type { OnboardingStatusSuccess } from '../lib/api/onboarding';
+
+const notFoundStatusPayload: OnboardingStatusSuccess = {
+  request_status: 'ok',
+  onboarding_status: 'ok',
+  tenant_id: 'tenant_missing',
+  provisioning_status: 'not_found',
+  validation_status: 'unknown',
+  progress_hint: 'not_started',
+  artifacts: {
+    draft: false,
+    validated: false,
+    validation_report: false,
+    idempotency_marker: false,
+  },
+};
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function renderedText(node: unknown): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return '';
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(renderedText).join(' ');
+  }
+  if (typeof node === 'object' && 'children' in node) {
+    const children = (node as { children?: unknown }).children;
+    return renderedText(children);
+  }
+  return '';
+}
 
 test('/api/onboarding/status maps request success separately from tenant existence for not-found tenants', async () => {
   const oldDataRoot = process.env.DATA_ROOT;
@@ -31,16 +60,7 @@ test('/api/onboarding/status maps request success separately from tenant existen
     const body = (await response.json()) as Record<string, unknown>;
 
     assert.equal(response.status, 200);
-    assert.equal(body.request_status, 'ok');
-    assert.equal(body.onboarding_status, 'ok');
-    assert.equal(body.provisioning_status, 'not_found');
-    assert.equal(body.progress_hint, 'not_started');
-    assert.deepEqual(body.artifacts, {
-      draft: false,
-      validated: false,
-      validation_report: false,
-      idempotency_marker: false,
-    });
+    assert.deepEqual(body, notFoundStatusPayload);
   } finally {
     if (oldDataRoot === undefined) {
       delete process.env.DATA_ROOT;
@@ -51,12 +71,51 @@ test('/api/onboarding/status maps request success separately from tenant existen
   }
 });
 
-test('onboarding status screen labels not-found tenants without a top-level OK badge', () => {
-  assert.match(statusRouteSource, /request_status: 'ok'/, 'status API should expose request success explicitly');
-  assert.match(statusScreenSource, /const tenantNotFound = success\?\.provisioning_status === 'not_found'/);
-  assert.match(statusScreenSource, /Tenant not found/);
-  assert.match(statusScreenSource, /The status request succeeded, but Aries could not find onboarding artifacts for this tenant ID yet\./);
-  assert.match(statusScreenSource, /<strong>request_status<\/strong>[\s\S]*?Request succeeded/);
-  assert.match(statusScreenSource, /<strong>tenant_status<\/strong>[\s\S]*?<StatusBadge status="not_found" \/>/);
-  assert.match(statusScreenSource, /tenantNotFound \? \([\s\S]*?<strong>tenant_status<\/strong>[\s\S]*?\) : \([\s\S]*?<strong>onboarding_status<\/strong>/);
+test('onboarding status screen behavior shows tenant-not-found copy and badge without top-level OK badge', async () => {
+  const previousFetch = globalThis.fetch;
+  const fetchedUrls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    fetchedUrls.push(url);
+    assert.equal(url, 'https://aries.example.com/api/onboarding/status/tenant_missing');
+    return new Response(JSON.stringify(notFoundStatusPayload), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const { act, create } = await import('react-test-renderer');
+    let root!: import('react-test-renderer').ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(OnboardingStatusScreen, {
+          baseUrl: 'https://aries.example.com',
+          initialTenantId: 'tenant_missing',
+        }),
+      );
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    assert.deepEqual(fetchedUrls, ['https://aries.example.com/api/onboarding/status/tenant_missing']);
+
+    const text = renderedText(root.toJSON());
+    assert.match(text, /Tenant not found/);
+    assert.match(
+      text,
+      /The status request succeeded, but Aries could not find onboarding artifacts for this tenant ID yet\./,
+    );
+    assert.match(text, /request_status\s+Request succeeded/);
+    assert.match(text, /tenant_status\s+Not found/);
+    assert.doesNotMatch(text, /onboarding_status\s+OK/);
+
+    const statusBadges = root.root.findAllByProps({ role: 'status' });
+    const statuses = statusBadges.map((badge) => badge.props['data-status']);
+    assert.ok(statuses.includes('not_found'), 'expected a not_found StatusBadge for the missing tenant');
+    assert.equal(statuses.includes('ok'), false, 'missing tenants should not render an OK onboarding_status badge');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
 });

--- a/tests/onboarding-status-not-found.regression-004.test.ts
+++ b/tests/onboarding-status-not-found.regression-004.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { GET as getOnboardingStatus } from '../app/api/onboarding/status/[tenantId]/route';
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const statusScreenSource = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'onboarding', 'status.tsx'),
+  'utf8',
+);
+const statusRouteSource = readFileSync(
+  path.join(PROJECT_ROOT, 'app', 'api', 'onboarding', 'status', '[tenantId]', 'route.ts'),
+  'utf8',
+);
+
+test('/api/onboarding/status maps request success separately from tenant existence for not-found tenants', async () => {
+  const oldDataRoot = process.env.DATA_ROOT;
+  const dataRoot = mkdtempSync(path.join(tmpdir(), 'aries-onboarding-status-not-found-'));
+
+  try {
+    process.env.DATA_ROOT = dataRoot;
+
+    const response = await getOnboardingStatus(
+      new Request('http://localhost/api/onboarding/status/tenant_missing'),
+      { params: Promise.resolve({ tenantId: 'tenant_missing' }) },
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 200);
+    assert.equal(body.request_status, 'ok');
+    assert.equal(body.onboarding_status, 'ok');
+    assert.equal(body.provisioning_status, 'not_found');
+    assert.equal(body.progress_hint, 'not_started');
+    assert.deepEqual(body.artifacts, {
+      draft: false,
+      validated: false,
+      validation_report: false,
+      idempotency_marker: false,
+    });
+  } finally {
+    if (oldDataRoot === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = oldDataRoot;
+    }
+    rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('onboarding status screen labels not-found tenants without a top-level OK badge', () => {
+  assert.match(statusRouteSource, /request_status: 'ok'/, 'status API should expose request success explicitly');
+  assert.match(statusScreenSource, /const tenantNotFound = success\?\.provisioning_status === 'not_found'/);
+  assert.match(statusScreenSource, /Tenant not found/);
+  assert.match(statusScreenSource, /The status request succeeded, but Aries could not find onboarding artifacts for this tenant ID yet\./);
+  assert.match(statusScreenSource, /<strong>request_status<\/strong>[\s\S]*?Request succeeded/);
+  assert.match(statusScreenSource, /<strong>tenant_status<\/strong>[\s\S]*?<StatusBadge status="not_found" \/>/);
+  assert.match(statusScreenSource, /tenantNotFound \? \([\s\S]*?<strong>tenant_status<\/strong>[\s\S]*?\) : \([\s\S]*?<strong>onboarding_status<\/strong>/);
+});

--- a/tests/onboarding-step-one-validation.regression-012.test.ts
+++ b/tests/onboarding-step-one-validation.regression-012.test.ts
@@ -3,6 +3,11 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 
+import {
+  COMPETITOR_URL_INVALID_ERROR,
+  COMPETITOR_URL_SOCIAL_ERROR,
+  validateCanonicalCompetitorUrl,
+} from '../lib/marketing-competitor';
 import { resolveProjectRoot } from './helpers/project-root';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
@@ -16,6 +21,11 @@ test('onboarding step one keeps Continue disabled until goal and offer are valid
     source,
     /return values\.goal\.trim\(\)\.length > 0 && values\.offer\.trim\(\)\.length > 0;/,
     'step-one validity should require both a selected goal and a non-empty offer summary',
+  );
+  assert.match(
+    source,
+    /const competitorValidation = validateCanonicalCompetitorUrl\(values\.competitorUrl \?\? ''\);[\s\S]*?if \(competitorValidation\.error\) \{[\s\S]*?return false;/,
+    'step-one validity should block Continue when the optional competitor URL fails canonical validation',
   );
   assert.match(
     source,
@@ -36,5 +46,43 @@ test('onboarding step one keeps Continue disabled until goal and offer are valid
     source,
     /disabled=\{continueDisabled\}/,
     'Continue should stay disabled until the current onboarding step is valid',
+  );
+});
+
+test('onboarding step one uses canonical competitor validation for inline errors before Continue', () => {
+  assert.match(
+    source,
+    /validateCanonicalCompetitorUrl\(competitorUrl\)/,
+    'step-one competitor input should use the same canonical validator as final submit',
+  );
+  assert.match(
+    source,
+    /const competitorUrlFieldError = competitorUrlError && \(touched\.competitorUrl \|\| currentStep\.key === 'goal'\)/,
+    'competitor URL errors should render inline while the step-one field is present',
+  );
+  assert.match(
+    source,
+    /Do not paste Facebook, Instagram, or Meta Ad Library URLs\./,
+    'the competitor field should warn against Meta locator URLs at entry time',
+  );
+  assert.match(
+    source,
+    /stepValidationMessage\(currentStep\.key, \{ businessName, businessType, goal, offer, competitorUrl \}\)/,
+    'Continue should surface canonical competitor validation messages instead of deferring to final submit',
+  );
+});
+
+test('canonical competitor validation rejects Facebook, Meta Ad Library, and unsupported step-one entries', () => {
+  assert.equal(
+    validateCanonicalCompetitorUrl('https://www.facebook.com/betterupco').error,
+    COMPETITOR_URL_SOCIAL_ERROR,
+  );
+  assert.equal(
+    validateCanonicalCompetitorUrl('https://www.facebook.com/ads/library/?id=123').error,
+    COMPETITOR_URL_SOCIAL_ERROR,
+  );
+  assert.equal(
+    validateCanonicalCompetitorUrl('http://competitor.example').error,
+    COMPETITOR_URL_INVALID_ERROR,
   );
 });

--- a/tests/onboarding-step-one-validation.regression-012.test.ts
+++ b/tests/onboarding-step-one-validation.regression-012.test.ts
@@ -1,88 +1,126 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
 import test from 'node:test';
 
+import React from 'react';
+
+import {
+  stepReady,
+  stepValidationMessage,
+} from '../frontend/aries-v1/onboarding-flow';
+import { useDisabledUntilValid } from '../lib/form-validation';
 import {
   COMPETITOR_URL_INVALID_ERROR,
   COMPETITOR_URL_SOCIAL_ERROR,
   validateCanonicalCompetitorUrl,
 } from '../lib/marketing-competitor';
-import { resolveProjectRoot } from './helpers/project-root';
 
-const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
-const source = readFileSync(
-  path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'onboarding-flow.tsx'),
-  'utf8',
-);
+type GoalStepValues = Parameters<typeof stepReady>[1];
 
-test('onboarding step one keeps Continue disabled until goal and offer are valid with inline alerts', () => {
-  assert.match(
-    source,
-    /return values\.goal\.trim\(\)\.length > 0 && values\.offer\.trim\(\)\.length > 0;/,
-    'step-one validity should require both a selected goal and a non-empty offer summary',
-  );
-  assert.match(
-    source,
-    /const competitorValidation = validateCanonicalCompetitorUrl\(values\.competitorUrl \?\? ''\);[\s\S]*?if \(competitorValidation\.error\) \{[\s\S]*?return false;/,
-    'step-one validity should block Continue when the optional competitor URL fails canonical validation',
-  );
-  assert.match(
-    source,
-    /const continueDisabled = useDisabledUntilValid\(currentStepIsReady, submitting \|\| creatingDraft\);/,
-    'onboarding should use the shared disabled-until-valid helper for Continue',
-  );
-  assert.match(
-    source,
-    /<p id="onboarding-goal-error" role="alert"/,
-    'onboarding should render an inline goal validation alert',
-  );
-  assert.match(
-    source,
-    /<p id="onboarding-offer-error" role="alert"/,
-    'onboarding should render an inline offer validation alert',
-  );
-  assert.match(
-    source,
-    /disabled=\{continueDisabled\}/,
-    'Continue should stay disabled until the current onboarding step is valid',
-  );
-});
+const validGoalValues: GoalStepValues = {
+  businessName: '',
+  businessType: '',
+  websiteUrl: '',
+  selectedChannels: [],
+  goal: 'Get leads',
+  customGoal: '',
+  offer: 'Lifecycle email automation for growing ecommerce brands.',
+  competitorUrl: '',
+};
 
-test('onboarding step one uses canonical competitor validation for inline errors before Continue', () => {
-  assert.match(
-    source,
-    /validateCanonicalCompetitorUrl\(competitorUrl\)/,
-    'step-one competitor input should use the same canonical validator as final submit',
-  );
-  assert.match(
-    source,
-    /const competitorUrlFieldError = competitorUrlError && \(touched\.competitorUrl \|\| currentStep\.key === 'goal'\)/,
-    'competitor URL errors should render inline while the step-one field is present',
-  );
-  assert.match(
-    source,
-    /Do not paste Facebook, Instagram, or Meta Ad Library URLs\./,
-    'the competitor field should warn against Meta locator URLs at entry time',
-  );
-  assert.match(
-    source,
-    /stepValidationMessage\(currentStep\.key, \{ businessName, businessType, goal, offer, competitorUrl \}\)/,
-    'Continue should surface canonical competitor validation messages instead of deferring to final submit',
-  );
-});
+function goalValues(overrides: Partial<GoalStepValues>): GoalStepValues {
+  return { ...validGoalValues, ...overrides };
+}
 
-test('canonical competitor validation rejects Facebook, Meta Ad Library, and unsupported step-one entries', () => {
+test('onboarding goal step behavior gates Continue until goal, offer, and canonical competitor URL are valid', () => {
   assert.equal(
-    validateCanonicalCompetitorUrl('https://www.facebook.com/betterupco').error,
+    stepReady('goal', goalValues({ goal: '' })),
+    false,
+    'goal step is not ready until an outcome is selected',
+  );
+  assert.equal(
+    stepValidationMessage('goal', goalValues({ goal: '' })),
+    'Choose a business outcome before continuing.',
+  );
+
+  assert.equal(
+    stepReady('goal', goalValues({ offer: '   ' })),
+    false,
+    'goal step is not ready until the offer is described',
+  );
+  assert.equal(
+    stepValidationMessage('goal', goalValues({ offer: '   ' })),
+    'Describe what your business offers before continuing.',
+  );
+
+  assert.equal(
+    stepReady('goal', goalValues({ competitorUrl: 'https://www.facebook.com/betterupco' })),
+    false,
+    'Meta/Facebook locator URLs must block Continue on the competitor field step',
+  );
+  assert.equal(
+    stepValidationMessage('goal', goalValues({ competitorUrl: 'https://www.facebook.com/betterupco' })),
     COMPETITOR_URL_SOCIAL_ERROR,
   );
+
   assert.equal(
-    validateCanonicalCompetitorUrl('https://www.facebook.com/ads/library/?id=123').error,
-    COMPETITOR_URL_SOCIAL_ERROR,
+    stepReady('goal', goalValues({ competitorUrl: 'http://competitor.example' })),
+    false,
+    'non-HTTPS competitor URLs must block Continue on the competitor field step',
   );
   assert.equal(
-    validateCanonicalCompetitorUrl('http://competitor.example').error,
+    stepValidationMessage('goal', goalValues({ competitorUrl: 'http://competitor.example' })),
     COMPETITOR_URL_INVALID_ERROR,
   );
+
+  assert.equal(
+    stepReady('goal', goalValues({ competitorUrl: 'competitor.example' })),
+    true,
+    'a valid canonical competitor website keeps the goal step ready',
+  );
+  assert.equal(
+    stepValidationMessage('goal', goalValues({ competitorUrl: 'competitor.example' })),
+    null,
+  );
+  assert.deepEqual(validateCanonicalCompetitorUrl('competitor.example'), {
+    normalized: 'https://competitor.example/',
+    error: null,
+  });
+});
+
+test('shared disabled helper keeps Continue disabled for invalid or busy onboarding goal state', async () => {
+  const { act, create } = await import('react-test-renderer');
+  let root!: import('react-test-renderer').ReactTestRenderer;
+
+  function ContinueHarness(props: { values: GoalStepValues; busy?: boolean }) {
+    const disabled = useDisabledUntilValid(stepReady('goal', props.values), props.busy ?? false);
+    return React.createElement('button', { disabled }, 'Continue');
+  }
+
+  await act(async () => {
+    root = create(
+      React.createElement(ContinueHarness, {
+        values: goalValues({ competitorUrl: 'https://www.instagram.com/competitor' }),
+      }),
+    );
+  });
+  assert.equal(root.root.findByType('button').props.disabled, true);
+
+  await act(async () => {
+    root.update(
+      React.createElement(ContinueHarness, {
+        values: goalValues({ competitorUrl: 'https://competitor.example' }),
+      }),
+    );
+  });
+  assert.equal(root.root.findByType('button').props.disabled, false);
+
+  await act(async () => {
+    root.update(
+      React.createElement(ContinueHarness, {
+        values: goalValues({ competitorUrl: 'https://competitor.example' }),
+        busy: true,
+      }),
+    );
+  });
+  assert.equal(root.root.findByType('button').props.disabled, true);
 });

--- a/tests/public-nav-landmarks.regression-003.test.ts
+++ b/tests/public-nav-landmarks.regression-003.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+function readProjectFile(...segments: string[]): string {
+  return readFileSync(path.join(PROJECT_ROOT, ...segments), 'utf8');
+}
+
+function countMatches(source: string, pattern: RegExp): number {
+  return source.match(pattern)?.length ?? 0;
+}
+
+// ISSUE-003 — public navigation should point at the standalone /features page,
+// and pages composed with shared shells should expose a single primary main landmark.
+test('public marketing Features links use the canonical /features route', () => {
+  const chromeSource = readProjectFile('frontend', 'donor', 'marketing', 'chrome.tsx');
+
+  assert.ok(
+    existsSync(path.join(PROJECT_ROOT, 'app', 'features', 'page.tsx')),
+    'canonical /features route should exist',
+  );
+  assert.match(
+    chromeSource,
+    /\{ name: 'Features', href: '\/features' \}/,
+    'global navigation should send Features to /features',
+  );
+  assert.match(
+    chromeSource,
+    /<a href="\/features" className="hover:text-white transition-colors">Features<\/a>/,
+    'footer Features link should send Features to /features',
+  );
+  assert.doesNotMatch(
+    chromeSource,
+    /href[:=]\s*["']\/#features["']/,
+    'public chrome should not link Features to the retired homepage #features anchor',
+  );
+});
+
+test('auth layout contributes exactly one primary main landmark', () => {
+  const authLayoutSource = readProjectFile('frontend', 'auth', 'auth-layout.tsx');
+
+  assert.equal(countMatches(authLayoutSource, /<main\b/g), 1);
+  assert.equal(countMatches(authLayoutSource, /<\/main>/g), 1);
+  assert.equal(countMatches(authLayoutSource, /\brole=["']main["']/g), 0);
+});
+
+test('documentation content does not nest a second main inside the marketing shell', () => {
+  const docsSource = readProjectFile('frontend', 'documentation', 'Docs.tsx');
+  const marketingShellSource = readProjectFile('frontend', 'donor', 'marketing', 'chrome.tsx');
+  const documentationPageSource = readProjectFile('app', 'documentation', 'page.tsx');
+
+  assert.match(documentationPageSource, /<MarketingLayout>[\s\S]*<Docs \/>[\s\S]*<\/MarketingLayout>/);
+  assert.equal(countMatches(marketingShellSource, /<main\b/g), 1, 'marketing shell should own the page main landmark');
+  assert.equal(countMatches(docsSource, /<main\b/g), 0, 'Docs content should not render a nested main landmark');
+  assert.equal(countMatches(docsSource, /\brole=["']main["']/g), 0, 'Docs content should not add a role=main landmark');
+});

--- a/tests/public-nav-landmarks.regression-003.test.ts
+++ b/tests/public-nav-landmarks.regression-003.test.ts
@@ -15,6 +15,21 @@ function countMatches(source: string, pattern: RegExp): number {
   return source.match(pattern)?.length ?? 0;
 }
 
+function navOpeningTags(source: string): string[] {
+  return source.match(/<nav\b[\s\S]*?>/g) ?? [];
+}
+
+function assertNavsAreNamed(source: string, context: string): void {
+  const navs = navOpeningTags(source);
+
+  assert.notEqual(navs.length, 0, `${context} should render at least one nav landmark`);
+  assert.deepEqual(
+    navs.filter((nav) => !/\baria-(?:label|labelledby)=/.test(nav)),
+    [],
+    `${context} should give every nav landmark an accessible name`,
+  );
+}
+
 // ISSUE-003 — public navigation should point at the standalone /features page,
 // and pages composed with shared shells should expose a single primary main landmark.
 test('public marketing Features links use the canonical /features route', () => {
@@ -58,4 +73,24 @@ test('documentation content does not nest a second main inside the marketing she
   assert.equal(countMatches(marketingShellSource, /<main\b/g), 1, 'marketing shell should own the page main landmark');
   assert.equal(countMatches(docsSource, /<main\b/g), 0, 'Docs content should not render a nested main landmark');
   assert.equal(countMatches(docsSource, /\brole=["']main["']/g), 0, 'Docs content should not add a role=main landmark');
+});
+
+test('documentation page labels marketing and section navigation landmarks', () => {
+  const docsSource = readProjectFile('frontend', 'documentation', 'Docs.tsx');
+  const marketingShellSource = readProjectFile('frontend', 'donor', 'marketing', 'chrome.tsx');
+  const documentationPageSource = readProjectFile('app', 'documentation', 'page.tsx');
+
+  assert.match(documentationPageSource, /<MarketingLayout>[\s\S]*<Docs \/>[\s\S]*<\/MarketingLayout>/);
+  assertNavsAreNamed(marketingShellSource, 'marketing shell');
+  assertNavsAreNamed(docsSource, 'documentation sections');
+  assert.match(
+    navOpeningTags(marketingShellSource).join('\n'),
+    /\baria-label="Primary"/,
+    'global marketing navigation should be named Primary',
+  );
+  assert.match(
+    navOpeningTags(docsSource).join('\n'),
+    /\baria-label="Documentation sections"/,
+    'Docs sidebar navigation should be named Documentation sections',
+  );
 });

--- a/tests/publish-status-redirect.test.ts
+++ b/tests/publish-status-redirect.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { isValidElement } from 'react';
 
+import DashboardPublishStatusPage from '../app/dashboard/publish-status/page';
 import PublishStatusPage from '../app/publish-status/page';
+import AppShellLayout from '../frontend/app-shell/layout';
+import { buildLoginRedirect } from '../lib/auth/callback-url';
 
 function expectRedirect(callable: () => unknown, location: string) {
   assert.throws(callable, (error: unknown) => {
@@ -13,4 +17,30 @@ function expectRedirect(callable: () => unknown, location: string) {
 
 test('/publish-status redirects to the canonical dashboard publish-status route', () => {
   expectRedirect(() => PublishStatusPage(), '/dashboard/publish-status');
+});
+
+test('/publish-status canonical route preserves the publish-status login callback', () => {
+  expectRedirect(() => PublishStatusPage(), '/dashboard/publish-status');
+
+  const element = DashboardPublishStatusPage();
+
+  assert.equal(isValidElement(element), true);
+  assert.equal(element.type, AppShellLayout);
+  assert.equal(element.props.loginRedirectPath, '/dashboard/publish-status');
+  assert.equal(
+    buildLoginRedirect(element.props.loginRedirectPath),
+    '/login?callbackUrl=%2Fdashboard%2Fpublish-status',
+  );
+});
+
+test('/dashboard/publish-status preserves the requested destination through login', () => {
+  const element = DashboardPublishStatusPage();
+
+  assert.equal(isValidElement(element), true);
+  assert.equal(element.type, AppShellLayout);
+  assert.equal(element.props.loginRedirectPath, '/dashboard/publish-status');
+  assert.equal(
+    buildLoginRedirect(element.props.loginRedirectPath),
+    '/login?callbackUrl=%2Fdashboard%2Fpublish-status',
+  );
 });

--- a/tests/reset-password-form-validation.regression-001.test.ts
+++ b/tests/reset-password-form-validation.regression-001.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const formSource = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'auth', 'reset-password-form.tsx'),
+  'utf8',
+);
+const pageSource = readFileSync(
+  path.join(PROJECT_ROOT, 'app', 'reset-password', 'page-client.tsx'),
+  'utf8',
+);
+
+test('reset password displays backend failures as accessible alerts', () => {
+  assert.match(
+    pageSource,
+    /if \(!response\.ok\) \{[\s\S]*Your recovery code is invalid or expired\. Request a new code and try again\.[\s\S]*throw new Error\(data\.error\?\.trim\(\) \|\| fallbackMessage\);[\s\S]*\}/,
+    'reset page should turn non-2xx reset responses into visible invalid/expired-code errors',
+  );
+  assert.match(
+    formSource,
+    /catch \(err: any\) \{\s*setError\(err\?\.message \|\| "Failed to update password\. Try again\."\);\s*\}/,
+    'reset form should preserve failed reset errors from the page submit handler',
+  );
+  assert.match(
+    formSource,
+    /\{error && \([\s\S]*role="alert"[\s\S]*\{error\}[\s\S]*\)\}/,
+    'reset form should render submit failures in an accessible alert region',
+  );
+});
+
+test('reset password blocks submit until code, password policy, and confirmation are valid', () => {
+  assert.ok(
+    formSource.includes('const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&]).{8,}$/;'),
+    'reset form should define the password policy once so button gating and submit-time validation stay in sync',
+  );
+  assert.ok(
+    formSource.includes('const codeIsValid = /^\\d{6}$/.test(normalizedCode);'),
+    'reset form should require a six-digit recovery code before enabling submit',
+  );
+  assert.match(
+    formSource,
+    /const passwordMeetsPolicy = PASSWORD_POLICY_REGEX\.test\(password\);/,
+    'reset form should require the password to satisfy the policy before enabling submit',
+  );
+  assert.match(
+    formSource,
+    /const passwordsMatch = confirmPassword\.length > 0 && password === confirmPassword;/,
+    'reset form should require confirmation to match before enabling submit',
+  );
+  assert.match(
+    formSource,
+    /const canSubmit = codeIsValid && passwordMeetsPolicy && passwordsMatch;/,
+    'reset form should derive submit validity from code, password, and confirmation validity',
+  );
+  assert.match(
+    formSource,
+    /const submitDisabled = useDisabledUntilValid\(canSubmit, isLoading\);/,
+    'reset form should gate the submit button through the shared disabled-until-valid helper',
+  );
+  assert.match(
+    formSource,
+    /disabled=\{submitDisabled\}/,
+    'Update Password should stay disabled until the reset form is valid',
+  );
+  assert.match(
+    formSource,
+    /if \(!canSubmit\) \{\s*return;\s*\}/,
+    'handleSubmit should still block invalid programmatic submits before the backend request',
+  );
+});
+
+test('reset password shows inline validation and labels each input with the visible label', () => {
+  assert.match(
+    formSource,
+    /<p id="reset-password-code-error" role="alert"/,
+    'reset form should show inline recovery-code validation feedback',
+  );
+  assert.match(
+    formSource,
+    /<p id="reset-password-new-password-error" role="alert"/,
+    'reset form should show inline password-policy validation feedback',
+  );
+  assert.match(
+    formSource,
+    /<p id="reset-password-confirm-password-error" role="alert"/,
+    'reset form should show inline confirmation mismatch validation feedback',
+  );
+  assert.match(
+    formSource,
+    /<label htmlFor="reset-password-code" className="auth-label">Recovery Code<\/label>[\s\S]*id="reset-password-code"/,
+    'Recovery Code input should be named by its visible label',
+  );
+  assert.match(
+    formSource,
+    /<label htmlFor="reset-password-new-password" className="auth-label">New Password<\/label>[\s\S]*id="reset-password-new-password"/,
+    'New Password input should be named by its visible label',
+  );
+  assert.match(
+    formSource,
+    /<label htmlFor="reset-password-confirm-password" className="auth-label">Confirm Password<\/label>[\s\S]*id="reset-password-confirm-password"/,
+    'Confirm Password input should be named by its visible label',
+  );
+});

--- a/tests/reset-password-form-validation.regression-001.test.ts
+++ b/tests/reset-password-form-validation.regression-001.test.ts
@@ -1,108 +1,133 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
 import test from 'node:test';
 
-import { resolveProjectRoot } from './helpers/project-root';
+import React from 'react';
+import type { ReactTestInstance, ReactTestRenderer } from 'react-test-renderer';
 
-const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
-const formSource = readFileSync(
-  path.join(PROJECT_ROOT, 'frontend', 'auth', 'reset-password-form.tsx'),
-  'utf8',
-);
-const pageSource = readFileSync(
-  path.join(PROJECT_ROOT, 'app', 'reset-password', 'page-client.tsx'),
-  'utf8',
-);
+import ResetPasswordForm from '../frontend/auth/reset-password-form';
 
-test('reset password displays backend failures as accessible alerts', () => {
-  assert.match(
-    pageSource,
-    /if \(!response\.ok\) \{[\s\S]*Your recovery code is invalid or expired\. Request a new code and try again\.[\s\S]*throw new Error\(data\.error\?\.trim\(\) \|\| fallbackMessage\);[\s\S]*\}/,
-    'reset page should turn non-2xx reset responses into visible invalid/expired-code errors',
-  );
-  assert.match(
-    formSource,
-    /catch \(err: any\) \{\s*setError\(err\?\.message \|\| "Failed to update password\. Try again\."\);\s*\}/,
-    'reset form should preserve failed reset errors from the page submit handler',
-  );
-  assert.match(
-    formSource,
-    /\{error && \([\s\S]*role="alert"[\s\S]*\{error\}[\s\S]*\)\}/,
-    'reset form should render submit failures in an accessible alert region',
+type ResetPasswordFormProps = React.ComponentProps<typeof ResetPasswordForm>;
+
+type RenderedResetPasswordForm = {
+  act: typeof import('react-test-renderer').act;
+  root: ReactTestRenderer;
+  submitCalls: Array<[email: string, code: string, password: string]>;
+};
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function renderResetPasswordForm(
+  overrides: Partial<ResetPasswordFormProps> = {},
+): Promise<RenderedResetPasswordForm> {
+  const { act, create } = await import('react-test-renderer');
+  const submitCalls: Array<[email: string, code: string, password: string]> = [];
+  const defaultProps: ResetPasswordFormProps = {
+    email: 'user@example.com',
+    onNavigate() {},
+    onSubmit(email, code, password) {
+      submitCalls.push([email, code, password]);
+    },
+    isLoading: false,
+  };
+
+  let root!: ReactTestRenderer;
+  await act(async () => {
+    root = create(React.createElement(ResetPasswordForm, { ...defaultProps, ...overrides }));
+    await flushMicrotasks();
+  });
+
+  return { act, root, submitCalls };
+}
+
+function textContent(node: ReactTestInstance | string | number | null | undefined): string {
+  if (node === null || node === undefined) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  return node.children.map((child) => textContent(child as ReactTestInstance | string)).join('');
+}
+
+function findSubmitButton(root: ReactTestRenderer): ReactTestInstance {
+  return root.root.findAllByType('button').find((button) => button.props.type === 'submit')!;
+}
+
+function findInputByVisibleLabel(root: ReactTestRenderer, labelText: string): ReactTestInstance {
+  const label = root.root.findAllByType('label').find((candidate) => textContent(candidate) === labelText);
+  assert.ok(label, `${labelText} label should render`);
+  assert.equal(typeof label.props.htmlFor, 'string', `${labelText} label should target an input`);
+
+  const input = root.root.findAllByType('input').find((candidate) => candidate.props.id === label.props.htmlFor);
+  assert.ok(input, `${labelText} input should be associated with its visible label`);
+  return input;
+}
+
+function alertMessages(root: ReactTestRenderer): string[] {
+  return root.root.findAllByProps({ role: 'alert' }).map((alert) => textContent(alert));
+}
+
+test('reset password keeps invalid forms disabled and ignores invalid submits', async () => {
+  const { act, root, submitCalls } = await renderResetPasswordForm();
+  const submitButton = findSubmitButton(root);
+
+  assert.equal(submitButton.props.disabled, true, 'Update Password should start disabled until all fields are valid');
+
+  const form = root.root.findByType('form');
+  await act(async () => {
+    await form.props.onSubmit({ preventDefault() {} });
+    await flushMicrotasks();
+  });
+
+  assert.deepEqual(submitCalls, [], 'invalid programmatic submit should not call onSubmit');
+  assert.equal(findSubmitButton(root).props.disabled, true, 'invalid submit should leave the button disabled');
+  assert.deepEqual(alertMessages(root), [
+    'Enter the 6-digit code from your email.',
+    'Enter your new password.',
+    'Enter your confirmation password.',
+  ]);
+});
+
+test('reset password renders rejected submit failures as accessible alerts', async () => {
+  const backendMessage = 'Your recovery code is invalid or expired.';
+  const submitCalls: Array<[email: string, code: string, password: string]> = [];
+  const { act, root } = await renderResetPasswordForm({
+    async onSubmit(email, code, password) {
+      submitCalls.push([email, code, password]);
+      throw new Error(backendMessage);
+    },
+  });
+
+  await act(async () => {
+    findInputByVisibleLabel(root, 'Recovery Code').props.onChange({ target: { value: ' 123456 ' } });
+    findInputByVisibleLabel(root, 'New Password').props.onChange({ target: { value: 'ValidPass1!' } });
+    findInputByVisibleLabel(root, 'Confirm Password').props.onChange({ target: { value: 'ValidPass1!' } });
+    await flushMicrotasks();
+  });
+
+  assert.equal(findSubmitButton(root).props.disabled, false, 'valid reset details should enable submit');
+
+  const form = root.root.findByType('form');
+  await act(async () => {
+    await form.props.onSubmit({ preventDefault() {} });
+    await flushMicrotasks();
+  });
+
+  assert.deepEqual(submitCalls, [['user@example.com', '123456', 'ValidPass1!']]);
+  assert.ok(
+    alertMessages(root).includes(backendMessage),
+    'failed reset submissions should render the backend message in a role=alert region',
   );
 });
 
-test('reset password blocks submit until code, password policy, and confirmation are valid', () => {
-  assert.ok(
-    formSource.includes('const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&]).{8,}$/;'),
-    'reset form should define the password policy once so button gating and submit-time validation stay in sync',
-  );
-  assert.ok(
-    formSource.includes('const codeIsValid = /^\\d{6}$/.test(normalizedCode);'),
-    'reset form should require a six-digit recovery code before enabling submit',
-  );
-  assert.match(
-    formSource,
-    /const passwordMeetsPolicy = PASSWORD_POLICY_REGEX\.test\(password\);/,
-    'reset form should require the password to satisfy the policy before enabling submit',
-  );
-  assert.match(
-    formSource,
-    /const passwordsMatch = confirmPassword\.length > 0 && password === confirmPassword;/,
-    'reset form should require confirmation to match before enabling submit',
-  );
-  assert.match(
-    formSource,
-    /const canSubmit = codeIsValid && passwordMeetsPolicy && passwordsMatch;/,
-    'reset form should derive submit validity from code, password, and confirmation validity',
-  );
-  assert.match(
-    formSource,
-    /const submitDisabled = useDisabledUntilValid\(canSubmit, isLoading\);/,
-    'reset form should gate the submit button through the shared disabled-until-valid helper',
-  );
-  assert.match(
-    formSource,
-    /disabled=\{submitDisabled\}/,
-    'Update Password should stay disabled until the reset form is valid',
-  );
-  assert.match(
-    formSource,
-    /if \(!canSubmit\) \{\s*return;\s*\}/,
-    'handleSubmit should still block invalid programmatic submits before the backend request',
-  );
-});
+test('reset password exposes visible label associations for each input', async () => {
+  const { root } = await renderResetPasswordForm();
 
-test('reset password shows inline validation and labels each input with the visible label', () => {
-  assert.match(
-    formSource,
-    /<p id="reset-password-code-error" role="alert"/,
-    'reset form should show inline recovery-code validation feedback',
-  );
-  assert.match(
-    formSource,
-    /<p id="reset-password-new-password-error" role="alert"/,
-    'reset form should show inline password-policy validation feedback',
-  );
-  assert.match(
-    formSource,
-    /<p id="reset-password-confirm-password-error" role="alert"/,
-    'reset form should show inline confirmation mismatch validation feedback',
-  );
-  assert.match(
-    formSource,
-    /<label htmlFor="reset-password-code" className="auth-label">Recovery Code<\/label>[\s\S]*id="reset-password-code"/,
-    'Recovery Code input should be named by its visible label',
-  );
-  assert.match(
-    formSource,
-    /<label htmlFor="reset-password-new-password" className="auth-label">New Password<\/label>[\s\S]*id="reset-password-new-password"/,
-    'New Password input should be named by its visible label',
-  );
-  assert.match(
-    formSource,
-    /<label htmlFor="reset-password-confirm-password" className="auth-label">Confirm Password<\/label>[\s\S]*id="reset-password-confirm-password"/,
-    'Confirm Password input should be named by its visible label',
-  );
+  const expectedLabels = ['Recovery Code', 'New Password', 'Confirm Password'];
+  for (const labelText of expectedLabels) {
+    const input = findInputByVisibleLabel(root, labelText);
+    assert.equal(input.props.required, true, `${labelText} should remain a required field`);
+  }
+
+  assert.equal(findInputByVisibleLabel(root, 'Recovery Code').props.autoComplete, 'one-time-code');
+  assert.equal(findInputByVisibleLabel(root, 'New Password').props.autoComplete, 'new-password');
+  assert.equal(findInputByVisibleLabel(root, 'Confirm Password').props.autoComplete, 'new-password');
 });

--- a/tests/sign-up-form-accessible-names.regression-002.test.ts
+++ b/tests/sign-up-form-accessible-names.regression-002.test.ts
@@ -63,7 +63,4 @@ test('signup interactive controls do not include an unnamed icon-only button', (
     /<button[\s\S]*?aria-label=\{showPassword \? 'Hide password' : 'Show password'\}[\s\S]*?<svg aria-hidden="true" focusable="false"/,
     'the icon-only password visibility button must have an accessible name',
   );
-  assert.match(source, />\s*\{isSubmitting \? 'Creating account…' : 'Create account'\}\s*<\/button>/);
-  assert.match(source, /<span className="text-white\/80 group-hover:text-white">Google<\/span>/);
-  assert.match(source, />Sign In<\/button>/);
 });

--- a/tests/sign-up-form-accessible-names.regression-002.test.ts
+++ b/tests/sign-up-form-accessible-names.regression-002.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'auth', 'sign-up-form.tsx'),
+  'utf8',
+);
+
+// Regression: ISSUE-QA-002 — signup controls lacked stable accessible names.
+// The password visibility toggle was icon-only, and Organization was named by
+// placeholder text instead of the visible label.
+
+test('signup password visibility toggle has updating accessible name and pressed state', () => {
+  assert.match(
+    source,
+    /aria-label=\{showPassword \? 'Hide password' : 'Show password'\}/,
+    'password toggle should announce Hide password when pressed and Show password when not pressed',
+  );
+  assert.match(
+    source,
+    /aria-pressed=\{showPassword\}/,
+    'password toggle should expose its pressed state from showPassword',
+  );
+  assert.match(
+    source,
+    /aria-controls="signup-password"/,
+    'password toggle should identify the password input it controls',
+  );
+  assert.match(
+    source,
+    /type=\{showPassword \? 'text' : 'password'\}/,
+    'password input type should still update from the same showPassword state as the toggle name',
+  );
+  assert.match(
+    source,
+    /<svg aria-hidden="true" focusable="false" className="w-5 h-5"[\s\S]*?<\/svg>/,
+    'password visibility icons should be hidden from assistive technology because the button has the accessible name',
+  );
+});
+
+test('signup organization input is associated with its visible label', () => {
+  assert.match(
+    source,
+    /<label htmlFor="signup-organization"[^>]*>Organization \{!invitationData && "\(Optional\)"\}<\/label>/,
+    'Organization (Optional) should be rendered as a label bound to the organization input',
+  );
+  assert.match(
+    source,
+    /<input\s+id="signup-organization"[\s\S]*?placeholder="e\.g\. Acme Corp"/,
+    'organization input should carry the id referenced by the visible label instead of relying on placeholder text',
+  );
+});
+
+test('signup interactive controls do not include an unnamed icon-only button', () => {
+  assert.match(
+    source,
+    /<button[\s\S]*?aria-label=\{showPassword \? 'Hide password' : 'Show password'\}[\s\S]*?<svg aria-hidden="true" focusable="false"/,
+    'the icon-only password visibility button must have an accessible name',
+  );
+  assert.match(source, />\s*\{isSubmitting \? 'Creating account…' : 'Create account'\}\s*<\/button>/);
+  assert.match(source, /<span className="text-white\/80 group-hover:text-white">Google<\/span>/);
+  assert.match(source, />Sign In<\/button>/);
+});


### PR DESCRIPTION
## Summary

Runs the post-deploy Ralph QA loop against `https://aries.sugarandleather.com` and fixes the live-site findings from the public/auth, onboarding, marketing job approval, and protected-route sweeps.

Baseline deployed SHA audited: `880e4dccaac4aa89c21c4cd68bb2027e9999d62d`.

## Issues fixed

| Issue | Severity | What was broken | Fix |
| --- | --- | --- | --- |
| ISSUE-001 | High | Reset-password failures were silent, submit enabled before valid code/password/confirm state, and inputs lacked accessible names | Added visible accessible errors, stricter submit gating, inline validation, label associations, and behavioral tests |
| ISSUE-002 | Medium | Signup password visibility toggle was unnamed, Organization input used placeholder as accessible name | Added accessible toggle name/state/control wiring, Organization label association, and regression tests |
| ISSUE-003 | Medium | Features nav split between `/#features` and `/features`; auth pages had no `main`; docs nested `main` landmarks | Canonicalized Features links to `/features`, added auth main landmark, removed nested docs main, labeled nav landmarks, and tests |
| ISSUE-004 | Medium | Onboarding competitor URL accepted Facebook URLs until final submit; invalid tenant status showed top-level OK | Added early canonical competitor validation, clearer not-found/request-success status UI/API shape, and behavioral tests |
| ISSUE-005 | Medium | Job approval CTA stayed enabled after status auth failure; approve API revealed job-not-found before auth | Gated approval on loaded active approval state, cleared stale status failures, authenticated before runtime lookup, and tests |
| ISSUE-006 | Medium | Publish-status redirects lost login callback URL | Preserved canonical dashboard publish-status callback and tests |

## Validation

Passed in canonical checkout `/home/node/openclaw/aries-app`:

- `npm run workspace:verify`
- `npm run typecheck`
- Targeted 87-test QA regression suite covering reset password, signup, publish-status redirects, public nav/landmarks, onboarding validation/status, marketing approval gating, and core route pages
- `git diff --check origin/master...HEAD`
- `npm run validate:repo-boundary`
- `npm run validate:banned-patterns`
- `npm run verify`

## Ralph loop notes

- Discovery covered 12 public/auth routes, onboarding/review/marketing job surfaces, invalid material/review IDs, and protected dashboard/legacy aliases while unauthenticated.
- Protected route sweep found no route-breaking issues.
- `.ralph/log.md` records the discovery, story resolution, review loop, and validation evidence.

## Caveats

- Browser vision analysis failed in this Hermes/Codex session because the configured vision model was unsupported. QA used browser snapshots, console checks, DOM checks, route status checks, and source lookup instead.
- Authenticated dashboard behavior was limited to unauthenticated redirects because no private credentials were available in the session.
