### PR TITLE
fix(lobster): auto-repair truncated copy before validation gate

### DIFF
--- a/lobster/bin/_marketing_profile_common.py
+++ b/lobster/bin/_marketing_profile_common.py
@@ -83,6 +83,44 @@ def is_truncated_phrase(value: Any) -> bool:
     return tokens[-1] in TRUNCATED_LAST_TOKENS
 
 
+_TRAILING_PUNCT_SUFFIXES = ("...", ":", "-", "/", "(")
+
+
+def repair_truncated_phrase(value: Any) -> str:
+    """Strip trailing punctuation and trailing preposition/conjunction tokens
+    that would cause is_truncated_phrase() to reject the string. Returns the
+    cleaned value (possibly empty).
+
+    Used to deterministically scrub LLM output before validation, since LLMs
+    routinely produce copy ending with 'for'/'to'/'with'/etc. even when the
+    prompt explicitly forbids it.
+    """
+    normalized = normalize_space(value)
+    if not normalized:
+        return ""
+    changed = True
+    while changed and normalized:
+        changed = False
+        for suffix in _TRAILING_PUNCT_SUFFIXES:
+            if normalized.endswith(suffix):
+                normalized = normalize_space(normalized[: -len(suffix)])
+                changed = True
+                break
+        if changed:
+            continue
+        tokens = re.findall(r"[A-Za-z0-9&']+", normalized.lower())
+        if tokens and tokens[-1] in TRUNCATED_LAST_TOKENS:
+            match = re.search(
+                r"\b" + re.escape(tokens[-1]) + r"\b[^A-Za-z0-9&']*$",
+                normalized,
+                flags=re.IGNORECASE,
+            )
+            if match:
+                normalized = normalize_space(normalized[: match.start()].rstrip(",;:- "))
+                changed = True
+    return normalized
+
+
 def validate_copy_text(label: str, value: Any, min_tokens: int = 3) -> str:
     normalized = normalize_space(value)
     if not normalized:

--- a/lobster/bin/website-brand-analysis
+++ b/lobster/bin/website-brand-analysis
@@ -17,6 +17,7 @@ from _marketing_profile_common import (
     normalize_marketing_url,
     normalize_space,
     record_or_empty,
+    repair_truncated_phrase,
     string_or_none,
     unique_strings,
     utc_now,
@@ -248,7 +249,53 @@ def _structured_analysis_prompt(
     return "\n".join(lines)
 
 
+_REPAIR_STRING_FIELDS = (
+    "audience",
+    "positioning",
+    "problem_statement",
+    "offer",
+    "primary_cta",
+    "style_vibe",
+    "business_type",
+    "primary_goal",
+)
+_REPAIR_LIST_FIELDS = ("proof_points",)
+_REPAIR_CHANNEL_DICT_FIELDS = ("channel_specific_angles",)
+_REPAIR_CHANNEL_LIST_FIELDS = ("hooks", "opening_lines")
+
+
+def _repair_structured_copy(parsed: dict) -> dict:
+    """Strip trailing prepositions/punctuation that would trip the truncation
+    quality gate. LLMs produce these despite explicit prompt rules; deterministic
+    cleanup avoids burning a retry on a fixable formatting error."""
+    if not isinstance(parsed, dict):
+        return parsed
+    for field in _REPAIR_STRING_FIELDS:
+        if field in parsed and isinstance(parsed[field], str):
+            parsed[field] = repair_truncated_phrase(parsed[field])
+    for field in _REPAIR_LIST_FIELDS:
+        if isinstance(parsed.get(field), list):
+            parsed[field] = [repair_truncated_phrase(item) if isinstance(item, str) else item for item in parsed[field]]
+    for field in _REPAIR_CHANNEL_DICT_FIELDS:
+        record = parsed.get(field)
+        if isinstance(record, dict):
+            parsed[field] = {k: (repair_truncated_phrase(v) if isinstance(v, str) else v) for k, v in record.items()}
+    for field in _REPAIR_CHANNEL_LIST_FIELDS:
+        record = parsed.get(field)
+        if isinstance(record, dict):
+            parsed[field] = {
+                channel: (
+                    [repair_truncated_phrase(item) if isinstance(item, str) else item for item in items]
+                    if isinstance(items, list)
+                    else items
+                )
+                for channel, items in record.items()
+            }
+    return parsed
+
+
 def _validated_analysis_fields(parsed: dict, brand_name: str) -> dict:
+    parsed = _repair_structured_copy(parsed)
     audience = validate_copy_text("audience", parsed.get("audience"), min_tokens=4)
     positioning = validate_copy_text("positioning", parsed.get("positioning"), min_tokens=4)
     problem_statement = validate_copy_text("problem_statement", parsed.get("problem_statement"), min_tokens=4)


### PR DESCRIPTION
## Summary

The `website-brand-analysis` stage of the marketing pipeline was failing with `quality_gate_failed:hooks.video[2]:truncated` (and similar) because Gemini routinely produces copy strings that end with prepositions (`for`, `to`, `with`, `and`, `or`) or trailing punctuation (`:`, `-`, `/`, `(`, `...`). The validator at `_marketing_profile_common.py:92` rejects these. The 1-retry loop in `website-brand-analysis:436` was burning its single retry on a fixable formatting mistake and then surfacing the original error to the operator.

## Fix

Deterministic auto-repair before validation:

- **`lobster/bin/_marketing_profile_common.py`** — new `repair_truncated_phrase()` helper. Strips trailing punctuation suffixes and trailing preposition/conjunction tokens. Loops until stable so chained issues (e.g. `"... and:"`) collapse.
- **`lobster/bin/website-brand-analysis`** — new `_repair_structured_copy()` that walks the structured JSON's copy fields (`audience`, `positioning`, `problem_statement`, `offer`, `primary_cta`, `proof_points`, `channel_specific_angles`, `hooks`, `opening_lines`, `style_vibe`, `business_type`, `primary_goal`) and applies the repair. Called at the top of `_validated_analysis_fields()`.

The 1-retry loop is preserved as a backstop for content issues that can't be cleaned by trimming (wrapper language, too-short, blank, duplicates).

## Verified behavior

- `"How we did it for"` → `"How we did it"` ✓
- `"no setup hassle and"` → `"no setup hassle"` ✓
- `"No more guesswork or"` → `"No more guesswork"` ✓
- `"Designed to ("` → `"Designed"` ✓
- `"Scale your pipeline:"` → `"Scale your pipeline"` ✓

End-to-end test against `_validated_analysis_fields()` passes with a payload mirroring the failure pattern.

## Risk

Low. Touches only `lobster/bin/*` (marketing pipeline subprocess). No auth, DB, or UI changes. The validator still catches genuine quality issues — repair only fixes the trailing-token class of mistakes.

## Test plan

- [x] `npm run verify` passes locally
- [x] Manual end-to-end repair+validate test on representative payload
- [ ] Watch first production run of `website-brand-analysis` after merge — confirm the `quality_gate_failed:*:truncated` warnings disappear from gateway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)