### PR TITLE
fix(ux): repair review and onboarding flows

### DIFF
--- a/frontend/aries-v1/campaign-workspace-state.ts
+++ b/frontend/aries-v1/campaign-workspace-state.ts
@@ -200,6 +200,8 @@ function countCompletedCreativeAssets(
   creativeReviewAssets: MarketingCreativeAssetReviewPayload[] | null | undefined,
   _dashboardImageAds: number | null | undefined,
 ): { imageCount: number; videoCount: number } {
+  // Keep the image-ad count in the internal signature for call-site stability,
+  // but readiness now comes from assets that expose actual previews.
   const reviewAssets = creativeReviewAssets || [];
   const readyReviewAssets = reviewAssets.filter(reviewAssetHasPreview);
   const readyDashboardAssets = (dashboardAssets || []).filter(dashboardAssetHasPreview);

--- a/frontend/aries-v1/campaign-workspace-state.ts
+++ b/frontend/aries-v1/campaign-workspace-state.ts
@@ -187,26 +187,33 @@ function isVideoDashboardAsset(asset: MarketingDashboardAsset): boolean {
   return (asset.contentType || '').toLowerCase().startsWith('video/') || videoLike(`${asset.platform} ${asset.title}`);
 }
 
+function dashboardAssetHasPreview(asset: MarketingDashboardAsset): boolean {
+  return Boolean(asset.previewUrl?.trim() || asset.thumbnailUrl?.trim());
+}
+
+function reviewAssetHasPreview(asset: MarketingCreativeAssetReviewPayload): boolean {
+  return Boolean(asset.previewUrl?.trim() || asset.fullPreviewUrl?.trim());
+}
+
 function countCompletedCreativeAssets(
   dashboardAssets: MarketingDashboardAsset[] | null | undefined,
   creativeReviewAssets: MarketingCreativeAssetReviewPayload[] | null | undefined,
-  dashboardImageAds: number | null | undefined,
+  _dashboardImageAds: number | null | undefined,
 ): { imageCount: number; videoCount: number } {
   const reviewAssets = creativeReviewAssets || [];
-  const reviewVideoCount = reviewAssets.filter(
+  const readyReviewAssets = reviewAssets.filter(reviewAssetHasPreview);
+  const readyDashboardAssets = (dashboardAssets || []).filter(dashboardAssetHasPreview);
+  const reviewVideoCount = readyReviewAssets.filter(
     (asset) => (asset.contentType || '').toLowerCase().startsWith('video/') || videoLike(`${asset.platformLabel} ${asset.title}`),
   ).length;
-  const reviewImageCount = reviewAssets.filter(
+  const reviewImageCount = readyReviewAssets.filter(
     (asset) => (asset.contentType || '').toLowerCase().startsWith('image/'),
   ).length;
 
-  const dashboardVideoCount = (dashboardAssets || []).filter((asset) => isVideoDashboardAsset(asset)).length;
-  const dashboardImageCount = Math.max(
-    dashboardImageAds || 0,
-    (dashboardAssets || []).filter(
-      (asset) => asset.type === 'image_ad' && !isVideoDashboardAsset(asset),
-    ).length,
-  );
+  const dashboardVideoCount = readyDashboardAssets.filter((asset) => isVideoDashboardAsset(asset)).length;
+  const dashboardImageCount = readyDashboardAssets.filter(
+    (asset) => asset.type === 'image_ad' && !isVideoDashboardAsset(asset),
+  ).length;
 
   return {
     imageCount: Math.max(reviewImageCount, dashboardImageCount),

--- a/frontend/aries-v1/campaign-workspace.tsx
+++ b/frontend/aries-v1/campaign-workspace.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { ArrowUpRight, CheckCircle2, LoaderCircle, MessageSquareText, XCircle } from 'lucide-react';
@@ -121,7 +121,7 @@ function currentStageHref(campaignId: string, view: WorkspaceView): string {
   return `/dashboard/campaigns/${encodeURIComponent(campaignId)}?view=${view}`;
 }
 
-function normalizeHttpUrlInput(value: string): string {
+function normalizeWebsiteUrlInput(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
     return '';
@@ -585,7 +585,7 @@ function BrandBriefCard(props: {
   const editRegionRef = useRef<HTMLDivElement | null>(null);
   const websiteInputRef = useRef<HTMLInputElement | null>(null);
 
-  const normalizedWebsiteUrl = normalizeHttpUrlInput(websiteUrl);
+  const normalizedWebsiteUrl = normalizeWebsiteUrlInput(websiteUrl);
   const trimmedUrl = normalizedWebsiteUrl.trim();
   const urlIsValid = /^https?:\/\/\S+/i.test(trimmedUrl);
   const urlErrorMessage = !trimmedUrl
@@ -594,7 +594,7 @@ function BrandBriefCard(props: {
     ? 'Enter a full URL starting with http:// or https://'
     : '';
 
-  function resetDraftFromBrief() {
+  const resetDraftFromBrief = useCallback(() => {
     setWebsiteUrl(props.brief.websiteUrl);
     setBrandVoice(props.brief.brandVoice);
     setStyleVibe(props.brief.styleVibe);
@@ -603,7 +603,7 @@ function BrandBriefCard(props: {
     setMustAvoidAesthetics(props.brief.mustAvoidAesthetics);
     setNotes(props.brief.notes);
     setBrandAssets([]);
-  }
+  }, [props.brief]);
 
   function handleCancelEdit() {
     resetDraftFromBrief();
@@ -624,14 +624,14 @@ function BrandBriefCard(props: {
     const node = editRegionRef.current;
     node?.addEventListener('keydown', onKeyDown);
     return () => node?.removeEventListener('keydown', onKeyDown);
-  }, [editing]);
+  }, [editing, resetDraftFromBrief]);
 
   useEffect(() => {
     if (editing) {
       return;
     }
     resetDraftFromBrief();
-  }, [editing, props.brief]);
+  }, [editing, resetDraftFromBrief]);
 
   async function handleSave() {
     if (!urlIsValid) {
@@ -737,7 +737,7 @@ function BrandBriefCard(props: {
               value={websiteUrl}
               onChange={(event) => setWebsiteUrl(event.target.value)}
               onBlur={() => {
-                setWebsiteUrl(normalizeHttpUrlInput(websiteUrl));
+                setWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl));
                 setUrlTouched(true);
               }}
               className="mt-3 w-full rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-sm text-white placeholder:text-white/30"

--- a/frontend/aries-v1/campaign-workspace.tsx
+++ b/frontend/aries-v1/campaign-workspace.tsx
@@ -121,6 +121,17 @@ function currentStageHref(campaignId: string, view: WorkspaceView): string {
   return `/dashboard/campaigns/${encodeURIComponent(campaignId)}?view=${view}`;
 }
 
+function normalizeHttpUrlInput(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return `https://${trimmed}`;
+}
+
 const PLATFORM_VIDEO_LABELS: Record<string, string> = {
   tiktok: 'TikTok',
   youtube: 'YouTube',
@@ -395,12 +406,14 @@ export default function AriesCampaignWorkspace(props: { campaignId: string; init
             key={view}
             href={currentStageHref(props.campaignId, view)}
             scroll={false}
-            className={`rounded-full border px-4 py-2.5 text-sm font-medium transition ${
+            aria-current={activeView === view ? 'step' : undefined}
+            className={`rounded-full border px-4 py-2.5 text-sm transition ${
               activeView === view
-                ? 'border-white/20 bg-white/[0.08] text-white'
-                : 'border-white/8 bg-white/[0.03] text-white/55 hover:border-white/15 hover:text-white'
+                ? 'border-white/20 bg-white/[0.08] text-white font-bold shadow-[0_0_0_1px_rgba(255,255,255,0.08)]'
+                : 'border-white/8 bg-white/[0.03] text-white/55 font-medium hover:border-white/15 hover:text-white'
             }`}
           >
+            {activeView === view ? <span className="mr-2 text-[#d6b8ff]">Current:</span> : null}
             {label}
           </Link>
         ))}
@@ -572,7 +585,8 @@ function BrandBriefCard(props: {
   const editRegionRef = useRef<HTMLDivElement | null>(null);
   const websiteInputRef = useRef<HTMLInputElement | null>(null);
 
-  const trimmedUrl = websiteUrl.trim();
+  const normalizedWebsiteUrl = normalizeHttpUrlInput(websiteUrl);
+  const trimmedUrl = normalizedWebsiteUrl.trim();
   const urlIsValid = /^https?:\/\/\S+/i.test(trimmedUrl);
   const urlErrorMessage = !trimmedUrl
     ? 'Website URL is required.'
@@ -580,7 +594,19 @@ function BrandBriefCard(props: {
     ? 'Enter a full URL starting with http:// or https://'
     : '';
 
+  function resetDraftFromBrief() {
+    setWebsiteUrl(props.brief.websiteUrl);
+    setBrandVoice(props.brief.brandVoice);
+    setStyleVibe(props.brief.styleVibe);
+    setVisualReferences(props.brief.visualReferences.join('\n'));
+    setMustUseCopy(props.brief.mustUseCopy);
+    setMustAvoidAesthetics(props.brief.mustAvoidAesthetics);
+    setNotes(props.brief.notes);
+    setBrandAssets([]);
+  }
+
   function handleCancelEdit() {
+    resetDraftFromBrief();
     setEditing(false);
     setUrlTouched(false);
   }
@@ -601,14 +627,11 @@ function BrandBriefCard(props: {
   }, [editing]);
 
   useEffect(() => {
-    setWebsiteUrl(props.brief.websiteUrl);
-    setBrandVoice(props.brief.brandVoice);
-    setStyleVibe(props.brief.styleVibe);
-    setVisualReferences(props.brief.visualReferences.join('\n'));
-    setMustUseCopy(props.brief.mustUseCopy);
-    setMustAvoidAesthetics(props.brief.mustAvoidAesthetics);
-    setNotes(props.brief.notes);
-  }, [props.brief]);
+    if (editing) {
+      return;
+    }
+    resetDraftFromBrief();
+  }, [editing, props.brief]);
 
   async function handleSave() {
     if (!urlIsValid) {
@@ -619,7 +642,7 @@ function BrandBriefCard(props: {
 
     if (brandAssets.length > 0) {
       const formData = new FormData();
-      formData.set('websiteUrl', websiteUrl.trim());
+      formData.set('websiteUrl', normalizedWebsiteUrl);
       formData.set('brandVoice', brandVoice.trim());
       formData.set('styleVibe', styleVibe.trim());
       formData.set('mustUseCopy', mustUseCopy.trim());
@@ -635,7 +658,7 @@ function BrandBriefCard(props: {
       await props.onSave(formData);
     } else {
       await props.onSave({
-        websiteUrl: websiteUrl.trim(),
+        websiteUrl: normalizedWebsiteUrl,
         brandVoice: brandVoice.trim(),
         styleVibe: styleVibe.trim(),
         visualReferences: visualReferenceEntries,
@@ -713,7 +736,10 @@ function BrandBriefCard(props: {
               aria-describedby={urlTouched && urlErrorMessage ? 'edit-brief-website-url-error' : undefined}
               value={websiteUrl}
               onChange={(event) => setWebsiteUrl(event.target.value)}
-              onBlur={() => setUrlTouched(true)}
+              onBlur={() => {
+                setWebsiteUrl(normalizeHttpUrlInput(websiteUrl));
+                setUrlTouched(true);
+              }}
               className="mt-3 w-full rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-sm text-white placeholder:text-white/30"
             />
             {urlTouched && urlErrorMessage ? (
@@ -947,6 +973,7 @@ function StageReviewSurface(props: {
             busy={props.busy}
             onApprove={isApproved ? undefined : props.onApprove}
             onChangesRequested={isApproved ? undefined : props.onChangesRequested}
+            approveLabel={`Authorize ${reviewSurfaceLabel(props.review.reviewType)} review`}
             placeholder={props.review.notePlaceholder}
           />
         )}
@@ -1024,6 +1051,7 @@ function CreativeReviewSurface(props: {
                   onApprove={() => props.onDecision(asset.reviewId, 'approve')}
                   onChangesRequested={() => props.onDecision(asset.reviewId, 'changes_requested')}
                   onReject={() => props.onDecision(asset.reviewId, 'reject')}
+                  approveLabel="Authorize asset review"
                   placeholder="Add per-asset notes or request revisions."
                 />
                 <HistoryCard history={asset.history} />
@@ -1147,6 +1175,7 @@ function ReviewDecisionCard(props: {
   onChangesRequested?: () => void;
   onReject?: () => void;
   placeholder?: string;
+  approveLabel?: string;
 }) {
   const [activeAction, setActiveAction] = useState<DecisionActionKind>('approve');
   const [progressIndex, setProgressIndex] = useState(0);
@@ -1207,7 +1236,7 @@ function ReviewDecisionCard(props: {
               className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
             >
               {props.busy && activeAction === 'approve' ? <LoaderCircle className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-              {props.busy && activeAction === 'approve' ? activeProgressLabel : 'Approve'}
+              {props.busy && activeAction === 'approve' ? activeProgressLabel : props.approveLabel || 'Approve'}
             </button>
           ) : null}
           {props.onChangesRequested ? (

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -230,7 +230,7 @@ function urlChipFromValue(value: string): UrlChipState {
   }
   const normalized = normalizeHttpsUrlInput(trimmed);
   const hostname = hostnameFromUrl(normalized);
-  if (!hostname || !isValidHttpsUrl(normalized)) {
+  if (!hostname || !isValidHttpsUrl(trimmed)) {
     return { kind: 'invalid' };
   }
   return { kind: 'valid', hostname };
@@ -302,7 +302,7 @@ export function stepReady(stepKey: StepKey, values: {
     return values.businessName.trim().length > 0 && values.businessType.trim().length > 0;
   }
   if (stepKey === 'website' || stepKey === 'brand') {
-    return isValidHttpsUrl(normalizeHttpsUrlInput(values.websiteUrl));
+    return isValidHttpsUrl(values.websiteUrl);
   }
   if (stepKey === 'channels') {
     return values.selectedChannels.length > 0;
@@ -785,7 +785,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   }, [ariesApi, draftId, loadedDraftId]);
 
   useEffect(() => {
-    if (!props.initialAuthenticated || profileHydrated) {
+    if (!props.initialAuthenticated || profileHydrated || draftId) {
       return;
     }
 
@@ -1239,7 +1239,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
     ? 'untouched'
     : websiteUrl.trim().length === 0
       ? 'invalid'
-      : isValidHttpsUrl(normalizeHttpsUrlInput(websiteUrl))
+      : isValidHttpsUrl(websiteUrl)
         ? 'valid'
         : 'invalid';
   const competitorUrlValidation = validateCanonicalCompetitorUrl(competitorUrl);
@@ -1290,7 +1290,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         return goal.trim() ? null : 'Choose a business outcome before continuing.';
       case 'websiteUrl': {
         if (!websiteUrl.trim()) return 'Enter a website so Aries can analyze it.';
-        return isValidHttpsUrl(normalizeHttpsUrlInput(websiteUrl)) ? null : 'Enter a valid website URL (we will add https:// if you omit it).';
+        return isValidHttpsUrl(websiteUrl) ? null : 'Enter a valid website URL (we will add https:// if you omit it).';
       }
       case 'competitorUrl': {
         if (!competitorUrl.trim()) return null; // optional

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -187,9 +187,20 @@ function goalFromBusinessProfile(primaryGoal: string | null | undefined): string
   return primaryGoal?.trim() || '';
 }
 
+export function normalizeHttpsUrlInput(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return `https://${trimmed}`;
+}
+
 function isValidHttpsUrl(value: string): boolean {
   try {
-    const parsed = new URL(value.trim());
+    const parsed = new URL(normalizeHttpsUrlInput(value));
     return parsed.protocol === 'https:' && Boolean(parsed.hostname);
   } catch {
     return false;
@@ -217,8 +228,9 @@ function urlChipFromValue(value: string): UrlChipState {
   if (!trimmed) {
     return { kind: 'idle' };
   }
-  const hostname = hostnameFromUrl(trimmed);
-  if (!hostname || !isValidHttpsUrl(trimmed)) {
+  const normalized = normalizeHttpsUrlInput(trimmed);
+  const hostname = hostnameFromUrl(normalized);
+  if (!hostname || !isValidHttpsUrl(normalized)) {
     return { kind: 'invalid' };
   }
   return { kind: 'valid', hostname };
@@ -290,7 +302,7 @@ export function stepReady(stepKey: StepKey, values: {
     return values.businessName.trim().length > 0 && values.businessType.trim().length > 0;
   }
   if (stepKey === 'website' || stepKey === 'brand') {
-    return isValidHttpsUrl(values.websiteUrl);
+    return isValidHttpsUrl(normalizeHttpsUrlInput(values.websiteUrl));
   }
   if (stepKey === 'channels') {
     return values.selectedChannels.length > 0;
@@ -599,7 +611,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   const localSaveTimerRef = useRef<number | null>(null);
   const savedIndicatorTimerRef = useRef<number | null>(null);
   const submittingRef = useRef(false);
-  const deferredWebsiteUrl = useDeferredValue(websiteUrl.trim());
+  const deferredWebsiteUrl = useDeferredValue(normalizeHttpsUrlInput(websiteUrl));
 
   const markTouched = useCallback((field: keyof TouchedFields) => {
     setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
@@ -657,6 +669,19 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   const finishDisabled = useDisabledUntilValid(canFinish, submitting || creatingDraft);
   const fieldInputClassName =
     'w-full rounded-[1rem] border border-white/12 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] px-4 py-3 text-white outline-none transition duration-200 placeholder:text-white/24 focus:border-[#b36cff] focus:shadow-[0_0_0_1px_rgba(179,108,255,0.24),0_0_24px_rgba(179,108,255,0.14)]';
+  const previousWebsiteUrl = normalizeHttpsUrlInput(profile?.websiteUrl || profile?.brandKit?.source_url || '');
+  const previousOffer = firstPresent(profile?.offer, profile?.brandIdentity?.offer, profile?.brandKit?.offer_summary);
+  const hasPreviousWebsiteChoice = Boolean(previousWebsiteUrl && previousWebsiteUrl !== normalizeHttpsUrlInput(websiteUrl));
+  const hasPreviousOfferChoice = Boolean(previousOffer && previousOffer !== offer.trim());
+
+  function applyWebsiteUrl(value: string) {
+    const normalized = normalizeHttpsUrlInput(value);
+    setWebsiteUrl(normalized);
+    setUrlPreview(null);
+    setPreviewError(null);
+    setWebsiteChip(urlChipFromValue(normalized));
+    markTouched('websiteUrl');
+  }
 
   useEffect(() => {
     setDraftId(draftParam);
@@ -730,7 +755,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
 
         const draft = response.draft;
         setBusinessName(draft.businessName);
-        setWebsiteUrl(draft.websiteUrl);
+        setWebsiteUrl(normalizeHttpsUrlInput(draft.websiteUrl));
         setBusinessType(draft.businessType);
         setApproverName(draft.approverName);
         setSelectedChannels(draft.channels);
@@ -760,7 +785,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
   }, [ariesApi, draftId, loadedDraftId]);
 
   useEffect(() => {
-    if (!props.initialAuthenticated || draftId || profileHydrated) {
+    if (!props.initialAuthenticated || profileHydrated) {
       return;
     }
 
@@ -773,14 +798,16 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         }
 
         const nextProfile = result.profileResponse.profile;
-        setBusinessName(nextProfile.businessName?.trim() ? nextProfile.businessName.trim() : '');
-        setWebsiteUrl(nextProfile.websiteUrl || nextProfile.brandKit?.source_url || '');
-        setBusinessType(nextProfile.businessType || '');
-        setApproverName(nextProfile.launchApproverName || '');
-        setGoal(goalFromBusinessProfile(nextProfile.primaryGoal));
-        setOffer(nextProfile.offer || nextProfile.brandIdentity?.offer || nextProfile.brandKit?.offer_summary || '');
-        setCompetitorUrl(nextProfile.competitorUrl || '');
-        setSelectedChannels(nextProfile.channels.length > 0 ? nextProfile.channels : []);
+        if (!draftId) {
+          setBusinessName(nextProfile.businessName?.trim() ? nextProfile.businessName.trim() : '');
+          setWebsiteUrl(normalizeHttpsUrlInput(nextProfile.websiteUrl || nextProfile.brandKit?.source_url || ''));
+          setBusinessType(nextProfile.businessType || '');
+          setApproverName(nextProfile.launchApproverName || '');
+          setGoal(goalFromBusinessProfile(nextProfile.primaryGoal));
+          setOffer(nextProfile.offer || nextProfile.brandIdentity?.offer || nextProfile.brandKit?.offer_summary || '');
+          setCompetitorUrl(nextProfile.competitorUrl || '');
+          setSelectedChannels(nextProfile.channels.length > 0 ? nextProfile.channels : []);
+        }
         setProfileHydrated(true);
       })
       .catch(() => {
@@ -808,8 +835,9 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
 
     setSaveStatus('saving');
     const timer = window.setTimeout(() => {
+      const autosaveWebsiteUrl = normalizeHttpsUrlInput(websiteUrl);
       void ariesApi.updateOnboardingDraft(draftId, {
-        websiteUrl,
+        websiteUrl: autosaveWebsiteUrl,
         businessName,
         businessType,
         approverName,
@@ -819,9 +847,9 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         competitorUrl,
         preview: urlPreview,
         provenance: {
-          source_url: websiteUrl,
+          source_url: autosaveWebsiteUrl,
           canonical_url: urlPreview?.canonicalUrl || null,
-          source_fingerprint: urlPreview?.canonicalUrl || websiteUrl || null,
+          source_fingerprint: urlPreview?.canonicalUrl || autosaveWebsiteUrl || null,
         },
       })
         .then(() => {
@@ -1136,9 +1164,13 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       }
 
       const resolvedGoal = goal === 'Other' ? customGoal.trim() : goal;
+      const normalizedWebsiteUrl = normalizeHttpsUrlInput(websiteUrl);
+      if (normalizedWebsiteUrl !== websiteUrl) {
+        setWebsiteUrl(normalizedWebsiteUrl);
+      }
       await ariesApi.updateOnboardingDraft(activeDraftId, {
         status: 'ready_for_auth',
-        websiteUrl,
+        websiteUrl: normalizeHttpsUrlInput(websiteUrl),
         businessName,
         businessType,
         approverName,
@@ -1148,9 +1180,9 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         competitorUrl: canonicalCompetitorUrl,
         preview: urlPreview,
         provenance: {
-          source_url: websiteUrl,
+          source_url: normalizeHttpsUrlInput(websiteUrl),
           canonical_url: urlPreview?.canonicalUrl || null,
-          source_fingerprint: urlPreview?.canonicalUrl || websiteUrl || null,
+          source_fingerprint: urlPreview?.canonicalUrl || normalizeHttpsUrlInput(websiteUrl) || null,
         },
       });
 
@@ -1179,7 +1211,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       router.push(
         authRedirectHref({
           draftId: activeDraftId,
-          businessName: businessName || hostnameFromUrl(websiteUrl) || 'your business',
+          businessName: businessName || hostnameFromUrl(normalizedWebsiteUrl) || 'your business',
         }),
       );
     } catch (submissionError) {
@@ -1207,7 +1239,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
     ? 'untouched'
     : websiteUrl.trim().length === 0
       ? 'invalid'
-      : isValidHttpsUrl(websiteUrl)
+      : isValidHttpsUrl(normalizeHttpsUrlInput(websiteUrl))
         ? 'valid'
         : 'invalid';
   const competitorUrlValidation = validateCanonicalCompetitorUrl(competitorUrl);
@@ -1258,7 +1290,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
         return goal.trim() ? null : 'Choose a business outcome before continuing.';
       case 'websiteUrl': {
         if (!websiteUrl.trim()) return 'Enter a website so Aries can analyze it.';
-        return isValidHttpsUrl(websiteUrl) ? null : 'Enter a valid HTTPS URL (e.g. https://yourbusiness.com).';
+        return isValidHttpsUrl(normalizeHttpsUrlInput(websiteUrl)) ? null : 'Enter a valid website URL (we will add https:// if you omit it).';
       }
       case 'competitorUrl': {
         if (!competitorUrl.trim()) return null; // optional
@@ -1404,7 +1436,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                       className={clsx(
                         'flex min-w-[126px] flex-1 items-center gap-2 rounded-full border px-3 py-2.5 text-[1.1rem] transition duration-300',
                         active
-                          ? 'border-[#a96cff]/45 bg-[linear-gradient(90deg,rgba(151,93,255,0.22),rgba(151,93,255,0.05))] text-white shadow-[inset_0_-1px_0_rgba(169,108,255,0.9),0_0_20px_rgba(169,108,255,0.15)]'
+                          ? 'border-[#a96cff]/45 bg-[linear-gradient(90deg,rgba(151,93,255,0.22),rgba(151,93,255,0.05))] font-bold text-white shadow-[inset_0_-1px_0_rgba(169,108,255,0.9),0_0_20px_rgba(169,108,255,0.15)]'
                           : 'border-white/8 bg-white/[0.02] text-white/50',
                       )}
                     >
@@ -1500,7 +1532,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                       <input
                         value={websiteUrl}
                         onChange={(event) => setWebsiteUrl(event.target.value)}
-                        onBlur={() => markTouched('websiteUrl')}
+                        onBlur={() => applyWebsiteUrl(websiteUrl)}
                         className={inputClassForValidity(websiteUrlValidity)}
                         placeholder="https://yourbusiness.com"
                       />
@@ -1542,10 +1574,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                           setPreviewError(null);
                           setWebsiteChip({ kind: 'idle' });
                         }}
-                        onBlur={() => {
-                          markTouched('websiteUrl');
-                          setWebsiteChip(urlChipFromValue(websiteUrl));
-                        }}
+                        onBlur={() => applyWebsiteUrl(websiteUrl)}
                         className={inputClassForValidity(websiteUrlValidity)}
                         placeholder="https://yourbusiness.com"
                       />
@@ -1553,6 +1582,15 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                         <div className="mt-3 inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 text-xs font-medium">
                           <Check className="w-3.5 h-3.5" /> {websiteChip.hostname} — ready to analyze
                         </div>
+                      ) : null}
+                      {hasPreviousWebsiteChoice ? (
+                        <button
+                          type="button"
+                          onClick={() => applyWebsiteUrl(previousWebsiteUrl)}
+                          className="mt-3 inline-flex items-center gap-2 rounded-full border border-white/12 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-white/72 transition hover:border-[#a96cff]/35 hover:text-white"
+                        >
+                          Use saved website · {hostnameFromUrl(previousWebsiteUrl) || previousWebsiteUrl}
+                        </button>
                       ) : null}
                       {websiteChip.kind === 'invalid' ? (
                         <div className="mt-3 inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-red-500/10 border border-red-500/30 text-red-400 text-xs font-medium">
@@ -1870,9 +1908,23 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                           <Check className="h-4 w-4 text-emerald-400" aria-hidden />
                         ) : null}
                       </div>
-                      <p className="text-xs leading-6 text-[#d6b8ff]">
-                        The more specific you are, the better Aries will do.
-                      </p>
+                      <div className="flex flex-wrap items-center gap-3">
+                        <p className="text-xs leading-6 text-[#d6b8ff]">
+                          The more specific you are, the better Aries will do.
+                        </p>
+                        {hasPreviousOfferChoice ? (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setOffer(previousOffer || '');
+                              markTouched('offer');
+                            }}
+                            className="rounded-full border border-white/12 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-white/72 transition hover:border-[#a96cff]/35 hover:text-white"
+                          >
+                            Use saved description
+                          </button>
+                        ) : null}
+                      </div>
                       <textarea
                         id="onboarding-core-offer"
                         value={offer}

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -14,6 +14,17 @@ function isErrorResult(value: unknown): value is MarketingApiError {
   return typeof (value as MarketingApiError)?.error === 'string';
 }
 
+export function normalizeWebsiteUrlInput(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return `https://${trimmed}`;
+}
+
 function splitLines(value: string): string[] {
   return value
     .split('\n')
@@ -92,7 +103,7 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
     event.preventDefault();
     setErrorText(null);
 
-    const trimmedWebsiteUrl = websiteUrl.trim();
+    const trimmedWebsiteUrl = normalizeWebsiteUrlInput(websiteUrl);
     if (!trimmedWebsiteUrl) {
       setErrorText('website URL is required');
       return;
@@ -212,6 +223,7 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                 <input
                   value={websiteUrl}
                   onChange={(event) => setWebsiteUrl(event.target.value)}
+                  onBlur={() => setWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl))}
                   placeholder="https://yourbrand.com"
                   required
                   aria-invalid={marketingCreate.fieldErrors?.websiteUrl ? true : undefined}
@@ -331,16 +343,16 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
 
               <button
                 type="submit"
-                disabled={submitting || !isValidWebsiteUrl(websiteUrl)}
+                disabled={submitting || !isValidWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl))}
                 className="w-full rounded-full bg-gradient-to-r from-primary to-secondary px-6 py-4 text-white font-semibold shadow-xl shadow-primary/20 disabled:opacity-60 disabled:cursor-not-allowed"
-                aria-describedby={!isValidWebsiteUrl(websiteUrl) && !submitting ? 'start-campaign-hint' : undefined}
+                aria-describedby={!isValidWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl)) && !submitting ? 'start-campaign-hint' : undefined}
               >
                 <span className="inline-flex items-center justify-center gap-2">
                   {submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
                   {submitButtonLabel}
                 </span>
               </button>
-              {!isValidWebsiteUrl(websiteUrl) && !submitting && (
+              {!isValidWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl)) && !submitting && (
                 <p id="start-campaign-hint" className="mt-2 text-center text-xs text-white/45">
                   {websiteUrl.trim()
                     ? 'Enter a valid URL like https://example.com to start the campaign.'
@@ -377,11 +389,23 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                   'Strategy output is surfaced in a readable proposal with comments and approval state.',
                   'Creative assets stay review-gated per asset until every required approval is complete.',
                   'Publish remains blocked until the workflow is explicitly approved.',
-                ].map((item) => (
-                  <div key={item} className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 text-white/70">
-                    {item}
-                  </div>
-                ))}
+                ].map((item, index) => {
+                  const [stage, detail] = item.split(' feed ');
+                  return (
+                    <div key={item} className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5 text-white/70">
+                      <span className="mr-2 rounded-full border border-primary/25 bg-primary/10 px-2 py-1 text-[11px] font-bold uppercase tracking-[0.18em] text-primary">
+                        Step {index + 1}
+                      </span>
+                      {stage && detail ? (
+                        <>
+                          <strong className="text-white">{stage}</strong> feed {detail}
+                        </>
+                      ) : (
+                        <strong className="text-white">{item}</strong>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
 

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -189,6 +189,8 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
   const submitButtonLabel = submitting
     ? `${SUBMIT_PROGRESS_MESSAGES[submitProgress.stepIndex]}${isFinalSubmitMessage ? '.'.repeat(Math.max(submitProgress.dotCount, 1)) : ''}`
     : 'Start campaign';
+  const normalizedWebsiteUrl = normalizeWebsiteUrlInput(websiteUrl);
+  const websiteUrlIsValid = isValidWebsiteUrl(normalizedWebsiteUrl);
 
   return (
     <div className={wrapperClassName}>
@@ -343,16 +345,16 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
 
               <button
                 type="submit"
-                disabled={submitting || !isValidWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl))}
+                disabled={submitting || !websiteUrlIsValid}
                 className="w-full rounded-full bg-gradient-to-r from-primary to-secondary px-6 py-4 text-white font-semibold shadow-xl shadow-primary/20 disabled:opacity-60 disabled:cursor-not-allowed"
-                aria-describedby={!isValidWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl)) && !submitting ? 'start-campaign-hint' : undefined}
+                aria-describedby={!websiteUrlIsValid && !submitting ? 'start-campaign-hint' : undefined}
               >
                 <span className="inline-flex items-center justify-center gap-2">
                   {submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
                   {submitButtonLabel}
                 </span>
               </button>
-              {!isValidWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl)) && !submitting && (
+              {!websiteUrlIsValid && !submitting && (
                 <p id="start-campaign-hint" className="mt-2 text-center text-xs text-white/45">
                   {websiteUrl.trim()
                     ? 'Enter a valid URL like https://example.com to start the campaign.'

--- a/tests/campaign-workspace-state.test.ts
+++ b/tests/campaign-workspace-state.test.ts
@@ -233,6 +233,8 @@ test('deriveGenerationProgressState maps creative asset progress from production
             title: 'Meta image',
             platform: 'meta-ads',
             contentType: 'image/png',
+            previewUrl: '/materials/assets/meta-image.png',
+            thumbnailUrl: null,
           },
         ],
       },
@@ -245,6 +247,62 @@ test('deriveGenerationProgressState maps creative asset progress from production
   assert.equal(progress?.currentLabel, 'Generating asset 2 of 4');
   assert.equal(progress?.imageCount, 3);
   assert.equal(progress?.videoCount, 1);
+});
+
+
+
+test('deriveGenerationProgressState does not count creative assets as ready until previews exist', () => {
+  const progress = deriveGenerationProgressState(
+    makeStatus({
+      workflowState: 'creative_review_required',
+      stageCards: [
+        {
+          stage: 'production',
+          label: 'Production',
+          status: 'running',
+          summary: 'Creative outputs are in production.',
+          highlight: 'Static contracts: 2',
+        },
+      ],
+      dashboard: {
+        ...emptyDashboard(),
+        campaign: {
+          counts: {
+            imageAds: 2,
+          },
+        },
+        assets: [
+          {
+            id: 'asset_pending',
+            type: 'image_ad',
+            title: 'Pending Meta image',
+            platform: 'meta-ads',
+            contentType: 'image/png',
+            previewUrl: null,
+            thumbnailUrl: null,
+          },
+        ],
+      },
+      creativeReview: {
+        assets: [
+          {
+            reviewId: 'review_pending',
+            assetId: 'asset_pending',
+            title: 'Pending Meta image',
+            platformLabel: 'Meta Ads',
+            contentType: 'image/png',
+            previewUrl: null,
+            fullPreviewUrl: null,
+          },
+        ],
+      },
+    }) as any,
+  );
+
+  assert.equal(progress?.totalCount, 2);
+  assert.equal(progress?.completedCount, 0);
+  assert.equal(progress?.currentLabel, 'Generating image 1 of 2');
+  assert.equal(progress?.isComplete, false);
 });
 
 test('deriveGenerationProgressState falls back to planned and created counts when contract counts are missing', () => {

--- a/tests/marketing-new-job-screen.test.ts
+++ b/tests/marketing-new-job-screen.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import React from 'react';
 
-import { MarketingNewJobScreenContent } from '../frontend/marketing/new-job';
+import { MarketingNewJobScreenContent, normalizeWebsiteUrlInput } from '../frontend/marketing/new-job';
 
 function flushMicrotasks() {
   return new Promise((resolve) => setTimeout(resolve, 0));
@@ -63,4 +63,10 @@ test('MarketingNewJobScreen shows the backend error after a valid submit fails',
       globalWithWindow.window = previousWindow;
     }
   }
+});
+
+
+test('MarketingNewJobScreen normalizes bare website domains to HTTPS', () => {
+  assert.equal(normalizeWebsiteUrlInput('example.com'), 'https://example.com');
+  assert.equal(normalizeWebsiteUrlInput(' https://example.com '), 'https://example.com');
 });

--- a/tests/onboarding-step-one-validation.regression-012.test.ts
+++ b/tests/onboarding-step-one-validation.regression-012.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import React from 'react';
 
 import {
+  normalizeHttpsUrlInput,
   stepReady,
   stepValidationMessage,
 } from '../frontend/aries-v1/onboarding-flow';
@@ -123,4 +124,22 @@ test('shared disabled helper keeps Continue disabled for invalid or busy onboard
     );
   });
   assert.equal(root.root.findByType('button').props.disabled, true);
+});
+
+
+test('onboarding website step accepts bare domains by normalizing to HTTPS', () => {
+  assert.equal(normalizeHttpsUrlInput('example.com'), 'https://example.com');
+  assert.equal(normalizeHttpsUrlInput(' https://example.com/path '), 'https://example.com/path');
+  assert.equal(
+    stepReady('website', {
+      businessName: '',
+      businessType: '',
+      websiteUrl: 'example.com',
+      selectedChannels: [],
+      goal: '',
+      customGoal: '',
+      offer: '',
+    }),
+    true,
+  );
 });


### PR DESCRIPTION
## Summary
- Adds explicit review authorization CTAs (`Authorize … review`) and stronger current-stage markers in the campaign workspace.
- Prevents in-progress brief edits from being reset by polling refreshes; cancel now intentionally restores the saved brief.
- Keeps creative progress in “running” state until review/dashboard assets have actual preview URLs, avoiding false “assets ready” copy.
- Normalizes bare website domains to `https://…` in onboarding and campaign intake.
- Adds reuse affordances for saved onboarding website/offer details from the business profile.

## Test Plan
- `NODE_ENV=test npx tsx --test tests/onboarding-step-one-validation.regression-012.test.ts tests/marketing-new-job-screen.test.ts tests/campaign-workspace-state.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run validate:repo-boundary`
- `npm run validate:banned-patterns`
- `npm run verify`
- `npm run workspace:verify`

## Notes
- Opened as a draft for owner review per normal Aries PR process.
