### PR TITLE
feat(onboarding): require Business Type on BrandStep with combobox + autocomplete

### DIFF
--- a/backend/marketing/orchestrator.ts
+++ b/backend/marketing/orchestrator.ts
@@ -189,10 +189,12 @@ function stringValue(value: unknown, fallback = ''): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
-function ensureBrandCampaignInput(input: StartMarketingJobRequest): { brandUrl: string; competitorUrl: string } {
+function ensureBrandCampaignInput(input: StartMarketingJobRequest): { brandUrl: string; businessType: string; competitorUrl: string } {
   const brandUrl = stringValue(input.payload?.brandUrl);
+  const businessType = stringValue(input.payload?.businessType);
   const missing: string[] = [];
   if (!brandUrl) missing.push('payload.brandUrl');
+  if (!businessType) missing.push('payload.businessType');
   if (missing.length > 0) {
     throw new Error(`missing_required_fields:${missing.join(',')}`);
   }
@@ -205,6 +207,7 @@ function ensureBrandCampaignInput(input: StartMarketingJobRequest): { brandUrl: 
   }
   return {
     brandUrl,
+    businessType,
     competitorUrl: competitorValidation.normalized || brandUrl,
   };
 }

--- a/frontend/onboarding/pipeline-intake/business-types.ts
+++ b/frontend/onboarding/pipeline-intake/business-types.ts
@@ -1,0 +1,90 @@
+export const BUSINESS_TYPES: readonly string[] = [
+  'Ecommerce / DTC brand',
+  'SaaS — B2B',
+  'SaaS — B2C',
+  'Marketplace',
+  'Mobile app',
+  'Tech hardware',
+  'Fintech',
+  'Healthtech',
+  'Edtech',
+  'Restaurant / Food service',
+  'Cafe / Bakery',
+  'Bar / Nightlife',
+  'Food / Beverage brand',
+  'Beauty & Cosmetics',
+  'Hair / Nail / Beauty salon',
+  'Spa / Wellness',
+  'Fitness studio / Gym',
+  'Yoga / Pilates studio',
+  'Personal trainer / Coach',
+  'Dental practice',
+  'Medical / Clinic',
+  'Mental health / Therapy',
+  'Veterinary clinic',
+  'Pharmacy / Health retail',
+  'Real estate brokerage',
+  'Real estate agent',
+  'Property management',
+  'Home services (plumbing, HVAC, etc.)',
+  'Construction / Contractor',
+  'Landscaping / Lawn care',
+  'Cleaning service',
+  'Auto dealership',
+  'Auto repair / Detailing',
+  'Hospitality / Hotel',
+  'Travel agency / Tours',
+  'Event venue',
+  'Wedding / Event planning',
+  'Photographer / Videographer',
+  'Creative agency',
+  'Marketing / PR agency',
+  'Consulting firm',
+  'Law firm',
+  'Accounting / Bookkeeping',
+  'Financial advisor',
+  'Insurance agency',
+  'Nonprofit / Charity',
+  'Religious organization',
+  'Education — K-12',
+  'Education — Higher ed',
+  'Online course creator',
+  'Coaching / Mentorship',
+  'Membership / Subscription community',
+  'Publisher / Media',
+  'Podcast / Newsletter',
+  'Content creator / Influencer',
+  'Musician / Band',
+  'Artist / Maker',
+  'Bookstore / Retail — small',
+  'Boutique retail',
+  'Pet products / Services',
+  'Childcare / Preschool',
+  'Manufacturer / Wholesaler',
+  'Logistics / Shipping',
+  'Other',
+];
+
+export function filterBusinessTypes(
+  query: string,
+  source: readonly string[] = BUSINESS_TYPES,
+): readonly string[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return source;
+  return source.filter((entry) => entry.toLowerCase().includes(trimmed));
+}
+
+export function topGhostSuffix(
+  query: string,
+  source: readonly string[] = BUSINESS_TYPES,
+): string {
+  const trimmed = query.trim();
+  if (!trimmed) return '';
+  const lowerQuery = trimmed.toLowerCase();
+  for (const entry of source) {
+    if (entry.toLowerCase().startsWith(lowerQuery)) {
+      return entry.slice(trimmed.length);
+    }
+  }
+  return '';
+}

--- a/frontend/onboarding/pipeline-intake/components/BusinessTypeCombobox.tsx
+++ b/frontend/onboarding/pipeline-intake/components/BusinessTypeCombobox.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { filterBusinessTypes, topGhostSuffix } from '../business-types';
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  suggestions?: readonly string[];
+  required?: boolean;
+  label?: string;
+  placeholder?: string;
+  id?: string;
+}
+
+export default function BusinessTypeCombobox({
+  value,
+  onChange,
+  suggestions,
+  required,
+  label = 'Business Type',
+  placeholder = 'e.g. Ecommerce / DTC brand',
+  id: idProp,
+}: Props) {
+  const reactId = useId();
+  const inputId = idProp ?? `business-type-${reactId}`;
+  const listboxId = `${inputId}-listbox`;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const filtered = useMemo(
+    () => filterBusinessTypes(value, suggestions),
+    [value, suggestions],
+  );
+  const ghostSuffix = useMemo(
+    () => topGhostSuffix(value, suggestions),
+    [value, suggestions],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (highlight >= filtered.length) {
+      setHighlight(0);
+    }
+  }, [filtered.length, highlight]);
+
+  const commit = (next: string) => {
+    onChange(next);
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setIsOpen(true);
+      setHighlight((h) => Math.min(h + 1, Math.max(filtered.length - 1, 0)));
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+      return;
+    }
+    if (event.key === 'Enter') {
+      if (isOpen && filtered[highlight]) {
+        event.preventDefault();
+        commit(filtered[highlight]);
+      }
+      return;
+    }
+    if (event.key === 'Escape') {
+      setIsOpen(false);
+      return;
+    }
+    if ((event.key === 'Tab' || event.key === 'ArrowRight') && ghostSuffix) {
+      event.preventDefault();
+      commit(value + ghostSuffix);
+    }
+  };
+
+  const activeDescendantId =
+    isOpen && filtered[highlight] ? `${inputId}-option-${highlight}` : undefined;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <label htmlFor={inputId} className="block text-xs uppercase tracking-wider text-[#888] mb-1.5">
+        {label}{required ? ' *' : ''}
+      </label>
+      <div className="relative">
+        {ghostSuffix && isOpen && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 px-3 py-2 text-sm whitespace-pre"
+            style={{ color: 'transparent' }}
+          >
+            <span style={{ color: 'transparent' }}>{value}</span>
+            <span style={{ color: '#555' }}>{ghostSuffix}</span>
+          </div>
+        )}
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="text"
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendantId}
+          aria-required={required}
+          autoComplete="off"
+          spellCheck={false}
+          value={value}
+          placeholder={placeholder}
+          onFocus={() => setIsOpen(true)}
+          onChange={(e) => {
+            onChange(e.target.value);
+            setIsOpen(true);
+            setHighlight(0);
+          }}
+          onKeyDown={handleKeyDown}
+          className="relative w-full rounded-lg bg-[#0f0f14] border border-[#222] px-3 py-2 text-sm text-white placeholder-[#555] focus:outline-none focus:border-aries-crimson"
+        />
+      </div>
+
+      {isOpen && filtered.length > 0 && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-lg border border-[#222] bg-[#0f0f14] py-1 shadow-lg"
+        >
+          {filtered.map((entry, idx) => {
+            const optionId = `${inputId}-option-${idx}`;
+            const isActive = idx === highlight;
+            return (
+              <li
+                id={optionId}
+                key={entry}
+                role="option"
+                aria-selected={isActive}
+                onMouseEnter={() => setHighlight(idx)}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  commit(entry);
+                }}
+                className={`px-3 py-1.5 text-sm cursor-pointer ${isActive ? 'bg-[#1a1a22] text-white' : 'text-[#bbb]'}`}
+              >
+                {entry}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/onboarding/pipeline-intake/components/BusinessTypeCombobox.tsx
+++ b/frontend/onboarding/pipeline-intake/components/BusinessTypeCombobox.tsx
@@ -63,6 +63,23 @@ export default function BusinessTypeCombobox({
     setIsOpen(false);
   };
 
+  // Ghost-text completion uses the trimmed prefix the suffix was computed
+  // against, so leading/trailing whitespace can't desync the committed string
+  // from what the user sees in the ghost overlay.
+  const acceptGhost = () => {
+    const trimmed = value.trim();
+    onChange(trimmed + ghostSuffix);
+    setIsOpen(false);
+  };
+
+  const caretAtEnd = () => {
+    const el = inputRef.current;
+    if (!el) return false;
+    const end = el.selectionEnd;
+    const start = el.selectionStart;
+    return start === end && end === el.value.length;
+  };
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'ArrowDown') {
       event.preventDefault();
@@ -86,17 +103,34 @@ export default function BusinessTypeCombobox({
       setIsOpen(false);
       return;
     }
-    if ((event.key === 'Tab' || event.key === 'ArrowRight') && ghostSuffix) {
+    // Tab: commit ghost text but allow native focus to advance — don't trap.
+    if (event.key === 'Tab' && ghostSuffix && caretAtEnd()) {
+      acceptGhost();
+      return;
+    }
+    // ArrowRight: only consume the keystroke when the caret is at the end of
+    // the input. Otherwise let the browser handle normal cursor movement so
+    // the user can edit mid-string.
+    if (event.key === 'ArrowRight' && ghostSuffix && caretAtEnd()) {
       event.preventDefault();
-      commit(value + ghostSuffix);
+      acceptGhost();
     }
   };
 
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget as Node | null;
+    if (next && containerRef.current?.contains(next)) {
+      return;
+    }
+    setIsOpen(false);
+  };
+
+  const listboxMounted = isOpen && filtered.length > 0;
   const activeDescendantId =
-    isOpen && filtered[highlight] ? `${inputId}-option-${highlight}` : undefined;
+    listboxMounted && filtered[highlight] ? `${inputId}-option-${highlight}` : undefined;
 
   return (
-    <div ref={containerRef} className="relative">
+    <div ref={containerRef} className="relative" onBlur={handleBlur}>
       <label htmlFor={inputId} className="block text-xs uppercase tracking-wider text-[#888] mb-1.5">
         {label}{required ? ' *' : ''}
       </label>
@@ -117,7 +151,7 @@ export default function BusinessTypeCombobox({
           type="text"
           role="combobox"
           aria-expanded={isOpen}
-          aria-controls={listboxId}
+          aria-controls={listboxMounted ? listboxId : undefined}
           aria-autocomplete="list"
           aria-activedescendant={activeDescendantId}
           aria-required={required}
@@ -136,7 +170,7 @@ export default function BusinessTypeCombobox({
         />
       </div>
 
-      {isOpen && filtered.length > 0 && (
+      {listboxMounted && (
         <ul
           id={listboxId}
           role="listbox"

--- a/frontend/onboarding/pipeline-intake/index.tsx
+++ b/frontend/onboarding/pipeline-intake/index.tsx
@@ -14,7 +14,7 @@ import type { Channel, ExecutionMode, Goal, PipelineInput } from './types';
 type StepIndex = 0 | 1 | 2 | 3 | 4;
 
 const LOCAL_DRAFT_KEY = 'aries:pipeline-intake-draft';
-const LOCAL_DRAFT_VERSION = 1;
+const LOCAL_DRAFT_VERSION = 2;
 
 const VALID_GOALS: readonly Goal[] = ['lead_generation', 'content_growth', 'product_sales', 'brand_awareness'];
 const VALID_CHANNELS: readonly Channel[] = ['tiktok', 'instagram', 'youtube', 'linkedin', 'x', 'meta-ads', 'email'];
@@ -35,6 +35,7 @@ function isExecutionMode(value: unknown): value is ExecutionMode {
 type LocalDraft = {
   version: number;
   brandUrl: string;
+  businessType: string;
   competitorUrl: string;
   goal: Goal | null;
   channels: Channel[];
@@ -54,6 +55,7 @@ function readLocalDraft(): LocalDraft | null {
     return {
       version: LOCAL_DRAFT_VERSION,
       brandUrl: typeof parsed.brandUrl === 'string' ? parsed.brandUrl : '',
+      businessType: typeof parsed.businessType === 'string' ? parsed.businessType : '',
       competitorUrl: typeof parsed.competitorUrl === 'string' ? parsed.competitorUrl : '',
       goal: isGoal(parsed.goal) ? parsed.goal : null,
       channels,
@@ -89,6 +91,7 @@ function hasDraftContent(draft: LocalDraft | null): boolean {
   if (!draft) return false;
   return Boolean(
     draft.brandUrl.trim() ||
+      draft.businessType.trim() ||
       draft.competitorUrl.trim() ||
       draft.goal ||
       (draft.channels && draft.channels.length > 0) ||
@@ -103,6 +106,7 @@ export default function PipelineIntake() {
 
   // Form state
   const [brandUrl, setBrandUrl] = useState('');
+  const [businessType, setBusinessType] = useState('');
   const [competitorUrl, setCompetitorUrl] = useState('');
   const [goal, setGoal] = useState<Goal | null>(null);
   const [channels, setChannels] = useState<Channel[]>([]);
@@ -122,6 +126,7 @@ export default function PipelineIntake() {
     const snapshot = readLocalDraft();
     if (hasDraftContent(snapshot) && snapshot) {
       setBrandUrl(snapshot.brandUrl);
+      setBusinessType(snapshot.businessType);
       setCompetitorUrl(snapshot.competitorUrl);
       setGoal(snapshot.goal);
       setChannels(snapshot.channels);
@@ -154,7 +159,7 @@ export default function PipelineIntake() {
       window.clearTimeout(draftSaveTimer.current);
     }
     draftSaveTimer.current = window.setTimeout(() => {
-      const snapshot = { brandUrl, competitorUrl, goal, channels, mode };
+      const snapshot = { brandUrl, businessType, competitorUrl, goal, channels, mode };
       if (hasDraftContent({ version: LOCAL_DRAFT_VERSION, ...snapshot })) {
         writeLocalDraft(snapshot);
       } else {
@@ -168,7 +173,7 @@ export default function PipelineIntake() {
         draftSaveTimer.current = null;
       }
     };
-  }, [brandUrl, competitorUrl, goal, channels, mode, draftHydrated]);
+  }, [brandUrl, businessType, competitorUrl, goal, channels, mode, draftHydrated]);
 
   // Unmount cleanup — clears any pending redirect timer so the user doesn't
   // get pushed to a job-status URL after navigating away during transition.
@@ -208,6 +213,10 @@ export default function PipelineIntake() {
       setSubmitError('Enter your brand URL on Step 2 before launching.');
       return;
     }
+    if (!businessType.trim()) {
+      setSubmitError('Enter your business type on Step 2 before launching.');
+      return;
+    }
     if (!competitorUrl) {
       setSubmitError('Enter a competitor URL on Step 3 before launching.');
       return;
@@ -223,6 +232,7 @@ export default function PipelineIntake() {
 
     const payload: PipelineInput = {
       brand_url: brandUrl,
+      business_type: businessType,
       competitor_url: competitorUrl,
       goal,
       channels,
@@ -239,8 +249,9 @@ export default function PipelineIntake() {
         body: JSON.stringify({
           jobType: 'brand_campaign',
           payload: {
-            brandUrl: brandUrl,
-            competitorUrl: competitorUrl,
+            brandUrl,
+            businessType,
+            competitorUrl,
             goal,
             channels,
             mode,
@@ -360,6 +371,8 @@ export default function PipelineIntake() {
           <BrandStep
             brandUrl={brandUrl}
             onBrandUrlChange={setBrandUrl}
+            businessType={businessType}
+            onBusinessTypeChange={setBusinessType}
             onNext={goNext}
             onBack={goBack}
           />

--- a/frontend/onboarding/pipeline-intake/steps/BrandStep.tsx
+++ b/frontend/onboarding/pipeline-intake/steps/BrandStep.tsx
@@ -4,16 +4,26 @@ import { useState } from 'react';
 import { Check } from 'lucide-react';
 import StepContainer from '../components/StepContainer';
 import UrlInputWithPreview from '../components/UrlInputWithPreview';
+import BusinessTypeCombobox from '../components/BusinessTypeCombobox';
 import type { UrlPreviewData } from '../types';
 
 interface BrandStepProps {
   brandUrl: string;
   onBrandUrlChange: (url: string) => void;
+  businessType: string;
+  onBusinessTypeChange: (next: string) => void;
   onNext: () => void;
   onBack?: () => void;
 }
 
-export default function BrandStep({ brandUrl, onBrandUrlChange, onNext, onBack }: BrandStepProps) {
+export default function BrandStep({
+  brandUrl,
+  onBrandUrlChange,
+  businessType,
+  onBusinessTypeChange,
+  onNext,
+  onBack,
+}: BrandStepProps) {
   const [preview, setPreview] = useState<UrlPreviewData | null>(null);
   const [blurChip, setBlurChip] = useState<{ kind: 'idle' | 'valid' | 'invalid'; hostname?: string }>({ kind: 'idle' });
 
@@ -35,13 +45,15 @@ export default function BrandStep({ brandUrl, onBrandUrlChange, onNext, onBack }
     }
   };
 
+  const businessTypeReady = businessType.trim().length > 0;
+
   return (
     <StepContainer
       stepNumber={2}
       totalSteps={5}
       title="Your Brand"
-      subtitle="Enter your brand's website URL. We'll analyse your positioning, voice, and visual identity."
-      canProceed={!!preview}
+      subtitle="Tell us about your business so we can tailor research, voice, and positioning."
+      canProceed={!!preview && businessTypeReady}
       onNext={onNext}
       onBack={onBack}
     >
@@ -74,6 +86,14 @@ export default function BrandStep({ brandUrl, onBrandUrlChange, onNext, onBack }
           Waiting for a valid, reachable HTTPS URL to proceed.
         </p>
       )}
+
+      <div className="mt-6">
+        <BusinessTypeCombobox
+          value={businessType}
+          onChange={onBusinessTypeChange}
+          required
+        />
+      </div>
     </StepContainer>
   );
 }

--- a/frontend/onboarding/pipeline-intake/types.ts
+++ b/frontend/onboarding/pipeline-intake/types.ts
@@ -4,6 +4,7 @@ export type ExecutionMode = "strategy_only" | "strategy_plus_assets" | "full_pip
 
 export interface PipelineInput {
   brand_url: string;
+  business_type: string;
   competitor_url: string;
   goal: Goal;
   channels: Channel[];

--- a/tests/marketing-flow-smoke.test.ts
+++ b/tests/marketing-flow-smoke.test.ts
@@ -165,6 +165,7 @@ test('canonical client-facing marketing smoke flow stays on the monolithic pipel
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });
@@ -270,6 +271,7 @@ test('startMarketingJob returns a failed campaign instead of throwing when the g
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });

--- a/tests/marketing-job-flow.test.ts
+++ b/tests/marketing-job-flow.test.ts
@@ -205,6 +205,7 @@ test('startMarketingJob rejects Facebook URLs in the canonical competitor field'
           jobType: 'brand_campaign',
           payload: {
             brandUrl: 'https://brand.example',
+            businessType: 'Test vertical',
             competitorUrl: 'https://www.facebook.com/betterupco',
           },
         }),
@@ -232,6 +233,7 @@ test('startMarketingJob keeps the client-facing marketing flow on the canonical 
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });
@@ -347,6 +349,7 @@ test('approveMarketingJob advances strategy, production, and publish approvals t
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });
@@ -532,6 +535,7 @@ test('approveMarketingJob preserves the second publish-as-paused approval checkp
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });
@@ -634,6 +638,7 @@ test('approveMarketingJob preserves the active approval checkpoint when resume f
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });
@@ -747,6 +752,7 @@ test('approveMarketingJob reseeds a missing Lobster resume state and retries the
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });
@@ -873,6 +879,7 @@ test('approveMarketingJob reseeds an invalid Lobster resume state and retries th
       jobType: 'brand_campaign',
       payload: {
         brandUrl: 'https://brand.example',
+        businessType: 'Test vertical',
         competitorUrl: 'https://betterup.com',
       },
     });
@@ -965,6 +972,7 @@ test('approveMarketingJob backfills a missing brand kit for legacy runtime docum
         inputs: {
           request: {
             brandUrl: 'https://brand.example',
+            businessType: 'Test vertical',
             competitorUrl: 'https://betterup.com',
           },
           brand_url: 'https://brand.example',

--- a/tests/marketing-job-route.smoke.test.ts
+++ b/tests/marketing-job-route.smoke.test.ts
@@ -72,6 +72,7 @@ test('/api/marketing/jobs reaches the first approval checkpoint through the real
           jobType: 'brand_campaign',
           payload: {
             brandUrl: 'https://brand.example/',
+            businessType: 'Test vertical',
             competitorUrl: 'https://betterup.com/',
           },
         }),

--- a/tests/marketing-public-mode.test.ts
+++ b/tests/marketing-public-mode.test.ts
@@ -45,6 +45,7 @@ test('/api/marketing/jobs rejects unauthenticated public create even when public
           payload: {
             brandUrl: 'https://theframex.com',
             businessName: 'The FrameX',
+            businessType: 'Boutique retail',
           },
         }),
       }),

--- a/tests/onboarding-business-type-flow.test.ts
+++ b/tests/onboarding-business-type-flow.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createElement, isValidElement } from 'react';
+
+import BrandStep from '../frontend/onboarding/pipeline-intake/steps/BrandStep';
+import { BUSINESS_TYPES } from '../frontend/onboarding/pipeline-intake/business-types';
+
+test('BrandStep is a function component', () => {
+  assert.equal(typeof BrandStep, 'function');
+});
+
+test('BrandStep accepts businessType + onBusinessTypeChange props (createElement contract)', () => {
+  const element = createElement(BrandStep, {
+    brandUrl: '',
+    onBrandUrlChange: () => {},
+    businessType: '',
+    onBusinessTypeChange: () => {},
+    onNext: () => {},
+    onBack: () => {},
+  });
+  assert.ok(isValidElement(element));
+  assert.equal(element.type, BrandStep);
+  assert.equal(element.props.businessType, '');
+  assert.equal(typeof element.props.onBusinessTypeChange, 'function');
+});
+
+test('BrandStep accepts a curated business type as businessType', () => {
+  const element = createElement(BrandStep, {
+    brandUrl: 'https://example.com',
+    onBrandUrlChange: () => {},
+    businessType: BUSINESS_TYPES[0],
+    onBusinessTypeChange: () => {},
+    onNext: () => {},
+    onBack: () => {},
+  });
+  assert.ok(isValidElement(element));
+  assert.equal(element.props.businessType, BUSINESS_TYPES[0]);
+});

--- a/tests/onboarding-business-type-helpers.test.ts
+++ b/tests/onboarding-business-type-helpers.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  BUSINESS_TYPES,
+  filterBusinessTypes,
+  topGhostSuffix,
+} from '../frontend/onboarding/pipeline-intake/business-types';
+
+test('BUSINESS_TYPES has at least 60 entries and no duplicates', () => {
+  assert.ok(BUSINESS_TYPES.length >= 60, `expected >=60 entries, got ${BUSINESS_TYPES.length}`);
+  const seen = new Set<string>();
+  for (const entry of BUSINESS_TYPES) {
+    const key = entry.toLowerCase().trim();
+    assert.ok(!seen.has(key), `duplicate entry: ${entry}`);
+    seen.add(key);
+  }
+});
+
+test('filterBusinessTypes returns full list for empty query', () => {
+  assert.equal(filterBusinessTypes(''), BUSINESS_TYPES);
+  assert.equal(filterBusinessTypes('   '), BUSINESS_TYPES);
+});
+
+test('filterBusinessTypes filters case-insensitively by substring', () => {
+  const results = filterBusinessTypes('saas');
+  assert.ok(results.length >= 2, 'expected multiple SaaS entries');
+  for (const entry of results) {
+    assert.match(entry.toLowerCase(), /saas/);
+  }
+});
+
+test('filterBusinessTypes returns empty array when nothing matches', () => {
+  assert.deepEqual(filterBusinessTypes('zzz-not-a-real-vertical'), []);
+});
+
+test('topGhostSuffix returns suffix of top match minus what user typed', () => {
+  assert.equal(topGhostSuffix('ec', BUSINESS_TYPES), 'ommerce / DTC brand');
+});
+
+test('topGhostSuffix is case-insensitive on the prefix match but preserves source casing in suffix', () => {
+  assert.equal(topGhostSuffix('EC', BUSINESS_TYPES), 'ommerce / DTC brand');
+});
+
+test('topGhostSuffix returns empty string when no entry begins with the query', () => {
+  assert.equal(topGhostSuffix('zzz', BUSINESS_TYPES), '');
+});
+
+test('topGhostSuffix returns empty string for empty/whitespace query', () => {
+  assert.equal(topGhostSuffix('', BUSINESS_TYPES), '');
+  assert.equal(topGhostSuffix('   ', BUSINESS_TYPES), '');
+});

--- a/tests/review-decision-idempotency.test.ts
+++ b/tests/review-decision-idempotency.test.ts
@@ -145,7 +145,7 @@ test('approve_stage_4_publish: duplicate recordMarketingReviewDecision does not 
       const started = await startMarketingJob({
         tenantId,
         jobType: 'brand_campaign',
-        payload: { brandUrl: 'https://brand.example', competitorUrl: 'https://betterup.com' },
+        payload: { brandUrl: 'https://brand.example', businessType: 'Test vertical', competitorUrl: 'https://betterup.com' },
       });
 
       const advance = async (stepId: string, stage: 'strategy' | 'production' | 'publish') => {

--- a/tests/runtime-api-truth.test.ts
+++ b/tests/runtime-api-truth.test.ts
@@ -71,6 +71,7 @@ test('/api/marketing/jobs requires authenticated tenant context', async () => {
         jobType: 'brand_campaign',
         payload: {
           brandUrl: 'https://brand.example',
+          businessType: 'Test vertical',
           competitorUrl: 'https://betterup.com',
         },
       }),

--- a/tests/verify-banned-patterns.test.ts
+++ b/tests/verify-banned-patterns.test.ts
@@ -173,6 +173,7 @@ test('marketing job creation response omits banned runtime and tenant fields', a
             jobType: 'brand_campaign',
             payload: {
               brandUrl: 'https://brand.example',
+              businessType: 'Test vertical',
               competitorUrl: 'https://betterup.com',
             },
           }),


### PR DESCRIPTION
## Summary
- Adds a required **Business Type** combobox to onboarding pipeline-intake **Step 2 (Brand)** with ~60 curated marketing-relevant suggestions, filter-as-you-type, ghost-text inline autocomplete, free-text override, and full keyboard / ARIA support
- Plumbs \`businessType\` end-to-end: \`PipelineInput\` type → BrandStep gate → draft autosave (LOCAL_DRAFT_VERSION bumped to 2) → \`/api/marketing/jobs\` payload → orchestrator \`ensureBrandCampaignInput\` requires it
- Updates every existing brand_campaign test fixture so \`businessType\` satisfies the new gate

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] New helper tests pass (8/8): substring filter, case-insensitive ghost suffix, no-match cases
- [x] BrandStep prop-contract test passes (3/3)
- [x] All 22 brand_campaign-touching tests pass (only pre-existing \`/api/contact\` unrelated failure remains on master)
- [ ] Manual UI smoke: dropdown opens on focus, \`Tab\`/\`→\` accepts ghost text, ↓/↑ + Enter selects, \`Esc\` closes, free-text accepted on blur, draft survives reload, Next disabled until both brand URL valid + business type non-empty
- [ ] Manual API smoke: \`POST /api/marketing/jobs\` without \`businessType\` returns \`missing_required_fields:payload.businessType\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)