### PR TITLE
test: add OpenClaw Lobster gateway smoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,9 @@ OPENCLAW_GATEWAY_URL=http://127.0.0.1:3456
 OPENCLAW_GATEWAY_TOKEN=replace-with-your-openclaw-gateway-token
 OPENCLAW_SESSION_KEY=main
 OAUTH_TOKEN_ENCRYPTION_KEY=replace-with-base64-32-byte-key
-OPENCLAW_GATEWAY_LOBSTER_CWD=lobster
+# If Aries runs in Docker while OpenClaw runs as the default host service from
+# /home/node, gateway Lobster cwd must be repo-relative to that service:
+OPENCLAW_GATEWAY_LOBSTER_CWD=aries-app/lobster
 OPENCLAW_LOBSTER_CWD=lobster
 
 # Optional Lobster Stage 4 media gateway. Enable this when image generation,
@@ -45,10 +47,13 @@ LOBSTER_STAGE2_CACHE_DIR=/data/lobster-stage2-cache
 LOBSTER_STAGE3_CACHE_DIR=/data/lobster-stage3-cache
 LOBSTER_STAGE4_CACHE_DIR=/data/lobster-stage4-cache
 
-# Host-checkout local development example:
+# Host-checkout local development examples:
+# If you start OpenClaw from /home/node/aries-app, use:
+# OPENCLAW_GATEWAY_LOBSTER_CWD=lobster
+# If you use the installed OpenClaw gateway service that starts from /home/node, use:
+# OPENCLAW_GATEWAY_LOBSTER_CWD=aries-app/lobster
 # CODE_ROOT=/home/node/aries-app
 # DATA_ROOT=/tmp/aries-data
-# OPENCLAW_GATEWAY_LOBSTER_CWD=lobster
 # OPENCLAW_LOCAL_LOBSTER_CWD=/home/node/aries-app/lobster
 # OPENCLAW_LOBSTER_CWD=/home/node/aries-app/lobster
 # MARKETING_STATUS_PUBLIC=1

--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ NODE_ENV=development npm ci
 cp .env.example .env
 export DB_HOST=localhost DB_PORT=5432 DB_USER=aries_user DB_PASSWORD=aries_pass DB_NAME=aries_dev
 export CODE_ROOT=/home/node/aries-app DATA_ROOT=/tmp/aries-data NODE_ENV=development
-export OPENCLAW_GATEWAY_LOBSTER_CWD=lobster
+export OPENCLAW_GATEWAY_LOBSTER_CWD=aries-app/lobster  # installed OpenClaw gateway service from /home/node
 export OPENCLAW_LOCAL_LOBSTER_CWD=/home/node/aries-app/lobster
 export OPENCLAW_LOBSTER_CWD=/home/node/aries-app/lobster
 export APP_BASE_URL=http://localhost:3000 NEXTAUTH_URL=http://localhost:3000 AUTH_URL=http://localhost:3000 AUTH_TRUST_HOST=true
 export MARKETING_STATUS_PUBLIC=1
 ```
 
-Use `OPENCLAW_GATEWAY_LOBSTER_CWD=lobster` for gateway calls. Keep `OPENCLAW_LOCAL_LOBSTER_CWD` / `OPENCLAW_LOBSTER_CWD` pointed at the absolute checkout path for local file reads and compatibility tooling.
+Use `OPENCLAW_GATEWAY_LOBSTER_CWD` as the path to `lobster/` relative to the OpenClaw gateway process, not relative to the Aries process. Use `lobster` when you start OpenClaw from `/home/node/aries-app`; use `aries-app/lobster` for the installed host gateway service that starts from `/home/node`. Keep `OPENCLAW_LOCAL_LOBSTER_CWD` / `OPENCLAW_LOBSTER_CWD` pointed at the absolute checkout path for local file reads and compatibility tooling. Run `npm run validate:openclaw-lobster` after gateway/config changes; it writes a diagnostic report under `.artifacts/openclaw-lobster-availability/` and fails with the fix hint if the `lobster` tool disappears again.
 
 ### 3) Start PostgreSQL
 

--- a/backend/openclaw/gateway-client.ts
+++ b/backend/openclaw/gateway-client.ts
@@ -206,6 +206,21 @@ function defaultLobsterStateDir(): string {
   );
 }
 
+function stripTrailingPathSeparators(value: string): string {
+  let normalized = value.trim();
+  while (normalized.length > 1 && /[\\/]$/.test(normalized)) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function defaultLocalLobsterCwd(): string {
+  return optionalEnv(
+    'OPENCLAW_LOCAL_LOBSTER_CWD',
+    optionalEnv('OPENCLAW_LOBSTER_CWD', resolveCodePath('lobster')),
+  );
+}
+
 function gatewayUrlOrNull(): string | null {
   return process.env.OPENCLAW_GATEWAY_URL?.trim() ? gatewayBaseUrl() : null;
 }
@@ -354,7 +369,9 @@ function asEnvelope(value: unknown): LobsterEnvelope {
 }
 
 function resolveLocalLobsterCwd(configuredCwd: string, localCwd?: string): string {
-  const normalized = localCwd?.trim() || configuredCwd.trim();
+  const normalized = stripTrailingPathSeparators(
+    localCwd?.trim() || defaultLocalLobsterCwd() || configuredCwd.trim(),
+  );
   if (!normalized) {
     return resolveCodePath('lobster');
   }

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -78,7 +78,7 @@ services:
       OPENCLAW_VIDEO_GENERATION_MODEL: ${OPENCLAW_VIDEO_GENERATION_MODEL:-}
       LOBSTER_VIDEO_GATEWAY_TIMEOUT_SECONDS: ${LOBSTER_VIDEO_GATEWAY_TIMEOUT_SECONDS:-}
       OPENCLAW_LOBSTER_CWD: ${OPENCLAW_LOBSTER_CWD:-/app/lobster}
-      OPENCLAW_GATEWAY_LOBSTER_CWD: ${OPENCLAW_GATEWAY_LOBSTER_CWD:-lobster}
+      OPENCLAW_GATEWAY_LOBSTER_CWD: ${OPENCLAW_GATEWAY_LOBSTER_CWD:-aries-app/lobster}
       OPENCLAW_LOCAL_LOBSTER_CWD: ${OPENCLAW_LOCAL_LOBSTER_CWD:-/app/lobster}
       # Lobster stage cache dirs must resolve to the same absolute paths on the
       # host (where OpenClaw/Lobster writes) and in the container (where Aries

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,10 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY}
       EMAIL_FROM: ${EMAIL_FROM}
       OPENCLAW_LOBSTER_CWD: ${OPENCLAW_LOBSTER_CWD:-/app/lobster}
-      OPENCLAW_GATEWAY_LOBSTER_CWD: ${OPENCLAW_GATEWAY_LOBSTER_CWD:-lobster}
+      # The default OpenClaw gateway service on this host starts from /home/node,
+      # while Aries runs from /home/node/aries-app (or /app in-container). Keep
+      # this gateway-facing cwd repo-relative to the gateway process.
+      OPENCLAW_GATEWAY_LOBSTER_CWD: ${OPENCLAW_GATEWAY_LOBSTER_CWD:-aries-app/lobster}
       OPENCLAW_LOCAL_LOBSTER_CWD: ${OPENCLAW_LOCAL_LOBSTER_CWD:-/app/lobster}
       # Lobster stage cache dirs. These MUST resolve to the same absolute paths
       # on the host (where OpenClaw/Lobster writes) and inside the container

--- a/lobster/bin/openclaw-lobster-availability-smoke.py
+++ b/lobster/bin/openclaw-lobster-availability-smoke.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Cheap Lobster workflow used by the OpenClaw gateway availability smoke test.
+
+The script intentionally avoids provider calls and external services. If the
+OpenClaw gateway can execute the `lobster` tool from the Aries `lobster` cwd,
+this writes a small JSON report to the requested output location and prints the
+same report to stdout so Lobster returns it in the tool envelope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _inside(path: Path, root: Path) -> bool:
+    return path == root or root in path.parents
+
+
+def resolve_output_location(raw_location: str) -> Path:
+    cwd = Path.cwd().resolve()
+    project_root = cwd.parent if cwd.name == "lobster" else cwd
+    default_location = Path("output/diagnostics/openclaw-lobster-availability.json")
+    requested = Path(raw_location) if raw_location.strip() else default_location
+    resolved = (cwd / requested).resolve() if not requested.is_absolute() else requested.resolve()
+
+    allowed_roots = [
+        cwd / "output",
+        project_root / ".artifacts",
+        Path(os.environ.get("TMPDIR", "/tmp")).resolve(),
+    ]
+    if not any(_inside(resolved, root.resolve()) for root in allowed_roots):
+        allowed = ", ".join(str(root.resolve()) for root in allowed_roots)
+        raise RuntimeError(
+            f"unsafe_output_location: {resolved} is outside allowed diagnostic roots: {allowed}"
+        )
+    return resolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--marker", default="")
+    parser.add_argument("--workflow", default="diagnostics/openclaw-gateway-availability.lobster")
+    parser.add_argument("--output-location", default="output/diagnostics/openclaw-lobster-availability.json")
+    args = parser.parse_args()
+
+    output_location = resolve_output_location(args.output_location)
+    output_location.parent.mkdir(parents=True, exist_ok=True)
+
+    report = {
+        "ok": True,
+        "lobster_tool": "available",
+        "marker": args.marker,
+        "workflow": args.workflow,
+        "cwd": str(Path.cwd().resolve()),
+        "output_location_requested": args.output_location,
+        "output_location": str(output_location),
+        "hostname": socket.gethostname(),
+        "pid": os.getpid(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    serialized = json.dumps(report, sort_keys=True)
+    output_location.write_text(serialized + "\n", encoding="utf-8")
+    print(serialized)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lobster/diagnostics/openclaw-gateway-availability.lobster
+++ b/lobster/diagnostics/openclaw-gateway-availability.lobster
@@ -1,0 +1,17 @@
+name: openclaw-lobster-gateway-availability
+args:
+  marker:
+    default: ""
+  output_location:
+    default: "output/diagnostics/openclaw-lobster-availability.json"
+steps:
+  - id: write_availability_report
+    env:
+      SMOKE_MARKER: "${marker}"
+      SMOKE_WORKFLOW: "diagnostics/openclaw-gateway-availability.lobster"
+      SMOKE_OUTPUT_LOCATION: "${output_location}"
+    command: >
+      python3 ./bin/openclaw-lobster-availability-smoke.py
+      --marker "$SMOKE_MARKER"
+      --workflow "$SMOKE_WORKFLOW"
+      --output-location "$SMOKE_OUTPUT_LOCATION"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "validate:public-routes": "tsx --test tests/runtime-pages.test.ts tests/public-marketing-pages.test.ts",
     "validate:banned-patterns": "node scripts/check-banned-patterns.mjs",
     "validate:marketing-flow": "APP_BASE_URL=https://aries.example.com tsx --test tests/marketing-job-flow.test.ts tests/onboarding-marketing-contracts.test.ts",
+    "validate:openclaw-lobster": "tsx --test tests/openclaw-lobster-gateway-availability.test.ts",
     "validate:repo-boundary": "node scripts/check-repo-boundary.mjs",
     "validate:homepage-perf": "mkdir -p .artifacts && CI=1 npx --yes lighthouse http://127.0.0.1:3000 --only-categories=performance --preset=desktop --no-enable-error-reporting --chrome-flags='--headless=new --no-sandbox --disable-dev-shm-usage' --output=json --output-path=.artifacts/lighthouse-homepage.json",
     "validate:homepage-perf:mobile": "mkdir -p .artifacts && CI=1 npx --yes lighthouse http://127.0.0.1:3000 --only-categories=performance --form-factor=mobile --screenEmulation.mobile=true --throttling-method=simulate --no-enable-error-reporting --chrome-flags='--headless=new --no-sandbox --disable-dev-shm-usage' --output=json --output-path=.artifacts/lighthouse-homepage-mobile.json",

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -34,6 +34,10 @@ const steps = [
     args: ['--test', 'tests/repo-boundary-guard.test.ts'],
   },
   {
+    name: 'OpenClaw Lobster live gateway availability smoke',
+    args: ['--test', 'tests/openclaw-lobster-gateway-availability.test.ts'],
+  },
+  {
     name: 'targeted marketing-flow smoke tests',
     args: ['--test', 'tests/marketing-flow-smoke.test.ts'],
   },

--- a/tests/marketing-gateway-logging.test.ts
+++ b/tests/marketing-gateway-logging.test.ts
@@ -85,6 +85,60 @@ test('runOpenClawLobsterWorkflow can disable PATH-based local fallback', async (
   }
 });
 
+test('runOpenClawLobsterWorkflow local fallback prefers OPENCLAW_LOCAL_LOBSTER_CWD over gateway cwd', async () => {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousGatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
+  const previousGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+  const previousGatewayLobsterCwd = process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
+  const previousLocalLobsterCwd = process.env.OPENCLAW_LOCAL_LOBSTER_CWD;
+  const originalConsoleWarn = console.warn;
+  const warnings: unknown[][] = [];
+
+  process.env.CODE_ROOT = '/app';
+  delete process.env.OPENCLAW_GATEWAY_URL;
+  process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
+  process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = 'aries-app/lobster';
+  process.env.OPENCLAW_LOCAL_LOBSTER_CWD = '/app/lobster';
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+
+  try {
+    const { OpenClawGatewayError, runOpenClawLobsterWorkflow } = await import('../backend/openclaw/gateway-client');
+
+    await assert.rejects(
+      () =>
+        runOpenClawLobsterWorkflow({
+          pipeline: 'stage-1-research/workflow.lobster',
+          argsJson: '{}',
+        }),
+      (error: unknown) =>
+        error instanceof OpenClawGatewayError &&
+        error.code === 'openclaw_gateway_unreachable' &&
+        /local lobster cli failed/i.test(error.message),
+    );
+
+    const fallback = warnings
+      .map((entry) => entry[1])
+      .find((entry): entry is Record<string, unknown> =>
+        Boolean(entry && typeof entry === 'object' && (entry as Record<string, unknown>).event === 'workflow-local-fallback'),
+      );
+    assert.equal(fallback?.cwd, '/app/lobster');
+  } finally {
+    console.warn = originalConsoleWarn;
+    if (previousCodeRoot === undefined) delete process.env.CODE_ROOT;
+    else process.env.CODE_ROOT = previousCodeRoot;
+    if (previousGatewayUrl === undefined) delete process.env.OPENCLAW_GATEWAY_URL;
+    else process.env.OPENCLAW_GATEWAY_URL = previousGatewayUrl;
+    if (previousGatewayToken === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    else process.env.OPENCLAW_GATEWAY_TOKEN = previousGatewayToken;
+    if (previousGatewayLobsterCwd === undefined) delete process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
+    else process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = previousGatewayLobsterCwd;
+    if (previousLocalLobsterCwd === undefined) delete process.env.OPENCLAW_LOCAL_LOBSTER_CWD;
+    else process.env.OPENCLAW_LOCAL_LOBSTER_CWD = previousLocalLobsterCwd;
+  }
+});
+
 test('resumeOpenClawLobsterWorkflow preserves detailed gateway failure messages from error.details', async () => {
   const previousGatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
   const previousGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;

--- a/tests/openclaw-lobster-gateway-availability.test.ts
+++ b/tests/openclaw-lobster-gateway-availability.test.ts
@@ -1,0 +1,318 @@
+import assert from 'node:assert/strict';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const ARTIFACT_DIR = path.join(PROJECT_ROOT, '.artifacts', 'openclaw-lobster-availability');
+const DIAGNOSTIC_WORKFLOW = 'diagnostics/openclaw-gateway-availability.lobster';
+const REPO_ROOT_GATEWAY_CWD = 'lobster';
+const HOST_HOME_GATEWAY_CWD = 'aries-app/lobster';
+
+const OPENCLAW_ENV_KEYS = [
+  'OPENCLAW_GATEWAY_URL',
+  'OPENCLAW_GATEWAY_TOKEN',
+  'OPENCLAW_SESSION_KEY',
+  'OPENCLAW_GATEWAY_LOBSTER_CWD',
+] as const;
+
+type OpenClawEnvKey = typeof OPENCLAW_ENV_KEYS[number];
+
+type DiagnosticReport = {
+  ok: boolean;
+  marker: string;
+  reportPath: string;
+  gatewayConfigured: boolean;
+  gatewayHost: string | null;
+  effectiveGatewayHost: string | null;
+  requested: {
+    tool: 'lobster';
+    cwd: string;
+    workflow: string;
+    outputLocation: string;
+  };
+  result?: unknown;
+  error?: {
+    name: string;
+    code?: string;
+    status?: number;
+    message: string;
+  };
+  fix?: string;
+};
+
+function parseDotenv(text: string): Record<string, string> {
+  const values: Record<string, string> = {};
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const equals = line.indexOf('=');
+    if (equals <= 0) continue;
+
+    const key = line.slice(0, equals).trim();
+    let value = line.slice(equals + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    values[key] = value;
+  }
+
+  return values;
+}
+
+function defaultGatewayCwdForSmoke(): string {
+  const raw = process.env.OPENCLAW_GATEWAY_URL?.trim();
+  if (raw) {
+    try {
+      const url = new URL(raw);
+      if (url.hostname === 'host.docker.internal') {
+        return HOST_HOME_GATEWAY_CWD;
+      }
+    } catch {
+      // Invalid URL is handled by gatewayConfigured/selectReachableGatewayUrlForSmoke.
+    }
+  }
+  return REPO_ROOT_GATEWAY_CWD;
+}
+
+async function loadGatewayEnvForSmoke(): Promise<{
+  previous: Map<OpenClawEnvKey, string | undefined>;
+  loadedFrom: string[];
+}> {
+  const previous = new Map<OpenClawEnvKey, string | undefined>();
+  for (const key of OPENCLAW_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+  }
+
+  const loadedFrom: string[] = [];
+  for (const envFile of ['.env.local', '.env']) {
+    const envPath = path.join(PROJECT_ROOT, envFile);
+    let text = '';
+    try {
+      text = await readFile(envPath, 'utf8');
+    } catch {
+      continue;
+    }
+
+    const values = parseDotenv(text);
+    let loadedAny = false;
+    for (const key of OPENCLAW_ENV_KEYS) {
+      if (!process.env[key] && values[key]) {
+        process.env[key] = values[key];
+        loadedAny = true;
+      }
+    }
+    if (loadedAny) loadedFrom.push(envFile);
+  }
+
+  // Aries must call the OpenClaw Lobster tool from the repo-relative Lobster cwd.
+  // This is the output-location contract the live gateway needs in order to find
+  // checked-in workflows and write diagnostics to ../.artifacts.
+  if (!process.env.OPENCLAW_GATEWAY_LOBSTER_CWD) {
+    process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = defaultGatewayCwdForSmoke();
+  }
+
+  return { previous, loadedFrom };
+}
+
+function restoreGatewayEnv(previous: Map<OpenClawEnvKey, string | undefined>): void {
+  for (const key of OPENCLAW_ENV_KEYS) {
+    const value = previous.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function hostForUrl(raw: string | undefined): string | null {
+  if (!raw?.trim()) return null;
+  try {
+    const url = new URL(raw);
+    return url.host;
+  } catch {
+    return '<invalid-url>';
+  }
+}
+
+function gatewayHostForReport(): string | null {
+  return hostForUrl(process.env.OPENCLAW_GATEWAY_URL);
+}
+
+async function gatewayHealthOk(rawUrl: string): Promise<boolean> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  url.pathname = '/health';
+  url.search = '';
+  url.hash = '';
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 2_500);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function selectReachableGatewayUrlForSmoke(): Promise<string | null> {
+  const configured = process.env.OPENCLAW_GATEWAY_URL?.trim();
+  if (!configured) return null;
+
+  const candidates = [configured];
+  try {
+    const parsed = new URL(configured);
+    if (parsed.hostname === 'host.docker.internal' && parsed.port) {
+      const loopback = new URL(configured);
+      loopback.hostname = '127.0.0.1';
+      candidates.push(loopback.toString().replace(/\/$/, ''));
+    }
+  } catch {
+    return null;
+  }
+
+  for (const candidate of candidates) {
+    if (await gatewayHealthOk(candidate)) {
+      process.env.OPENCLAW_GATEWAY_URL = candidate.replace(/\/$/, '');
+      return process.env.OPENCLAW_GATEWAY_URL;
+    }
+  }
+
+  return null;
+}
+
+function gatewayConfigured(): boolean {
+  return Boolean(process.env.OPENCLAW_GATEWAY_URL?.trim() && process.env.OPENCLAW_GATEWAY_TOKEN?.trim());
+}
+
+async function writeDiagnosticReport(report: DiagnosticReport): Promise<void> {
+  await mkdir(path.dirname(report.reportPath), { recursive: true });
+  const serialized = `${JSON.stringify(report, null, 2)}\n`;
+  await writeFile(report.reportPath, serialized);
+  await writeFile(path.join(ARTIFACT_DIR, 'latest.json'), serialized);
+}
+
+function outputRecordFromEnvelope(envelope: unknown): Record<string, unknown> {
+  assert.ok(envelope && typeof envelope === 'object', 'Lobster gateway smoke returned a non-object envelope.');
+  const candidate = envelope as { ok?: unknown; status?: unknown; output?: unknown };
+  assert.equal(candidate.ok, true, 'Lobster gateway smoke envelope must report ok=true.');
+  assert.equal(candidate.status, 'ok', 'Lobster gateway smoke envelope must complete without approvals.');
+  assert.ok(Array.isArray(candidate.output), 'Lobster gateway smoke envelope must include an output array.');
+  const output = candidate.output as unknown[];
+  assert.equal(output.length, 1, 'Lobster gateway smoke must emit exactly one diagnostic output object.');
+  const first = output[0];
+  assert.ok(first && typeof first === 'object' && !Array.isArray(first), 'Diagnostic output must be an object.');
+  return first as Record<string, unknown>;
+}
+
+test('live OpenClaw gateway exposes the lobster tool and writes the diagnostic output location', async (t) => {
+  const marker = `aries-lobster-gateway-${Date.now()}`;
+  const reportPath = path.join(ARTIFACT_DIR, `${marker}.json`);
+  const outputLocation = `../.artifacts/openclaw-lobster-availability/${marker}.workflow.json`;
+  const { previous } = await loadGatewayEnvForSmoke();
+
+  try {
+    if (!gatewayConfigured()) {
+      t.skip('OPENCLAW_GATEWAY_URL and OPENCLAW_GATEWAY_TOKEN are not configured; skipping live Lobster gateway availability smoke.');
+      return;
+    }
+
+    const configuredGatewayHost = gatewayHostForReport();
+    const effectiveGatewayUrl = await selectReachableGatewayUrlForSmoke();
+    const cwd = process.env.OPENCLAW_GATEWAY_LOBSTER_CWD?.trim() || defaultGatewayCwdForSmoke();
+    const baseReport: Omit<DiagnosticReport, 'ok'> = {
+      marker,
+      reportPath,
+      gatewayConfigured: true,
+      gatewayHost: configuredGatewayHost,
+      effectiveGatewayHost: hostForUrl(effectiveGatewayUrl ?? undefined),
+      requested: {
+        tool: 'lobster',
+        cwd,
+        workflow: DIAGNOSTIC_WORKFLOW,
+        outputLocation,
+      },
+    };
+
+    assert.ok(
+      !path.isAbsolute(cwd) && (cwd === REPO_ROOT_GATEWAY_CWD || cwd.endsWith(`/${REPO_ROOT_GATEWAY_CWD}`)),
+      `OpenClaw Lobster gateway cwd must be a repo-relative path ending in '${REPO_ROOT_GATEWAY_CWD}' ` +
+        `so Aries workflows and diagnostic output resolve correctly. Set OPENCLAW_GATEWAY_LOBSTER_CWD to ` +
+        `'${REPO_ROOT_GATEWAY_CWD}' when OpenClaw starts from the repo root, or '${HOST_HOME_GATEWAY_CWD}' ` +
+        `when the OpenClaw gateway service starts from /home/node. Diagnostic report: ${reportPath}`,
+    );
+
+    const { OpenClawGatewayError, runOpenClawLobsterWorkflow } = await import('../backend/openclaw/gateway-client');
+
+    try {
+      const envelope = await runOpenClawLobsterWorkflow({
+        pipeline: DIAGNOSTIC_WORKFLOW,
+        argsJson: JSON.stringify({
+          marker,
+          output_location: outputLocation,
+        }),
+        cwd,
+        timeoutMs: 15_000,
+        maxStdoutBytes: 256 * 1024,
+        allowLocalFallback: false,
+      });
+      const diagnostic = outputRecordFromEnvelope(envelope);
+
+      assert.equal(diagnostic.lobster_tool, 'available');
+      assert.equal(diagnostic.marker, marker);
+      assert.equal(diagnostic.output_location_requested, outputLocation);
+      assert.equal(diagnostic.workflow, DIAGNOSTIC_WORKFLOW);
+
+      await writeDiagnosticReport({
+        ...baseReport,
+        ok: true,
+        result: diagnostic,
+      });
+    } catch (error) {
+      const gatewayError = error instanceof OpenClawGatewayError ? error : null;
+      const report: DiagnosticReport = {
+        ...baseReport,
+        ok: false,
+        error: {
+          name: error instanceof Error ? error.name : typeof error,
+          ...(gatewayError?.code ? { code: gatewayError.code } : {}),
+          ...(gatewayError?.status ? { status: gatewayError.status } : {}),
+          message: error instanceof Error ? error.message : String(error),
+        },
+        fix:
+          gatewayError?.code === 'openclaw_gateway_tool_unavailable'
+            ? "OpenClaw is reachable but does not expose the 'lobster' tool. Add tools.alsoAllow: ['lobster'] for the active gateway/agent config path and restart OpenClaw."
+            : "Check the OpenClaw gateway process, OPENCLAW_GATEWAY_* env, OPENCLAW_GATEWAY_LOBSTER_CWD, and the diagnostic workflow output location.",
+      };
+      await writeDiagnosticReport(report);
+
+      if (gatewayError?.code === 'openclaw_gateway_tool_unavailable') {
+        assert.fail(
+          "OpenClaw gateway is reachable but does not expose the 'lobster' tool. " +
+            "Add tools.alsoAllow: ['lobster'] to the active gateway/agent config path and restart OpenClaw. " +
+            `Diagnostic report: ${reportPath}`,
+        );
+      }
+
+      assert.fail(
+        `OpenClaw Lobster gateway availability smoke failed: ${report.error?.message}. Diagnostic report: ${reportPath}`,
+      );
+    }
+  } finally {
+    restoreGatewayEnv(previous);
+  }
+});

--- a/tests/openclaw-lobster-gateway-availability.test.ts
+++ b/tests/openclaw-lobster-gateway-availability.test.ts
@@ -233,7 +233,8 @@ test('live OpenClaw gateway exposes the lobster tool and writes the diagnostic o
 
     const configuredGatewayHost = gatewayHostForReport();
     const effectiveGatewayUrl = await selectReachableGatewayUrlForSmoke();
-    const cwd = process.env.OPENCLAW_GATEWAY_LOBSTER_CWD?.trim() || defaultGatewayCwdForSmoke();
+    const rawCwd = process.env.OPENCLAW_GATEWAY_LOBSTER_CWD?.trim() || defaultGatewayCwdForSmoke();
+    const normalizedCwd = rawCwd.replace(/[\\/]+$/g, '');
     const baseReport: Omit<DiagnosticReport, 'ok'> = {
       marker,
       reportPath,
@@ -242,14 +243,15 @@ test('live OpenClaw gateway exposes the lobster tool and writes the diagnostic o
       effectiveGatewayHost: hostForUrl(effectiveGatewayUrl ?? undefined),
       requested: {
         tool: 'lobster',
-        cwd,
+        cwd: rawCwd,
         workflow: DIAGNOSTIC_WORKFLOW,
         outputLocation,
       },
     };
 
     assert.ok(
-      !path.isAbsolute(cwd) && (cwd === REPO_ROOT_GATEWAY_CWD || cwd.endsWith(`/${REPO_ROOT_GATEWAY_CWD}`)),
+      !path.isAbsolute(normalizedCwd) &&
+        (normalizedCwd === REPO_ROOT_GATEWAY_CWD || normalizedCwd.endsWith(`/${REPO_ROOT_GATEWAY_CWD}`)),
       `OpenClaw Lobster gateway cwd must be a repo-relative path ending in '${REPO_ROOT_GATEWAY_CWD}' ` +
         `so Aries workflows and diagnostic output resolve correctly. Set OPENCLAW_GATEWAY_LOBSTER_CWD to ` +
         `'${REPO_ROOT_GATEWAY_CWD}' when OpenClaw starts from the repo root, or '${HOST_HOME_GATEWAY_CWD}' ` +
@@ -265,7 +267,7 @@ test('live OpenClaw gateway exposes the lobster tool and writes the diagnostic o
           marker,
           output_location: outputLocation,
         }),
-        cwd,
+        cwd: rawCwd,
         timeoutMs: 15_000,
         maxStdoutBytes: 256 * 1024,
         allowLocalFallback: false,


### PR DESCRIPTION
## Summary
- add a live OpenClaw Lobster availability smoke test that invokes the `lobster` tool with local fallback disabled
- write a deterministic diagnostic workflow/report under `.artifacts/openclaw-lobster-availability/` so failures include the requested cwd and output location
- wire the smoke into `npm run verify` and document/use the host-service cwd default `aries-app/lobster`
- updated the running local Aries container env so `OPENCLAW_GATEWAY_LOBSTER_CWD=aries-app/lobster`

## Validation
- `npm run validate:openclaw-lobster`
- `npx tsx --test tests/marketing-flow-smoke.test.ts`
- `python3 -m py_compile lobster/bin/openclaw-lobster-availability-smoke.py`
- `npm run typecheck`
- `npm run verify`
- `npm run workspace:verify`
- `npm run validate:repo-boundary`
- `npm run validate:banned-patterns`

## Notes
The live smoke first failed here because `.env` pointed Docker at `host.docker.internal:3456` while the OpenClaw gateway service starts from `/home/node`; the gateway-facing Lobster cwd therefore needs `aries-app/lobster`, not `lobster`.