### PR TITLE
fix(settings): restore My Account / Settings screen at /dashboard/settings

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,5 +1,10 @@
-import { redirect } from 'next/navigation';
+import AppShellLayout from '@/frontend/app-shell/layout';
+import AriesSettingsScreen from '@/frontend/aries-v1/settings-screen';
 
 export default function DashboardSettingsPage() {
-  redirect('/dashboard/settings/business-profile');
+  return (
+    <AppShellLayout currentRouteId="settings">
+      <AriesSettingsScreen />
+    </AppShellLayout>
+  );
 }

--- a/tests/settings-route.regression-204.test.ts
+++ b/tests/settings-route.regression-204.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+const source = readFileSync(
+  path.join(PROJECT_ROOT, 'app', 'dashboard', 'settings', 'page.tsx'),
+  'utf8',
+);
+
+test('settings route renders AppShellLayout with currentRouteId="settings"', () => {
+  assert.match(
+    source,
+    /AppShellLayout/,
+    'page.tsx must import and render AppShellLayout',
+  );
+  assert.match(
+    source,
+    /currentRouteId=["']settings["']/,
+    'AppShellLayout must receive currentRouteId="settings"',
+  );
+});
+
+test('settings route renders AriesSettingsScreen', () => {
+  assert.match(
+    source,
+    /AriesSettingsScreen/,
+    'page.tsx must import and render AriesSettingsScreen',
+  );
+});
+
+test('settings route does not redirect away from /dashboard/settings', () => {
+  assert.doesNotMatch(
+    source,
+    /redirect\s*\(/,
+    'page.tsx must NOT call redirect() — the My Account / Settings screen must be reachable',
+  );
+});


### PR DESCRIPTION
## Summary

- `app/dashboard/settings/page.tsx` was calling `redirect('/dashboard/settings/business-profile')`, making the My Account / Settings screen (Business Profile + Channels/Integrations + Team/Approvals) completely unreachable from the Settings nav item
- Replaced the redirect with the correct render: `AppShellLayout` with `currentRouteId="settings"` wrapping `AriesSettingsScreen`
- `frontend/aries-v1/settings-screen.tsx` already contained the full Business Profile panel with Add Profile CTA, connect/reconnect/disconnect channel buttons, and team approvals — it just wasn't reachable

## Root cause

The route `app/dashboard/settings/page.tsx` hard-redirected away from itself instead of rendering the existing settings screen. PR #206 correctly added the Add Profile CTA to `business-profile-screen.tsx` but missed that the Settings nav item was routing to a dead end.

## Test plan

- [x] `tests/settings-route.regression-204.test.ts` — new regression test (3 assertions): page renders `AppShellLayout` with `currentRouteId="settings"`, renders `AriesSettingsScreen`, does **not** call `redirect()`
- [x] `tests/business-profile-screen.test.ts` — existing tests all pass (4 assertions)
- [x] `tests/app-shell-tenant-resolution.test.ts` — existing test passes
- [x] `npm run validate:repo-boundary` — ✅ 507 files checked
- [x] `npm run validate:banned-patterns` — ✅ no violations

Fixes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)