### PR TITLE
fix(onboarding): keep retry action outside status live region

### DIFF
--- a/app/onboarding/resume/pending.tsx
+++ b/app/onboarding/resume/pending.tsx
@@ -43,16 +43,6 @@ export default function OnboardingResumePending(): JSX.Element {
                 The workspace handoff hasn&apos;t completed yet. Your draft is saved. Try again,
                 and if this keeps happening, contact support so we can investigate.
               </p>
-              <button
-                type="button"
-                onClick={() => {
-                  setStuck(false);
-                  router.refresh();
-                }}
-                className="mt-8 rounded-full border border-white/20 bg-white/5 px-6 py-2 text-sm text-white transition hover:bg-white/10"
-              >
-                Try again
-              </button>
             </>
           ) : (
             <>
@@ -66,6 +56,18 @@ export default function OnboardingResumePending(): JSX.Element {
             </>
           )}
         </div>
+        {stuck ? (
+          <button
+            type="button"
+            onClick={() => {
+              setStuck(false);
+              router.refresh();
+            }}
+            className="mt-8 rounded-full border border-white/20 bg-white/5 px-6 py-2 text-sm text-white transition hover:bg-white/10"
+          >
+            Try again
+          </button>
+        ) : null}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Move the stuck-state Try again button outside the aria-live status region.
- Keep the pending/stuck heading and explanatory copy announced politely without including an interactive control in the atomic live region.

## Context
Follow-up to Copilot feedback posted on duplicate PR #234 after canonical follow-up PR #232 had already merged.

## Test Plan
- [x] npm run typecheck
- [x] npm run validate:repo-boundary
- [x] npm run validate:banned-patterns
- [x] git diff --check
- [x] npm run verify