### PR TITLE
ci: fix agent workflow auth handling

### DIFF
--- a/.github/workflows/issue-agent-fix.yml
+++ b/.github/workflows/issue-agent-fix.yml
@@ -77,7 +77,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           base_branch: master
           branch_prefix: issue-agent/
-          track_progress: true
+          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: #${{ steps.issue.outputs.number }}

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -25,6 +25,8 @@ permissions:
   issues: write
   actions: read
   checks: read
+  # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
+  id-token: write
 
 concurrency:
   group: pr-agent-autofix-automerge-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}


### PR DESCRIPTION
## Summary
- Grants the PR autofix/automerge workflow `id-token: write` so `anthropics/claude-code-action@v1` can obtain the OIDC token it now requests before agent mode.
- Disables Claude progress tracking only for `workflow_dispatch` issue-agent runs, matching the action's supported event list while keeping progress tracking for issue events.

## Validation
- [x] YAML parse for `.github/workflows/issue-agent-fix.yml` and `.github/workflows/pr-agent-autofix-automerge.yml`
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`
- [x] `git diff --check`
- [ ] `npm run workspace:verify` (cannot pass in temp worktree: canonical root guard expects `/home/node/aries-app`; no repo-boundary issues found)

## Notes
This PR intentionally does **not** use the `issue-agent/*` branch prefix or `agent:auto-merge` label so the trusted PR agent guard should skip agent execution while the workflow itself is being repaired.
