### PR TITLE
ci: restore agent OIDC permission

### DIFF
--- a/.github/workflows/issue-agent-fix.yml
+++ b/.github/workflows/issue-agent-fix.yml
@@ -14,6 +14,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
+  id-token: write
 
 concurrency:
   group: issue-agent-fix-${{ github.event.issue.number || inputs.issue_number }}

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -26,6 +26,7 @@ permissions:
   actions: read
   checks: read
   # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
+  id-token: write
 
 concurrency:
   group: pr-agent-autofix-automerge-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}


### PR DESCRIPTION
## Summary
- Restores id-token: write for the issue-agent and PR-agent workflows after switching the Claude action to OAuth token auth.
- Keeps the existing trusted same-repo guardrails intact so the Claude Code Action can fetch its required GitHub OIDC token.

## Test Plan
- [x] Parsed issue-agent-fix.yml and pr-agent-autofix-automerge.yml with PyYAML
- [x] npm run workspace:verify
- [x] npm run validate:repo-boundary
- [x] npm run validate:banned-patterns