### PR TITLE
fix(onboarding): address handoff stuck accessibility

### DIFF
--- a/app/onboarding/resume/pending.tsx
+++ b/app/onboarding/resume/pending.tsx
@@ -33,38 +33,39 @@ export default function OnboardingResumePending(): JSX.Element {
       <div className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center px-6 text-center">
         <div className="h-16 w-16 rounded-full border border-white/12 bg-white/5" aria-hidden="true" />
         <p className="mt-6 text-xs uppercase tracking-[0.35em] text-white/45">Onboarding handoff</p>
-        {stuck ? (
-          <>
-            <h1 className="mt-4 text-4xl font-normal tracking-[-0.04em] text-white">
-              The campaign service is taking longer than expected
-            </h1>
-            <p className="mt-4 max-w-xl text-sm leading-7 text-white/65">
-              Aries can&apos;t reach the OpenClaw gateway right now, so the workspace handoff
-              hasn&apos;t completed. Your draft is saved. Try again, and if this keeps happening,
-              ping support so we can look at the gateway logs.
-            </p>
-            <button
-              type="button"
-              onClick={() => {
-                setStuck(false);
-                router.refresh();
-              }}
-              className="mt-8 rounded-full border border-white/20 bg-white/5 px-6 py-2 text-sm text-white transition hover:bg-white/10"
-            >
-              Try again
-            </button>
-          </>
-        ) : (
-          <>
-            <h1 className="mt-4 text-4xl font-normal tracking-[-0.04em] text-white">
-              Building your first campaign plan
-            </h1>
-            <p className="mt-4 max-w-xl text-sm leading-7 text-white/65">
-              Aries is finishing the workspace handoff now. This page will refresh automatically and open the live
-              workspace as soon as the campaign is ready.
-            </p>
-          </>
-        )}
+        <div role="status" aria-live="polite" aria-atomic="true">
+          {stuck ? (
+            <>
+              <h1 className="mt-4 text-4xl font-normal tracking-[-0.04em] text-white">
+                The campaign service is taking longer than expected
+              </h1>
+              <p className="mt-4 max-w-xl text-sm leading-7 text-white/65">
+                The workspace handoff hasn&apos;t completed yet. Your draft is saved. Try again,
+                and if this keeps happening, contact support so we can investigate.
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  setStuck(false);
+                  router.refresh();
+                }}
+                className="mt-8 rounded-full border border-white/20 bg-white/5 px-6 py-2 text-sm text-white transition hover:bg-white/10"
+              >
+                Try again
+              </button>
+            </>
+          ) : (
+            <>
+              <h1 className="mt-4 text-4xl font-normal tracking-[-0.04em] text-white">
+                Building your first campaign plan
+              </h1>
+              <p className="mt-4 max-w-xl text-sm leading-7 text-white/65">
+                Aries is finishing the workspace handoff now. This page will refresh automatically and open the live
+                workspace as soon as the campaign is ready.
+              </p>
+            </>
+          )}
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Rewords the onboarding handoff stuck state to avoid asserting a specific gateway root cause without server evidence.
- Wraps the pending/stuck copy in a polite `role="status"` live region so timeout changes are announced to assistive tech.

## Context
Follow-up for Copilot review comments on merged PR #231. The original PR had already merged before the created-review-comment webhook was handled, so this is a small cleanup PR from `origin/master`.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run validate:banned-patterns`
- [x] `npm run validate:repo-boundary`
- [x] `npm run verify`
- [x] `npm run workspace:verify` attempted in temp worktree; failed only because the temp worktree is not the canonical root (`/home/node/aries-app`), as expected.
