### PR TITLE
feat(execution): add Hermes demo path and artifact store

### DIFF
--- a/backend/execution/index.ts
+++ b/backend/execution/index.ts
@@ -28,6 +28,16 @@ export {
 } from './provider-factory';
 
 export {
+  HermesExecutionAdapter,
+  buildHermesRequestEnvelope,
+  type HermesCancelRequestEnvelope,
+  type HermesRequestEnvelope,
+  type HermesRequestEnvelopeInput,
+  type HermesResumeRequestEnvelope,
+  type HermesRunRequestEnvelope,
+} from './providers/hermes';
+
+export {
   LegacyOpenClawExecutionAdapter,
   mapLegacyOpenClawGatewayError,
   type LegacyOpenClawCancelInput,

--- a/backend/execution/provider-factory.ts
+++ b/backend/execution/provider-factory.ts
@@ -1,5 +1,5 @@
 import { runAriesOpenClawWorkflow } from '../openclaw/aries-execution';
-import { ExecutionError } from './errors';
+import { HermesExecutionAdapter } from './providers/hermes';
 import { mapLegacyOpenClawGatewayError } from './providers/legacy-openclaw';
 import type { ExecutionProvider, WorkflowExecutionResult } from './types';
 import type { AriesWorkflowKey } from './workflow-catalog';
@@ -53,27 +53,10 @@ class LegacyOpenClawWorkflowProvider implements ExecutionProvider {
   }
 }
 
-class HermesExecutionProviderStub implements ExecutionProvider {
-  readonly name = 'hermes' as const;
-
-  async runWorkflow(): Promise<WorkflowExecutionResult> {
-    return {
-      kind: 'gateway_error',
-      error: new ExecutionError({
-        provider: 'hermes',
-        code: 'not_configured',
-        status: 503,
-        message:
-          'ARIES_EXECUTION_PROVIDER=hermes is not implemented yet. Set HERMES_GATEWAY_URL and HERMES_GATEWAY_TOKEN when the Hermes execution adapter lands; HERMES_SESSION_KEY stays optional.',
-      }),
-    };
-  }
-}
-
 export function getExecutionProvider(env: ExecutionProviderEnv = process.env): ExecutionProvider {
   const providerName = resolveExecutionProviderName(env);
   if (providerName === 'hermes') {
-    return new HermesExecutionProviderStub();
+    return new HermesExecutionAdapter(env);
   }
   return new LegacyOpenClawWorkflowProvider();
 }

--- a/backend/execution/providers/hermes.ts
+++ b/backend/execution/providers/hermes.ts
@@ -1,0 +1,320 @@
+import { ExecutionError } from '../errors';
+import type { WorkflowEnvelope, WorkflowExecutionResult } from '../types';
+
+type HermesExecutionEnv = Partial<Record<string, string | undefined>>;
+type HermesFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+const HERMES_RUN_TOOL = 'aries.workflow.run';
+const HERMES_SUPPORTED_RUN_WORKFLOWS = new Set(['demo_start']);
+
+type HermesRequestBase = {
+  provider: 'hermes';
+  sessionKey?: string;
+  cwd?: string;
+  timeoutMs?: number;
+  maxStdoutBytes?: number;
+};
+
+export type HermesRunRequestEnvelope = HermesRequestBase & {
+  action: 'run';
+  workflowId: string;
+  argsJson: string;
+};
+
+export type HermesResumeRequestEnvelope = HermesRequestBase & {
+  action: 'resume';
+  workflowId: string;
+  argsJson: string;
+  approvalResumeToken: string;
+  approve: boolean;
+};
+
+export type HermesCancelRequestEnvelope = HermesRequestBase & {
+  action: 'cancel';
+  cancelCorrelationId: string;
+};
+
+export type HermesRequestEnvelope =
+  | HermesRunRequestEnvelope
+  | HermesResumeRequestEnvelope
+  | HermesCancelRequestEnvelope;
+
+export type HermesRequestEnvelopeInput =
+  | {
+      action: 'run';
+      workflowId: string;
+      args: Record<string, unknown>;
+      sessionKey?: string;
+      cwd?: string;
+      timeoutMs?: number;
+      maxStdoutBytes?: number;
+    }
+  | {
+      action: 'resume';
+      workflowId: string;
+      args: Record<string, unknown>;
+      approvalResumeToken: string;
+      approve: boolean;
+      sessionKey?: string;
+      cwd?: string;
+      timeoutMs?: number;
+      maxStdoutBytes?: number;
+    }
+  | {
+      action: 'cancel';
+      cancelCorrelationId: string;
+      sessionKey?: string;
+      cwd?: string;
+      timeoutMs?: number;
+      maxStdoutBytes?: number;
+    };
+
+function readEnvValue(env: HermesExecutionEnv, key: string): string {
+  const value = env[key];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function addOptionalRequestFields<T extends HermesRequestEnvelope>(
+  envelope: T,
+  input: HermesRequestEnvelopeInput,
+): T {
+  if (input.sessionKey) envelope.sessionKey = input.sessionKey;
+  if (input.cwd) envelope.cwd = input.cwd;
+  if (input.timeoutMs !== undefined) envelope.timeoutMs = input.timeoutMs;
+  if (input.maxStdoutBytes !== undefined) envelope.maxStdoutBytes = input.maxStdoutBytes;
+  return envelope;
+}
+
+/**
+ * Hermes execution request contract.
+ *
+ * Real invocation will send this provider-owned envelope to the Hermes gateway:
+ * workflow id, JSON args, optional workspace/cwd, timeout and output caps,
+ * approval resume token for paused approvals, and cancel correlation id for
+ * cancellation. Phase 6 only pins the contract and returns honest unsupported
+ * results; it must not silently fall back to OpenClaw.
+ */
+export function buildHermesRequestEnvelope(
+  input: HermesRequestEnvelopeInput,
+): HermesRequestEnvelope {
+  switch (input.action) {
+    case 'run':
+      return addOptionalRequestFields(
+        {
+          provider: 'hermes',
+          action: 'run',
+          workflowId: input.workflowId,
+          argsJson: JSON.stringify(input.args),
+        },
+        input,
+      );
+    case 'resume':
+      return addOptionalRequestFields(
+        {
+          provider: 'hermes',
+          action: 'resume',
+          workflowId: input.workflowId,
+          argsJson: JSON.stringify(input.args),
+          approvalResumeToken: input.approvalResumeToken,
+          approve: input.approve,
+        },
+        input,
+      );
+    case 'cancel':
+      return addOptionalRequestFields(
+        {
+          provider: 'hermes',
+          action: 'cancel',
+          cancelCorrelationId: input.cancelCorrelationId,
+        },
+        input,
+      );
+    default: {
+      const _exhaustive: never = input;
+      return _exhaustive;
+    }
+  }
+}
+
+function missingHermesConfigError(keys: 'HERMES_GATEWAY_URL' | 'HERMES_GATEWAY_TOKEN' | 'HERMES_GATEWAY_URL and HERMES_GATEWAY_TOKEN'): ExecutionError {
+  return new ExecutionError({
+    provider: 'hermes',
+    code: 'not_configured',
+    status: 503,
+    message: `${keys} required when ARIES_EXECUTION_PROVIDER=hermes. Set the Hermes gateway URL and token, or set ARIES_EXECUTION_PROVIDER=legacy-openclaw to keep the current runtime.`,
+  });
+}
+
+function notImplementedResult(route: string): WorkflowExecutionResult {
+  return {
+    kind: 'not_implemented',
+    payload: {
+      status: 'not_implemented',
+      code: 'workflow_missing_for_route',
+      route,
+      message:
+        'Hermes execution adapter is selected and configured, but real Hermes workflow invocation is not implemented in this phase.',
+      provider: 'hermes',
+    },
+  };
+}
+
+function primaryOutputRecord(envelope: WorkflowEnvelope): Record<string, unknown> | null {
+  const output = envelope.output;
+  if (!Array.isArray(output) || output.length === 0) {
+    return null;
+  }
+
+  const first = output[0];
+  if (!first || typeof first !== 'object' || Array.isArray(first)) {
+    return null;
+  }
+
+  return first as Record<string, unknown>;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function errorCodeForStatus(status: number): ExecutionError['code'] {
+  if (status === 401 || status === 403) {
+    return 'unauthorized';
+  }
+  if (status === 404) {
+    return 'tool_unavailable';
+  }
+  if (status >= 500) {
+    return 'server_error';
+  }
+  return 'request_invalid';
+}
+
+function gatewayErrorResult(error: ExecutionError): WorkflowExecutionResult {
+  return {
+    kind: 'gateway_error',
+    error,
+  };
+}
+
+export class HermesExecutionAdapter {
+  readonly name = 'hermes' as const;
+
+  constructor(
+    private readonly env: HermesExecutionEnv = process.env,
+    private readonly fetchImpl: HermesFetch = globalThis.fetch,
+  ) {}
+
+  async runWorkflow(
+    key: string,
+    input: Record<string, unknown>,
+  ): Promise<WorkflowExecutionResult> {
+    const configError = this.configurationError();
+    if (configError) {
+      return gatewayErrorResult(configError);
+    }
+    if (!HERMES_SUPPORTED_RUN_WORKFLOWS.has(key)) {
+      return notImplementedResult(key);
+    }
+
+    const envelope = buildHermesRequestEnvelope({
+      action: 'run',
+      workflowId: key,
+      args: input,
+      sessionKey: this.sessionKey(),
+    }) as HermesRunRequestEnvelope;
+
+    return this.invokeRunTool(envelope);
+  }
+
+  private configurationError(): ExecutionError | null {
+    const missingGatewayUrl = !readEnvValue(this.env, 'HERMES_GATEWAY_URL');
+    const missingGatewayToken = !readEnvValue(this.env, 'HERMES_GATEWAY_TOKEN');
+
+    if (missingGatewayUrl && missingGatewayToken) {
+      return missingHermesConfigError('HERMES_GATEWAY_URL and HERMES_GATEWAY_TOKEN');
+    }
+    if (missingGatewayUrl) {
+      return missingHermesConfigError('HERMES_GATEWAY_URL');
+    }
+    if (missingGatewayToken) {
+      return missingHermesConfigError('HERMES_GATEWAY_TOKEN');
+    }
+    return null;
+  }
+
+  private sessionKey(): string {
+    return readEnvValue(this.env, 'HERMES_SESSION_KEY') || 'main';
+  }
+
+  private gatewayUrl(): string {
+    return readEnvValue(this.env, 'HERMES_GATEWAY_URL').replace(/\/+$/, '');
+  }
+
+  private async invokeRunTool(envelope: HermesRunRequestEnvelope): Promise<WorkflowExecutionResult> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.gatewayUrl()}/tools/invoke`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${readEnvValue(this.env, 'HERMES_GATEWAY_TOKEN')}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          tool: HERMES_RUN_TOOL,
+          sessionKey: this.sessionKey(),
+          args: envelope,
+        }),
+      });
+    } catch (error) {
+      return gatewayErrorResult(new ExecutionError({
+        provider: 'hermes',
+        code: 'unreachable',
+        status: 503,
+        message: 'Hermes gateway is unreachable.',
+        cause: error,
+      }));
+    }
+
+    if (!response.ok) {
+      return gatewayErrorResult(new ExecutionError({
+        provider: 'hermes',
+        code: errorCodeForStatus(response.status),
+        status: response.status,
+        message: `Hermes gateway returned HTTP ${response.status}.`,
+      }));
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = await response.json();
+    } catch (error) {
+      return gatewayErrorResult(new ExecutionError({
+        provider: 'hermes',
+        code: 'response_invalid',
+        status: response.status,
+        message: 'Hermes gateway returned invalid JSON.',
+        cause: error,
+      }));
+    }
+
+    const responseRecord = recordValue(parsed);
+    if (!responseRecord) {
+      return gatewayErrorResult(new ExecutionError({
+        provider: 'hermes',
+        code: 'response_invalid',
+        status: response.status,
+        message: 'Hermes gateway returned a non-object response.',
+      }));
+    }
+
+    const workflowEnvelope = (recordValue(responseRecord.envelope) ?? responseRecord) as WorkflowEnvelope;
+    return {
+      kind: 'ok',
+      envelope: workflowEnvelope,
+      primaryOutput: recordValue(responseRecord.primaryOutput) ?? primaryOutputRecord(workflowEnvelope),
+    };
+  }
+}

--- a/backend/marketing/artifact-store.ts
+++ b/backend/marketing/artifact-store.ts
@@ -1,0 +1,171 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
+
+import { remapHostOutputToMount } from './host-output-path';
+
+export type MarketingArtifactStageNumber = 1 | 2 | 3 | 4;
+
+const DEFAULT_HOST_OUTPUT_MOUNT = '/host-lobster-output';
+
+const STAGE_CACHE_DEFAULTS: Record<MarketingArtifactStageNumber, { envKey: string; folder: string }> = {
+  1: { envKey: 'LOBSTER_STAGE1_CACHE_DIR', folder: 'lobster-stage1-cache' },
+  2: { envKey: 'LOBSTER_STAGE2_CACHE_DIR', folder: 'lobster-stage2-cache' },
+  3: { envKey: 'LOBSTER_STAGE3_CACHE_DIR', folder: 'lobster-stage3-cache' },
+  4: { envKey: 'LOBSTER_STAGE4_CACHE_DIR', folder: 'lobster-stage4-cache' },
+};
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map((value) => stringValue(value)).filter(Boolean)));
+}
+
+export function stageCacheRoot(stage: MarketingArtifactStageNumber): string {
+  const config = STAGE_CACHE_DEFAULTS[stage];
+  return stringValue(process.env[config.envKey]) || path.join(tmpdir(), config.folder);
+}
+
+export function hostOutputMount(): string {
+  return path.normalize(stringValue(process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT) || DEFAULT_HOST_OUTPUT_MOUNT);
+}
+
+export function lobsterRoots(): string[] {
+  return uniqueStrings([
+    process.env.OPENCLAW_LOCAL_LOBSTER_CWD,
+    process.env.OPENCLAW_LOBSTER_CWD,
+    resolveCodePath('lobster'),
+  ]).map((root) => path.resolve(root));
+}
+
+export function lobsterOutputRoots(): string[] {
+  return uniqueStrings([
+    ...lobsterRoots().map((root) => path.join(root, 'output')),
+    hostOutputMount(),
+  ]);
+}
+
+export function marketingAssetRoots(): string[] {
+  return uniqueStrings([
+    resolveDataRoot(),
+    resolveCodeRoot(),
+    resolveCodePath('lobster'),
+    process.env.OPENCLAW_LOCAL_LOBSTER_CWD,
+    process.env.OPENCLAW_LOBSTER_CWD,
+    hostOutputMount(),
+    stageCacheRoot(1),
+    stageCacheRoot(2),
+    stageCacheRoot(3),
+    stageCacheRoot(4),
+  ]).map((root) => path.normalize(root));
+}
+
+function absoluteCompatibilityCandidates(filePath: string): string[] {
+  const normalized = path.normalize(filePath);
+  const codeRoot = path.normalize(resolveCodeRoot());
+  const candidates = new Set([normalized]);
+  const remapPrefixes = [
+    '/home/node/workspace/aries-app',
+    '/app/aries-app',
+    path.join(codeRoot, 'aries-app'),
+  ].map((prefix) => path.normalize(prefix));
+
+  for (const prefix of remapPrefixes) {
+    if (normalized !== prefix && !normalized.startsWith(`${prefix}${path.sep}`)) {
+      continue;
+    }
+
+    const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '');
+    candidates.add(path.join(codeRoot, suffix));
+    for (const lobsterRoot of lobsterRoots()) {
+      if (suffix === 'lobster' || suffix.startsWith(`lobster${path.sep}`)) {
+        candidates.add(path.join(lobsterRoot, suffix.replace(/^lobster[\\/]+/, '')));
+      }
+    }
+  }
+
+  const hostMountCandidate = remapHostOutputToMount(normalized);
+  if (hostMountCandidate) {
+    candidates.add(hostMountCandidate);
+  }
+
+  return Array.from(candidates);
+}
+
+function relativeGeneratedAssetPath(filePath: string): string | null {
+  const segments = filePath.split(/[\\/]+/).filter(Boolean);
+  if (segments.length === 0) {
+    return null;
+  }
+  if (segments.some((segment) => segment === '.' || segment === '..' || segment.includes('\0'))) {
+    return null;
+  }
+  return path.join(...segments);
+}
+
+export function generatedAssetCandidates(filePath: string): string[] {
+  const raw = stringValue(filePath);
+  if (!raw) {
+    return [];
+  }
+
+  const normalized = path.normalize(raw);
+  if (path.isAbsolute(normalized)) {
+    return absoluteCompatibilityCandidates(normalized);
+  }
+
+  const relativePath = relativeGeneratedAssetPath(raw);
+  if (!relativePath) {
+    return [];
+  }
+
+  return marketingAssetRoots().map((root) => path.resolve(root, relativePath));
+}
+
+function resolvedPath(filePath: string): string | null {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return existsSync(filePath) ? path.resolve(filePath) : null;
+  }
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function isTrustedGeneratedAssetPath(candidate: string): boolean {
+  const resolvedCandidate = resolvedPath(candidate);
+  if (!resolvedCandidate) {
+    return false;
+  }
+
+  for (const root of marketingAssetRoots()) {
+    const resolvedRoot = resolvedPath(root) || path.resolve(root);
+    if (isWithinRoot(resolvedRoot, resolvedCandidate)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function resolveGeneratedAsset(filePath: string | null | undefined): string | null {
+  const raw = stringValue(filePath);
+  if (!raw) {
+    return null;
+  }
+
+  for (const candidate of generatedAssetCandidates(raw)) {
+    if (existsSync(candidate) && isTrustedGeneratedAssetPath(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -1,11 +1,8 @@
-import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
-
+import { lobsterOutputRoots, resolveGeneratedAsset } from './artifact-store';
 import { listMarketingDashboardAssetsForJob } from './dashboard-content';
-import { remapHostOutputToMount } from './host-output-path';
 import { collectResearchStageArtifacts, collectStrategyReviewArtifacts } from './artifact-collector';
 import { createMarketingJobFacts, type MarketingJobFacts } from './job-facts';
 import {
@@ -34,87 +31,8 @@ export type MarketingAssetLink = {
   posterUrl?: string | null;
 };
 
-function resolveExistingAbsoluteAssetPath(filePath: string): string | null {
-  const normalizedPath = path.normalize(filePath);
-  const codeRoot = path.normalize(resolveCodeRoot());
-  const remapPrefixes = [
-    '/home/node/workspace/aries-app',
-    '/app/aries-app',
-    path.join(codeRoot, 'aries-app'),
-  ].map((prefix) => path.normalize(prefix));
-  const candidates = new Set([normalizedPath]);
-
-  for (const prefix of remapPrefixes) {
-    if (normalizedPath !== prefix && !normalizedPath.startsWith(`${prefix}${path.sep}`)) {
-      continue;
-    }
-
-    const suffix = normalizedPath.slice(prefix.length).replace(/^[\\/]+/, '');
-    candidates.add(path.join(codeRoot, suffix));
-  }
-
-  const hostMountCandidate = remapHostOutputToMount(normalizedPath);
-  if (hostMountCandidate) {
-    candidates.add(hostMountCandidate);
-  }
-
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  return null;
-}
-
-function assetRoots(): string[] {
-  return Array.from(
-    new Set(
-      [
-        resolveDataRoot(),
-        resolveCodeRoot(),
-        process.env.OPENCLAW_LOCAL_LOBSTER_CWD?.trim(),
-        process.env.OPENCLAW_LOBSTER_CWD?.trim(),
-        process.env.LOBSTER_STAGE1_CACHE_DIR?.trim(),
-        process.env.LOBSTER_STAGE2_CACHE_DIR?.trim(),
-        process.env.LOBSTER_STAGE3_CACHE_DIR?.trim(),
-        process.env.LOBSTER_STAGE4_CACHE_DIR?.trim(),
-      ].filter((value): value is string => typeof value === 'string' && value.length > 0)
-    )
-  );
-}
-
 function outputRoots(): string[] {
-  // Include the host bind-mount (ARIES_LOBSTER_HOST_OUTPUT_MOUNT) so the
-  // container can resolve asset files the host's Lobster pipeline wrote to
-  // the host's lobster/output directory. Matches the roots resolved in
-  // real-artifacts.ts / dashboard-content.ts / public-pages.ts /
-  // stage-artifact-resolution.ts.
-  const hostMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
-  return Array.from(
-    new Set(
-      [
-        process.env.OPENCLAW_LOCAL_LOBSTER_CWD?.trim()
-          ? path.join(process.env.OPENCLAW_LOCAL_LOBSTER_CWD.trim(), 'output')
-          : null,
-        process.env.OPENCLAW_LOBSTER_CWD?.trim()
-          ? path.join(process.env.OPENCLAW_LOBSTER_CWD.trim(), 'output')
-          : null,
-        path.join(resolveCodeRoot(), 'lobster', 'output'),
-        hostMount ? path.normalize(hostMount) : null,
-      ].filter((value): value is string => typeof value === 'string' && value.length > 0),
-    ),
-  );
-}
-
-function resolveExistingRelativeAssetPath(filePath: string): string | null {
-  for (const root of assetRoots()) {
-    const candidate = path.resolve(root, filePath);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  return null;
+  return lobsterOutputRoots();
 }
 
 function stringValue(value: unknown, fallback = ''): string {
@@ -299,14 +217,7 @@ export async function buildMarketingAssetLibrary(
       .filter(Boolean);
 
     for (const candidate of candidates) {
-      if (!path.isAbsolute(candidate)) {
-        const resolved = resolveExistingRelativeAssetPath(candidate);
-        if (resolved) {
-          return resolved;
-        }
-        continue;
-      }
-      const resolved = resolveExistingAbsoluteAssetPath(candidate);
+      const resolved = resolveGeneratedAsset(candidate);
       if (resolved) {
         return resolved;
       }
@@ -371,8 +282,10 @@ export async function buildMarketingAssetLibrary(
   let websiteAnalysis: Record<string, unknown> | null = null;
   if (websiteAnalysisPath) {
     try {
-      const resolvedWebsiteAnalysisPath = resolveAssetPath(websiteAnalysisPath) || websiteAnalysisPath;
-      websiteAnalysis = recordValue(JSON.parse(await readFile(resolvedWebsiteAnalysisPath, 'utf8')));
+      const resolvedWebsiteAnalysisPath = resolveAssetPath(websiteAnalysisPath);
+      websiteAnalysis = resolvedWebsiteAnalysisPath
+        ? recordValue(JSON.parse(await readFile(resolvedWebsiteAnalysisPath, 'utf8')))
+        : null;
     } catch {
       websiteAnalysis = null;
     }

--- a/backend/marketing/asset-read.ts
+++ b/backend/marketing/asset-read.ts
@@ -1,10 +1,7 @@
 import { readFile, realpath } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
-
-import { remapHostOutputToMount } from './host-output-path';
+import { generatedAssetCandidates, marketingAssetRoots } from './artifact-store';
 
 /**
  * Safe reader for files referenced by the marketing runtime documents.
@@ -110,52 +107,11 @@ function normalizeAssetPath(filePath: string): NormalizedAssetPath | null {
 }
 
 function trustedRoots(): string[] {
-  return Array.from(
-    new Set(
-      [
-        resolveDataRoot(),
-        resolveCodeRoot(),
-        resolveCodePath('lobster'),
-        process.env.OPENCLAW_LOCAL_LOBSTER_CWD?.trim(),
-        process.env.OPENCLAW_LOBSTER_CWD?.trim(),
-        // Host bind-mount of the host's lobster/output tree (creative
-        // images written by the host pipeline are only reachable from
-        // inside the container via this read-only mount).
-        process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim(),
-        process.env.LOBSTER_STAGE1_CACHE_DIR?.trim() || path.join(tmpdir(), 'lobster-stage1-cache'),
-        process.env.LOBSTER_STAGE2_CACHE_DIR?.trim() || path.join(tmpdir(), 'lobster-stage2-cache'),
-        process.env.LOBSTER_STAGE3_CACHE_DIR?.trim() || path.join(tmpdir(), 'lobster-stage3-cache'),
-        process.env.LOBSTER_STAGE4_CACHE_DIR?.trim() || path.join(tmpdir(), 'lobster-stage4-cache'),
-      ].filter((value): value is string => typeof value === 'string' && value.trim().length > 0),
-    ),
-  );
+  return marketingAssetRoots();
 }
 
 function absoluteCompatibilityCandidates(filePath: string): string[] {
-  const normalized = path.normalize(filePath);
-  const candidates = new Set([normalized]);
-  const codeRoot = path.normalize(resolveCodeRoot());
-  const remapPrefixes = [
-    '/home/node/workspace/aries-app',
-    '/app/aries-app',
-    path.join(codeRoot, 'aries-app'),
-  ].map((prefix) => path.normalize(prefix));
-
-  for (const prefix of remapPrefixes) {
-    if (normalized !== prefix && !normalized.startsWith(`${prefix}${path.sep}`)) {
-      continue;
-    }
-
-    const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '');
-    candidates.add(path.join(codeRoot, suffix));
-  }
-
-  const hostMountCandidate = remapHostOutputToMount(normalized);
-  if (hostMountCandidate) {
-    candidates.add(hostMountCandidate);
-  }
-
-  return Array.from(candidates);
+  return generatedAssetCandidates(filePath);
 }
 
 /**

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -1,11 +1,8 @@
 import crypto from 'node:crypto'
 import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import path from 'node:path'
 
-import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths'
-
-import { remapHostOutputToMount } from './host-output-path'
+import { lobsterOutputRoots, resolveGeneratedAsset } from './artifact-store'
 import type { MarketingCampaignWindow } from './jobs-status'
 import { extractPublishReviewBundle } from './publish-review'
 import { publishReviewLinkedAssetId, publishReviewMediaAssetId } from './publish-review-asset-ids'
@@ -640,43 +637,6 @@ function statusLabel(status: MarketingDashboardItemStatus): string {
 
 async function rawPublishReviewBundle(runtimeDoc: MarketingJobRuntimeDocument): Promise<Record<string, unknown> | null> {
   return await extractPublishReviewBundle(runtimeDoc)
-}
-
-function envCacheRoot(stage: 1 | 2 | 3 | 4): string {
-  const envKey =
-    stage === 1
-      ? 'LOBSTER_STAGE1_CACHE_DIR'
-      : stage === 2
-        ? 'LOBSTER_STAGE2_CACHE_DIR'
-        : stage === 3
-          ? 'LOBSTER_STAGE3_CACHE_DIR'
-          : 'LOBSTER_STAGE4_CACHE_DIR'
-  const fallback =
-    stage === 1
-      ? 'lobster-stage1-cache'
-      : stage === 2
-        ? 'lobster-stage2-cache'
-        : stage === 3
-          ? 'lobster-stage3-cache'
-          : 'lobster-stage4-cache'
-  return process.env[envKey]?.trim() || path.join(tmpdir(), fallback)
-}
-
-function lobsterRoots(): string[] {
-  return uniqueStrings([
-    process.env.OPENCLAW_LOCAL_LOBSTER_CWD,
-    process.env.OPENCLAW_LOBSTER_CWD,
-    resolveCodePath('lobster'),
-  ]).map((root) => path.resolve(root))
-}
-
-function lobsterOutputRoots(): string[] {
-  // See real-artifacts.lobsterOutputRoots for why the host bind-mount is included.
-  const hostMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim()
-  return uniqueStrings([
-    ...lobsterRoots().map((root) => path.join(root, 'output')),
-    hostMount ? path.normalize(hostMount) : null,
-  ])
 }
 
 function collectVeoVideoPaths(
@@ -1614,22 +1574,6 @@ function resolveDashboardAssetFilePath(
   filePath: string | null | undefined,
   fallbackPaths: Array<string | null | undefined> = [],
 ): string | null {
-  const codeRoot = path.normalize(resolveCodeRoot())
-  const remapPrefixes = [
-    '/home/node/workspace/aries-app',
-    '/app/aries-app',
-    path.join(codeRoot, 'aries-app'),
-  ].map((prefix) => path.normalize(prefix))
-  const roots = [
-    resolveDataRoot(),
-    resolveCodeRoot(),
-    ...lobsterRoots(),
-    envCacheRoot(1),
-    envCacheRoot(2),
-    envCacheRoot(3),
-    envCacheRoot(4),
-  ]
-
   for (const rawPath of [filePath, ...fallbackPaths]) {
     const candidate = stringValue(rawPath)
     if (!candidate) {
@@ -1637,35 +1581,12 @@ function resolveDashboardAssetFilePath(
     }
 
     if (!path.isAbsolute(candidate)) {
-      for (const root of roots) {
-        const resolved = path.resolve(root, candidate)
-        if (existsSync(resolved)) {
-          return resolved
-        }
-      }
-      return candidate
+      return resolveGeneratedAsset(candidate) || candidate
     }
 
-    const normalized = path.normalize(candidate)
-    const compatibilityCandidates = new Set([normalized])
-    for (const prefix of remapPrefixes) {
-      if (normalized !== prefix && !normalized.startsWith(`${prefix}${path.sep}`)) {
-        continue
-      }
-
-      const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '')
-      compatibilityCandidates.add(path.join(codeRoot, suffix))
-    }
-
-    const hostMountCandidate = remapHostOutputToMount(normalized)
-    if (hostMountCandidate) {
-      compatibilityCandidates.add(hostMountCandidate)
-    }
-
-    for (const compatibilityCandidate of compatibilityCandidates) {
-      if (existsSync(compatibilityCandidate)) {
-        return compatibilityCandidate
-      }
+    const resolved = resolveGeneratedAsset(candidate)
+    if (resolved) {
+      return resolved
     }
   }
 

--- a/backend/marketing/public-pages.ts
+++ b/backend/marketing/public-pages.ts
@@ -1,7 +1,7 @@
 import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
-import { resolveCodePath } from '@/lib/runtime-paths';
+import { lobsterOutputRoots } from './artifact-store';
 
 type PublicMarketingArtifact = {
   body: string | Buffer;
@@ -39,28 +39,6 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
-function lobsterRoots(): string[] {
-  return Array.from(
-    new Set(
-      [
-        process.env.OPENCLAW_LOCAL_LOBSTER_CWD?.trim(),
-        process.env.OPENCLAW_LOBSTER_CWD?.trim(),
-        resolveCodePath('lobster'),
-      ].filter((value): value is string => typeof value === 'string' && value.length > 0)
-    )
-  ).map((root) => path.resolve(root));
-}
-
-function lobsterOutputRoots(): string[] {
-  // See real-artifacts.lobsterOutputRoots for why the host bind-mount is included.
-  const hostMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
-  const roots = lobsterRoots().map((root) => path.join(root, 'output'));
-  if (hostMount) {
-    roots.push(path.normalize(hostMount));
-  }
-  return Array.from(new Set(roots));
-}
-
 function readJsonIfExists(filePath: string | null | undefined): Record<string, unknown> | null {
   if (!filePath || !existsSync(filePath)) {
     return null;
@@ -78,16 +56,21 @@ function readJsonIfExists(filePath: string | null | undefined): Record<string, u
 
 function normalizePublicPath(pathname: string): string | null {
   const withoutQuery = pathname.split('?')[0] || pathname;
-  const segments = withoutQuery
-    .split('/')
-    .map((segment) => {
-      try {
-        return decodeURIComponent(segment);
-      } catch {
-        return segment;
-      }
-    })
-    .filter(Boolean);
+  const segments: string[] = [];
+
+  for (const segment of withoutQuery.split('/')) {
+    if (!segment) {
+      continue;
+    }
+    let decoded = segment;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {}
+    if (decoded.includes('/') || decoded.includes('\\')) {
+      return null;
+    }
+    segments.push(decoded);
+  }
 
   if (segments.length === 0) {
     return null;

--- a/backend/marketing/real-artifacts.ts
+++ b/backend/marketing/real-artifacts.ts
@@ -2,7 +2,11 @@ import { existsSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { resolveCodePath, resolveCodeRoot, resolveDataRoot } from '@/lib/runtime-paths';
+import {
+  lobsterOutputRoots as artifactStoreLobsterOutputRoots,
+  lobsterRoots as artifactStoreLobsterRoots,
+  resolveGeneratedAsset,
+} from './artifact-store';
 
 import type { MarketingJobRuntimeDocument } from './runtime-state';
 
@@ -31,10 +35,6 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
-function uniqueStrings(values: Array<string | null | undefined>): string[] {
-  return Array.from(new Set(values.map((value) => stringValue(value)).filter(Boolean)));
-}
-
 function slugify(value: string, fallback = 'campaign'): string {
   const normalized = value
     .toLowerCase()
@@ -43,89 +43,16 @@ function slugify(value: string, fallback = 'campaign'): string {
   return normalized || fallback;
 }
 
-function trustedRoots(): string[] {
-  return uniqueStrings([
-    resolveDataRoot(),
-    resolveCodeRoot(),
-    process.env.OPENCLAW_LOCAL_LOBSTER_CWD,
-    process.env.OPENCLAW_LOBSTER_CWD,
-    resolveCodePath('lobster'),
-    process.env.LOBSTER_STAGE1_CACHE_DIR,
-    process.env.LOBSTER_STAGE2_CACHE_DIR,
-    process.env.LOBSTER_STAGE3_CACHE_DIR,
-    process.env.LOBSTER_STAGE4_CACHE_DIR,
-  ]).map((root) => path.normalize(root));
-}
-
 export function lobsterRoots(): string[] {
-  return uniqueStrings([
-    process.env.OPENCLAW_LOCAL_LOBSTER_CWD,
-    process.env.OPENCLAW_LOBSTER_CWD,
-    resolveCodePath('lobster'),
-  ]).map((root) => path.normalize(root));
+  return artifactStoreLobsterRoots();
 }
 
 export function lobsterOutputRoots(): string[] {
-  // In the aries-app container the host's lobster/output dir is bind-mounted
-  // read-only at ARIES_LOBSTER_HOST_OUTPUT_MOUNT. Include it here so directory
-  // scans (landing-pages, ad-images, scripts, proposals) find the real files
-  // written by the host-side Lobster pipeline. Without this, campaignRootForBrand
-  // falls back to a path that only exists on the host, listFiles returns empty,
-  // and the dashboard shows zero creative assets even though the pipeline ran.
-  const hostMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
-  return uniqueStrings([
-    ...lobsterRoots().map((root) => path.join(root, 'output')),
-    hostMount ? path.normalize(hostMount) : null,
-  ]);
-}
-
-function absoluteCompatibilityCandidates(filePath: string): string[] {
-  const normalized = path.normalize(filePath);
-  const codeRoot = path.normalize(resolveCodeRoot());
-  const candidates = new Set([normalized]);
-  const remapPrefixes = [
-    '/home/node/workspace/aries-app',
-    '/app/aries-app',
-    path.join(codeRoot, 'aries-app'),
-  ].map((prefix) => path.normalize(prefix));
-
-  for (const prefix of remapPrefixes) {
-    if (normalized === prefix || normalized.startsWith(`${prefix}${path.sep}`)) {
-      const suffix = normalized.slice(prefix.length).replace(/^[\\/]+/, '');
-      candidates.add(path.join(codeRoot, suffix));
-      for (const lobsterRoot of lobsterRoots()) {
-        if (suffix === 'lobster' || suffix.startsWith(`lobster${path.sep}`)) {
-          candidates.add(path.join(lobsterRoot, suffix.replace(/^lobster[\\/]+/, '')));
-        }
-      }
-    }
-  }
-
-  return Array.from(candidates);
+  return artifactStoreLobsterOutputRoots();
 }
 
 export function resolveMarketingArtifactPath(filePath: string | null | undefined): string | null {
-  const raw = stringValue(filePath);
-  if (!raw) {
-    return null;
-  }
-
-  if (path.isAbsolute(raw)) {
-    for (const candidate of absoluteCompatibilityCandidates(raw)) {
-      if (existsSync(candidate)) {
-        return candidate;
-      }
-    }
-  }
-
-  for (const root of trustedRoots()) {
-    const candidate = path.resolve(root, raw);
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  return null;
+  return resolveGeneratedAsset(filePath);
 }
 
 export async function readMarketingArtifactText(filePath: string | null | undefined): Promise<string | null> {

--- a/backend/marketing/stage-artifact-resolution.ts
+++ b/backend/marketing/stage-artifact-resolution.ts
@@ -1,10 +1,8 @@
 import { existsSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { resolveCodePath } from '@/lib/runtime-paths';
-
+import { lobsterOutputRoots, stageCacheRoot } from './artifact-store';
 import type { MarketingJobRuntimeDocument, MarketingStage } from './runtime-state';
 
 export type MarketingArtifactStageNumber = 1 | 2 | 3 | 4;
@@ -45,48 +43,11 @@ function stageKey(stage: MarketingArtifactStageNumber): MarketingStage {
   return 'publish';
 }
 
-function cacheRoot(stage: MarketingArtifactStageNumber): string {
-  const envKey =
-    stage === 1
-      ? 'LOBSTER_STAGE1_CACHE_DIR'
-      : stage === 2
-        ? 'LOBSTER_STAGE2_CACHE_DIR'
-        : stage === 3
-          ? 'LOBSTER_STAGE3_CACHE_DIR'
-          : 'LOBSTER_STAGE4_CACHE_DIR';
-  const fallback =
-    stage === 1
-      ? 'lobster-stage1-cache'
-      : stage === 2
-        ? 'lobster-stage2-cache'
-        : stage === 3
-          ? 'lobster-stage3-cache'
-          : 'lobster-stage4-cache';
-  return process.env[envKey]?.trim() || path.join(tmpdir(), fallback);
-}
-
 function stageFolder(stage: MarketingArtifactStageNumber): string {
   if (stage === 1) return 'stage-1-research';
   if (stage === 2) return 'stage-2-strategy';
   if (stage === 3) return 'stage-3-production';
   return 'stage-4-publish-optimize';
-}
-
-function lobsterRoots(): string[] {
-  return uniqueStrings([
-    process.env.OPENCLAW_LOCAL_LOBSTER_CWD,
-    process.env.OPENCLAW_LOBSTER_CWD,
-    resolveCodePath('lobster'),
-  ]).map((root) => path.resolve(root));
-}
-
-function lobsterOutputRoots(): string[] {
-  // See real-artifacts.lobsterOutputRoots for why the host bind-mount is included.
-  const hostMount = process.env.ARIES_LOBSTER_HOST_OUTPUT_MOUNT?.trim();
-  return uniqueStrings([
-    ...lobsterRoots().map((root) => path.join(root, 'output')),
-    hostMount ? path.normalize(hostMount) : null,
-  ]);
 }
 
 async function readJsonIfExists(filePath: string | null | undefined): Promise<Record<string, unknown> | null> {
@@ -163,9 +124,9 @@ export async function inferMarketingStageRunId(
   const candidates: Array<{ runId: string; score: number; mtimeMs: number }> = [];
   const seenRunIds = new Set<string>();
 
-  const stageCacheRoot = cacheRoot(stage);
-  if (existsSync(stageCacheRoot)) {
-    for (const entry of await readdir(stageCacheRoot)) {
+  const cacheRoot = stageCacheRoot(stage);
+  if (existsSync(cacheRoot)) {
+    for (const entry of await readdir(cacheRoot)) {
       if (!prefixes.some((prefix) => entry.startsWith(`${prefix}-`))) {
         continue;
       }
@@ -173,7 +134,7 @@ export async function inferMarketingStageRunId(
         continue;
       }
       try {
-        const entryPath = path.join(stageCacheRoot, entry);
+        const entryPath = path.join(cacheRoot, entry);
         const stats = await stat(entryPath);
         if (!stats.isDirectory()) {
           continue;
@@ -235,7 +196,7 @@ export async function readMarketingStageStepPayload(
   ]);
 
   for (const runId of runIds) {
-    const cachePath = path.join(cacheRoot(stage), runId, `${stepName}.json`);
+    const cachePath = path.join(stageCacheRoot(stage), runId, `${stepName}.json`);
     const cached = await readJsonIfExists(cachePath);
     if (cached) {
       return {

--- a/tests/deploy-manifest-parity.test.ts
+++ b/tests/deploy-manifest-parity.test.ts
@@ -2,26 +2,18 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 const repoRoot = process.cwd();
 const distComposePath = path.join(repoRoot, 'dist', 'docker-compose.yml');
-const distComposeSource = fs.readFileSync(distComposePath, 'utf8');
 
-test('tracked dist deploy shim requires an explicit prebuilt Aries image and cannot build stale sources', () => {
-  assert.match(
-    distComposeSource,
-    /image:\s*\$\{ARIES_APP_IMAGE:\?Set ARIES_APP_IMAGE to a root-built Aries image tag\}/,
-  );
-  assert.doesNotMatch(distComposeSource, /^\s*build:\s*/m);
-  assert.doesNotMatch(distComposeSource, /^\s*-\s+\.\:\/app\/aries-app\s*$/m);
-});
+test('legacy dist deploy shim stays out of the tracked runtime surface', () => {
+  const trackedDistCompose = execFileSync('git', ['ls-files', '--', distComposePath], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
 
-test('tracked dist deploy shim uses the canonical runtime lobster cwd defaults', () => {
-  assert.match(distComposeSource, /OPENCLAW_LOBSTER_CWD:\s*\$\{OPENCLAW_LOBSTER_CWD:-\/app\/lobster\}/);
-  assert.match(
-    distComposeSource,
-    /OPENCLAW_LOCAL_LOBSTER_CWD:\s*\$\{OPENCLAW_LOCAL_LOBSTER_CWD:-\/app\/lobster\}/,
-  );
+  assert.equal(trackedDistCompose, '');
 });
 
 test('runtime env examples advertise optional execution-provider knobs without changing the legacy default', () => {
@@ -42,6 +34,12 @@ test('runtime env examples advertise optional execution-provider knobs without c
   assert.match(envExampleSource, /^# HERMES_SESSION_KEY=main$/m);
 });
 
-test('tracked dist deploy shim cannot reintroduce the stale public onboarding path', () => {
+test('legacy dist deploy shim cannot reintroduce the stale public onboarding path', () => {
+  if (!fs.existsSync(distComposePath)) {
+    assert.ok(true);
+    return;
+  }
+
+  const distComposeSource = fs.readFileSync(distComposePath, 'utf8');
   assert.doesNotMatch(distComposeSource, /\/onboarding\/start/);
 });

--- a/tests/execution-hermes-adapter.test.ts
+++ b/tests/execution-hermes-adapter.test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { ExecutionError } from '../backend/execution';
+import {
+  HermesExecutionAdapter,
+  buildHermesRequestEnvelope,
+} from '../backend/execution/providers/hermes';
+
+test('HermesExecutionAdapter reports missing HERMES_GATEWAY_URL with an actionable ExecutionError', async () => {
+  const adapter = new HermesExecutionAdapter({
+    HERMES_GATEWAY_TOKEN: 'token-123',
+  });
+
+  const result = await adapter.runWorkflow('marketing_demo', { tenantId: 'tenant-123' });
+
+  assert.equal(result.kind, 'gateway_error');
+  if (result.kind !== 'gateway_error') {
+    assert.fail('expected gateway_error result');
+  }
+
+  assert.ok(result.error instanceof ExecutionError);
+  assert.equal(result.error.provider, 'hermes');
+  assert.equal(result.error.code, 'not_configured');
+  assert.equal(result.error.status, 503);
+  assert.match(result.error.message, /HERMES_GATEWAY_URL/);
+  assert.match(result.error.message, /ARIES_EXECUTION_PROVIDER=legacy-openclaw/);
+});
+
+test('HermesExecutionAdapter reports missing HERMES_GATEWAY_TOKEN with an actionable ExecutionError', async () => {
+  const adapter = new HermesExecutionAdapter({
+    HERMES_GATEWAY_URL: 'http://127.0.0.1:8787',
+  });
+
+  const result = await adapter.runWorkflow('marketing_demo', { tenantId: 'tenant-123' });
+
+  assert.equal(result.kind, 'gateway_error');
+  if (result.kind !== 'gateway_error') {
+    assert.fail('expected gateway_error result');
+  }
+
+  assert.ok(result.error instanceof ExecutionError);
+  assert.equal(result.error.provider, 'hermes');
+  assert.equal(result.error.code, 'not_configured');
+  assert.equal(result.error.status, 503);
+  assert.match(result.error.message, /HERMES_GATEWAY_TOKEN/);
+  assert.match(result.error.message, /ARIES_EXECUTION_PROVIDER=legacy-openclaw/);
+});
+
+test('HermesExecutionAdapter returns an honest not_implemented result when configured before real Hermes calls land', async () => {
+  const adapter = new HermesExecutionAdapter({
+    HERMES_GATEWAY_URL: 'http://127.0.0.1:8787',
+    HERMES_GATEWAY_TOKEN: 'token-123',
+    HERMES_SESSION_KEY: 'campaign-runtime',
+  });
+
+  const result = await adapter.runWorkflow('marketing_demo', { tenantId: 'tenant-123' });
+
+  assert.equal(result.kind, 'not_implemented');
+  if (result.kind !== 'not_implemented') {
+    assert.fail('expected not_implemented result');
+  }
+
+  assert.equal(result.payload.status, 'not_implemented');
+  assert.equal(result.payload.code, 'workflow_missing_for_route');
+  assert.equal(result.payload.route, 'marketing_demo');
+  assert.match(result.payload.message, /Hermes execution adapter/);
+  assert.equal(result.payload.provider, 'hermes');
+});
+
+test('HermesExecutionAdapter invokes the Hermes gateway for the low-risk demo_start workflow', async () => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const adapter = new HermesExecutionAdapter(
+    {
+      HERMES_GATEWAY_URL: 'http://127.0.0.1:8787/',
+      HERMES_GATEWAY_TOKEN: 'token-123',
+      HERMES_SESSION_KEY: 'campaign-runtime',
+    },
+    async (url, init) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          status: 'ok',
+          output: [{ provisioned: true, lead_id: 'lead-123' }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    },
+  );
+
+  const result = await adapter.runWorkflow('demo_start', {
+    user: { email: 'founder@example.com' },
+    surface: 'marketing-site',
+  });
+
+  assert.equal(result.kind, 'ok');
+  if (result.kind !== 'ok') {
+    assert.fail('expected ok result');
+  }
+
+  assert.deepEqual(result.primaryOutput, { provisioned: true, lead_id: 'lead-123' });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, 'http://127.0.0.1:8787/tools/invoke');
+  assert.deepEqual(calls[0].init.headers, {
+    authorization: 'Bearer token-123',
+    'content-type': 'application/json',
+  });
+  assert.deepEqual(JSON.parse(String(calls[0].init.body)), {
+    tool: 'aries.workflow.run',
+    sessionKey: 'campaign-runtime',
+    args: {
+      provider: 'hermes',
+      action: 'run',
+      workflowId: 'demo_start',
+      argsJson: '{"user":{"email":"founder@example.com"},"surface":"marketing-site"}',
+      sessionKey: 'campaign-runtime',
+    },
+  });
+});
+
+test('HermesExecutionAdapter leaves unsupported workflows as not_implemented without calling Hermes', async () => {
+  let called = false;
+  const adapter = new HermesExecutionAdapter(
+    {
+      HERMES_GATEWAY_URL: 'http://127.0.0.1:8787',
+      HERMES_GATEWAY_TOKEN: 'token-123',
+    },
+    async () => {
+      called = true;
+      return new Response('{}');
+    },
+  );
+
+  const result = await adapter.runWorkflow('calendar_sync', { tenant_id: 'tenant-123' });
+
+  assert.equal(called, false);
+  assert.equal(result.kind, 'not_implemented');
+  if (result.kind !== 'not_implemented') {
+    assert.fail('expected not_implemented result');
+  }
+  assert.equal(result.payload.route, 'calendar_sync');
+});
+
+test('buildHermesRequestEnvelope defines the run request contract', () => {
+  assert.deepEqual(
+    buildHermesRequestEnvelope({
+      action: 'run',
+      workflowId: 'marketing_demo',
+      args: { tenantId: 'tenant-123' },
+      cwd: '/home/node/aries-app',
+      timeoutMs: 45_000,
+      maxStdoutBytes: 65_536,
+      sessionKey: 'campaign-runtime',
+    }),
+    {
+      provider: 'hermes',
+      action: 'run',
+      workflowId: 'marketing_demo',
+      argsJson: '{"tenantId":"tenant-123"}',
+      cwd: '/home/node/aries-app',
+      timeoutMs: 45_000,
+      maxStdoutBytes: 65_536,
+      sessionKey: 'campaign-runtime',
+    },
+  );
+});
+
+test('buildHermesRequestEnvelope defines approval resume and cancel correlation fields', () => {
+  assert.deepEqual(
+    buildHermesRequestEnvelope({
+      action: 'resume',
+      workflowId: 'marketing_pipeline',
+      args: { reviewer: 'tenant_admin' },
+      approvalResumeToken: 'approval_resume_token_123',
+      approve: true,
+      sessionKey: 'campaign-runtime',
+    }),
+    {
+      provider: 'hermes',
+      action: 'resume',
+      workflowId: 'marketing_pipeline',
+      argsJson: '{"reviewer":"tenant_admin"}',
+      approvalResumeToken: 'approval_resume_token_123',
+      approve: true,
+      sessionKey: 'campaign-runtime',
+    },
+  );
+
+  assert.deepEqual(
+    buildHermesRequestEnvelope({
+      action: 'cancel',
+      cancelCorrelationId: 'job-123',
+      sessionKey: 'campaign-runtime',
+    }),
+    {
+      provider: 'hermes',
+      action: 'cancel',
+      cancelCorrelationId: 'job-123',
+      sessionKey: 'campaign-runtime',
+    },
+  );
+});

--- a/tests/execution-provider-selection.test.ts
+++ b/tests/execution-provider-selection.test.ts
@@ -57,8 +57,16 @@ test('runAriesWorkflow honors ARIES_EXECUTION_PROVIDER=hermes through the export
   // Public-path integration: route helpers must actually consult the factory.
   // Without this, ARIES_EXECUTION_PROVIDER has no runtime effect for any
   // route handler that calls runAriesWorkflow.
-  const previous = process.env.ARIES_EXECUTION_PROVIDER;
+  const previous = {
+    ARIES_EXECUTION_PROVIDER: process.env.ARIES_EXECUTION_PROVIDER,
+    HERMES_GATEWAY_URL: process.env.HERMES_GATEWAY_URL,
+    HERMES_GATEWAY_TOKEN: process.env.HERMES_GATEWAY_TOKEN,
+    HERMES_SESSION_KEY: process.env.HERMES_SESSION_KEY,
+  };
   process.env.ARIES_EXECUTION_PROVIDER = 'hermes';
+  delete process.env.HERMES_GATEWAY_URL;
+  delete process.env.HERMES_GATEWAY_TOKEN;
+  delete process.env.HERMES_SESSION_KEY;
   try {
     const { runAriesWorkflow } = await import('../backend/execution');
     const result = await runAriesWorkflow(
@@ -74,10 +82,12 @@ test('runAriesWorkflow honors ARIES_EXECUTION_PROVIDER=hermes through the export
     assert.equal(result.error.provider, 'hermes');
     assert.equal(result.error.code, 'not_configured');
   } finally {
-    if (previous === undefined) {
-      delete process.env.ARIES_EXECUTION_PROVIDER;
-    } else {
-      process.env.ARIES_EXECUTION_PROVIDER = previous;
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
   }
 });

--- a/tests/marketing-artifact-store.test.ts
+++ b/tests/marketing-artifact-store.test.ts
@@ -1,0 +1,229 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { buildMarketingAssetLibrary } from '../backend/marketing/asset-library';
+import {
+  hostOutputMount,
+  lobsterOutputRoots,
+  resolveGeneratedAsset,
+  stageCacheRoot,
+} from '../backend/marketing/artifact-store';
+import { createMarketingJobRuntimeDocument } from '../backend/marketing/runtime-state';
+import { resolvePublicMarketingArtifact } from '../backend/marketing/public-pages';
+
+type EnvKey =
+  | 'ARIES_LOBSTER_HOST_OUTPUT_DIR'
+  | 'ARIES_LOBSTER_HOST_OUTPUT_MOUNT'
+  | 'LOBSTER_STAGE1_CACHE_DIR'
+  | 'LOBSTER_STAGE2_CACHE_DIR'
+  | 'LOBSTER_STAGE3_CACHE_DIR'
+  | 'LOBSTER_STAGE4_CACHE_DIR'
+  | 'OPENCLAW_LOCAL_LOBSTER_CWD'
+  | 'OPENCLAW_LOBSTER_CWD';
+
+const ENV_KEYS: EnvKey[] = [
+  'ARIES_LOBSTER_HOST_OUTPUT_DIR',
+  'ARIES_LOBSTER_HOST_OUTPUT_MOUNT',
+  'LOBSTER_STAGE1_CACHE_DIR',
+  'LOBSTER_STAGE2_CACHE_DIR',
+  'LOBSTER_STAGE3_CACHE_DIR',
+  'LOBSTER_STAGE4_CACHE_DIR',
+  'OPENCLAW_LOCAL_LOBSTER_CWD',
+  'OPENCLAW_LOBSTER_CWD',
+];
+
+async function withEnv<T>(overrides: Partial<Record<EnvKey, string | undefined>>, run: () => Promise<T> | T): Promise<T> {
+  const previous = new Map<EnvKey, string | undefined>();
+  for (const key of ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(overrides) as Array<[EnvKey, string | undefined]>) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await run();
+  } finally {
+    for (const key of ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test('stageCacheRoot preserves Lobster stage cache env vars and tmp fallbacks', async () => {
+  await withEnv(
+    {
+      LOBSTER_STAGE1_CACHE_DIR: '/tmp/custom-stage-1',
+      LOBSTER_STAGE2_CACHE_DIR: '/tmp/custom-stage-2',
+      LOBSTER_STAGE3_CACHE_DIR: '/tmp/custom-stage-3',
+      LOBSTER_STAGE4_CACHE_DIR: '/tmp/custom-stage-4',
+    },
+    () => {
+      assert.equal(stageCacheRoot(1), '/tmp/custom-stage-1');
+      assert.equal(stageCacheRoot(2), '/tmp/custom-stage-2');
+      assert.equal(stageCacheRoot(3), '/tmp/custom-stage-3');
+      assert.equal(stageCacheRoot(4), '/tmp/custom-stage-4');
+    },
+  );
+
+  await withEnv(
+    {},
+    () => {
+      assert.equal(stageCacheRoot(1), path.join(tmpdir(), 'lobster-stage1-cache'));
+      assert.equal(stageCacheRoot(2), path.join(tmpdir(), 'lobster-stage2-cache'));
+      assert.equal(stageCacheRoot(3), path.join(tmpdir(), 'lobster-stage3-cache'));
+      assert.equal(stageCacheRoot(4), path.join(tmpdir(), 'lobster-stage4-cache'));
+    },
+  );
+});
+
+test('hostOutputMount exposes the current container mount default', async () => {
+  await withEnv({}, () => {
+    assert.equal(hostOutputMount(), '/host-lobster-output');
+  });
+
+  await withEnv({ ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/mnt/generated-output' }, () => {
+    assert.equal(hostOutputMount(), '/mnt/generated-output');
+  });
+});
+
+test('lobsterOutputRoots includes legacy Lobster outputs and the host output mount', async () => {
+  await withEnv(
+    {
+      OPENCLAW_LOCAL_LOBSTER_CWD: '/runtime/lobster',
+      OPENCLAW_LOBSTER_CWD: '/gateway/lobster',
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: '/host-lobster-output',
+    },
+    () => {
+      assert.deepEqual(lobsterOutputRoots(), [
+        '/runtime/lobster/output',
+        '/gateway/lobster/output',
+        path.resolve('lobster', 'output'),
+        '/host-lobster-output',
+      ]);
+    },
+  );
+});
+
+test('resolveGeneratedAsset finds relative paths under stage cache roots', async () => {
+  const stageRoot = await mkdtemp(path.join(tmpdir(), 'aries-stage-cache-'));
+  const assetPath = path.join(stageRoot, 'run-123', 'creative.json');
+  await mkdir(path.dirname(assetPath), { recursive: true });
+  await writeFile(assetPath, '{"ok":true}');
+
+  await withEnv(
+    {
+      LOBSTER_STAGE3_CACHE_DIR: stageRoot,
+    },
+    () => {
+      assert.equal(resolveGeneratedAsset(path.join('run-123', 'creative.json')), assetPath);
+    },
+  );
+});
+
+test('resolveGeneratedAsset remaps host lobster output paths to the container mount', async () => {
+  const hostRoot = '/host/source/lobster/output';
+  const mountRoot = await mkdtemp(path.join(tmpdir(), 'aries-host-output-'));
+  const mountedAsset = path.join(mountRoot, 'images', 'ad.png');
+  await mkdir(path.dirname(mountedAsset), { recursive: true });
+  await writeFile(mountedAsset, 'png');
+
+  await withEnv(
+    {
+      ARIES_LOBSTER_HOST_OUTPUT_DIR: hostRoot,
+      ARIES_LOBSTER_HOST_OUTPUT_MOUNT: mountRoot,
+    },
+    () => {
+      assert.equal(resolveGeneratedAsset('/host/source/lobster/output/images/ad.png'), mountedAsset);
+    },
+  );
+});
+
+test('resolveGeneratedAsset rejects paths outside configured artifact roots', async () => {
+  await withEnv({}, () => {
+    assert.equal(resolveGeneratedAsset('/etc/passwd'), null);
+    assert.equal(resolveGeneratedAsset('../../../../etc/passwd'), null);
+    assert.equal(resolveGeneratedAsset('run-123/../secret.json'), null);
+  });
+});
+
+test('asset library does not read website analysis paths rejected by the artifact store', async () => {
+  const stageRoot = await mkdtemp(path.join(tmpdir(), 'aries-safe-artifacts-'));
+  const safeBrandBible = path.join(stageRoot, 'brand-bible.md');
+  await writeFile(safeBrandBible, '# Safe brand bible');
+
+  const unsafeRoot = await mkdtemp(path.join(tmpdir(), 'aries-unsafe-analysis-'));
+  const unsafeAnalysis = path.join(unsafeRoot, 'analysis.json');
+  await writeFile(
+    unsafeAnalysis,
+    JSON.stringify({
+      brand_slug: 'unsafe-brand',
+      artifacts: {
+        brand_bible_markdown_path: safeBrandBible,
+      },
+    }),
+  );
+
+  const runtimeDoc = createMarketingJobRuntimeDocument({
+    jobId: 'job-unsafe-analysis',
+    tenantId: 'tenant-unsafe-analysis',
+    payload: { brandUrl: 'https://example.com' },
+    brandKit: {
+      source_url: 'https://example.com',
+      canonical_url: 'https://example.com',
+      brand_name: 'Example',
+      logo_urls: [],
+      colors: { primary: null, secondary: null, accent: null, palette: [] },
+      font_families: [],
+      external_links: [],
+      extracted_at: new Date(0).toISOString(),
+      brand_voice_summary: null,
+      offer_summary: null,
+      path: path.join(stageRoot, 'brand-kit.json'),
+    },
+  });
+  runtimeDoc.stages.strategy.outputs = {
+    website_brand_analysis_path: unsafeAnalysis,
+  };
+
+  await withEnv(
+    {
+      LOBSTER_STAGE1_CACHE_DIR: stageRoot,
+    },
+    async () => {
+      const assets = await buildMarketingAssetLibrary(runtimeDoc.job_id, runtimeDoc);
+      assert.equal(assets.some((asset) => asset.id === 'brand-bible-markdown'), false);
+    },
+  );
+});
+
+test('public marketing artifacts reject encoded-slash traversal outside output roots', async () => {
+  const lobsterRoot = await mkdtemp(path.join(tmpdir(), 'aries-public-lobster-'));
+  const outputRoot = path.join(lobsterRoot, 'output');
+  await mkdir(path.join(outputRoot, 'public-brand'), { recursive: true });
+  const escapedFile = path.join(lobsterRoot, 'secret.txt');
+  await writeFile(escapedFile, 'secret');
+
+  await withEnv(
+    {
+      OPENCLAW_LOCAL_LOBSTER_CWD: lobsterRoot,
+    },
+    () => {
+      const artifact = resolvePublicMarketingArtifact('/public-brand%2f..%2f..%2fsecret.txt');
+      assert.equal(artifact, null);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Adds a provider-backed Hermes execution adapter while keeping `legacy-openclaw` as the default provider.
- Wires the low-risk `demo_start` workflow through the Hermes HTTP tool contract when Hermes is explicitly selected.
- Centralizes marketing generated-asset resolution behind `backend/marketing/artifact-store.ts` and adds traversal/host-output safety coverage.

## Test plan
- `npx tsx --test tests/deploy-manifest-parity.test.ts tests/execution-provider-selection.test.ts tests/execution-hermes-adapter.test.ts tests/marketing-artifact-store.test.ts tests/asset-ingest.test.ts tests/video-artifact-collector.test.ts tests/marketing-jobs-cache.test.ts`
- `npm run typecheck`
- `git diff --check`
- `node scripts/check-banned-patterns.mjs`

## Notes
- Broader `tests/frontend-api-layer.test.ts` still has unrelated marketing hydration failures when run directly; this PR keeps the verified phase-targeted scope.