### PR TITLE
fix(ci): skip post-merge PR agent retriggers

### DIFF
--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -74,7 +74,14 @@ jobs:
             exit 1
           fi
 
-          gh pr view "$pr_number" --json number,title,body,url,isDraft,headRefName,baseRefName,labels,reviewDecision,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,headRepository,author,files > /tmp/pr.json
+          gh pr view "$pr_number" --json number,title,body,url,state,isDraft,headRefName,baseRefName,labels,reviewDecision,mergeStateStatus,mergeable,isCrossRepository,headRepositoryOwner,headRepository,author,files > /tmp/pr.json
+
+          pr_state="$(jq -r '.state' /tmp/pr.json)"
+          if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+            echo "PR #$pr_number is already $pr_state; nothing to do."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           is_cross_repo="$(jq -r '.isCrossRepository' /tmp/pr.json)"
           if [ "$is_cross_repo" = "true" ]; then

--- a/tests/deploy-workflow-self-hosted.regression-015.test.ts
+++ b/tests/deploy-workflow-self-hosted.regression-015.test.ts
@@ -133,6 +133,19 @@ test('agent automerge skips Claude action when the PR edits the agent workflow i
   );
 });
 
+test('agent automerge exits before checkout when a retrigger sees an already-terminal PR', () => {
+  assert.match(
+    prAgentWorkflow,
+    /gh pr view "\$pr_number" --json [^\n]*\bstate\b/,
+    'PR agent should request PR state before any checkout side effects',
+  );
+  assert.match(
+    prAgentWorkflow,
+    /pr_state="\$\(jq -r '\.state' \/tmp\/pr\.json\)"[\s\S]*?\[ "\$pr_state" = "MERGED" \] \|\| \[ "\$pr_state" = "CLOSED" \][\s\S]*?should_run=false[\s\S]*?exit 0[\s\S]*?is_cross_repo=/,
+    'PR agent should short-circuit merged or closed PRs before guardrails and checkout steps run',
+  );
+});
+
 test('deploy workflow builds and force-recreates the exact commit image', () => {
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
- add an early terminal-state guard to `pr-agent-autofix-automerge.yml` after PR resolution
- skip merged/closed PR retriggers before checkout so deleted post-merge branches do not fail the workflow
- add a regression assertion covering the merged/closed short-circuit

Fixes #239

## Test Plan
- [x] `npx tsx --test tests/deploy-workflow-self-hosted.regression-015.test.ts`
- [x] YAML parse for `.github/workflows/pr-agent-autofix-automerge.yml`
- [x] `git diff --check origin/master...HEAD`
- [x] `npm run validate:repo-boundary`
- [x] `npm run validate:banned-patterns`
- [x] `npm run verify`

Note: `npm run workspace:verify` is canonical-root-only and fails in the temp worktree with `git root /tmp/aries-pr239-post-merge-guard does not match canonical root /home/node/aries-app`; the canonical checkout is currently being left untouched for active PR #238.
