### PR TITLE
refactor(execution): remove route-level openclaw imports

### DIFF
--- a/app/api/calendar/sync/handler.ts
+++ b/app/api/calendar/sync/handler.ts
@@ -1,5 +1,5 @@
 import { buildCalendarSyncEvent } from '../../../../backend/integrations/workflow-orchestrator';
-import { mapOpenClawGatewayError, runAriesOpenClawWorkflow } from '../../../../backend/openclaw/aries-execution';
+import { mapAriesExecutionError, runAriesWorkflow } from '../../../../backend/execution';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 export async function handleCalendarSync(req: Request, tenantContextLoader?: TenantContextLoader) {
@@ -21,13 +21,19 @@ export async function handleCalendarSync(req: Request, tenantContextLoader?: Ten
       window_start: body.window_start,
       window_end: body.window_end
     });
-    const executed = await runAriesOpenClawWorkflow('calendar_sync', {
+    const executed = await runAriesWorkflow('calendar_sync', {
       tenant_id: tenantResult.tenantContext.tenantId,
       window_start: body.window_start || null,
       window_end: body.window_end || null,
     });
     if (executed.kind === 'gateway_error') {
-      const mapped = mapOpenClawGatewayError(executed.error);
+      const mapped = mapAriesExecutionError(executed.error);
+      if (!mapped) {
+        return new Response(JSON.stringify({ status: 'error', reason: 'Execution failed.' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
       return new Response(JSON.stringify(mapped.body), {
         status: mapped.status,
         headers: { 'content-type': 'application/json' },

--- a/app/api/demo/route.ts
+++ b/app/api/demo/route.ts
@@ -1,5 +1,5 @@
 import { buildPayload, successResponse, errorResponse } from '../../../lib/api-service';
-import { runAriesOpenClawWorkflow, mapOpenClawGatewayError } from '../../../backend/openclaw/aries-execution';
+import { mapAriesExecutionError, runAriesWorkflow } from '../../../backend/execution';
 
 /**
  * POST /api/demo
@@ -27,14 +27,17 @@ export async function POST(req: Request) {
     details: (body.details as Record<string, string>) || {},
   } as any);
 
-  const executed = await runAriesOpenClawWorkflow('demo_start', {
+  const executed = await runAriesWorkflow('demo_start', {
     source: payload.source,
     surface: payload.surface,
     user: payload.user,
     details: payload.details ?? {},
   });
   if (executed.kind === 'gateway_error') {
-    const mapped = mapOpenClawGatewayError(executed.error);
+    const mapped = mapAriesExecutionError(executed.error);
+    if (!mapped) {
+      return errorResponse(500, 'Execution failed.');
+    }
     return new Response(JSON.stringify(mapped.body), {
       status: mapped.status,
       headers: { 'content-type': 'application/json' },

--- a/app/api/integrations/handlers.ts
+++ b/app/api/integrations/handlers.ts
@@ -4,7 +4,7 @@ import { oauthReconnect } from '../../../backend/integrations/reconnect';
 import { oauthStatusAsync } from '../../../backend/integrations/status';
 import { buildIntegrationSyncEvent } from '../../../backend/integrations/workflow-orchestrator';
 import { resolveTokenHealth } from '../../../backend/integrations/connection-schema';
-import { mapOpenClawGatewayError, runAriesOpenClawWorkflow } from '../../../backend/openclaw/aries-execution';
+import { mapAriesExecutionError, runAriesWorkflow } from '../../../backend/execution';
 import { PROVIDER_REGISTRY } from '../../../backend/integrations/provider-registry';
 import { buildOauthConnectInput } from '@/lib/oauth-connect-input';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
@@ -340,12 +340,18 @@ export async function handleIntegrationsSync(req: Request, tenantContextLoader?:
       tenant_id: tenantId,
       provider,
     });
-    const executed = await runAriesOpenClawWorkflow('integrations_sync', {
+    const executed = await runAriesWorkflow('integrations_sync', {
       tenant_id: tenantId,
       provider,
     });
     if (executed.kind === 'gateway_error') {
-      const mapped = mapOpenClawGatewayError(executed.error);
+      const mapped = mapAriesExecutionError(executed.error);
+      if (!mapped) {
+        return new Response(JSON.stringify({ status: 'error', reason: 'Execution failed.' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
       return new Response(JSON.stringify(mapped.body), {
         status: mapped.status,
         headers: { 'content-type': 'application/json' }

--- a/app/api/marketing/jobs/[jobId]/approve/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/approve/handler.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 
+import { mapAriesExecutionError } from '@/backend/execution';
 import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import { approveMarketingJob } from '@/backend/marketing/orchestrator';
 import { loadMarketingJobRuntime } from '@/backend/marketing/runtime-state';
-import { OpenClawGatewayError } from '@/backend/openclaw/gateway-client';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 const MARKETING_ONBOARDING_REQUIRED = {
@@ -132,20 +132,9 @@ export async function handleApproveMarketingJob(
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof OpenClawGatewayError) {
-      const status =
-        error.code === 'openclaw_gateway_unauthorized'
-          ? 401
-          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
-            ? 503
-            : error.status || 500;
-      return NextResponse.json(
-        {
-          error: error.message,
-          reason: error.code,
-        },
-        { status }
-      );
+    const mapped = mapAriesExecutionError(error);
+    if (mapped) {
+      return NextResponse.json(mapped.body, { status: mapped.status });
     }
     if (message.startsWith('workflow_missing_for_route:')) {
       return NextResponse.json(

--- a/app/api/marketing/jobs/[jobId]/delete/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/delete/handler.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 
+import { cancelAriesWorkflow } from '@/backend/execution';
 import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
-import { cancelOpenClawLobsterWorkflow } from '@/backend/openclaw/gateway-client';
 import {
   isPipelineActive,
   loadMarketingJobRuntime,
@@ -128,7 +128,7 @@ export async function handleDeleteMarketingJob(
   // finish the current stage before the soft-cancel boundary check picks up.
   // The call swallows errors internally; soft-delete succeeds regardless.
   if (wasActive) {
-    await cancelOpenClawLobsterWorkflow({ correlationId: jobId }).catch(() => {});
+    await cancelAriesWorkflow({ correlationId: jobId }).catch(() => {});
   }
 
   invalidateMarketingJobStatus(jobId);

--- a/app/api/marketing/jobs/handler.ts
+++ b/app/api/marketing/jobs/handler.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { mapAriesExecutionError } from '@/backend/execution';
 import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import { startMarketingJob } from '@/backend/marketing/orchestrator';
 import {
@@ -7,7 +8,6 @@ import {
   saveCampaignWorkspaceAssets,
   type CampaignWorkspaceAssetUpload,
 } from '@/backend/marketing/workspace-store';
-import { OpenClawGatewayError } from '@/backend/openclaw/gateway-client';
 import {
   marketingPayloadDefaultsFromBusinessProfile,
   persistBusinessProfileFieldsFromMarketingPayload,
@@ -322,14 +322,9 @@ export async function handlePostMarketingJobs(
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof OpenClawGatewayError) {
-      const status =
-        error.code === 'openclaw_gateway_unauthorized'
-          ? 401
-          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
-            ? 503
-            : error.status || 500;
-      return NextResponse.json({ error: message, reason: error.code }, { status });
+    const mapped = mapAriesExecutionError(error);
+    if (mapped) {
+      return NextResponse.json(mapped.body, { status: mapped.status });
     }
     if (message.startsWith('workflow_missing_for_route:')) {
       return NextResponse.json({ error: message, reason: 'workflow_missing_for_route' }, { status: 501 });

--- a/app/api/marketing/reviews/[reviewId]/decision/route.ts
+++ b/app/api/marketing/reviews/[reviewId]/decision/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 
+import { mapAriesExecutionError } from '@/backend/execution';
 import { invalidateMarketingJobStatus } from '@/backend/marketing/jobs-status';
 import { RuntimeReviewDecisionError, recordMarketingReviewDecision } from '@/backend/marketing/runtime-views';
-import { OpenClawGatewayError } from '@/backend/openclaw/gateway-client';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 function decodeReviewIdParam(reviewId: string): string {
@@ -76,20 +76,9 @@ export async function handlePostMarketingReviewDecision(
         { status: error.status },
       );
     }
-    if (error instanceof OpenClawGatewayError) {
-      const status =
-        error.code === 'openclaw_gateway_unauthorized'
-          ? 401
-          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
-            ? 503
-            : error.status || 500;
-      return NextResponse.json(
-        {
-          error: error.message,
-          reason: error.code,
-        },
-        { status },
-      );
+    const mapped = mapAriesExecutionError(error);
+    if (mapped) {
+      return NextResponse.json(mapped.body, { status: mapped.status });
     }
 
     const message = error instanceof Error ? error.message : String(error);

--- a/app/api/onboarding/start/route.ts
+++ b/app/api/onboarding/start/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
+import { mapAriesExecutionError } from '../../../../backend/execution';
 import { startOnboarding } from '../../../../backend/onboarding/start';
-import { OpenClawGatewayError } from '../../../../backend/openclaw/gateway-client';
 
 export async function POST(req: Request) {
   let payload: any = {};
@@ -14,20 +14,15 @@ export async function POST(req: Request) {
   try {
     result = await startOnboarding(payload);
   } catch (error) {
-    if (error instanceof OpenClawGatewayError) {
-      const status =
-        error.code === 'openclaw_gateway_unauthorized'
-          ? 401
-          : error.code === 'openclaw_gateway_unreachable' || error.code === 'openclaw_gateway_not_configured'
-            ? 503
-            : error.status || 500;
+    const mapped = mapAriesExecutionError(error);
+    if (mapped) {
       return NextResponse.json(
         {
           onboarding_status: 'error',
-          reason: error.code,
-          message: error.message,
+          reason: mapped.body.reason,
+          message: mapped.body.error,
         },
-        { status }
+        { status: mapped.status }
       );
     }
     throw error;

--- a/app/api/publish/dispatch/handler.ts
+++ b/app/api/publish/dispatch/handler.ts
@@ -1,5 +1,5 @@
 import { normalizePublishDispatch } from '../../../../backend/integrations/workflow-orchestrator';
-import { mapOpenClawGatewayError, runAriesOpenClawWorkflow } from '../../../../backend/openclaw/aries-execution';
+import { mapAriesExecutionError, runAriesWorkflow } from '../../../../backend/execution';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 export async function handlePublishDispatch(req: Request, tenantContextLoader?: TenantContextLoader) {
@@ -24,7 +24,7 @@ export async function handlePublishDispatch(req: Request, tenantContextLoader?: 
       media_urls: body.media_urls || [],
       scheduled_for: body.scheduled_for,
     });
-    const executed = await runAriesOpenClawWorkflow('publish_dispatch', {
+    const executed = await runAriesWorkflow('publish_dispatch', {
       tenant_id: tenantId,
       provider: event.provider,
       content_text: event.payload.content_text || '',
@@ -32,7 +32,13 @@ export async function handlePublishDispatch(req: Request, tenantContextLoader?: 
       scheduled_for: event.payload.scheduled_for || null,
     });
     if (executed.kind === 'gateway_error') {
-      const mapped = mapOpenClawGatewayError(executed.error);
+      const mapped = mapAriesExecutionError(executed.error);
+      if (!mapped) {
+        return new Response(JSON.stringify({ status: 'error', reason: 'Execution failed.' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
       return new Response(JSON.stringify(mapped.body), {
         status: mapped.status,
         headers: { 'content-type': 'application/json' },

--- a/app/api/publish/retry/handler.ts
+++ b/app/api/publish/retry/handler.ts
@@ -1,5 +1,5 @@
 import { buildRetryEvent } from '../../../../backend/integrations/workflow-orchestrator';
-import { mapOpenClawGatewayError, runAriesOpenClawWorkflow } from '../../../../backend/openclaw/aries-execution';
+import { mapAriesExecutionError, runAriesWorkflow } from '../../../../backend/execution';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 export async function handlePublishRetry(req: Request, tenantContextLoader?: TenantContextLoader) {
@@ -17,12 +17,18 @@ export async function handlePublishRetry(req: Request, tenantContextLoader?: Ten
 
   try {
     const event = buildRetryEvent({ tenant_id: tenantResult.tenantContext.tenantId, max_attempts: body.max_attempts });
-    const executed = await runAriesOpenClawWorkflow('publish_retry', {
+    const executed = await runAriesWorkflow('publish_retry', {
       tenant_id: tenantResult.tenantContext.tenantId,
       max_attempts: event.payload.max_attempts,
     });
     if (executed.kind === 'gateway_error') {
-      const mapped = mapOpenClawGatewayError(executed.error);
+      const mapped = mapAriesExecutionError(executed.error);
+      if (!mapped) {
+        return new Response(JSON.stringify({ status: 'error', reason: 'Execution failed.' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
       return new Response(JSON.stringify(mapped.body), {
         status: mapped.status,
         headers: { 'content-type': 'application/json' },

--- a/app/api/sandbox/launch/route.ts
+++ b/app/api/sandbox/launch/route.ts
@@ -1,5 +1,5 @@
 import { buildPayload, successResponse, errorResponse } from '../../../../lib/api-service';
-import { runAriesOpenClawWorkflow, mapOpenClawGatewayError } from '../../../../backend/openclaw/aries-execution';
+import { mapAriesExecutionError, runAriesWorkflow } from '../../../../backend/execution';
 
 /**
  * POST /api/sandbox/launch
@@ -27,14 +27,17 @@ export async function POST(req: Request) {
     details: (body.details as Record<string, string>) || {},
   } as any);
 
-  const executed = await runAriesOpenClawWorkflow('sandbox_launch', {
+  const executed = await runAriesWorkflow('sandbox_launch', {
     source: payload.source,
     surface: payload.surface,
     user: payload.user,
     details: payload.details ?? {},
   });
   if (executed.kind === 'gateway_error') {
-    const mapped = mapOpenClawGatewayError(executed.error);
+    const mapped = mapAriesExecutionError(executed.error);
+    if (!mapped) {
+      return errorResponse(500, 'Execution failed.');
+    }
     return new Response(JSON.stringify(mapped.body), {
       status: mapped.status,
       headers: { 'content-type': 'application/json' },

--- a/app/api/tenant/workflows/[workflowId]/runs/route.ts
+++ b/app/api/tenant/workflows/[workflowId]/runs/route.ts
@@ -1,4 +1,4 @@
-import { mapOpenClawGatewayError, runAriesOpenClawWorkflow } from '@/backend/openclaw/aries-execution';
+import { mapAriesExecutionError, runAriesWorkflow } from '@/backend/execution';
 import { ARIES_WORKFLOWS, type AriesWorkflowKey } from '@/backend/execution/workflow-catalog';
 import { getTenantContext } from '@/lib/tenant-context';
 
@@ -23,12 +23,12 @@ export async function POST(req: Request, context: { params: Promise<{ workflowId
     payload = {};
   }
 
-  if (!Object.hasOwn(ARIES_WORKFLOWS, workflowId)) {
+  if (!(workflowId in ARIES_WORKFLOWS)) {
     return json({ error: 'not_found' }, 404);
   }
   const key = workflowId as AriesWorkflowKey;
 
-  const executed = await runAriesOpenClawWorkflow(key, {
+  const executed = await runAriesWorkflow(key, {
     tenant_id: tenantContext.tenantId,
     actor_id: tenantContext.userId,
     inputs: payload.inputs || {},
@@ -36,7 +36,10 @@ export async function POST(req: Request, context: { params: Promise<{ workflowId
   }).catch((error) => ({ kind: 'gateway_error' as const, error }));
 
   if (executed.kind === 'gateway_error') {
-    const mapped = mapOpenClawGatewayError(executed.error);
+    const mapped = mapAriesExecutionError(executed.error);
+    if (!mapped) {
+      return json({ error: 'Execution failed.' }, 500);
+    }
     return json(mapped.body, mapped.status);
   }
   if (executed.kind === 'not_implemented') {

--- a/backend/execution/index.ts
+++ b/backend/execution/index.ts
@@ -1,10 +1,9 @@
 /**
  * Aries provider-neutral execution surface.
  *
- * This barrel exports the types and errors that callers should depend on
- * instead of importing provider-specific names (e.g. OpenClawGatewayError,
- * AriesWorkflowExecutionResult). Adding this module is a no-op for runtime
- * behavior; migration of existing callers happens in a later task.
+ * Route handlers and backend callers should import this surface instead of
+ * provider-specific modules. OpenClaw remains the current implementation behind
+ * these helpers, but callers should treat it as a swappable execution provider.
  */
 
 export {
@@ -28,6 +27,13 @@ export {
   type LegacyOpenClawResumeInput,
   type LegacyOpenClawRunInput,
 } from './providers/legacy-openclaw';
+
+export {
+  cancelAriesWorkflow,
+  mapAriesExecutionError,
+  runAriesWorkflow,
+  type AriesRouteExecutionResult,
+} from './route-helpers';
 
 export type {
   ExecutionProvider,

--- a/backend/execution/route-helpers.ts
+++ b/backend/execution/route-helpers.ts
@@ -1,0 +1,76 @@
+import { runAriesOpenClawWorkflow } from '../openclaw/aries-execution';
+import { OpenClawGatewayError } from '../openclaw/gateway-client';
+import {
+  LegacyOpenClawExecutionAdapter,
+  mapLegacyOpenClawGatewayError,
+  type LegacyOpenClawCancelInput,
+} from './providers/legacy-openclaw';
+import { ExecutionError } from './errors';
+import type { WorkflowExecutionResult } from './types';
+import type { AriesWorkflowKey } from './workflow-catalog';
+
+export type AriesRouteExecutionResult = WorkflowExecutionResult;
+
+const legacyAdapter = new LegacyOpenClawExecutionAdapter();
+
+function mapExecutionErrorStatus(error: ExecutionError): number {
+  switch (error.code) {
+    case 'unauthorized':
+      return 401;
+    case 'not_configured':
+    case 'unreachable':
+      return 503;
+    case 'request_invalid':
+      return 400;
+    case 'tool_unavailable':
+      return 500;
+    default:
+      return error.status ?? 500;
+  }
+}
+
+function executionErrorReason(error: ExecutionError): string {
+  const cause = error.cause;
+  if (cause instanceof OpenClawGatewayError) {
+    return cause.code;
+  }
+  return error.code;
+}
+
+export async function runAriesWorkflow(
+  key: AriesWorkflowKey,
+  input: Record<string, unknown>,
+): Promise<AriesRouteExecutionResult> {
+  const executed = await runAriesOpenClawWorkflow(key, input);
+  if (executed.kind === 'gateway_error') {
+    return {
+      kind: 'gateway_error',
+      error: mapLegacyOpenClawGatewayError(executed.error),
+    };
+  }
+  return executed;
+}
+
+export function mapAriesExecutionError(
+  error: unknown,
+): { status: number; body: Record<string, unknown> } | null {
+  if (error instanceof OpenClawGatewayError) {
+    return mapAriesExecutionError(mapLegacyOpenClawGatewayError(error));
+  }
+  if (!(error instanceof ExecutionError)) {
+    return null;
+  }
+  return {
+    status: mapExecutionErrorStatus(error),
+    body: {
+      status: 'error',
+      error: error.message,
+      reason: executionErrorReason(error),
+      message: error.message,
+    },
+  };
+}
+
+export async function cancelAriesWorkflow(input: LegacyOpenClawCancelInput): Promise<{ cancelled: boolean; reason?: string }> {
+  return legacyAdapter.cancel(input);
+}

--- a/backend/execution/types.ts
+++ b/backend/execution/types.ts
@@ -1,11 +1,9 @@
 /**
  * Provider-neutral execution types for Aries.
  *
- * These mirror the runtime outcomes currently expressed by the OpenClaw-coupled
- * AriesWorkflowExecutionResult (backend/openclaw/aries-execution.ts) but use
- * provider-neutral names so future Hermes-native execution can share the same
- * contract. Adding these types is a no-op for runtime behavior; callers are
- * not migrated in this task.
+ * These mirror the runtime outcomes currently expressed by the legacy OpenClaw
+ * execution path, but use provider-neutral names so route handlers and future
+ * Hermes-native execution can share the same public contract.
  */
 
 import type { ExecutionError, ExecutionProviderName } from './errors';

--- a/backend/onboarding/start.ts
+++ b/backend/onboarding/start.ts
@@ -4,8 +4,7 @@ import {
   resolveDraftRoot,
   resolveValidatedRoot
 } from '../../lib/runtime-paths';
-import { runAriesOpenClawWorkflow } from '../openclaw/aries-execution';
-import { OpenClawGatewayError } from '../openclaw/gateway-client';
+import { runAriesWorkflow } from '../execution';
 
 type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
 
@@ -67,7 +66,7 @@ export async function startOnboarding(payload: StartRequest): Promise<StartResul
   const tenantType = payload.tenant_type!;
   const signupEventId = payload.signup_event_id!;
 
-  const executed = await runAriesOpenClawWorkflow('onboarding_start', {
+  const executed = await runAriesWorkflow('onboarding_start', {
     tenant_id: tenantId,
     tenant_type: tenantType,
     signup_event_id: signupEventId,

--- a/docs/plans/2026-05-02-hermes-native-aries-execution-migration.md
+++ b/docs/plans/2026-05-02-hermes-native-aries-execution-migration.md
@@ -2,7 +2,7 @@
 
 > **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
 
-**Goal:** Move Aries runtime execution from OpenClaw/Lobster-owned contracts to Aries-owned interfaces backed by Hermes-compatible execution, without breaking marketing jobs, approval resumes, generated assets, Docker runtime, or live deployment.
+**Goal:** Move Aries/Ares runtime execution from OpenClaw/Lobster-owned contracts to Aries-owned interfaces backed by Hermes-compatible execution, without breaking marketing jobs, approval resumes, generated assets, Docker runtime, or live deployment.
 
 **Architecture:** Introduce an Aries-owned execution boundary first, then adapt the existing OpenClaw/Lobster implementation behind it as the legacy adapter. Add a Hermes adapter only after the Aries contract, runtime envelopes, approval tokens, cancellation, and artifact contracts are pinned by tests. Keep current OpenClaw/Lobster paths working until Hermes parity is proven route-by-route.
 

--- a/tests/execution-route-imports.test.ts
+++ b/tests/execution-route-imports.test.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  cancelAriesWorkflow,
+  mapAriesExecutionError,
+  runAriesWorkflow,
+} from '../backend/execution';
+import { OpenClawGatewayError } from '../backend/openclaw/gateway-client';
+
+const APP_API_ROOT = path.join(process.cwd(), 'app', 'api');
+
+function setOpenClawTestInvoker(
+  impl: (payload: Record<string, unknown>) => unknown | Promise<unknown>,
+): void {
+  (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__ = impl;
+}
+
+function clearOpenClawTestInvoker(): void {
+  delete (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__;
+}
+
+async function collectRouteFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return collectRouteFiles(fullPath);
+      }
+      if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
+        return [fullPath];
+      }
+      return [];
+    }),
+  );
+  return files.flat();
+}
+
+test('backend/execution exports provider-neutral route helpers', () => {
+  assert.equal(typeof runAriesWorkflow, 'function');
+  assert.equal(typeof mapAriesExecutionError, 'function');
+  assert.equal(typeof cancelAriesWorkflow, 'function');
+});
+
+test('runAriesWorkflow maps legacy gateway errors into provider-neutral route errors', async () => {
+  setOpenClawTestInvoker(() => {
+    throw new OpenClawGatewayError('openclaw_gateway_request_invalid', 'bad payload', 400);
+  });
+
+  try {
+    const executed = await runAriesWorkflow('demo_start', {
+      source: 'marketing-site',
+      surface: 'marketing-site',
+      user: { name: 'Test', email: 'test@example.com' },
+      details: {},
+    });
+
+    assert.equal(executed.kind, 'gateway_error');
+    if (executed.kind !== 'gateway_error') {
+      assert.fail('expected gateway_error result');
+      return;
+    }
+
+    const mapped = mapAriesExecutionError(executed.error);
+    assert.deepEqual(mapped, {
+      status: 400,
+      body: {
+        status: 'error',
+        error: 'bad payload',
+        reason: 'openclaw_gateway_request_invalid',
+        message: 'bad payload',
+      },
+    });
+  } finally {
+    clearOpenClawTestInvoker();
+  }
+});
+
+
+test('mapAriesExecutionError preserves legacy tool-unavailable route semantics', () => {
+  const mapped = mapAriesExecutionError(
+    new OpenClawGatewayError(
+      'openclaw_gateway_tool_unavailable',
+      'OpenClaw gateway does not expose the requested tool.',
+      404,
+    ),
+  );
+
+  assert.deepEqual(mapped, {
+    status: 500,
+    body: {
+      status: 'error',
+      error: 'OpenClaw gateway does not expose the requested tool.',
+      reason: 'openclaw_gateway_tool_unavailable',
+      message: 'OpenClaw gateway does not expose the requested tool.',
+    },
+  });
+});
+
+test('cancelAriesWorkflow delegates the legacy cancel payload through the neutral helper', async () => {
+  const captured: Record<string, unknown>[] = [];
+  setOpenClawTestInvoker((payload) => {
+    captured.push(payload);
+    return { ok: true, status: 'ok', output: [], requiresApproval: null };
+  });
+
+  try {
+    const result = await cancelAriesWorkflow({
+      correlationId: 'job-123',
+      cwd: '/tmp/aries-workflow',
+      timeoutMs: 2_500,
+    });
+
+    assert.deepEqual(result, { cancelled: true });
+    assert.deepEqual(captured, [
+      {
+        tool: 'lobster',
+        sessionKey: 'main',
+        args: {
+          action: 'cancel',
+          correlationId: 'job-123',
+          cwd: '/tmp/aries-workflow',
+          timeoutMs: 2_500,
+        },
+      },
+    ]);
+  } finally {
+    clearOpenClawTestInvoker();
+  }
+});
+
+test('app/api route handlers no longer import backend/openclaw directly', async () => {
+  const routeFiles = await collectRouteFiles(APP_API_ROOT);
+  const offenders: string[] = [];
+
+  for (const filePath of routeFiles) {
+    const source = await readFile(filePath, 'utf8');
+    if (source.includes('backend/openclaw')) {
+      offenders.push(path.relative(process.cwd(), filePath));
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});

--- a/tests/execution-workflow-catalog.test.ts
+++ b/tests/execution-workflow-catalog.test.ts
@@ -33,11 +33,10 @@ test('Aries-owned workflow catalog preserves every legacy workflow definition', 
   }
 });
 
-test('tenant workflow routes import the Aries-owned workflow catalog', async () => {
+test('tenant workflow routes do not import the legacy OpenClaw workflow catalog', async () => {
   for (const relativePath of TENANT_WORKFLOW_ROUTE_FILES) {
     const source = await readFile(path.join(PROJECT_ROOT, relativePath), 'utf8');
 
-    assert.match(source, /@\/backend\/execution(?:\/workflow-catalog)?['"/]/);
-    assert.doesNotMatch(source, /@\/backend\/openclaw\/workflow-catalog/);
+    assert.doesNotMatch(source, /backend\/openclaw\/workflow-catalog/);
   }
 });


### PR DESCRIPTION
## Summary
- add provider-neutral route execution helpers for run/error-map/cancel
- migrate browser-facing API routes off direct backend/openclaw imports
- add regression coverage that app/api routes no longer import backend/openclaw

## Test Plan
- npx tsx --test tests/execution-route-imports.test.ts tests/auth/workflow-route-tenant-context.test.ts
- ARIES_CANONICAL_REPO_ROOT=$PWD npm run workspace:verify