### PR TITLE
refactor(workspace): remove unused creative progress param

### DIFF
--- a/frontend/aries-v1/campaign-workspace-state.ts
+++ b/frontend/aries-v1/campaign-workspace-state.ts
@@ -198,10 +198,7 @@ function reviewAssetHasPreview(asset: MarketingCreativeAssetReviewPayload): bool
 function countCompletedCreativeAssets(
   dashboardAssets: MarketingDashboardAsset[] | null | undefined,
   creativeReviewAssets: MarketingCreativeAssetReviewPayload[] | null | undefined,
-  _dashboardImageAds: number | null | undefined,
 ): { imageCount: number; videoCount: number } {
-  // Keep the image-ad count in the internal signature for call-site stability,
-  // but readiness now comes from assets that expose actual previews.
   const reviewAssets = creativeReviewAssets || [];
   const readyReviewAssets = reviewAssets.filter(reviewAssetHasPreview);
   const readyDashboardAssets = (dashboardAssets || []).filter(dashboardAssetHasPreview);
@@ -306,7 +303,6 @@ export function deriveGenerationProgressState(
   const completedCreativeCounts = countCompletedCreativeAssets(
     status.dashboard.assets,
     status.creativeReview?.assets,
-    status.dashboard.campaign?.counts.imageAds,
   );
   const fallbackTotal = positiveCount(status.plannedPostCount);
   const totalCount = explicitTotal && explicitTotal > 0 ? explicitTotal : fallbackTotal;


### PR DESCRIPTION
## Summary
- Removes the now-unused `dashboardImageAds` parameter from `countCompletedCreativeAssets`.
- Keeps the creative-progress readiness logic unchanged while cleaning up the internal API after PR #228 review.

## Context
Follow-up to merged PR #228 to address the remaining non-blocking Copilot review nit about the intentionally unused parameter.

## Test Plan
- `NODE_ENV=test npx tsx --test tests/campaign-workspace-state.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run workspace:verify`
