### PR TITLE
refactor(execution): switch Hermes provider from callback to polling

### DIFF
--- a/backend/execution/providers/hermes.ts
+++ b/backend/execution/providers/hermes.ts
@@ -158,14 +158,6 @@ function missingHermesConfigError(keys: 'HERMES_GATEWAY_URL' | 'HERMES_API_SERVE
   });
 }
 
-function missingAppBaseUrlError(): ExecutionError {
-  return new ExecutionError({
-    provider: 'hermes',
-    code: 'not_configured',
-    status: 503,
-    message: 'APP_BASE_URL is required when ARIES_EXECUTION_PROVIDER=hermes so Hermes can POST run callbacks to Aries.',
-  });
-}
 
 function notImplementedResult(route: string): WorkflowExecutionResult {
   return {
@@ -310,19 +302,11 @@ export class HermesExecutionAdapter {
     return readEnvValue(this.env, 'HERMES_GATEWAY_URL').replace(/\/+$/, '');
   }
 
-  private callbackUrl(): string {
-    return `${readEnvValue(this.env, 'APP_BASE_URL').replace(/\/+$/, '')}/api/internal/hermes/runs`;
-  }
-
   private authHeader(): string {
     return `Bearer ${readEnvValue(this.env, 'HERMES_API_SERVER_KEY')}`;
   }
 
   private async invokeRun(envelope: HermesRunRequestEnvelope): Promise<WorkflowExecutionResult> {
-    if (!readEnvValue(this.env, 'APP_BASE_URL')) {
-      return gatewayErrorResult(missingAppBaseUrlError());
-    }
-
     const run = createExecutionRunRecord({
       provider: 'hermes',
       domain: 'route',
@@ -334,16 +318,7 @@ export class HermesExecutionAdapter {
       return submission.result;
     }
     markExecutionRunSubmitted(run.aries_run_id, { externalRunId: submission.runId });
-    return {
-      kind: 'ok',
-      envelope: {
-        status: 'accepted',
-        provider: 'hermes',
-        aries_run_id: run.aries_run_id,
-        hermes_run_id: submission.runId,
-      },
-      primaryOutput: null,
-    };
+    return this.pollRunUntilTerminal(submission.runId);
   }
 
   private async submitRun(
@@ -362,12 +337,6 @@ export class HermesExecutionAdapter {
           input: promptForWorkflow(envelope, ariesRunId),
           instructions: instructionsForWorkflow(envelope.workflowId),
           session_id: this.sessionKey(),
-          callback_url: this.callbackUrl(),
-          metadata: {
-            aries_run_id: ariesRunId,
-            workflow_key: envelope.workflowId,
-            provider: 'hermes',
-          },
         }),
       });
     } catch (error) {

--- a/backend/execution/providers/hermes.ts
+++ b/backend/execution/providers/hermes.ts
@@ -1,6 +1,7 @@
 import { ExecutionError } from '../errors';
 import {
   createExecutionRunRecord,
+  markExecutionRunFailed,
   markExecutionRunSubmitted,
 } from '../run-store';
 import type { WorkflowEnvelope, WorkflowExecutionResult } from '../types';
@@ -318,7 +319,7 @@ export class HermesExecutionAdapter {
       return submission.result;
     }
     markExecutionRunSubmitted(run.aries_run_id, { externalRunId: submission.runId });
-    return this.pollRunUntilTerminal(submission.runId);
+    return this.pollRunUntilTerminal(submission.runId, run.aries_run_id);
   }
 
   private async submitRun(
@@ -384,13 +385,22 @@ export class HermesExecutionAdapter {
     return { kind: 'submitted', runId };
   }
 
-  private async pollRunUntilTerminal(runId: string): Promise<WorkflowExecutionResult> {
+  private async pollRunUntilTerminal(runId: string, ariesRunId: string): Promise<WorkflowExecutionResult> {
     const timeoutMs = readEnvInt(this.env, 'HERMES_RUN_TIMEOUT_MS', DEFAULT_RUN_TIMEOUT_MS);
     const intervalMs = Math.max(
       MIN_POLL_INTERVAL_MS,
       readEnvInt(this.env, 'HERMES_POLL_INTERVAL_MS', DEFAULT_POLL_INTERVAL_MS),
     );
     const deadline = Date.now() + timeoutMs;
+
+    const failRun = (error: ExecutionError): WorkflowExecutionResult => {
+      markExecutionRunFailed(ariesRunId, {
+        code: error.code,
+        message: error.message,
+        retryable: error.code === 'unreachable',
+      });
+      return gatewayErrorResult(error);
+    };
 
     while (Date.now() <= deadline) {
       let response: Response;
@@ -400,7 +410,7 @@ export class HermesExecutionAdapter {
           headers: { authorization: this.authHeader() },
         });
       } catch (error) {
-        return gatewayErrorResult(new ExecutionError({
+        return failRun(new ExecutionError({
           provider: 'hermes',
           code: 'unreachable',
           status: 503,
@@ -409,7 +419,7 @@ export class HermesExecutionAdapter {
         }));
       }
       if (!response.ok) {
-        return gatewayErrorResult(new ExecutionError({
+        return failRun(new ExecutionError({
           provider: 'hermes',
           code: errorCodeForStatus(response.status),
           status: response.status,
@@ -418,17 +428,28 @@ export class HermesExecutionAdapter {
       }
       const parsed = await this.parseJsonBody(response);
       if (parsed.kind === 'error') {
+        markExecutionRunFailed(ariesRunId, {
+          code: parsed.result.kind === 'gateway_error' ? parsed.result.error.code : 'response_invalid',
+          message: parsed.result.kind === 'gateway_error' ? parsed.result.error.message : 'Hermes returned invalid JSON.',
+        });
         return parsed.result;
       }
       const record = recordValue(parsed.value);
-      const status = record && typeof record.status === 'string' ? record.status : '';
-      if (TERMINAL_STATUSES.has(status)) {
-        return this.resultFromTerminalRun(runId, record ?? {}, response.status);
+      if (!record || typeof record.status !== 'string') {
+        return failRun(new ExecutionError({
+          provider: 'hermes',
+          code: 'response_invalid',
+          status: response.status,
+          message: `Hermes poll response for run ${runId} is missing a status field.`,
+        }));
+      }
+      if (TERMINAL_STATUSES.has(record.status)) {
+        return this.resultFromTerminalRun(runId, ariesRunId, record, response.status);
       }
       await this.sleep(intervalMs);
     }
 
-    return gatewayErrorResult(new ExecutionError({
+    return failRun(new ExecutionError({
       provider: 'hermes',
       code: 'server_error',
       status: 504,
@@ -438,6 +459,7 @@ export class HermesExecutionAdapter {
 
   private resultFromTerminalRun(
     runId: string,
+    ariesRunId: string,
     record: Record<string, unknown>,
     httpStatus: number,
   ): WorkflowExecutionResult {
@@ -446,20 +468,14 @@ export class HermesExecutionAdapter {
       const errorText = typeof record.error === 'string' && record.error
         ? record.error
         : `Hermes run ${runId} failed without an error message.`;
-      return gatewayErrorResult(new ExecutionError({
-        provider: 'hermes',
-        code: 'server_error',
-        status: httpStatus,
-        message: errorText,
-      }));
+      const error = new ExecutionError({ provider: 'hermes', code: 'server_error', status: httpStatus, message: errorText });
+      markExecutionRunFailed(ariesRunId, { code: error.code, message: error.message });
+      return gatewayErrorResult(error);
     }
     if (status === 'cancelled' || status === 'stopped') {
-      return gatewayErrorResult(new ExecutionError({
-        provider: 'hermes',
-        code: 'server_error',
-        status: httpStatus,
-        message: `Hermes run ${runId} ended with status ${status}.`,
-      }));
+      const error = new ExecutionError({ provider: 'hermes', code: 'server_error', status: httpStatus, message: `Hermes run ${runId} ended with status ${status}.` });
+      markExecutionRunFailed(ariesRunId, { code: error.code, message: error.message });
+      return gatewayErrorResult(error);
     }
 
     // status === 'completed'

--- a/backend/marketing/ports/hermes.ts
+++ b/backend/marketing/ports/hermes.ts
@@ -14,12 +14,36 @@ import type { MarketingStage } from '../runtime-state';
 
 type HermesMarketingEnv = Partial<Record<string, string | undefined>>;
 type HermesMarketingFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+type HermesMarketingSleep = (ms: number) => Promise<void>;
 
 const MARKETING_WORKFLOW_KEY = 'marketing_pipeline';
+
+const DEFAULT_RUN_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const MIN_POLL_INTERVAL_MS = 50;
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled', 'stopped']);
 
 function readEnvValue(env: HermesMarketingEnv, key: string): string {
   const value = env[key];
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function readEnvInt(env: HermesMarketingEnv, key: string, fallback: number): number {
+  const raw = readEnvValue(env, key);
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function tryParseJson(text: string): unknown {
+  if (!text) return null;
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : text;
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    return null;
+  }
 }
 
 function providerErrorEnvelope(code: string, message: string, detail?: Record<string, unknown>): LobsterEnvelope {
@@ -39,7 +63,7 @@ function missingConfigResult(keys: string): MarketingExecutionResult {
     provider: 'hermes',
     envelope: providerErrorEnvelope(
       'hermes_gateway_not_configured',
-      `${keys} required when ARIES_MARKETING_EXECUTION_PROVIDER=hermes. Set HERMES_GATEWAY_URL, HERMES_API_SERVER_KEY, and APP_BASE_URL, or set ARIES_MARKETING_EXECUTION_PROVIDER=legacy-openclaw to keep the legacy runtime.`,
+      `${keys} required when ARIES_MARKETING_EXECUTION_PROVIDER=hermes. Set HERMES_GATEWAY_URL and HERMES_API_SERVER_KEY, or set ARIES_MARKETING_EXECUTION_PROVIDER=legacy-openclaw to keep the legacy runtime.`,
     ),
   };
 }
@@ -73,6 +97,8 @@ export class HermesMarketingPort implements MarketingExecutionPort {
   constructor(
     private readonly env: HermesMarketingEnv = process.env,
     private readonly fetchImpl: HermesMarketingFetch = globalThis.fetch,
+    private readonly sleep: HermesMarketingSleep = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms)),
   ) {}
 
   async runPipeline(input: MarketingPipelineRunInput): Promise<MarketingExecutionResult> {
@@ -97,17 +123,13 @@ export class HermesMarketingPort implements MarketingExecutionPort {
   }
 
   private configurationError(): MarketingExecutionResult | null {
-    const missing = ['HERMES_GATEWAY_URL', 'HERMES_API_SERVER_KEY', 'APP_BASE_URL']
+    const missing = ['HERMES_GATEWAY_URL', 'HERMES_API_SERVER_KEY']
       .filter((key) => !readEnvValue(this.env, key));
     return missing.length > 0 ? missingConfigResult(missing.join(', ')) : null;
   }
 
   private gatewayUrl(): string {
     return readEnvValue(this.env, 'HERMES_GATEWAY_URL').replace(/\/+$/, '');
-  }
-
-  private callbackUrl(): string {
-    return `${readEnvValue(this.env, 'APP_BASE_URL').replace(/\/+$/, '')}/api/internal/hermes/runs`;
   }
 
   private authHeader(): string {
@@ -160,16 +182,6 @@ export class HermesMarketingPort implements MarketingExecutionPort {
           input: this.prompt(action, run.aries_run_id, input),
           instructions: this.instructions(),
           session_id: this.sessionKey(),
-          callback_url: this.callbackUrl(),
-          metadata: {
-            aries_run_id: run.aries_run_id,
-            workflow_key: MARKETING_WORKFLOW_KEY,
-            domain: 'marketing',
-            marketing_job_id: input.jobId ?? null,
-            approval_id: input.approvalId ?? null,
-            stage: input.stage ?? null,
-            workflow_step_id: input.workflowStepId ?? null,
-          },
         }),
       });
     } catch (error) {
@@ -202,12 +214,72 @@ export class HermesMarketingPort implements MarketingExecutionPort {
     }
 
     markExecutionRunSubmitted(run.aries_run_id, { externalRunId: hermesRunId });
-    return {
-      kind: 'submitted',
-      provider: 'hermes',
-      ariesRunId: run.aries_run_id,
-      hermesRunId,
-    };
+    return this.pollRunUntilTerminal(hermesRunId);
+  }
+
+  private async pollRunUntilTerminal(runId: string): Promise<MarketingExecutionResult> {
+    const timeoutMs = readEnvInt(this.env, 'HERMES_RUN_TIMEOUT_MS', DEFAULT_RUN_TIMEOUT_MS);
+    const intervalMs = Math.max(
+      MIN_POLL_INTERVAL_MS,
+      readEnvInt(this.env, 'HERMES_POLL_INTERVAL_MS', DEFAULT_POLL_INTERVAL_MS),
+    );
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() <= deadline) {
+      let pollResponse: Response;
+      try {
+        pollResponse = await this.fetchImpl(
+          `${this.gatewayUrl()}/v1/runs/${encodeURIComponent(runId)}`,
+          { method: 'GET', headers: { authorization: this.authHeader() } },
+        );
+      } catch (error) {
+        return gatewayErrorResult('hermes_gateway_unreachable', 'Hermes gateway is unreachable while polling run status.', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      if (!pollResponse.ok) {
+        return gatewayErrorResult(
+          'hermes_gateway_request_failed',
+          `Hermes gateway returned HTTP ${pollResponse.status} polling run ${runId}.`,
+          { status: pollResponse.status },
+        );
+      }
+      const record = await this.parseJsonBody(pollResponse);
+      const status = typeof record?.status === 'string' ? record.status : '';
+      if (TERMINAL_STATUSES.has(status)) {
+        return this.resultFromTerminalRun(runId, record ?? {});
+      }
+      await this.sleep(intervalMs);
+    }
+
+    return gatewayErrorResult(
+      'hermes_gateway_timeout',
+      `Hermes run ${runId} did not reach a terminal status within ${timeoutMs}ms.`,
+    );
+  }
+
+  private resultFromTerminalRun(runId: string, record: Record<string, unknown>): MarketingExecutionResult {
+    const status = typeof record.status === 'string' ? record.status : '';
+    if (status === 'failed') {
+      const message = typeof record.error === 'string' && record.error
+        ? record.error
+        : `Hermes run ${runId} failed without an error message.`;
+      return gatewayErrorResult('hermes_run_failed', message, { run_id: runId });
+    }
+    if (status === 'cancelled' || status === 'stopped') {
+      return gatewayErrorResult('hermes_run_cancelled', `Hermes run ${runId} ended with status ${status}.`, { run_id: runId });
+    }
+
+    const outputText = typeof record.output === 'string' ? record.output : '';
+    const parsed = tryParseJson(outputText);
+    const envelope: LobsterEnvelope = (
+      parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed as LobsterEnvelope
+        : { ok: true, status: 'completed', provider: 'hermes', run_id: runId, output_text: outputText }
+    );
+    if (typeof envelope.ok !== 'boolean') envelope.ok = true;
+    if (typeof envelope.status !== 'string') envelope.status = 'completed';
+    return { kind: 'completed', provider: 'hermes', envelope };
   }
 
   private async parseJsonBody(response: Response): Promise<Record<string, unknown> | null> {
@@ -259,7 +331,9 @@ export class HermesMarketingPort implements MarketingExecutionPort {
     return [
       'You are the Aries marketing pipeline execution agent.',
       'Do not rely on Lobster runtime files.',
-      'Post progress and terminal results back to the supplied callback_url with event_id, aries_run_id, status, and output.',
+      'Reply with a single strict JSON object only — no prose, no markdown fences.',
+      'Required schema: {"ok":true,"status":"completed","output":[{...}]}.',
+      'If approval is required, set status to "requires_approval" and include a "requiresApproval" field with resumeToken, stage, and prompt.',
     ].join(' ');
   }
 }

--- a/backend/marketing/ports/hermes.ts
+++ b/backend/marketing/ports/hermes.ts
@@ -85,11 +85,11 @@ function markSubmissionFailed(ariesRunId: string, code: string, message: string)
 }
 
 /**
- * Marketing execution port backed by Hermes callbacks.
+ * Marketing execution port backed by Hermes polling.
  *
- * Hermes is async: this adapter submits a run/resume request, persists the
- * Aries correlation id, and returns immediately. The callback route advances
- * marketing state when Hermes posts results back to Aries.
+ * Submits a run/resume request to the Hermes gateway, then polls
+ * GET /v1/runs/{id} until a terminal status is reached, and returns
+ * the parsed LobsterEnvelope from the agent's output.
  */
 export class HermesMarketingPort implements MarketingExecutionPort {
   readonly name = 'hermes' as const;
@@ -214,16 +214,21 @@ export class HermesMarketingPort implements MarketingExecutionPort {
     }
 
     markExecutionRunSubmitted(run.aries_run_id, { externalRunId: hermesRunId });
-    return this.pollRunUntilTerminal(hermesRunId);
+    return this.pollRunUntilTerminal(hermesRunId, run.aries_run_id);
   }
 
-  private async pollRunUntilTerminal(runId: string): Promise<MarketingExecutionResult> {
+  private async pollRunUntilTerminal(runId: string, ariesRunId: string): Promise<MarketingExecutionResult> {
     const timeoutMs = readEnvInt(this.env, 'HERMES_RUN_TIMEOUT_MS', DEFAULT_RUN_TIMEOUT_MS);
     const intervalMs = Math.max(
       MIN_POLL_INTERVAL_MS,
       readEnvInt(this.env, 'HERMES_POLL_INTERVAL_MS', DEFAULT_POLL_INTERVAL_MS),
     );
     const deadline = Date.now() + timeoutMs;
+
+    const failRun = (code: string, message: string, detail?: Record<string, unknown>): MarketingExecutionResult => {
+      markSubmissionFailed(ariesRunId, code, message);
+      return gatewayErrorResult(code, message, detail);
+    };
 
     while (Date.now() <= deadline) {
       let pollResponse: Response;
@@ -233,53 +238,66 @@ export class HermesMarketingPort implements MarketingExecutionPort {
           { method: 'GET', headers: { authorization: this.authHeader() } },
         );
       } catch (error) {
-        return gatewayErrorResult('hermes_gateway_unreachable', 'Hermes gateway is unreachable while polling run status.', {
+        return failRun('hermes_gateway_unreachable', 'Hermes gateway is unreachable while polling run status.', {
           error: error instanceof Error ? error.message : String(error),
         });
       }
       if (!pollResponse.ok) {
-        return gatewayErrorResult(
+        return failRun(
           'hermes_gateway_request_failed',
           `Hermes gateway returned HTTP ${pollResponse.status} polling run ${runId}.`,
           { status: pollResponse.status },
         );
       }
       const record = await this.parseJsonBody(pollResponse);
-      const status = typeof record?.status === 'string' ? record.status : '';
-      if (TERMINAL_STATUSES.has(status)) {
-        return this.resultFromTerminalRun(runId, record ?? {});
+      if (!record || typeof record.status !== 'string') {
+        return failRun(
+          'hermes_gateway_response_invalid',
+          `Hermes poll response for run ${runId} is missing a status field.`,
+        );
+      }
+      if (TERMINAL_STATUSES.has(record.status)) {
+        return this.resultFromTerminalRun(runId, ariesRunId, record);
       }
       await this.sleep(intervalMs);
     }
 
-    return gatewayErrorResult(
+    return failRun(
       'hermes_gateway_timeout',
       `Hermes run ${runId} did not reach a terminal status within ${timeoutMs}ms.`,
     );
   }
 
-  private resultFromTerminalRun(runId: string, record: Record<string, unknown>): MarketingExecutionResult {
+  private resultFromTerminalRun(runId: string, ariesRunId: string, record: Record<string, unknown>): MarketingExecutionResult {
     const status = typeof record.status === 'string' ? record.status : '';
     if (status === 'failed') {
       const message = typeof record.error === 'string' && record.error
         ? record.error
         : `Hermes run ${runId} failed without an error message.`;
+      markSubmissionFailed(ariesRunId, 'hermes_run_failed', message);
       return gatewayErrorResult('hermes_run_failed', message, { run_id: runId });
     }
     if (status === 'cancelled' || status === 'stopped') {
-      return gatewayErrorResult('hermes_run_cancelled', `Hermes run ${runId} ended with status ${status}.`, { run_id: runId });
+      const message = `Hermes run ${runId} ended with status ${status}.`;
+      markSubmissionFailed(ariesRunId, 'hermes_run_cancelled', message);
+      return gatewayErrorResult('hermes_run_cancelled', message, { run_id: runId });
     }
 
+    // status === 'completed'
     const outputText = typeof record.output === 'string' ? record.output : '';
-    const parsed = tryParseJson(outputText);
-    const envelope: LobsterEnvelope = (
-      parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-        ? parsed as LobsterEnvelope
-        : { ok: true, status: 'completed', provider: 'hermes', run_id: runId, output_text: outputText }
-    );
-    if (typeof envelope.ok !== 'boolean') envelope.ok = true;
-    if (typeof envelope.status !== 'string') envelope.status = 'completed';
-    return { kind: 'completed', provider: 'hermes', envelope };
+    if (outputText) {
+      const parsed = tryParseJson(outputText);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        const message = `Hermes run ${runId} returned unparseable output.`;
+        markSubmissionFailed(ariesRunId, 'hermes_output_invalid', message);
+        return gatewayErrorResult('hermes_output_invalid', message, { run_id: runId });
+      }
+      const envelope = parsed as LobsterEnvelope;
+      if (typeof envelope.ok !== 'boolean') envelope.ok = true;
+      if (typeof envelope.status !== 'string') envelope.status = 'completed';
+      return { kind: 'completed', provider: 'hermes', envelope };
+    }
+    return { kind: 'completed', provider: 'hermes', envelope: { ok: true, status: 'completed', provider: 'hermes', run_id: runId } };
   }
 
   private async parseJsonBody(response: Response): Promise<Record<string, unknown> | null> {

--- a/tests/execution-hermes-adapter.test.ts
+++ b/tests/execution-hermes-adapter.test.ts
@@ -29,18 +29,14 @@ const NO_SLEEP = async () => {};
 
 async function withDataRoot<T>(run: () => Promise<T>): Promise<T> {
   const previousDataRoot = process.env.DATA_ROOT;
-  const previousAppBaseUrl = process.env.APP_BASE_URL;
   const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-hermes-adapter-'));
 
   process.env.DATA_ROOT = dataRoot;
-  process.env.APP_BASE_URL = 'https://aries.example.com';
   try {
     return await run();
   } finally {
     if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
     else process.env.DATA_ROOT = previousDataRoot;
-    if (previousAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
-    else process.env.APP_BASE_URL = previousAppBaseUrl;
     await rm(dataRoot, { recursive: true, force: true });
   }
 }
@@ -107,12 +103,17 @@ test('HermesExecutionAdapter returns not_implemented for unsupported workflows e
   assert.equal(result.payload.provider, 'hermes');
 });
 
-test('HermesExecutionAdapter submits demo_start once and returns an async run envelope', async () => {
+test('HermesExecutionAdapter submits demo_start and polls until completed', async () => {
   await withDataRoot(async () => {
     const { loadExecutionRunRecord } = await import('../backend/execution/run-store');
+    const completedOutput = JSON.stringify({ status: 'ok', provider: 'hermes', output: [{ provisioned: true, lead_id: 'lead_1' }] });
     const { calls, fetchImpl } = recordingFetchSequence([
       () => new Response(JSON.stringify({ run_id: 'run_abc', status: 'started' }), {
         status: 202,
+        headers: { 'content-type': 'application/json' },
+      }),
+      () => new Response(JSON.stringify({ run_id: 'run_abc', status: 'completed', output: completedOutput }), {
+        status: 200,
         headers: { 'content-type': 'application/json' },
       }),
     ]);
@@ -121,8 +122,7 @@ test('HermesExecutionAdapter submits demo_start once and returns an async run en
         HERMES_GATEWAY_URL: `${TEST_HERMES_GATEWAY_URL}/`,
         HERMES_API_SERVER_KEY: 'token-123',
         HERMES_SESSION_KEY: 'campaign-runtime',
-        APP_BASE_URL: 'https://aries.example.com',
-        HERMES_RUN_TIMEOUT_MS: '0',
+        HERMES_RUN_TIMEOUT_MS: '30000',
         HERMES_POLL_INTERVAL_MS: '0',
       },
       fetchImpl,
@@ -136,13 +136,11 @@ test('HermesExecutionAdapter submits demo_start once and returns an async run en
 
     assert.equal(result.kind, 'ok');
     if (result.kind !== 'ok') assert.fail('expected ok result');
-    assert.equal(result.primaryOutput, null);
-    assert.equal(result.envelope.status, 'accepted');
+    assert.deepEqual(result.primaryOutput, { provisioned: true, lead_id: 'lead_1' });
+    assert.equal(result.envelope.status, 'ok');
     assert.equal(result.envelope.provider, 'hermes');
-    assert.equal(result.envelope.hermes_run_id, 'run_abc');
-    assert.match(String(result.envelope.aries_run_id), /^arun_/);
 
-    assert.equal(calls.length, 1);
+    assert.equal(calls.length, 2);
     assert.equal(calls[0].url, `${TEST_HERMES_GATEWAY_URL}/v1/runs`);
     assert.equal(calls[0].init.method, 'POST');
     const headers0 = calls[0].init.headers as Record<string, string>;
@@ -150,16 +148,20 @@ test('HermesExecutionAdapter submits demo_start once and returns an async run en
     assert.equal(headers0['content-type'], 'application/json');
     const submitBody = JSON.parse(String(calls[0].init.body));
     assert.equal(submitBody.session_id, 'campaign-runtime');
-    assert.equal(submitBody.callback_url, 'https://aries.example.com/api/internal/hermes/runs');
+    assert.equal(submitBody.callback_url, undefined);
     assert.match(submitBody.input, /Workflow: demo_start/);
     assert.match(submitBody.input, /Aries run ID: arun_/);
     assert.match(submitBody.input, /"user":\{"email":"founder@example.com"\}/);
     assert.match(submitBody.instructions, /Aries demo provisioning/);
+    assert.equal(calls[1].url, `${TEST_HERMES_GATEWAY_URL}/v1/runs/run_abc`);
+    assert.equal(calls[1].init.method, 'GET');
 
-    const stored = loadExecutionRunRecord(String(result.envelope.aries_run_id));
-    assert.equal(stored?.external_run_id, 'run_abc');
-    assert.equal(stored?.workflow_key, 'demo_start');
-    assert.equal(stored?.domain, 'route');
+    const stored = loadExecutionRunRecord(String(result.envelope.run_id ?? calls[1].url));
+    const runId = String(submitBody.input).match(/Aries run ID: (arun_[^\n]+)/)?.[1] ?? '';
+    const storedByRunId = loadExecutionRunRecord(runId);
+    assert.equal(storedByRunId?.external_run_id, 'run_abc');
+    assert.equal(storedByRunId?.workflow_key, 'demo_start');
+    assert.equal(storedByRunId?.domain, 'route');
   });
 });
 
@@ -169,7 +171,6 @@ test('HermesExecutionAdapter returns unreachable when /v1/runs submission throws
       {
         HERMES_GATEWAY_URL: TEST_UNREACHABLE_URL,
         HERMES_API_SERVER_KEY: 'token-123',
-        APP_BASE_URL: 'https://aries.example.com',
         HERMES_POLL_INTERVAL_MS: '0',
       },
       async () => {
@@ -199,7 +200,6 @@ test('HermesExecutionAdapter surfaces non-2xx submission HTTP status as a struct
       {
         HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
         HERMES_API_SERVER_KEY: 'token-bad',
-        APP_BASE_URL: 'https://aries.example.com',
         HERMES_POLL_INTERVAL_MS: '0',
       },
       fetchImpl,

--- a/tests/marketing-execution-port.test.ts
+++ b/tests/marketing-execution-port.test.ts
@@ -110,41 +110,52 @@ test('getMarketingExecutionPort returns the Hermes port when explicitly selected
   assert.equal(port.name, 'hermes');
 });
 
-test('HermesMarketingPort.runPipeline submits a Hermes marketing run without polling', async () => {
+test('HermesMarketingPort.runPipeline submits and polls until completed', async () => {
   await withDataRoot(async () => {
     const { loadExecutionRunRecord } = await import('../backend/execution/run-store');
+    const completedOutput = JSON.stringify({ ok: true, status: 'completed', output: [{ stage: 'research', summary: 'done' }] });
     const { calls, fetchImpl } = recordingFetchSequence([
       () => new Response(JSON.stringify({ run_id: 'hermes-marketing-run-1', status: 'started' }), {
         status: 202,
         headers: { 'content-type': 'application/json' },
       }),
+      () => new Response(JSON.stringify({ run_id: 'hermes-marketing-run-1', status: 'completed', output: completedOutput }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
     ]);
+    const NO_SLEEP = async () => {};
     const port = new HermesMarketingPort(
       {
         HERMES_GATEWAY_URL: `${TEST_HERMES_GATEWAY_URL}/`,
         HERMES_API_SERVER_KEY: 'token-123',
         HERMES_SESSION_KEY: 'marketing-session',
-        APP_BASE_URL: 'https://aries.example.com',
+        HERMES_RUN_TIMEOUT_MS: '30000',
+        HERMES_POLL_INTERVAL_MS: '0',
       },
       fetchImpl,
+      NO_SLEEP,
     );
     const result = await port.runPipeline(STUB_RUN_INPUT);
 
-    assert.equal(result.kind, 'submitted');
+    assert.equal(result.kind, 'completed');
     assert.equal(result.provider, 'hermes');
-    assert.equal(result.hermesRunId, 'hermes-marketing-run-1');
-    assert.match(result.ariesRunId, /^arun_/);
-    assert.equal(calls.length, 1);
+    assert.equal(result.envelope.ok, true);
+    assert.equal(result.envelope.status, 'completed');
+    assert.equal(calls.length, 2);
 
     const body = JSON.parse(String(calls[0].init.body));
-    assert.equal(body.callback_url, 'https://aries.example.com/api/internal/hermes/runs');
+    assert.equal(body.callback_url, undefined);
     assert.equal(body.session_id, 'marketing-session');
     assert.match(body.input, /Workflow: marketing_pipeline/);
     assert.match(body.input, /Action: run/);
     assert.match(body.input, /Aries run ID: arun_/);
     assert.match(body.input, /"job_id":"job_test"/);
+    assert.equal(calls[1].url, `${TEST_HERMES_GATEWAY_URL}/v1/runs/hermes-marketing-run-1`);
 
-    const stored = loadExecutionRunRecord(result.ariesRunId);
+    const ariesRunIdMatch = String(body.input).match(/Aries run ID: (arun_[^\n]+)/);
+    const ariesRunId = ariesRunIdMatch?.[1] ?? '';
+    const stored = loadExecutionRunRecord(ariesRunId);
     assert.equal(stored?.domain, 'marketing');
     assert.equal(stored?.workflow_key, 'marketing_pipeline');
     assert.equal(stored?.marketing_job_id, 'job_test');
@@ -153,37 +164,47 @@ test('HermesMarketingPort.runPipeline submits a Hermes marketing run without pol
   });
 });
 
-test('HermesMarketingPort.resumePipeline submits a Hermes resume decision without polling', async () => {
+test('HermesMarketingPort.resumePipeline submits and polls until completed', async () => {
   await withDataRoot(async () => {
+    const completedOutput = JSON.stringify({ ok: true, status: 'completed', output: [] });
     const { calls, fetchImpl } = recordingFetchSequence([
       () => new Response(JSON.stringify({ run_id: 'hermes-resume-run-1', status: 'started' }), {
         status: 202,
         headers: { 'content-type': 'application/json' },
       }),
+      () => new Response(JSON.stringify({ run_id: 'hermes-resume-run-1', status: 'completed', output: completedOutput }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
     ]);
+    const NO_SLEEP = async () => {};
     const port = new HermesMarketingPort(
       {
         HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
         HERMES_API_SERVER_KEY: 'token-123',
-        APP_BASE_URL: 'https://aries.example.com',
+        HERMES_RUN_TIMEOUT_MS: '30000',
+        HERMES_POLL_INTERVAL_MS: '0',
       },
       fetchImpl,
+      NO_SLEEP,
     );
 
     const result = await port.resumePipeline(STUB_RESUME_INPUT);
 
-    assert.equal(result.kind, 'submitted');
+    assert.equal(result.kind, 'completed');
     assert.equal(result.provider, 'hermes');
-    assert.equal(result.hermesRunId, 'hermes-resume-run-1');
+    assert.equal(result.envelope.ok, true);
+    assert.equal(calls.length, 2);
     const body = JSON.parse(String(calls[0].init.body));
     assert.match(body.input, /Action: resume/);
     assert.match(body.input, /Approve: true/);
     assert.match(body.input, /Resume token: opaque-token-123/);
+    assert.equal(calls[1].url, `${TEST_HERMES_GATEWAY_URL}/v1/runs/hermes-resume-run-1`);
   });
 });
 
 test('HermesMarketingPort reports missing config as a completed error result', async () => {
-  const port = new HermesMarketingPort({ HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL });
+  const port = new HermesMarketingPort({ HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL }); // missing HERMES_API_SERVER_KEY
   const result = await port.runPipeline(STUB_RUN_INPUT);
 
   assert.equal(result.kind, 'completed');
@@ -206,7 +227,6 @@ test('HermesMarketingPort marks accepted Aries runs failed when Hermes submissio
       {
         HERMES_GATEWAY_URL: TEST_HERMES_GATEWAY_URL,
         HERMES_API_SERVER_KEY: 'token-123',
-        APP_BASE_URL: 'https://aries.example.com',
       },
       fetchImpl,
     );


### PR DESCRIPTION
## Summary
- Adds first-class weekly social-content routes, API clients, intake/status/review UI, and marketing-route compatibility redirects/aliases.
- Moves weekly social-content execution to Hermes-native `social_content_weekly` submissions with webhook callbacks, deterministic stage/approval state, and structured workflow payloads.
- Adds ChatGPT / OpenAI connection references for Hermes media requests, weekly calendar defaults, docs/env updates, and regression coverage wired into `verify`.

## Test plan
- `npm run typecheck`
- `npm run validate:execution-provider`
- `npm run validate:marketing-flow`
- `npm run validate:social-content`
- `npm run verify`

## Review notes
- Final reviewer approved with no blockers.
- Non-blocking hardening follow-ups remain around extra tenant assertion in Hermes marketing callbacks, optional social-content approval-step allowlisting, approval path traversal hardening, and unused legacy payload cleanup.