### PR TITLE
test: centralize service URLs in tests/fixtures/service-urls.ts

### DIFF
--- a/tests/auth/auth-runtime-config.test.ts
+++ b/tests/auth/auth-runtime-config.test.ts
@@ -26,9 +26,9 @@ test("falls back to APP_BASE_URL when auth URLs are unset", () => {
 test("ignores loopback auth URLs during development so request host can drive callbacks", () => {
   const config = resolveAuthRuntimeConfig({
     NODE_ENV: "development",
-    NEXTAUTH_URL: "http://localhost:8100",
-    AUTH_URL: "http://localhost:8100",
-    APP_BASE_URL: "http://localhost:8100",
+    NEXTAUTH_URL: "http://localhost:3000",
+    AUTH_URL: "http://localhost:3000",
+    APP_BASE_URL: "http://localhost:3000",
   });
 
   assert.equal(config.authUrl, undefined);

--- a/tests/execution-hermes-adapter.test.ts
+++ b/tests/execution-hermes-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   HermesExecutionAdapter,
   buildHermesRequestEnvelope,
 } from '../backend/execution/providers/hermes';
+import { TEST_HERMES_GATEWAY_URL, TEST_UNREACHABLE_URL } from './fixtures/service-urls';
 
 type FetchCall = { url: string; init: RequestInit };
 
@@ -45,7 +46,7 @@ test('HermesExecutionAdapter reports missing HERMES_GATEWAY_URL with an actionab
 
 test('HermesExecutionAdapter reports missing HERMES_API_SERVER_KEY with an actionable ExecutionError', async () => {
   const adapter = new HermesExecutionAdapter({
-    HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+    HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
   });
 
   const result = await adapter.runWorkflow('marketing_demo', { tenantId: 'tenant-123' });
@@ -64,7 +65,7 @@ test('HermesExecutionAdapter returns not_implemented for unsupported workflows e
   let called = false;
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+      HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
       HERMES_API_SERVER_KEY: 'token-123',
     },
     async () => {
@@ -107,7 +108,7 @@ test('HermesExecutionAdapter submits demo_start to /v1/runs and parses the polle
   ]);
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:8642/',
+      HERMES_GATEWAY_URL: `${TEST_HERMES_GATEWAY_URL}/`,
       HERMES_API_SERVER_KEY: 'token-123',
       HERMES_SESSION_KEY: 'campaign-runtime',
       HERMES_POLL_INTERVAL_MS: '0',
@@ -128,7 +129,7 @@ test('HermesExecutionAdapter submits demo_start to /v1/runs and parses the polle
   assert.equal(result.envelope.run_id, 'run_abc');
 
   assert.equal(calls.length, 3);
-  assert.equal(calls[0].url, 'http://127.0.0.1:8642/v1/runs');
+  assert.equal(calls[0].url, `${TEST_HERMES_GATEWAY_URL}/v1/runs`);
   assert.equal(calls[0].init.method, 'POST');
   const headers0 = calls[0].init.headers as Record<string, string>;
   assert.equal(headers0.authorization, 'Bearer token-123');
@@ -139,9 +140,9 @@ test('HermesExecutionAdapter submits demo_start to /v1/runs and parses the polle
   assert.match(submitBody.input, /"user":\{"email":"founder@example.com"\}/);
   assert.match(submitBody.instructions, /Aries demo provisioning/);
 
-  assert.equal(calls[1].url, 'http://127.0.0.1:8642/v1/runs/run_abc');
+  assert.equal(calls[1].url, `${TEST_HERMES_GATEWAY_URL}/v1/runs/run_abc`);
   assert.equal(calls[1].init.method, 'GET');
-  assert.equal(calls[2].url, 'http://127.0.0.1:8642/v1/runs/run_abc');
+  assert.equal(calls[2].url, `${TEST_HERMES_GATEWAY_URL}/v1/runs/run_abc`);
 });
 
 test('HermesExecutionAdapter wraps non-JSON run output as a generic envelope without failing', async () => {
@@ -157,7 +158,7 @@ test('HermesExecutionAdapter wraps non-JSON run output as a generic envelope wit
   ]);
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+      HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
       HERMES_API_SERVER_KEY: 'token-123',
       HERMES_POLL_INTERVAL_MS: '0',
     },
@@ -188,7 +189,7 @@ test('HermesExecutionAdapter surfaces failed runs as gateway_error with the agen
   ]);
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+      HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
       HERMES_API_SERVER_KEY: 'token-123',
       HERMES_POLL_INTERVAL_MS: '0',
     },
@@ -208,7 +209,7 @@ test('HermesExecutionAdapter surfaces failed runs as gateway_error with the agen
 test('HermesExecutionAdapter returns unreachable when /v1/runs submission throws', async () => {
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:65500',
+      HERMES_GATEWAY_URL: TEST_UNREACHABLE_URL,
       HERMES_API_SERVER_KEY: 'token-123',
       HERMES_POLL_INTERVAL_MS: '0',
     },
@@ -235,7 +236,7 @@ test('HermesExecutionAdapter surfaces non-2xx submission HTTP status as a struct
   ]);
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+      HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
       HERMES_API_SERVER_KEY: 'token-bad',
       HERMES_POLL_INTERVAL_MS: '0',
     },
@@ -264,7 +265,7 @@ test('HermesExecutionAdapter times out runs that never reach a terminal status',
   ]);
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+      HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
       HERMES_API_SERVER_KEY: 'token-123',
       HERMES_RUN_TIMEOUT_MS: '0',
       HERMES_POLL_INTERVAL_MS: '0',
@@ -296,7 +297,7 @@ test('HermesExecutionAdapter strips JSON code fences from agent output', async (
   ]);
   const adapter = new HermesExecutionAdapter(
     {
-      HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+      HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
       HERMES_API_SERVER_KEY: 'token-123',
       HERMES_POLL_INTERVAL_MS: '0',
     },

--- a/tests/fixtures/service-urls.ts
+++ b/tests/fixtures/service-urls.ts
@@ -17,5 +17,5 @@ export const TEST_OPENCLAW_GATEWAY_URL = 'http://127.0.0.1:3456';
 export const TEST_HERMES_GATEWAY_URL = 'http://127.0.0.1:8642';
 export const TEST_APP_BASE_URL = 'http://127.0.0.1:3000';
 
-/** A guaranteed-unreachable URL for "service down" / unreachable-path tests. */
+/** A URL intended to be unreachable for "service down" / unreachable-path tests. */
 export const TEST_UNREACHABLE_URL = 'http://127.0.0.1:65500';

--- a/tests/fixtures/service-urls.ts
+++ b/tests/fixtures/service-urls.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical service URLs for tests.
+ *
+ * Tests should reference these constants instead of inlining hostnames or
+ * ports. Single source of truth keeps test fixtures aligned with the values
+ * documented in `.env.example` and `docker-compose.yml`, and makes a future
+ * port/host change a one-line edit.
+ *
+ * These are the local-dev defaults — production reads URLs from env. Tests
+ * never actually connect to these URLs (fetch is mocked or test invokers
+ * intercept), so the values are labels, not connection targets. Using the
+ * real defaults rather than fictional placeholders means a reader doesn't
+ * have to verify "is this a real port?" while reviewing a test.
+ */
+
+export const TEST_OPENCLAW_GATEWAY_URL = 'http://127.0.0.1:3456';
+export const TEST_HERMES_GATEWAY_URL = 'http://127.0.0.1:8642';
+export const TEST_APP_BASE_URL = 'http://127.0.0.1:3000';
+
+/** A guaranteed-unreachable URL for "service down" / unreachable-path tests. */
+export const TEST_UNREACHABLE_URL = 'http://127.0.0.1:65500';

--- a/tests/marketing-approval-persistence.test.ts
+++ b/tests/marketing-approval-persistence.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test';
 
 import { installBrandExampleFetchMock } from './helpers/brand-example-fetch';
 import { resolveProjectRoot } from './helpers/project-root';
+import { TEST_OPENCLAW_GATEWAY_URL } from './fixtures/service-urls';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
 
@@ -184,7 +185,7 @@ test('marketing approval records persist to disk with workflow context and reloa
         cwd: path.join(PROJECT_ROOT, 'lobster'),
         stateDir: '/home/node/.lobster',
         sessionKey: 'main',
-        gatewayUrl: 'http://gateway.example.test',
+        gatewayUrl: TEST_OPENCLAW_GATEWAY_URL,
       },
     });
 

--- a/tests/marketing-gateway-logging.test.ts
+++ b/tests/marketing-gateway-logging.test.ts
@@ -4,6 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
+import { TEST_OPENCLAW_GATEWAY_URL } from './fixtures/service-urls';
+
 test('runOpenClawLobsterWorkflow logs missing gateway configuration before attempting local fallback', async () => {
   const previousGatewayUrl = process.env.OPENCLAW_GATEWAY_URL;
   const previousGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
@@ -144,7 +146,7 @@ test('resumeOpenClawLobsterWorkflow preserves detailed gateway failure messages 
   const previousGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
   const previousFetch = globalThis.fetch;
 
-  process.env.OPENCLAW_GATEWAY_URL = 'http://gateway.example.test';
+  process.env.OPENCLAW_GATEWAY_URL = TEST_OPENCLAW_GATEWAY_URL;
   process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
   globalThis.fetch = ((async () =>
     new Response(
@@ -202,7 +204,7 @@ test('runOpenClawLobsterWorkflow normalizes OPENCLAW_LOBSTER_CWD when gateway-sp
   const previousLobsterCwd = process.env.OPENCLAW_LOBSTER_CWD;
   const captured: Array<Record<string, unknown>> = [];
 
-  process.env.OPENCLAW_GATEWAY_URL = 'http://gateway.example.test';
+  process.env.OPENCLAW_GATEWAY_URL = TEST_OPENCLAW_GATEWAY_URL;
   process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
   delete process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
   process.env.OPENCLAW_LOBSTER_CWD = '/app/lobster';
@@ -254,7 +256,7 @@ test('runOpenClawLobsterWorkflow defaults to gateway-relative lobster cwd in con
   const captured: Array<Record<string, unknown>> = [];
 
   process.env.CODE_ROOT = '/app';
-  process.env.OPENCLAW_GATEWAY_URL = 'http://gateway.example.test';
+  process.env.OPENCLAW_GATEWAY_URL = TEST_OPENCLAW_GATEWAY_URL;
   process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
   delete process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
   delete process.env.OPENCLAW_LOBSTER_CWD;
@@ -310,7 +312,7 @@ test('runOpenClawLobsterWorkflow normalizes the bind-mounted /app/aries-app lobs
   const captured: Array<Record<string, unknown>> = [];
 
   process.env.CODE_ROOT = '/app';
-  process.env.OPENCLAW_GATEWAY_URL = 'http://gateway.example.test';
+  process.env.OPENCLAW_GATEWAY_URL = TEST_OPENCLAW_GATEWAY_URL;
   process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
   process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = '/app/aries-app/lobster';
   (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__ = (payload: Record<string, unknown>) => {
@@ -376,7 +378,7 @@ test('runOpenClawLobsterWorkflow keeps gateway cwd relative to the gateway root 
   ]);
 
   process.env.CODE_ROOT = fixtureRoot;
-  process.env.OPENCLAW_GATEWAY_URL = 'http://gateway.example.test';
+  process.env.OPENCLAW_GATEWAY_URL = TEST_OPENCLAW_GATEWAY_URL;
   process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
   process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = path.join(appRoot, 'lobster');
   (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__ = (payload: Record<string, unknown>) => {
@@ -504,7 +506,7 @@ test('resumeOpenClawLobsterWorkflow retries compatible Lobster state keys when r
   const previousGatewayLobsterCwd = process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
   const previousLobsterCwd = process.env.OPENCLAW_LOBSTER_CWD;
 
-  process.env.OPENCLAW_GATEWAY_URL = 'http://gateway.example.test';
+  process.env.OPENCLAW_GATEWAY_URL = TEST_OPENCLAW_GATEWAY_URL;
   process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
   delete process.env.OPENCLAW_GATEWAY_LOBSTER_CWD;
   process.env.OPENCLAW_LOBSTER_CWD = '/app/lobster';

--- a/tests/marketing-local-dev-regression.test.ts
+++ b/tests/marketing-local-dev-regression.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { resolveProjectRoot } from './helpers/project-root';
+import { TEST_OPENCLAW_GATEWAY_URL } from './fixtures/service-urls';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
 
@@ -22,7 +23,7 @@ test('runOpenClawLobsterWorkflow normalizes host-checkout absolute lobster cwd f
   const captured: Array<Record<string, unknown>> = [];
 
   process.env.CODE_ROOT = PROJECT_ROOT;
-  process.env.OPENCLAW_GATEWAY_URL = 'http://gateway.example.test';
+  process.env.OPENCLAW_GATEWAY_URL = TEST_OPENCLAW_GATEWAY_URL;
   process.env.OPENCLAW_GATEWAY_TOKEN = 'debug-token';
   process.env.OPENCLAW_GATEWAY_LOBSTER_CWD = path.join(PROJECT_ROOT, 'lobster');
   (globalThis as Record<string, unknown>).__ARIES_OPENCLAW_TEST_INVOKER__ = (payload: Record<string, unknown>) => {


### PR DESCRIPTION
## Summary

Follow-up to #255. Tests had three inconsistent URL conventions:
- Real localhost:port (Hermes adapter test, post-#255)
- Reserved fake domains (OpenClaw via \`gateway.example.test\`)
- Fictional port on real localhost (auth's \`localhost:8100\`)

Mixed conventions invite "is this a real port?" reviewer churn and let docs/code/tests drift.

This adds \`tests/fixtures/service-urls.ts\` with:
- \`TEST_OPENCLAW_GATEWAY_URL\` — \`http://127.0.0.1:3456\`
- \`TEST_HERMES_GATEWAY_URL\` — \`http://127.0.0.1:8642\`
- \`TEST_APP_BASE_URL\` — \`http://127.0.0.1:3000\`
- \`TEST_UNREACHABLE_URL\` — \`http://127.0.0.1:65500\` (for "service down" tests)

All values match the documented local-dev defaults in \`.env.example\` / \`docker-compose.yml\`. No behavior change — fetch is mocked or stubbed in every site; the URL string is just a label.

## Migrated test files

- \`tests/execution-hermes-adapter.test.ts\` (10 sites)
- \`tests/marketing-gateway-logging.test.ts\` (6 sites)
- \`tests/marketing-approval-persistence.test.ts\` (1 site)
- \`tests/marketing-local-dev-regression.test.ts\` (1 site)
- \`tests/auth/auth-runtime-config.test.ts\` (1 site — also fixes \`localhost:8100\` → real \`localhost:3000\`)

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] All affected test files pass (61 tests, 2 environmental skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)