### PR TITLE
fix(ci): skip PR agent for terminal PR states

### DIFF
--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -74,7 +74,14 @@ jobs:
             exit 1
           fi
 
-          gh pr view "$pr_number" --json number,title,body,url,isDraft,headRefName,baseRefName,labels,reviewDecision,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,headRepository,author,files > /tmp/pr.json
+          gh pr view "$pr_number" --json number,title,body,url,state,isDraft,headRefName,baseRefName,labels,reviewDecision,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,headRepository,author,files > /tmp/pr.json
+
+          pr_state="$(jq -r '.state' /tmp/pr.json)"
+          if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+            echo "PR #$pr_number is already $pr_state; nothing to do."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           is_cross_repo="$(jq -r '.isCrossRepository' /tmp/pr.json)"
           if [ "$is_cross_repo" = "true" ]; then


### PR DESCRIPTION
## Summary
- Add a terminal-state guard to the PR-agent workflow before checkout.
- Skip already merged or closed PRs with `should_run=false` so late review/comment events do not fail after the head branch is deleted.

Fixes #239

## Test Plan
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `npm run validate:repo-boundary`
- `npm run validate:banned-patterns`
- `git diff --check origin/master...HEAD`
- `npm run verify` (passed in temp worktree using canonical `node_modules` symlink; live OpenClaw gateway smoke skipped because gateway env was not configured)
