### PR TITLE
ci: restore agent workflow auth handling

### DIFF
--- a/.github/workflows/issue-agent-fix.yml
+++ b/.github/workflows/issue-agent-fix.yml
@@ -77,7 +77,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           base_branch: master
           branch_prefix: issue-agent/
-          track_progress: true
+          track_progress: ${{ github.event_name != 'workflow_dispatch' }}
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: #${{ steps.issue.outputs.number }}

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -25,6 +25,8 @@ permissions:
   issues: write
   actions: read
   checks: read
+  # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
+  id-token: write
 
 concurrency:
   group: pr-agent-autofix-automerge-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}


### PR DESCRIPTION
## Summary
- Allows issue-agent workflow_dispatch runs by disabling Claude progress tracking on manual dispatch events.
- Grants id-token: write to the PR agent workflow because anthropics/claude-code-action v1 requests a GitHub OIDC token in agent mode.

## Test Plan
- [x] Parsed .github/workflows/issue-agent-fix.yml with PyYAML
- [x] Parsed .github/workflows/pr-agent-autofix-automerge.yml with PyYAML
- [x] git diff --check

Recovery context: unblocks PR #214 / issue #204 automation after runs failed on track_progress workflow_dispatch and missing OIDC permissions.