### PR TITLE
Fix GBrain skill frontmatter sync error

### DIFF
--- a/skills/orchestrating-subagents/SKILL.md
+++ b/skills/orchestrating-subagents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrating-subagents
-description: Design subagent orchestration plans for multi-step work. Use when a task needs decomposition across multiple specialized agents, model selection, tool assignment, skill selection, handoff contracts, sequencing, or parallelization. Default orchestrator: Opus. Default subagents: openai-codex/gpt-5.4 for coding and research, gemini-3-pro-image-preview for image creation.
+description: "Design subagent orchestration plans for multi-step work. Use when a task needs decomposition across multiple specialized agents, model selection, tool assignment, skill selection, handoff contracts, sequencing, or parallelization. Default orchestrator: Opus. Default subagents: openai-codex/gpt-5.4 for coding and research, gemini-3-pro-image-preview for image creation."
 ---
 
 # Orchestrating Subagents


### PR DESCRIPTION
## Summary
- Quote the `skills/orchestrating-subagents` frontmatter description so YAML parsers do not treat the embedded colons as malformed mapping pairs.
- This fixes the GBrain sync failure for `skills/orchestrating-subagents/SKILL.md`.

## Validation
- `npm run workspace:verify`
- `npm run validate:repo-boundary`
- `npm run validate:banned-patterns`
- `git diff --check`
- `gbrain-openai doctor --json` now reports the prior sync failure as historical/acknowledged and embeddings at 100% coverage, 0 missing.
