### PR TITLE
fix(ci): make deploy image metadata fallback host-agnostic

### DIFF
--- a/scripts/release/publish-image.sh
+++ b/scripts/release/publish-image.sh
@@ -36,7 +36,7 @@ fi
 # GHCR requires lowercase registry paths; normalize so GitHub org casing does not break pushes.
 GHCR_IMAGE="${GHCR_IMAGE,,}"
 
-if [[ -z "${IMAGE_DESCRIPTION:-}" ]]; then
+if [[ -z "${IMAGE_DESCRIPTION:-}" ]] && command -v python3 >/dev/null 2>&1; then
   IMAGE_DESCRIPTION="$(python3 - <<'PY'
 import json
 from pathlib import Path
@@ -50,7 +50,7 @@ else:
 PY
 )"
 fi
-if [[ -z "${IMAGE_DESCRIPTION}" ]]; then
+if [[ -z "${IMAGE_DESCRIPTION:-}" ]]; then
   IMAGE_DESCRIPTION="Aries marketing automation runtime"
 fi
 

--- a/tests/deploy-workflow-self-hosted.regression-015.test.ts
+++ b/tests/deploy-workflow-self-hosted.regression-015.test.ts
@@ -79,7 +79,7 @@ test('publish image script supports SHA-only deploy publishing', () => {
   );
   assert.match(
     publishImageScript,
-    /python3[\s\S]*?package\.json[\s\S]*?Aries marketing automation runtime/,
+    /command -v python3[\s\S]*?package\.json[\s\S]*?Aries marketing automation runtime/,
     'publish script should read package metadata without Node and fall back to a stable image description',
   );
   assert.match(


### PR DESCRIPTION
## Summary
- guards the optional package metadata read with a python3 availability check
- keeps the static image description fallback non-fatal on minimal deploy hosts
- updates the deploy workflow regression to cover the guarded metadata path

## Context
Follow-up to PR #225 / PR #223 deploy recovery. Copilot correctly noted that removing the Node dependency still left the fallback path vulnerable to missing python3 under `set -euo pipefail`.

## Test Plan
- [x] `npx tsx --test tests/deploy-workflow-self-hosted.regression-015.test.ts`
- [x] `bash -n scripts/release/publish-image.sh`
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`
- [x] `npm run verify`
- [x] `npm run workspace:verify`
- [x] `git diff --check`
