### PR TITLE
fix(onboarding): keep resume page stable on gateway failure

### DIFF
--- a/backend/marketing/orchestrator.ts
+++ b/backend/marketing/orchestrator.ts
@@ -1058,11 +1058,11 @@ async function advancePublishStage(doc: MarketingJobRuntimeDocument, resumeToken
   saveMarketingJobRuntime(doc.job_id, doc);
 }
 
-function handleFailure(
+function recordFailure(
   doc: MarketingJobRuntimeDocument,
   stage: MarketingStage,
   error: unknown
-): never {
+): void {
   if (error instanceof OpenClawGatewayError) {
     recordStageFailure(doc, stage, {
       code: error.code,
@@ -1080,6 +1080,14 @@ function handleFailure(
     });
   }
   saveMarketingJobRuntime(doc.job_id, doc);
+}
+
+function handleFailure(
+  doc: MarketingJobRuntimeDocument,
+  stage: MarketingStage,
+  error: unknown
+): never {
+  recordFailure(doc, stage, error);
   throw error;
 }
 
@@ -1121,7 +1129,7 @@ export async function startMarketingJob(input: StartMarketingJobRequest): Promis
     if (error instanceof MarketingJobCancelledError) {
       // Document was already saved as cancelled by applySoftCancelIfRequested.
     } else {
-      handleFailure(doc, doc.current_stage, error);
+      recordFailure(doc, doc.current_stage, error);
     }
   }
 

--- a/tests/marketing-flow-smoke.test.ts
+++ b/tests/marketing-flow-smoke.test.ts
@@ -250,3 +250,39 @@ test('canonical client-facing marketing smoke flow stays on the monolithic pipel
     assert.equal(runtimeDoc.approvals.current, null);
   });
 });
+
+test('startMarketingJob returns a failed campaign instead of throwing when the gateway tool is unavailable', async () => {
+  await withMarketingRuntimeEnv(async () => {
+    const { OpenClawGatewayError } = await import('../backend/openclaw/gateway-client');
+    const { startMarketingJob } = await import('../backend/marketing/orchestrator');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+
+    setOpenClawTestInvoker(() => {
+      throw new OpenClawGatewayError(
+        'openclaw_gateway_tool_unavailable',
+        'OpenClaw gateway does not expose the requested tool.',
+        404,
+      );
+    });
+
+    const startResult = await startMarketingJob({
+      tenantId: 'tenant_gateway_unavailable',
+      jobType: 'brand_campaign',
+      payload: {
+        brandUrl: 'https://brand.example',
+        competitorUrl: 'https://betterup.com',
+      },
+    });
+
+    assert.equal(startResult.status, 'accepted');
+    assert.equal(startResult.approvalRequired, false);
+    assert.equal(startResult.currentStage, 'research');
+
+    const failedDoc = (await loadMarketingJobRuntime(startResult.jobId))!;
+    assert.equal(failedDoc.state, 'failed');
+    assert.equal(failedDoc.status, 'failed');
+    assert.equal(failedDoc.current_stage, 'research');
+    assert.equal(failedDoc.last_error?.code, 'openclaw_gateway_tool_unavailable');
+    assert.equal(failedDoc.stages.research.status, 'failed');
+  });
+});


### PR DESCRIPTION
## Summary
- record first-stage marketing runtime failures without rethrowing from startMarketingJob
- let authenticated onboarding resume redirect into the campaign workspace instead of surfacing a Next page-load exception
- add regression coverage for OpenClaw gateway tool-unavailable failures

## Verification
- npm run validate:repo-boundary
- npm run validate:banned-patterns
- npx tsx --test tests/marketing-flow-smoke.test.ts tests/onboarding-resume.test.ts tests/marketing-job-route.smoke.test.ts
- npm run workspace:verify
- npm run verify
