### PR TITLE
ci: install Node before deploy image publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up Node.js for release metadata
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
       - name: Publish exact deploy image
         env:
           TARGET_IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}

--- a/tests/deploy-workflow-self-hosted.regression-015.test.ts
+++ b/tests/deploy-workflow-self-hosted.regression-015.test.ts
@@ -136,6 +136,11 @@ test('deploy workflow builds and force-recreates the exact commit image', () => 
   );
   assert.match(
     workflow,
+    /actions\/setup-node@v4[\s\S]*?node-version-file: package\.json[\s\S]*?- name: Publish exact deploy image/,
+    'self-hosted deploy runner should install Node before publish-image reads package metadata',
+  );
+  assert.match(
+    workflow,
     /Publishing \$\{TARGET_IMAGE_TAG\} plus \$\{default_branch\}\/latest aliases because it is the current default branch head\./,
     'push deploys and current default-branch deploys should still update default-branch/latest aliases',
   );


### PR DESCRIPTION
## Summary
- installs Node on the self-hosted Deploy runner before `publish-image.sh` runs
- adds a regression assertion so exact-SHA deploy publishing keeps Node available for package metadata

## Recovery context
- PR #223 merged at `13b37ce841cd80a8630951acca4487dbbb5d7944`
- the push-triggered Deploy run failed in `Publish exact deploy image` with `./scripts/release/publish-image.sh: line 39: node: command not found`
- after this fix lands, dispatch Deploy for `13b37ce841cd80a8630951acca4487dbbb5d7944` with both `image_tag` and `git_ref` pinned to that SHA

## Test Plan
- [x] YAML parse for `.github/workflows/deploy.yml`
- [x] `npx tsx --test tests/deploy-workflow-self-hosted.regression-015.test.ts`
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`
- [x] `npm run verify`
- [ ] `npm run workspace:verify` (not runnable in temp worktree: canonical-root guard expects `/home/node/aries-app`)
