### PR TITLE
ci: restore Claude action OIDC permission

### DIFF
--- a/.github/workflows/issue-agent-fix.yml
+++ b/.github/workflows/issue-agent-fix.yml
@@ -14,6 +14,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
+  id-token: write
 
 concurrency:
   group: issue-agent-fix-${{ github.event.issue.number || inputs.issue_number }}

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -26,6 +26,7 @@ permissions:
   actions: read
   checks: read
   # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
+  id-token: write
 
 concurrency:
   group: pr-agent-autofix-automerge-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}


### PR DESCRIPTION
## Summary
- Restores the `id-token: write` permission required by `anthropics/claude-code-action@v1` when it requests a GitHub OIDC token.
- Applies the permission to both `issue-agent-fix` and `pr-agent-autofix-automerge` so issue and PR automation can run with the Claude Code OAuth token.

## Test Plan
- [x] Parsed `.github/workflows/issue-agent-fix.yml` and `.github/workflows/pr-agent-autofix-automerge.yml` with `python3` / `yaml.safe_load`
- [x] `/tmp/actionlint-bin/actionlint .github/workflows/issue-agent-fix.yml .github/workflows/pr-agent-autofix-automerge.yml`
- [x] `npm run workspace:verify`
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`
- [x] `npm run verify`

Unblocks PR #214 automation after the `Could not fetch an OIDC token` failure.