### PR TITLE
feat: wrap legacy OpenClaw execution adapter

### DIFF
--- a/backend/execution/index.ts
+++ b/backend/execution/index.ts
@@ -13,6 +13,14 @@ export {
   type ExecutionErrorInit,
 } from './errors';
 
+export {
+  LegacyOpenClawExecutionAdapter,
+  mapLegacyOpenClawGatewayError,
+  type LegacyOpenClawCancelInput,
+  type LegacyOpenClawResumeInput,
+  type LegacyOpenClawRunInput,
+} from './providers/legacy-openclaw';
+
 export type {
   ExecutionProvider,
   ExecutionProviderName,

--- a/backend/execution/providers/legacy-openclaw.ts
+++ b/backend/execution/providers/legacy-openclaw.ts
@@ -1,0 +1,107 @@
+import {
+  OpenClawGatewayError,
+  type LobsterEnvelope,
+  type OpenClawCancelCallInput,
+  type OpenClawResumeCallInput,
+  type OpenClawWorkflowCallInput,
+  cancelOpenClawLobsterWorkflow,
+  resumeOpenClawLobsterWorkflow,
+  runOpenClawLobsterWorkflow,
+} from '../../openclaw/gateway-client';
+import { ExecutionError, type ExecutionErrorCode } from '../errors';
+import type { WorkflowExecutionResult } from '../types';
+
+function primaryOutputRecord(envelope: LobsterEnvelope): Record<string, unknown> | null {
+  if (!Array.isArray(envelope.output) || envelope.output.length === 0) {
+    return null;
+  }
+
+  const first = envelope.output[0];
+  if (!first || typeof first !== 'object' || Array.isArray(first)) {
+    return null;
+  }
+
+  return first as Record<string, unknown>;
+}
+
+function mapLegacyOpenClawCode(
+  code: OpenClawGatewayError['code'],
+): ExecutionErrorCode {
+  switch (code) {
+    case 'openclaw_gateway_not_configured':
+      return 'not_configured';
+    case 'openclaw_gateway_unauthorized':
+      return 'unauthorized';
+    case 'openclaw_gateway_unreachable':
+      return 'unreachable';
+    case 'openclaw_gateway_tool_unavailable':
+      return 'tool_unavailable';
+    case 'openclaw_gateway_request_invalid':
+      return 'request_invalid';
+    case 'openclaw_gateway_response_invalid':
+      return 'response_invalid';
+    case 'openclaw_gateway_server_error':
+      return 'server_error';
+  }
+}
+
+export function mapLegacyOpenClawGatewayError(error: OpenClawGatewayError): ExecutionError {
+  return new ExecutionError({
+    provider: 'openclaw',
+    code: mapLegacyOpenClawCode(error.code),
+    message: error.message,
+    status: error.status,
+    cause: error,
+  });
+}
+
+function asOkResult(envelope: LobsterEnvelope): WorkflowExecutionResult {
+  return {
+    kind: 'ok',
+    envelope,
+    primaryOutput: primaryOutputRecord(envelope),
+  };
+}
+
+function asGatewayErrorResult(error: OpenClawGatewayError): WorkflowExecutionResult {
+  return {
+    kind: 'gateway_error',
+    error: mapLegacyOpenClawGatewayError(error),
+  };
+}
+
+export class LegacyOpenClawExecutionAdapter {
+  readonly name = 'openclaw' as const;
+
+  async run(input: OpenClawWorkflowCallInput): Promise<WorkflowExecutionResult> {
+    try {
+      return asOkResult(await runOpenClawLobsterWorkflow(input));
+    } catch (error) {
+      if (error instanceof OpenClawGatewayError) {
+        return asGatewayErrorResult(error);
+      }
+      throw error;
+    }
+  }
+
+  async resume(input: OpenClawResumeCallInput): Promise<WorkflowExecutionResult> {
+    try {
+      return asOkResult(await resumeOpenClawLobsterWorkflow(input));
+    } catch (error) {
+      if (error instanceof OpenClawGatewayError) {
+        return asGatewayErrorResult(error);
+      }
+      throw error;
+    }
+  }
+
+  async cancel(input: OpenClawCancelCallInput): Promise<{ cancelled: boolean; reason?: string }> {
+    return cancelOpenClawLobsterWorkflow(input);
+  }
+}
+
+export type {
+  OpenClawCancelCallInput as LegacyOpenClawCancelInput,
+  OpenClawResumeCallInput as LegacyOpenClawResumeInput,
+  OpenClawWorkflowCallInput as LegacyOpenClawRunInput,
+};

--- a/tests/execution-legacy-openclaw-adapter.test.ts
+++ b/tests/execution-legacy-openclaw-adapter.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { ExecutionError, LegacyOpenClawExecutionAdapter } from '../backend/execution';
+import { OpenClawGatewayError } from '../backend/openclaw/gateway-client';
+
+function setOpenClawTestInvoker(
+  impl: (payload: Record<string, unknown>) => unknown | Promise<unknown>,
+): void {
+  (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__ = impl;
+}
+
+function clearOpenClawTestInvoker(): void {
+  delete (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__;
+}
+
+test('LegacyOpenClawExecutionAdapter.run delegates the legacy run payload shape and returns ok results', async () => {
+  const adapter = new LegacyOpenClawExecutionAdapter();
+  const captured: Record<string, unknown>[] = [];
+
+  setOpenClawTestInvoker((payload) => {
+    captured.push(payload);
+    return {
+      ok: true,
+      status: 'ok',
+      output: [{ accepted: true, runId: 'run-123' }],
+      requiresApproval: null,
+    };
+  });
+
+  try {
+    const result = await adapter.run({
+      pipeline: 'marketing-pipeline.lobster',
+      cwd: '/tmp/aries-workflow',
+      argsJson: '{"tenantId":"tenant-123"}',
+      timeoutMs: 45_000,
+      maxStdoutBytes: 65_536,
+      allowLocalFallback: false,
+    });
+
+    assert.equal(adapter.name, 'openclaw');
+    assert.equal(result.kind, 'ok');
+    if (result.kind !== 'ok') {
+      assert.fail('expected ok result');
+    }
+
+    assert.deepEqual(result.primaryOutput, { accepted: true, runId: 'run-123' });
+    assert.equal(captured.length, 1);
+    assert.deepEqual(captured[0], {
+      tool: 'lobster',
+      sessionKey: 'main',
+      args: {
+        action: 'run',
+        pipeline: 'marketing-pipeline.lobster',
+        argsJson: '{"tenantId":"tenant-123"}',
+        cwd: '/tmp/aries-workflow',
+        timeoutMs: 45_000,
+        maxStdoutBytes: 65_536,
+      },
+    });
+  } finally {
+    clearOpenClawTestInvoker();
+  }
+});
+
+test('LegacyOpenClawExecutionAdapter.run maps OpenClawGatewayError to ExecutionError without losing status or code', async () => {
+  const adapter = new LegacyOpenClawExecutionAdapter();
+
+  setOpenClawTestInvoker(() => {
+    throw new OpenClawGatewayError(
+      'openclaw_gateway_request_invalid',
+      'workflow args are invalid',
+      400,
+    );
+  });
+
+  try {
+    const result = await adapter.run({
+      pipeline: 'marketing-pipeline.lobster',
+      cwd: '/tmp/aries-workflow',
+      argsJson: '{}',
+      allowLocalFallback: false,
+    });
+
+    assert.equal(result.kind, 'gateway_error');
+    if (result.kind !== 'gateway_error') {
+      assert.fail('expected gateway_error result');
+    }
+
+    assert.ok(result.error instanceof ExecutionError);
+    assert.equal(result.error.provider, 'openclaw');
+    assert.equal(result.error.code, 'request_invalid');
+    assert.equal(result.error.message, 'workflow args are invalid');
+    assert.equal(result.error.status, 400);
+    assert.ok(result.error.cause instanceof OpenClawGatewayError);
+  } finally {
+    clearOpenClawTestInvoker();
+  }
+});
+
+test('LegacyOpenClawExecutionAdapter.resume delegates the legacy resume payload shape and returns ok results', async () => {
+  const adapter = new LegacyOpenClawExecutionAdapter();
+  const captured: Record<string, unknown>[] = [];
+
+  setOpenClawTestInvoker((payload) => {
+    captured.push(payload);
+    return {
+      ok: true,
+      status: 'ok',
+      output: [{ resumed: true }],
+      requiresApproval: null,
+    };
+  });
+
+  try {
+    const result = await adapter.resume({
+      token: 'workflow_resume_run-123',
+      approve: true,
+      cwd: '/tmp/aries-workflow',
+      timeoutMs: 30_000,
+      maxStdoutBytes: 4_096,
+      allowLocalFallback: false,
+    });
+
+    assert.equal(result.kind, 'ok');
+    if (result.kind !== 'ok') {
+      assert.fail('expected ok result');
+    }
+
+    assert.deepEqual(result.primaryOutput, { resumed: true });
+    assert.equal(captured.length, 1);
+    assert.deepEqual(captured[0], {
+      tool: 'lobster',
+      sessionKey: 'main',
+      args: {
+        action: 'resume',
+        token: 'workflow_resume_run-123',
+        approve: true,
+        cwd: '/tmp/aries-workflow',
+        timeoutMs: 30_000,
+        maxStdoutBytes: 4_096,
+      },
+    });
+  } finally {
+    clearOpenClawTestInvoker();
+  }
+});
+
+test('LegacyOpenClawExecutionAdapter.cancel delegates the legacy cancel payload shape', async () => {
+  const adapter = new LegacyOpenClawExecutionAdapter();
+  const captured: Record<string, unknown>[] = [];
+
+  setOpenClawTestInvoker((payload) => {
+    captured.push(payload);
+    return {
+      ok: true,
+      status: 'ok',
+      output: [],
+      requiresApproval: null,
+    };
+  });
+
+  try {
+    const result = await adapter.cancel({
+      correlationId: 'job-123',
+      cwd: '/tmp/aries-workflow',
+      timeoutMs: 2_500,
+    });
+
+    assert.deepEqual(result, { cancelled: true });
+    assert.equal(captured.length, 1);
+    assert.deepEqual(captured[0], {
+      tool: 'lobster',
+      sessionKey: 'main',
+      args: {
+        action: 'cancel',
+        correlationId: 'job-123',
+        cwd: '/tmp/aries-workflow',
+        timeoutMs: 2_500,
+      },
+    });
+  } finally {
+    clearOpenClawTestInvoker();
+  }
+});


### PR DESCRIPTION
## Summary
- add a LegacyOpenClawExecutionAdapter that wraps legacy run/resume/cancel calls behind backend/execution
- map OpenClawGatewayError into provider-neutral ExecutionError without dropping code or status
- add TDD coverage for adapter payload passthrough plus legacy gateway logging regression coverage

## Test Plan
- npx tsx --test tests/execution-provider-contract.test.ts tests/execution-legacy-openclaw-adapter.test.ts tests/marketing-gateway-logging.test.ts
- ARIES_CANONICAL_REPO_ROOT=$PWD npm run workspace:verify

Depends on #242
