### PR TITLE
ci: use Claude OAuth token for agent workflows

### DIFF
--- a/.github/workflows/issue-agent-fix.yml
+++ b/.github/workflows/issue-agent-fix.yml
@@ -14,7 +14,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 concurrency:
   group: issue-agent-fix-${{ github.event.issue.number || inputs.issue_number }}
@@ -74,7 +73,7 @@ jobs:
       - name: Claude issue fixer
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           base_branch: master
           branch_prefix: issue-agent/
           track_progress: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -26,7 +26,6 @@ permissions:
   actions: read
   checks: read
   # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
-  id-token: write
 
 concurrency:
   group: pr-agent-autofix-automerge-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
@@ -149,11 +148,10 @@ jobs:
         if: steps.pr.outputs.should_run == 'true'
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: #${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary
- Switches both Aries agent workflows from the invalid `ANTHROPIC_API_KEY` secret to `CLAUDE_CODE_OAUTH_TOKEN`.
- Removes unnecessary `id-token: write` permissions now that the workflows authenticate Claude Code directly with OAuth.
- Keeps the workflow_dispatch `track_progress` guard from the prior auth hotfix.

## Validation
- [x] YAML parse for both workflow files
- [x] actionlint for both workflow files
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`
- [x] `git diff --check`

Fixes the failing issue-agent runs seen on #204 (`Invalid API key`).
