### PR TITLE
fix(ci): remove Node dependency from deploy image publish

### DIFF
--- a/scripts/release/publish-image.sh
+++ b/scripts/release/publish-image.sh
@@ -36,10 +36,22 @@ fi
 # GHCR requires lowercase registry paths; normalize so GitHub org casing does not break pushes.
 GHCR_IMAGE="${GHCR_IMAGE,,}"
 
-IMAGE_DESCRIPTION="${IMAGE_DESCRIPTION:-$(node -p "const pkg = require('./package.json'); pkg.description || ''")}"
+if [[ -z "${IMAGE_DESCRIPTION:-}" ]]; then
+  IMAGE_DESCRIPTION="$(python3 - <<'PY'
+import json
+from pathlib import Path
+
+try:
+    package = json.loads(Path('package.json').read_text())
+except Exception:
+    print('')
+else:
+    print(package.get('description') or '')
+PY
+)"
+fi
 if [[ -z "${IMAGE_DESCRIPTION}" ]]; then
-  echo "ERROR: IMAGE_DESCRIPTION is required." >&2
-  exit 1
+  IMAGE_DESCRIPTION="Aries marketing automation runtime"
 fi
 
 if [[ -n "${GHCR_TOKEN:-}" ]]; then

--- a/tests/deploy-workflow-self-hosted.regression-015.test.ts
+++ b/tests/deploy-workflow-self-hosted.regression-015.test.ts
@@ -72,6 +72,16 @@ test('deploy workflow uses a self-hosted runner on the deploy host with no SSH h
 });
 
 test('publish image script supports SHA-only deploy publishing', () => {
+  assert.doesNotMatch(
+    publishImageScript,
+    /\bnode\s+-p\b/,
+    'publish script should not depend on host Node being on PATH before publishing',
+  );
+  assert.match(
+    publishImageScript,
+    /python3[\s\S]*?package\.json[\s\S]*?Aries marketing automation runtime/,
+    'publish script should read package metadata without Node and fall back to a stable image description',
+  );
   assert.match(
     publishImageScript,
     /PUBLISH_SHA_ONLY="\$\{PUBLISH_SHA_ONLY:-0\}"/,


### PR DESCRIPTION
## Summary
- Removes the runtime Node dependency from scripts/release/publish-image.sh by reading package metadata with Python and falling back to a static description.
- Keeps the exact-SHA deploy/publish path usable on the self-hosted deploy runner where the failed Deploy run did not have node on PATH.

## Context
- Follow-up to PR #223; the push Deploy for merge SHA 13b37ce841cd80a8630951acca4487dbbb5d7944 failed in Publish exact deploy image with: `./scripts/release/publish-image.sh: line 39: node: command not found`.

## Test Plan
- [x] npx tsx --test tests/deploy-workflow-self-hosted.regression-015.test.ts
- [x] bash -n scripts/release/publish-image.sh
- [x] python3 YAML parse for .github/workflows/deploy.yml
- [x] npm run validate:repo-boundary
- [x] npm run validate:banned-patterns
- [x] npm run workspace:verify
- [x] git diff --check