### PR TITLE
fix(settings): add Business Profile Add Profile CTA

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,5 +1,10 @@
-import { redirect } from 'next/navigation';
+import AppShellLayout from '@/frontend/app-shell/layout';
+import AriesSettingsScreen from '@/frontend/aries-v1/settings-screen';
 
 export default function DashboardSettingsPage() {
-  redirect('/dashboard/settings/business-profile');
+  return (
+    <AppShellLayout currentRouteId="settings">
+      <AriesSettingsScreen />
+    </AppShellLayout>
+  );
 }

--- a/frontend/aries-v1/business-profile-screen.tsx
+++ b/frontend/aries-v1/business-profile-screen.tsx
@@ -11,6 +11,7 @@ import {
   type BusinessProfileFieldErrors,
 } from '@/lib/validation/business-profile';
 
+import { connectedProfileLabel } from './connected-profile-labels';
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { DashboardHero, EmptyStatePanel, LoadingStateGrid, ShellPanel } from './components';
 
@@ -45,16 +46,6 @@ const CHANNEL_OPTIONS: ChannelOption[] = [
 
 const DEFAULT_CHANNEL_IDS = ['meta-ads', 'instagram'];
 
-const CONNECTED_PROFILE_LABELS: Record<string, string> = {
-  facebook: 'Meta',
-  instagram: 'Instagram',
-  linkedin: 'LinkedIn',
-  x: 'X',
-  youtube: 'YouTube',
-  reddit: 'Reddit',
-  tiktok: 'TikTok',
-};
-
 function brandKitFontStyle(family: string): CSSProperties {
   return {
     fontFamily: `"${family}", ${family}, ui-sans-serif, system-ui, sans-serif`,
@@ -73,10 +64,6 @@ function firstPresent(...values: Array<string | null | undefined>): string | nul
 
 function channelLabel(channelId: string): string {
   return CHANNEL_OPTIONS.find((option) => option.id === channelId)?.label || channelId;
-}
-
-function connectedProfileLabel(platform: string, fallback: string): string {
-  return CONNECTED_PROFILE_LABELS[platform] || fallback || platform;
 }
 
 function joinedValues(values: string[], connectedProfileLabels: string[] = []): string {

--- a/frontend/aries-v1/connected-profile-labels.ts
+++ b/frontend/aries-v1/connected-profile-labels.ts
@@ -1,0 +1,13 @@
+const CONNECTED_PROFILE_LABELS: Record<string, string> = {
+  facebook: 'Meta',
+  instagram: 'Instagram',
+  linkedin: 'LinkedIn',
+  x: 'X',
+  youtube: 'YouTube',
+  reddit: 'Reddit',
+  tiktok: 'TikTok',
+};
+
+export function connectedProfileLabel(platform: string, fallback: string): string {
+  return CONNECTED_PROFILE_LABELS[platform] || fallback || platform;
+}

--- a/frontend/aries-v1/settings-screen.tsx
+++ b/frontend/aries-v1/settings-screen.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 import { useIntegrations } from '@/hooks/use-integrations';
 import { useBusinessProfile } from '@/hooks/use-business-profile';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { EmptyStatePanel, LoadingStateGrid, ShellPanel, StatusChip } from './components';
+import { connectedProfileLabel } from './connected-profile-labels';
 
 export default function AriesSettingsScreen() {
   const integrations = useIntegrations({ autoLoad: true });
@@ -20,6 +22,17 @@ export default function AriesSettingsScreen() {
   const profile = business.profile.data?.profile ?? null;
   const teamProfiles = business.team.data?.profiles ?? [];
   const integrationCards = integrations.data?.status === 'ok' ? integrations.data.cards : [];
+  const integrationsUnavailable = integrations.error || integrations.data?.status === 'error';
+  const connectedProfileLabels = Array.from(new Set(
+    integrationCards
+      .filter((card) => card.connection_state === 'connected')
+      .map((card) => connectedProfileLabel(card.platform, card.display_name)),
+  ));
+  const connectedProfilesSummary = integrationsUnavailable
+    ? 'Connected profile status is not available right now.'
+    : connectedProfileLabels.length > 0
+      ? connectedProfileLabels.join(', ')
+      : 'No connected social profiles yet.';
 
   const ready = !business.profile.isLoading && !business.team.isLoading;
 
@@ -79,6 +92,23 @@ export default function AriesSettingsScreen() {
               <Field label="Business type"><input value={businessType} onChange={(e) => setBusinessType(e.target.value)} className="w-full rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-white" /></Field>
               <Field label="Primary goal"><input value={primaryGoal} onChange={(e) => setPrimaryGoal(e.target.value)} className="w-full rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-white" /></Field>
             </div>
+            <div className="rounded-[1.25rem] border border-white/8 bg-black/12 px-4 py-4 text-white">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-sm font-medium">Connected profiles</p>
+                  <p className="mt-2 text-sm leading-7 text-white/58">{connectedProfilesSummary}</p>
+                </div>
+                <Link
+                  href="/dashboard/settings/channel-integrations?from=business-profile"
+                  className="inline-flex shrink-0 items-center justify-center rounded-full border border-white/15 bg-white px-4 py-2 text-sm font-semibold text-[#11161c] transition hover:bg-white/90"
+                >
+                  Add Profile
+                </Link>
+              </div>
+              <p className="mt-3 text-xs leading-6 text-white/42">
+                Newly connected media portals update this Business Profile summary automatically.
+              </p>
+            </div>
             <button type="button" onClick={() => void saveProfile()} disabled={business.save.isLoading} className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] disabled:opacity-60">
               {business.save.isLoading ? 'Saving…' : 'Save business profile'}
             </button>
@@ -91,9 +121,12 @@ export default function AriesSettingsScreen() {
 
       <div className="grid gap-4 xl:grid-cols-[1fr_1fr]">
         <ShellPanel eyebrow="Channels / Integrations" title="Where Aries can publish or monitor">
-          {integrations.error ? (
+          {integrationsUnavailable ? (
             <div className="rounded-[1.5rem] border border-red-500/20 bg-red-500/10 p-5 text-red-100">
-              {customerSafeUiErrorMessage(integrations.error.message, 'Channel status is not available right now.')}
+              {customerSafeUiErrorMessage(
+                integrations.error?.message || (integrations.data?.status === 'error' ? integrations.data.error.message : undefined),
+                'Channel status is not available right now.',
+              )}
             </div>
           ) : integrationCards.length === 0 ? (
             <EmptyStatePanel compact title="No integrations yet" description="Connect channels so Aries can publish, schedule, and monitor launches." />

--- a/tests/runtime-pages.test.ts
+++ b/tests/runtime-pages.test.ts
@@ -485,7 +485,13 @@ test('/platforms redirects to the canonical dashboard settings route', () => {
 });
 
 test('/dashboard/settings wraps the settings screen in the app shell', () => {
-  expectRedirect(() => DashboardSettingsPage(), '/dashboard/settings/business-profile');
+  const element = DashboardSettingsPage();
+
+  assert.equal(isValidElement(element), true);
+  assert.equal(element.type, AppShellLayout);
+  assert.equal(element.props.currentRouteId, 'settings');
+  assert.equal(isValidElement(element.props.children), true);
+  assert.equal(element.props.children.type, AriesSettingsScreen);
 });
 
 test('/settings redirects to the canonical dashboard settings route', () => {

--- a/tests/settings-route.regression-204.test.ts
+++ b/tests/settings-route.regression-204.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'app', 'dashboard', 'settings', 'page.tsx'),
+  'utf8',
+);
+
+test('settings route renders AppShellLayout with currentRouteId="settings"', () => {
+  assert.match(
+    source,
+    /AppShellLayout/,
+    'page.tsx must import and render AppShellLayout',
+  );
+  assert.match(
+    source,
+    /currentRouteId=["']settings["']/,
+    'AppShellLayout must receive currentRouteId="settings"',
+  );
+});
+
+test('settings route renders AriesSettingsScreen', () => {
+  assert.match(
+    source,
+    /AriesSettingsScreen/,
+    'page.tsx must import and render AriesSettingsScreen',
+  );
+});
+
+test('settings route does not redirect away from /dashboard/settings', () => {
+  assert.doesNotMatch(
+    source,
+    /redirect\s*\(/,
+    'page.tsx must NOT call redirect() — the My Account / Settings screen must be reachable',
+  );
+});

--- a/tests/settings-screen.test.ts
+++ b/tests/settings-screen.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'settings-screen.tsx'),
+  'utf8',
+);
+const businessProfileSource = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'business-profile-screen.tsx'),
+  'utf8',
+);
+
+test('settings Business Profile panel exposes Add Profile CTA and connected portal summary', () => {
+  const businessProfilePanelStart = source.indexOf('eyebrow="Business Profile"');
+  const channelPanelStart = source.indexOf('eyebrow="Channels / Integrations"');
+  assert.ok(businessProfilePanelStart >= 0, 'Settings should render a Business Profile panel');
+  assert.ok(channelPanelStart > businessProfilePanelStart, 'Settings should render channels after the Business Profile panel');
+
+  const businessProfilePanelSource = source.slice(businessProfilePanelStart, channelPanelStart);
+
+  assert.equal(
+    businessProfilePanelSource.includes('Add Profile'),
+    true,
+    'The My Account / Settings Business Profile panel must include an Add Profile CTA',
+  );
+  assert.equal(
+    businessProfilePanelSource.includes('/dashboard/settings/channel-integrations?from=business-profile'),
+    true,
+    'The Add Profile CTA should deep-link into the existing channel integration connection flow',
+  );
+  assert.equal(
+    businessProfilePanelSource.includes('Connected profiles'),
+    true,
+    'The Business Profile panel should summarize connected media portals beside the CTA',
+  );
+  assert.equal(
+    source.includes("connection_state === 'connected'") && source.includes('connectedProfilesSummary'),
+    true,
+    'The Business Profile panel should derive its portal summary from live connected integration cards',
+  );
+});
+
+test('settings and Business Profile screens share connected profile labels', () => {
+  assert.match(
+    source,
+    /import \{ connectedProfileLabel \} from '\.\/connected-profile-labels';/,
+    'Settings should use the shared connected profile label helper',
+  );
+  assert.match(
+    businessProfileSource,
+    /import \{ connectedProfileLabel \} from '\.\/connected-profile-labels';/,
+    'Business Profile should use the shared connected profile label helper',
+  );
+  assert.equal(
+    source.includes('const CONNECTED_PROFILE_LABELS'),
+    false,
+    'Settings must not duplicate the connected profile label mapping',
+  );
+  assert.equal(
+    businessProfileSource.includes('const CONNECTED_PROFILE_LABELS'),
+    false,
+    'Business Profile must not duplicate the connected profile label mapping',
+  );
+});
+
+test('settings Channels panel treats integrations status:error as unavailable', () => {
+  const channelPanelStart = source.indexOf('eyebrow="Channels / Integrations"');
+  const teamPanelStart = source.indexOf('eyebrow="Team / Approvals"');
+  assert.ok(channelPanelStart >= 0, 'Settings should render a Channels / Integrations panel');
+  assert.ok(teamPanelStart > channelPanelStart, 'Settings should render Team after Channels');
+
+  const channelPanelSource = source.slice(channelPanelStart, teamPanelStart);
+  assert.equal(
+    channelPanelSource.includes('integrationsUnavailable ?'),
+    true,
+    'Channels panel should use integrationsUnavailable so HTTP 200 status:error payloads render as unavailable',
+  );
+  assert.equal(
+    channelPanelSource.includes('integrations.error ?'),
+    false,
+    'Channels panel must not treat status:error payloads as the empty integrations state',
+  );
+});


### PR DESCRIPTION
## Summary
- Restores `/dashboard/settings` so the My Account / Settings screen renders `AriesSettingsScreen` inside `AppShellLayout` instead of redirecting away to `/dashboard/settings/business-profile`.
- Adds the missing **Add Profile** CTA directly to the My Account / Settings **Business Profile** panel, pointing to `/dashboard/settings/channel-integrations?from=business-profile`.
- Adds a **Connected profiles** summary in that panel, backed by live connected integration cards, so newly connected portals update Business Profile context automatically.
- Shares connected-profile label formatting between Settings and Business Profile, and treats integrations `{ status: 'error' }` payloads as unavailable instead of empty.

Fixes #204

## Test Plan
- [x] RED: copied `tests/settings-screen.test.ts` to a clean `origin/master` worktree and confirmed it failed because the Settings Business Profile panel lacked the Add Profile CTA.
- [x] RED: copied the route regression to a clean `origin/master` worktree and confirmed `/dashboard/settings` still redirected away.
- [x] `npx tsx --test tests/settings-screen.test.ts tests/settings-route.regression-204.test.ts tests/runtime-pages.test.ts tests/business-profile-screen.test.ts` — 46/46 pass.
- [x] `npm run typecheck`
- [x] `npm run validate:repo-boundary` — ok, 509 files checked.
- [x] `npm run validate:banned-patterns` — ok.
- [x] `ARIES_CANONICAL_REPO_ROOT=/tmp/aries-pr214-update npm run workspace:verify`
- [x] `npm run verify` — full regression verifier passed before the latest base merge; targeted/typecheck/validators re-run after merging latest master.
- [x] `git diff --check`

## Notes
- PR #215 was the route-only duplicate; this PR now includes that route fix plus the Settings CTA/connected profiles fix.
- PR #216 was superseded by PR #217/#218 workflow auth fixes and has been closed.