### PR TITLE
fix(execution): address Copilot review followups from #242-#245

### DIFF
--- a/app/api/tenant/workflows/[workflowId]/runs/route.ts
+++ b/app/api/tenant/workflows/[workflowId]/runs/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request, context: { params: Promise<{ workflowId
     payload = {};
   }
 
-  if (!(workflowId in ARIES_WORKFLOWS)) {
+  if (!Object.prototype.hasOwnProperty.call(ARIES_WORKFLOWS, workflowId)) {
     return json({ error: 'not_found' }, 404);
   }
   const key = workflowId as AriesWorkflowKey;

--- a/backend/execution/providers/legacy-openclaw.ts
+++ b/backend/execution/providers/legacy-openclaw.ts
@@ -42,6 +42,11 @@ function mapLegacyOpenClawCode(
       return 'response_invalid';
     case 'openclaw_gateway_server_error':
       return 'server_error';
+    default: {
+      const _exhaustive: never = code;
+      void _exhaustive;
+      return 'server_error';
+    }
   }
 }
 

--- a/docs/plans/2026-05-02-hermes-native-aries-execution-migration.md
+++ b/docs/plans/2026-05-02-hermes-native-aries-execution-migration.md
@@ -2,7 +2,7 @@
 
 > **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
 
-**Goal:** Move Aries/Ares runtime execution from OpenClaw/Lobster-owned contracts to Aries-owned interfaces backed by Hermes-compatible execution, without breaking marketing jobs, approval resumes, generated assets, Docker runtime, or live deployment.
+**Goal:** Move Aries runtime execution from OpenClaw/Lobster-owned contracts to Aries-owned interfaces backed by Hermes-compatible execution, without breaking marketing jobs, approval resumes, generated assets, Docker runtime, or live deployment.
 
 **Architecture:** Introduce an Aries-owned execution boundary first, then adapt the existing OpenClaw/Lobster implementation behind it as the legacy adapter. Add a Hermes adapter only after the Aries contract, runtime envelopes, approval tokens, cancellation, and artifact contracts are pinned by tests. Keep current OpenClaw/Lobster paths working until Hermes parity is proven route-by-route.
 

--- a/tests/execution-legacy-openclaw-adapter.test.ts
+++ b/tests/execution-legacy-openclaw-adapter.test.ts
@@ -4,6 +4,8 @@ import test from 'node:test';
 import { ExecutionError, LegacyOpenClawExecutionAdapter } from '../backend/execution';
 import { OpenClawGatewayError } from '../backend/openclaw/gateway-client';
 
+const EXPECTED_SESSION_KEY = process.env.OPENCLAW_SESSION_KEY?.trim() || 'main';
+
 function setOpenClawTestInvoker(
   impl: (payload: Record<string, unknown>) => unknown | Promise<unknown>,
 ): void {
@@ -48,7 +50,7 @@ test('LegacyOpenClawExecutionAdapter.run delegates the legacy run payload shape 
     assert.equal(captured.length, 1);
     assert.deepEqual(captured[0], {
       tool: 'lobster',
-      sessionKey: 'main',
+      sessionKey: EXPECTED_SESSION_KEY,
       args: {
         action: 'run',
         pipeline: 'marketing-pipeline.lobster',
@@ -131,7 +133,7 @@ test('LegacyOpenClawExecutionAdapter.resume delegates the legacy resume payload 
     assert.equal(captured.length, 1);
     assert.deepEqual(captured[0], {
       tool: 'lobster',
-      sessionKey: 'main',
+      sessionKey: EXPECTED_SESSION_KEY,
       args: {
         action: 'resume',
         token: 'workflow_resume_run-123',
@@ -171,7 +173,7 @@ test('LegacyOpenClawExecutionAdapter.cancel delegates the legacy cancel payload 
     assert.equal(captured.length, 1);
     assert.deepEqual(captured[0], {
       tool: 'lobster',
-      sessionKey: 'main',
+      sessionKey: EXPECTED_SESSION_KEY,
       args: {
         action: 'cancel',
         correlationId: 'job-123',


### PR DESCRIPTION
## Summary

Audit pass over the four closed migration PRs (#242, #243, #244, #245). Most Copilot inline comments were already addressed at merge time, but four valid ones slipped through. This PR applies them.

## Findings

| PR | Comment | Status |
|---|---|---|
| #242 | "Aries/Ares" typo in plan goal | Fixed at merge of #242 (`bed6a46`), but #245 re-created the plan file from scratch and regressed it. Reapplied. |
| #243 | `sessionKey: 'main'` hard-coded in 3 test cases | Now derived from `OPENCLAW_SESSION_KEY` so the test no longer breaks when the env var is set. |
| #243 | `mapLegacyOpenClawCode` lacks default/exhaustiveness guard | Added `never`-typed exhaustiveness check with `'server_error'` fallback. |
| #244 | `workflowId in ARIES_WORKFLOWS` accepts inherited props | Switched to `Object.prototype.hasOwnProperty.call` so requests for `toString`, `__proto__`, etc. get a clean 404 instead of a downstream crash. |

## Comments deliberately not applied (reasoning)

- **#243 barrel header**: already rewritten at merge to no longer claim "no-op."
- **#244 / #245 test specifier brittleness**: current test uses *negative* assertion (`doesNotMatch(/openclaw/)`), not the positive specifier Copilot complained about.
- **#245 stale "no-op" headers**: rewritten at merge to reflect that callers were migrated.
- **#245 body shape claim**: Copilot misread; body already has `status: 'error' | error | reason | message`.
- **#245 `tool_unavailable` status claim**: switch case explicitly returns 500.
- **#245 leaking OpenClaw types**: `WorkflowEnvelope` is `Record<string, unknown>` and `ParityStubPayload` is locally defined — no leakage at the public surface.

## Test plan

- [x] `tsx --test tests/execution-legacy-openclaw-adapter.test.ts tests/execution-provider-contract.test.ts tests/execution-workflow-catalog.test.ts` (12/12 pass)
- [x] `tsx --test tests/auth/workflow-route-tenant-context.test.ts tests/openclaw-marketing-workflows.test.ts` (18/18 pass)
- [x] `npm run typecheck` clean
- [x] `node scripts/check-banned-patterns.mjs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)