### PR TITLE
ci: deploy exact SHA after agent merges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,11 @@
 name: Deploy
 
 # Operational contract (documented in DOCKER.md and docs/SYSTEM-REFERENCE.md):
-# - Pushes to master trigger this workflow and deploy the :latest GHCR image.
-# - The publish script (scripts/release/publish-image.sh) tags every build as :latest,
-#   :<commit-sha>, and :<branch>. The deploy workflow pulls :latest on push events.
-# - Manual workflow_dispatch deploys still accept an explicit image_tag (SHA or other tag).
+# - Pushes to master build/publish and deploy the exact merge commit SHA.
+# - Agent automerge uses GITHUB_TOKEN, so its merge push does not trigger push workflows;
+#   pr-agent-autofix-automerge dispatches this workflow manually with image_tag/git_ref
+#   pinned to the merge SHA.
+# - Manual workflow_dispatch deploys accept an explicit image_tag (SHA or other tag).
 # - If package linkage/permissions are not ready for GITHUB_TOKEN, set GHCR_WORKFLOW_TOKEN.
 
 on:
@@ -28,7 +29,7 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -78,7 +79,7 @@ jobs:
           owner_lc="${GITHUB_REPOSITORY_OWNER,,}"
 
           if [[ "${EVENT_NAME}" == "push" ]]; then
-            image_tag="latest"
+            image_tag="${CURRENT_SHA}"
             checkout_ref="${CURRENT_SHA}"
           else
             image_tag="${INPUT_IMAGE_TAG}"
@@ -107,6 +108,35 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_WORKFLOW_TOKEN || github.token }}
+
+      - name: Checkout deploy source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.resolve.outputs.checkout_ref }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Publish exact deploy image
+        env:
+          TARGET_IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
+          GHCR_OWNER: ${{ github.repository_owner }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${TARGET_IMAGE_TAG}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Skipping image publish for non-SHA tag ${TARGET_IMAGE_TAG}; assuming it already exists."
+            exit 0
+          fi
+
+          checkout_sha="$(git rev-parse HEAD)"
+          if [[ "${checkout_sha}" != "${TARGET_IMAGE_TAG}" ]]; then
+            echo "ERROR: Ref checkout ${checkout_sha} does not match target image tag ${TARGET_IMAGE_TAG}." >&2
+            exit 1
+          fi
+
+          ./scripts/release/publish-image.sh
 
       - name: Deploy on host
         env:
@@ -183,7 +213,19 @@ jobs:
 
           cd "${repo_path}"
           ARIES_APP_IMAGE="${TARGET_IMAGE}" docker compose pull "${SERVICE_NAME}"
-          ARIES_APP_IMAGE="${TARGET_IMAGE}" docker compose up -d --no-deps "${SERVICE_NAME}"
+          ARIES_APP_IMAGE="${TARGET_IMAGE}" docker compose up -d --no-deps --force-recreate --pull always "${SERVICE_NAME}"
+
+          container_id="$(ARIES_APP_IMAGE="${TARGET_IMAGE}" docker compose ps -q "${SERVICE_NAME}")"
+          if [[ -z "${container_id}" ]]; then
+            echo "ERROR: Compose did not return a running container id for ${SERVICE_NAME}." >&2
+            exit 1
+          fi
+          target_image_id="$(docker image inspect -f '{{.Id}}' "${TARGET_IMAGE}")"
+          container_image_id="$(docker inspect -f '{{.Image}}' "${container_id}")"
+          if [[ "${container_image_id}" != "${target_image_id}" ]]; then
+            echo "ERROR: Running container image ${container_image_id} does not match target ${target_image_id}." >&2
+            exit 1
+          fi
 
           healthy=0
           for attempt in $(seq 1 30); do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,8 +121,8 @@ jobs:
       - name: Publish exact deploy image
         env:
           TARGET_IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
-          GHCR_OWNER: ${{ github.repository_owner }}
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if [[ ! "${TARGET_IMAGE_TAG}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -136,7 +136,18 @@ jobs:
             exit 1
           fi
 
-          ./scripts/release/publish-image.sh
+          default_branch="${DEFAULT_BRANCH_NAME:-master}"
+          git fetch --no-tags origin "${default_branch}"
+          default_branch_sha="$(git rev-parse "origin/${default_branch}")"
+          publish_sha_only=0
+          if [[ "${TARGET_IMAGE_TAG}" != "${default_branch_sha}" ]]; then
+            publish_sha_only=1
+            echo "Publishing only ${TARGET_IMAGE_TAG}; not moving mutable aliases because origin/${default_branch} is ${default_branch_sha}."
+          else
+            echo "Publishing ${TARGET_IMAGE_TAG} plus ${default_branch}/latest aliases because it is the current default branch head."
+          fi
+
+          PUBLISH_SHA_ONLY="${publish_sha_only}" ./scripts/release/publish-image.sh
 
       - name: Deploy on host
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,11 +138,11 @@ jobs:
 
           default_branch="${DEFAULT_BRANCH_NAME:-master}"
           git fetch --no-tags origin "${default_branch}"
-          default_branch_sha="$(git rev-parse "origin/${default_branch}")"
+          default_head="$(git rev-parse "origin/${default_branch}")"
           publish_sha_only=0
-          if [[ "${TARGET_IMAGE_TAG}" != "${default_branch_sha}" ]]; then
+          if [[ "${TARGET_IMAGE_TAG}" != "${default_head}" ]]; then
             publish_sha_only=1
-            echo "Publishing only ${TARGET_IMAGE_TAG}; not moving mutable aliases because origin/${default_branch} is ${default_branch_sha}."
+            echo "Publishing only ${TARGET_IMAGE_TAG}; not moving mutable aliases because origin/${default_branch} is ${default_head}."
           else
             echo "Publishing ${TARGET_IMAGE_TAG} plus ${default_branch}/latest aliases because it is the current default branch head."
           fi

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -23,7 +23,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  actions: read
+  actions: write
   checks: read
   # anthropics/claude-code-action requests a GitHub OIDC token before agent mode.
   id-token: write
@@ -249,4 +249,24 @@ jobs:
             fi
           fi
 
-          gh pr comment "$PR_NUMBER" --body "Autonomous maintenance completed for ${pr_url}. ${merge_summary} Validations run: npm run workspace:verify, npm run validate:repo-boundary, npm run validate:banned-patterns, npm run verify."
+          merge_sha=""
+          for attempt in $(seq 1 60); do
+            gh pr view "$PR_NUMBER" --json state,mergeCommit,url > /tmp/pr-after-merge.json
+            state="$(jq -r '.state' /tmp/pr-after-merge.json)"
+            merge_sha="$(jq -r '.mergeCommit.oid // ""' /tmp/pr-after-merge.json)"
+            if [[ "${state}" == "MERGED" && -n "${merge_sha}" ]]; then
+              break
+            fi
+            echo "Waiting for PR #${PR_NUMBER} to merge before dispatching Deploy (${attempt}/60). Current state: ${state}."
+            sleep 30
+          done
+
+          if [[ -z "${merge_sha}" ]]; then
+            gh pr edit "$PR_NUMBER" --add-label agent:needs-attention || true
+            gh pr comment "$PR_NUMBER" --body "Autonomous maintenance validated this PR and requested merge, but the PR did not reach MERGED within 30 minutes. Deploy was not dispatched; added agent:needs-attention."
+            exit 1
+          fi
+
+          gh workflow run Deploy --ref master -f image_tag="${merge_sha}" -f git_ref="${merge_sha}"
+
+          gh pr comment "$PR_NUMBER" --body "Autonomous maintenance completed for ${pr_url}. ${merge_summary} Validations run: npm run workspace:verify, npm run validate:repo-boundary, npm run validate:banned-patterns, npm run verify. Dispatched Deploy for merge SHA ${merge_sha}."

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -74,7 +74,7 @@ jobs:
             exit 1
           fi
 
-          gh pr view "$pr_number" --json number,title,body,url,isDraft,headRefName,baseRefName,labels,reviewDecision,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,headRepository,author > /tmp/pr.json
+          gh pr view "$pr_number" --json number,title,body,url,isDraft,headRefName,baseRefName,labels,reviewDecision,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,headRepository,author,files > /tmp/pr.json
 
           is_cross_repo="$(jq -r '.isCrossRepository' /tmp/pr.json)"
           if [ "$is_cross_repo" = "true" ]; then
@@ -91,10 +91,18 @@ jobs:
             exit 0
           fi
 
+          claude_allowed="true"
+          edits_agent_workflow="$(jq -r '[.files[].path] | any(. == ".github/workflows/pr-agent-autofix-automerge.yml")' /tmp/pr.json)"
+          if [[ "${edits_agent_workflow}" == "true" ]]; then
+            claude_allowed="false"
+            echo "PR #${pr_number} edits pr-agent-autofix-automerge.yml; skipping Claude action because modified Claude workflows cannot exchange app tokens until merged to default branch."
+          fi
+
           {
             echo "number=$pr_number"
             echo "head_ref=$head_ref"
             echo "should_run=true"
+            echo "claude_allowed=$claude_allowed"
             echo "url=$(jq -r '.url' /tmp/pr.json)"
           } >> "$GITHUB_OUTPUT"
 
@@ -146,7 +154,7 @@ jobs:
         run: npm ci
 
       - name: Claude PR autofix
-        if: steps.pr.outputs.should_run == 'true'
+        if: steps.pr.outputs.should_run == 'true' && steps.pr.outputs.claude_allowed == 'true'
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ github.token }}

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -14,8 +14,15 @@
 
 ## Production release
 
-For `aries-app`, deploy by publishing the image for the exact commit SHA first, then pushing that same commit to `master`.
-The GitHub Actions deploy workflow expects `ghcr.io/delicioushouse/aries-app:<sha>` to exist before the self-hosted deploy host pulls it locally.
+For `aries-app`, deploy by merging or pushing to `master`. The GitHub Actions Deploy workflow builds and publishes `ghcr.io/delicioushouse/aries-app:<sha>` for the exact target commit, then the self-hosted deploy host pulls that pinned image and force-recreates the `aries-app` service.
+
+Manual deploys still use workflow dispatch with an explicit image tag. Use the full commit SHA for normal production recovery so the workflow can build and verify the exact image before restart:
+
+```bash
+gh workflow run Deploy --ref master \
+  -f image_tag=<full-commit-sha> \
+  -f git_ref=<full-commit-sha>
+```
 
 ## Build
 ```bash

--- a/PRODUCTION_HANDOFF.md
+++ b/PRODUCTION_HANDOFF.md
@@ -4,9 +4,9 @@ This document is the concise production runbook for `aries-app`.
 
 ## Release flow
 
-1. Publish the container image for the exact commit SHA to GHCR.
-2. Push that same commit to `master`.
-3. Let the GitHub Actions deploy workflow running on the self-hosted deploy host pull the verified image and restart the `aries-app` service.
+1. Merge or push the target commit to `master`, or manually dispatch Deploy with `image_tag` and `git_ref` set to the full commit SHA.
+2. Let the GitHub Actions Deploy workflow build/publish `ghcr.io/delicioushouse/aries-app:<sha>` for that exact commit.
+3. Let the self-hosted deploy host pull the pinned image and force-recreate the `aries-app` service.
 
 ## Deployment checklist
 
@@ -23,7 +23,7 @@ This document is the concise production runbook for `aries-app`.
 ### Application
 - [ ] Run `npm ci`.
 - [ ] Run `npm run build`.
-- [ ] Confirm the image for the target SHA is available in GHCR.
+- [ ] Confirm the Deploy workflow published and pulled the target SHA image.
 
 ### Validation
 - [ ] Verify core public routes respond.

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ The repo includes `docker-compose.yml`, `docker-compose.local.yml`, and a produc
 
 ### Production release
 
-Production deploy is triggered by pushing to `master`, but **only after** the GHCR image for that **exact commit SHA** is already published. The GitHub Actions Deploy workflow runs on the self-hosted deploy host, logs the local Docker daemon into GHCR, and then pulls `ghcr.io/<owner>/aries-app:<sha>`/`:latest` there; pushing `master` first without the image fails by design.
+Production deploy is handled by the GitHub Actions Deploy workflow on the self-hosted deploy host. On `master` pushes, and on agent automerge recovery dispatches, it builds and publishes `ghcr.io/<owner>/aries-app:<sha>` for the exact target commit, pulls that pinned image, and force-recreates the live `aries-app` container so new code and env take effect.
 
-Step-by-step commands and environment variables: see **`DOCKER.md`** → *Production release (GHCR image before `master`)*. A short operational summary also lives in **`docs/SYSTEM-REFERENCE.md`** → *Production release (operational)*.
+Step-by-step commands and environment variables: see **`DOCKER.md`** → *Production release*. A short operational summary also lives in **`docs/SYSTEM-REFERENCE.md`** → *Production release (operational)*.
 
 ### Production-style local container run
 

--- a/docs/automations/README.md
+++ b/docs/automations/README.md
@@ -2,7 +2,7 @@
 
 This workspace now includes runtime-error intake/repair automation alongside the other repo automations plus a ready-to-apply OpenClaw cron installer. The jobs are designed to run as **isolated cron agent turns** so each execution stays separate from the main conversation.
 
-**Production release** (GHCR image publish, then `master` push, GitHub Actions self-hosted deploy on the host) is **not** part of this cron runbook. See repository **`DOCKER.md`** (*Production release*) and **`docs/SYSTEM-REFERENCE.md`** (*Production release (operational)*).
+**Production release** (GitHub Actions Deploy builds/publishes the exact SHA image, then the self-hosted deploy host pulls it and force-recreates `aries-app`) is **not** part of this cron runbook. See repository **`DOCKER.md`** (*Production release*) and **`docs/SYSTEM-REFERENCE.md`** (*Production release (operational)*).
 
 ## Files added
 

--- a/scripts/release/publish-image.sh
+++ b/scripts/release/publish-image.sh
@@ -56,19 +56,37 @@ fi
 
 GIT_SHA="$(git rev-parse HEAD)"
 PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+PUBLISH_SHA_ONLY="${PUBLISH_SHA_ONLY:-0}"
+if [[ "${PUBLISH_SHA_ONLY}" != "0" && "${PUBLISH_SHA_ONLY}" != "1" ]]; then
+  echo "ERROR: PUBLISH_SHA_ONLY must be 0 or 1, got '${PUBLISH_SHA_ONLY}'." >&2
+  exit 1
+fi
 
-docker buildx build \
-  --platform "${PLATFORMS}" \
-  --push \
-  --label "org.opencontainers.image.source=https://github.com/DeliciousHouse/aries-app" \
-  --label "org.opencontainers.image.revision=${GIT_SHA}" \
-  --annotation "index:org.opencontainers.image.description=${IMAGE_DESCRIPTION}" \
-  -t "${GHCR_IMAGE}:${GIT_SHA}" \
-  -t "${GHCR_IMAGE}:${DEFAULT_BRANCH}" \
-  -t "${GHCR_IMAGE}:latest" \
-  -f Dockerfile \
+build_args=(
+  --platform "${PLATFORMS}"
+  --push
+  --label "org.opencontainers.image.source=https://github.com/DeliciousHouse/aries-app"
+  --label "org.opencontainers.image.revision=${GIT_SHA}"
+  --annotation "index:org.opencontainers.image.description=${IMAGE_DESCRIPTION}"
+  -t "${GHCR_IMAGE}:${GIT_SHA}"
+)
+
+if [[ "${PUBLISH_SHA_ONLY}" != "1" ]]; then
+  build_args+=(
+    -t "${GHCR_IMAGE}:${DEFAULT_BRANCH}"
+    -t "${GHCR_IMAGE}:latest"
+  )
+fi
+
+build_args+=(
+  -f Dockerfile
   .
+)
+
+docker buildx build "${build_args[@]}"
 
 echo "Published ${GHCR_IMAGE}:${GIT_SHA}"
-echo "Published ${GHCR_IMAGE}:${DEFAULT_BRANCH}"
-echo "Published ${GHCR_IMAGE}:latest"
+if [[ "${PUBLISH_SHA_ONLY}" != "1" ]]; then
+  echo "Published ${GHCR_IMAGE}:${DEFAULT_BRANCH}"
+  echo "Published ${GHCR_IMAGE}:latest"
+fi

--- a/tests/deploy-workflow-self-hosted.regression-015.test.ts
+++ b/tests/deploy-workflow-self-hosted.regression-015.test.ts
@@ -87,6 +87,24 @@ test('agent automerge dispatches an exact-SHA deploy after the PR is actually me
   );
 });
 
+test('agent automerge skips Claude action when the PR edits the agent workflow itself', () => {
+  assert.match(
+    prAgentWorkflow,
+    /claude_allowed=/,
+    'PR agent should expose a claude_allowed output from the guardrail step',
+  );
+  assert.match(
+    prAgentWorkflow,
+    /\.github\/workflows\/pr-agent-autofix-automerge\.yml/,
+    'PR agent should detect edits to its own workflow file',
+  );
+  assert.match(
+    prAgentWorkflow,
+    /Claude PR autofix[\s\S]*?if: steps\.pr\.outputs\.should_run == 'true' && steps\.pr\.outputs\.claude_allowed == 'true'/,
+    'Claude action should be skipped for self-modifying workflow PRs to avoid default-branch validation failures',
+  );
+});
+
 test('deploy workflow builds and force-recreates the exact commit image', () => {
   assert.match(
     workflow,

--- a/tests/deploy-workflow-self-hosted.regression-015.test.ts
+++ b/tests/deploy-workflow-self-hosted.regression-015.test.ts
@@ -12,6 +12,11 @@ const workflow = readFileSync(
   'utf8',
 );
 
+const prAgentWorkflow = readFileSync(
+  path.join(PROJECT_ROOT, '.github', 'workflows', 'pr-agent-autofix-automerge.yml'),
+  'utf8',
+);
+
 // Regression: deploy workflow must run on the deploy host itself instead of SSHing into a remote VM.
 test('deploy workflow uses a self-hosted runner on the deploy host with no SSH hop', () => {
   assert.match(
@@ -58,5 +63,54 @@ test('deploy workflow uses a self-hosted runner on the deploy host with no SSH h
     workflow,
     /DEPLOY_SSH_PRIVATE_KEY|DEPLOY_HOST|DEPLOY_USER/,
     'deploy workflow should not require remote-host SSH secrets after the self-hosted migration',
+  );
+});
+
+// Regression: PR merges made by GITHUB_TOKEN do not emit normal push-triggered workflows.
+// The agent merge workflow must explicitly dispatch Deploy with the merge SHA, and Deploy
+// must build/pull that exact SHA instead of recycling :latest.
+test('agent automerge dispatches an exact-SHA deploy after the PR is actually merged', () => {
+  assert.match(
+    prAgentWorkflow,
+    /actions:\s*write/,
+    'PR agent needs actions: write so it can dispatch the Deploy workflow after GITHUB_TOKEN merges',
+  );
+  assert.match(
+    prAgentWorkflow,
+    /mergeCommit[\s\S]*?\.mergeCommit\.oid/,
+    'PR agent should read the actual merge commit SHA after GitHub finishes merging',
+  );
+  assert.match(
+    prAgentWorkflow,
+    /gh workflow run Deploy[\s\S]*?-f image_tag="\$\{merge_sha\}"[\s\S]*?-f git_ref="\$\{merge_sha\}"/,
+    'PR agent should dispatch Deploy pinned to the exact merge SHA',
+  );
+});
+
+test('deploy workflow builds and force-recreates the exact commit image', () => {
+  assert.match(
+    workflow,
+    /if \[\[ "\$\{EVENT_NAME\}" == "push" \]\]; then\s*image_tag="\$\{CURRENT_SHA\}"/,
+    'push deploys should target the current commit SHA, not mutable :latest',
+  );
+  assert.match(
+    workflow,
+    /- name: Publish exact deploy image[\s\S]*?\.\/scripts\/release\/publish-image\.sh/,
+    'deploy workflow should publish the exact target image before trying to pull it on the host',
+  );
+  assert.match(
+    workflow,
+    /ARIES_APP_IMAGE="\$\{TARGET_IMAGE\}" docker compose pull "\$\{SERVICE_NAME\}"/,
+    'deploy workflow should pull the pinned target image before recreate',
+  );
+  assert.match(
+    workflow,
+    /docker compose up -d --no-deps --force-recreate --pull always "\$\{SERVICE_NAME\}"/,
+    'deploy workflow should force-recreate the live app so new image and env take effect',
+  );
+  assert.doesNotMatch(
+    workflow,
+    /image_tag="latest"/,
+    'deploy workflow should not deploy mutable :latest for push events',
   );
 });

--- a/tests/deploy-workflow-self-hosted.regression-015.test.ts
+++ b/tests/deploy-workflow-self-hosted.regression-015.test.ts
@@ -17,6 +17,11 @@ const prAgentWorkflow = readFileSync(
   'utf8',
 );
 
+const publishImageScript = readFileSync(
+  path.join(PROJECT_ROOT, 'scripts', 'release', 'publish-image.sh'),
+  'utf8',
+);
+
 // Regression: deploy workflow must run on the deploy host itself instead of SSHing into a remote VM.
 test('deploy workflow uses a self-hosted runner on the deploy host with no SSH hop', () => {
   assert.match(
@@ -63,6 +68,19 @@ test('deploy workflow uses a self-hosted runner on the deploy host with no SSH h
     workflow,
     /DEPLOY_SSH_PRIVATE_KEY|DEPLOY_HOST|DEPLOY_USER/,
     'deploy workflow should not require remote-host SSH secrets after the self-hosted migration',
+  );
+});
+
+test('publish image script supports SHA-only deploy publishing', () => {
+  assert.match(
+    publishImageScript,
+    /PUBLISH_SHA_ONLY="\$\{PUBLISH_SHA_ONLY:-0\}"/,
+    'publish script should expose a SHA-only mode for rollback-safe deploy publishes',
+  );
+  assert.match(
+    publishImageScript,
+    /if \[\[ "\$\{PUBLISH_SHA_ONLY\}" != "1" \]\]; then[\s\S]*?-t "\$\{GHCR_IMAGE\}:\$\{DEFAULT_BRANCH\}"[\s\S]*?-t "\$\{GHCR_IMAGE\}:latest"[\s\S]*?fi/,
+    'mutable branch/latest tags should only be pushed outside SHA-only mode',
   );
 });
 
@@ -113,8 +131,18 @@ test('deploy workflow builds and force-recreates the exact commit image', () => 
   );
   assert.match(
     workflow,
-    /- name: Publish exact deploy image[\s\S]*?\.\/scripts\/release\/publish-image\.sh/,
-    'deploy workflow should publish the exact target image before trying to pull it on the host',
+    /- name: Publish exact deploy image[\s\S]*?git fetch --no-tags origin "\$\{default_branch\}"[\s\S]*?publish_sha_only=1[\s\S]*?PUBLISH_SHA_ONLY="\$\{publish_sha_only\}" \.\/scripts\/release\/publish-image\.sh/,
+    'manual rollback deploys should publish only the requested SHA instead of retagging default-branch aliases',
+  );
+  assert.match(
+    workflow,
+    /Publishing \$\{TARGET_IMAGE_TAG\} plus \$\{default_branch\}\/latest aliases because it is the current default branch head\./,
+    'push deploys and current default-branch deploys should still update default-branch/latest aliases',
+  );
+  assert.match(
+    publishImageScript,
+    /if \[\[ "\$\{PUBLISH_SHA_ONLY\}" != "1" \]\]; then[\s\S]*?-t "\$\{GHCR_IMAGE\}:\$\{DEFAULT_BRANCH\}"[\s\S]*?-t "\$\{GHCR_IMAGE\}:latest"/,
+    'publish-image should omit mutable branch/latest tags when PUBLISH_SHA_ONLY=1',
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
- Fixes the CI/CD gap where agent merges made with `GITHUB_TOKEN` can skip normal push-triggered deploys.
- Makes Deploy build/publish `ghcr.io/<owner>/aries-app:<merge-sha>` itself and deploy that exact pinned image instead of mutable `:latest`.
- Forces Compose to recreate the live `aries-app` container and verifies the running container image id matches the target image.
- Updates deployment docs/runbooks to match the new exact-SHA deploy contract.

## Root cause
`pr-agent-autofix-automerge` merges with GitHub automation. GitHub suppresses most follow-on workflow runs created by `GITHUB_TOKEN`, so a merge can land without a push-triggered Deploy run. When a Deploy did run, push deploys targeted mutable `:latest` and `docker compose up -d --no-deps` did not explicitly force a container recreate.

## Test plan
- [x] Added regression coverage for exact-SHA deploy dispatch and force recreate.
- [x] `python3` YAML parse for Deploy and PR agent workflows.
- [x] `npx tsx --test tests/deploy-workflow-self-hosted.regression-015.test.ts`
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`
- [x] `npm run workspace:verify`
- [x] `npm run typecheck`
- [x] `npm run verify`
