### PR TITLE
fix(ci): remove Node dependency from image publisher

### DIFF
--- a/scripts/release/publish-image.sh
+++ b/scripts/release/publish-image.sh
@@ -36,10 +36,22 @@ fi
 # GHCR requires lowercase registry paths; normalize so GitHub org casing does not break pushes.
 GHCR_IMAGE="${GHCR_IMAGE,,}"
 
-IMAGE_DESCRIPTION="${IMAGE_DESCRIPTION:-$(node -p "const pkg = require('./package.json'); pkg.description || ''")}"
+if [[ -z "${IMAGE_DESCRIPTION:-}" ]]; then
+  IMAGE_DESCRIPTION="$(python3 - <<'PYDESC'
+import json
+from pathlib import Path
+
+try:
+    package = json.loads(Path('package.json').read_text())
+except Exception:
+    print('')
+else:
+    print(package.get('description') or '')
+PYDESC
+)"
+fi
 if [[ -z "${IMAGE_DESCRIPTION}" ]]; then
-  echo "ERROR: IMAGE_DESCRIPTION is required." >&2
-  exit 1
+  IMAGE_DESCRIPTION="Aries marketing automation runtime"
 fi
 
 if [[ -n "${GHCR_TOKEN:-}" ]]; then


### PR DESCRIPTION
## Summary
- Removes the deploy-time Node.js dependency from scripts/release/publish-image.sh
- Reads package metadata with python3, which is already available on the self-hosted deploy runner
- Falls back to the standard Aries image description if metadata cannot be read

## Test Plan
- node -e no-node smoke for publish-image.sh
- bash -n scripts/release/publish-image.sh
- npm run validate:repo-boundary
- npm run validate:banned-patterns

Recovery for failed Deploy run https://github.com/DeliciousHouse/aries-app/actions/runs/25147264464 from PR #223.