### PR TITLE
fix(execution): treat Hermes tool-level ok:false as gateway_error (PR #248 followup)

### DIFF
--- a/backend/execution/providers/hermes.ts
+++ b/backend/execution/providers/hermes.ts
@@ -310,6 +310,20 @@ export class HermesExecutionAdapter {
       }));
     }
 
+    if (responseRecord.ok === false) {
+      const errorRecord = recordValue(responseRecord.error);
+      const errorMessage =
+        (typeof responseRecord.error === 'string' && responseRecord.error) ||
+        (errorRecord && typeof errorRecord.message === 'string' && errorRecord.message) ||
+        'Hermes gateway reported a tool-level failure.';
+      return gatewayErrorResult(new ExecutionError({
+        provider: 'hermes',
+        code: 'response_invalid',
+        status: response.status,
+        message: errorMessage,
+      }));
+    }
+
     const workflowEnvelope = (recordValue(responseRecord.envelope) ?? responseRecord) as WorkflowEnvelope;
     return {
       kind: 'ok',

--- a/tests/execution-hermes-adapter.test.ts
+++ b/tests/execution-hermes-adapter.test.ts
@@ -166,6 +166,83 @@ test('buildHermesRequestEnvelope defines the run request contract', () => {
   );
 });
 
+test('HermesExecutionAdapter surfaces tool-level ok:false payloads as gateway_error rather than success', async () => {
+  const adapter = new HermesExecutionAdapter(
+    {
+      HERMES_GATEWAY_URL: 'http://127.0.0.1:8787',
+      HERMES_GATEWAY_TOKEN: 'token-123',
+      HERMES_SESSION_KEY: 'campaign-runtime',
+    },
+    async () =>
+      new Response(
+        JSON.stringify({
+          ok: false,
+          error: { message: 'tool blew up: gateway refused workflow' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+  );
+
+  const result = await adapter.runWorkflow('demo_start', {
+    user: { email: 'founder@example.com' },
+    surface: 'marketing-site',
+  });
+
+  assert.equal(result.kind, 'gateway_error');
+  if (result.kind !== 'gateway_error') {
+    assert.fail('expected gateway_error result for tool-level ok:false');
+  }
+  assert.ok(result.error instanceof ExecutionError);
+  assert.equal(result.error.provider, 'hermes');
+  assert.equal(result.error.code, 'response_invalid');
+  assert.equal(result.error.status, 200);
+  assert.match(result.error.message, /tool blew up/);
+});
+
+test('HermesExecutionAdapter surfaces ok:false with a string error as gateway_error', async () => {
+  const adapter = new HermesExecutionAdapter(
+    {
+      HERMES_GATEWAY_URL: 'http://127.0.0.1:8787',
+      HERMES_GATEWAY_TOKEN: 'token-123',
+    },
+    async () =>
+      new Response(JSON.stringify({ ok: false, error: 'workflow_unavailable' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  );
+
+  const result = await adapter.runWorkflow('demo_start', { user: { email: 'a@b.co' } });
+
+  assert.equal(result.kind, 'gateway_error');
+  if (result.kind !== 'gateway_error') {
+    assert.fail('expected gateway_error result for tool-level ok:false');
+  }
+  assert.equal(result.error.message, 'workflow_unavailable');
+});
+
+test('HermesExecutionAdapter surfaces ok:false with no error detail as a generic tool failure', async () => {
+  const adapter = new HermesExecutionAdapter(
+    {
+      HERMES_GATEWAY_URL: 'http://127.0.0.1:8787',
+      HERMES_GATEWAY_TOKEN: 'token-123',
+    },
+    async () =>
+      new Response(JSON.stringify({ ok: false }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  );
+
+  const result = await adapter.runWorkflow('demo_start', { user: { email: 'a@b.co' } });
+
+  assert.equal(result.kind, 'gateway_error');
+  if (result.kind !== 'gateway_error') {
+    assert.fail('expected gateway_error result for tool-level ok:false');
+  }
+  assert.match(result.error.message, /tool-level failure/);
+});
+
 test('buildHermesRequestEnvelope defines approval resume and cancel correlation fields', () => {
   assert.deepEqual(
     buildHermesRequestEnvelope({


### PR DESCRIPTION
## Summary

Post-merge follow-up addressing one valid Copilot inline comment from PR #248 (already merged at `0126e024`).

Copilot flagged that the Hermes adapter's `invokeRunTool` returned `kind: 'ok'` for any 2xx JSON-object response, even when the gateway returned a tool-style failure envelope such as `{ ok: false, error: ... }`. That made tool-level workflow failures look like successful results to upstream callers.

This PR adds an explicit `responseRecord.ok === false` short-circuit before the success path, surfacing the failure as `kind: 'gateway_error'` with the tool-supplied message:

- Object-shaped error → `responseRecord.error.message`
- String-shaped error → `responseRecord.error`
- No detail → generic `"... tool-level failure."`

## Test plan

- `npx tsx --test tests/execution-hermes-adapter.test.ts` — 10/10 pass (3 new regression tests for object/string/no-detail `ok:false` payloads).
- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm run validate:repo-boundary` — `ok: true`, 526 files.
- `npm run validate:banned-patterns` — `ok: true`.

## Notes on the other Copilot comment

Copilot also flagged `tests/deploy-manifest-parity.test.ts:16` claiming `git ls-files -- <absolute-path>` returns empty. **Verified false positive locally**: `git ls-files` accepts absolute paths within the repo and returns the same relative path output as for relative paths (confirmed against tracked files in this repo). The assertion `assert.equal(trackedDistCompose, '')` works correctly — it's asserting the file is *not* tracked, and `git ls-files` returns empty for an untracked path regardless of whether it was passed as absolute or relative. No change needed.

## Trust / safety

- Branched from `origin/master` at `0126e024` (PR #248 merge SHA).
- Pre-push guard verified `origin/master` had not advanced.
- No `master` direct push.

Refs: PR #248
