### PR TITLE
fix: resolve live QA blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ npm run dev
 
 ## Docker Compose
 
-The repo includes `docker-compose.yml`, `docker-compose.local.yml`, and a production `Dockerfile`. Local Compose provisions a companion `postgres` service and wires the app to it with `DB_HOST=postgres`; production deploys may use external PostgreSQL instead. Hermes is always external, so `HERMES_*` and callback auth values still need to point at working services.
+The repo includes `docker-compose.yml`, `docker-compose.local.yml`, and a production `Dockerfile`. Compose expects an external PostgreSQL database and passes through the `DB_*` values from `.env` or the production secret store; it does not provision Postgres or pgAdmin containers. Hermes is always external, so `HERMES_*` and callback auth values still need to point at working services.
 
 ### Production release
 
@@ -211,7 +211,7 @@ cp .env.example .env
 docker network create docker-stack || true
 ```
 
-3. Start the app with the local overrides file so localhost-oriented URL defaults are applied. Local Compose starts the companion `postgres` service from `docker-compose.yml`; the app container uses `DB_HOST=postgres` internally while `.env` supplies `DB_USER`, `DB_PASSWORD`, `DB_NAME`, and the host-published `DB_PORT`.
+3. Start the app with the local overrides file so localhost-oriented URL defaults are applied. Before starting Compose, make sure `.env` points `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` at an existing PostgreSQL database reachable from the container.
 
 ```bash
 docker compose --env-file .env -f docker-compose.yml -f docker-compose.local.yml up --build -d aries-app
@@ -237,7 +237,7 @@ docker compose --env-file .env -f docker-compose.yml -f docker-compose.local.yml
 - The app container stores generated runtime artifacts under `/data`, which is a bind mount from `${ARIES_SHARED_DATA_ROOT:-/home/node/data}` on the host.
 - `docker-compose.yml` now publishes `${PORT:-3000}` for the main `aries-app` service because both deploys and local production-style runs depend on that host port existing.
 - `docker-compose.local.yml` layers in localhost-friendly URL defaults and merges into the same `aries-app` service rather than creating a second production container.
-- Local Compose includes a `postgres` service and wires the app container to it with `DB_HOST=postgres`. Production deploys may still use external PostgreSQL; in that case, configure the production environment/secret store with the external `DB_*` values instead of relying on local Compose defaults.
+- Compose does **not** provision PostgreSQL or pgAdmin. Configure `.env` locally, or the production environment/secret store in deploys, with external `DB_*` values that the app container can reach.
 - For production-style Compose runs, `NODE_ENV` is set to `production` and the container starts with `npm run start`.
 
 ## Environment variables

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -25,7 +25,7 @@ const ENDPOINTS = [
   {
     method: 'POST',
     path: '/api/marketing/jobs',
-    desc: 'Create a new marketing campaign.',
+    desc: 'Create a new weekly social content plan.',
     body:
       '{ "jobType": "brand_campaign", "payload": { "brandUrl", "competitorUrl"?, "competitorBrand"?, "facebookPageUrl"?, "adLibraryUrl"?, "metaPageId"? } }',
     response:
@@ -34,7 +34,7 @@ const ENDPOINTS = [
   {
     method: 'GET',
     path: '/api/marketing/jobs/:jobId',
-    desc: 'Read the current state of a marketing campaign.',
+    desc: 'Read the current state of a weekly social content plan.',
     body: '\u2014',
     response:
       '{ "jobId": "...", "marketing_job_state": "...", "marketing_job_status": "...", "marketing_stage": "...", "approvalRequired": true, "summary": { ... }, "stageCards": [...], "artifacts": [...], "timeline": [...], "approval": { ... }, "nextStep": "submit_approval" }',
@@ -42,7 +42,7 @@ const ENDPOINTS = [
   {
     method: 'POST',
     path: '/api/marketing/jobs/:jobId/approve',
-    desc: 'Approve a campaign checkpoint and resume the next stage.',
+    desc: 'Approve a social content checkpoint and resume the next stage.',
     body:
       '{ "approvedBy", "approvedStages"?: ["strategy"|"production"|"publish"], "resumePublishIfNeeded"?: true, "publishConfig"?: { ... } }',
     response:

--- a/app/api/onboarding/draft/route.ts
+++ b/app/api/onboarding/draft/route.ts
@@ -34,9 +34,33 @@ function draftIdFrom(req: Request): string | null {
   return draftId?.trim() || null;
 }
 
+function redactDiagnostic(value: string): string {
+  return value
+    .replace(/password=[^\s&]+/gi, 'password=[REDACTED]')
+    .replace(/postgres(?:ql)?:\/\/[^\s@]+@/gi, 'postgres://[REDACTED]@');
+}
+
+function onboardingDraftErrorResponse(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (message === 'draft_not_found') {
+    return NextResponse.json({ error: 'draft_not_found' }, { status: 404 });
+  }
+  if (message === 'invalid_draft_token') {
+    return NextResponse.json({ error: 'invalid_draft_token' }, { status: 400 });
+  }
+
+  console.error('[onboarding-draft] persistence error', redactDiagnostic(message));
+  return NextResponse.json({ error: 'onboarding_draft_unavailable' }, { status: 503 });
+}
+
 export async function POST() {
-  const draft = await createOnboardingDraft();
-  return NextResponse.json({ draft }, { status: 201 });
+  try {
+    const draft = await createOnboardingDraft();
+    return NextResponse.json({ draft }, { status: 201 });
+  } catch (error) {
+    return onboardingDraftErrorResponse(error);
+  }
 }
 
 export async function GET(req: Request) {
@@ -45,12 +69,16 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'draft_token_required' }, { status: 400 });
   }
 
-  const draft = await getOnboardingDraft(draftId);
-  if (!draft) {
-    return NextResponse.json({ error: 'draft_not_found' }, { status: 404 });
-  }
+  try {
+    const draft = await getOnboardingDraft(draftId);
+    if (!draft) {
+      return NextResponse.json({ error: 'draft_not_found' }, { status: 404 });
+    }
 
-  return NextResponse.json({ draft }, { status: 200 });
+    return NextResponse.json({ draft }, { status: 200 });
+  } catch (error) {
+    return onboardingDraftErrorResponse(error);
+  }
 }
 
 export async function PATCH(req: Request) {
@@ -92,8 +120,6 @@ export async function PATCH(req: Request) {
 
     return NextResponse.json({ draft }, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const status = message === 'draft_not_found' ? 404 : message === 'invalid_draft_token' ? 400 : 500;
-    return NextResponse.json({ error: message }, { status });
+    return onboardingDraftErrorResponse(error);
   }
 }

--- a/app/creative-memory/page.tsx
+++ b/app/creative-memory/page.tsx
@@ -165,9 +165,9 @@ export default function CreativeMemoryPage() {
           <p className="text-xs font-semibold uppercase tracking-[0.4em] text-cyan-300">Creative Memory</p>
           <div className="mt-4 grid gap-6 lg:grid-cols-[1.35fr_0.65fr] lg:items-end">
             <div>
-              <h1 className="text-4xl font-semibold tracking-tight text-white md:text-6xl">Campaign Learning</h1>
+              <h1 className="text-4xl font-semibold tracking-tight text-white md:text-6xl">Content Learning</h1>
               <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-300">
-                Prove each campaign gets sharper: inspect retrieved memory, compare baseline vs memory-assisted prompts, approve the selected pattern, review results, and write outcome labels back into Aries.
+                Prove each week of social content gets sharper: inspect retrieved memory, compare baseline vs memory-assisted prompts, approve the selected pattern, review results, and write outcome labels back into Aries.
               </p>
             </div>
             <div className="rounded-3xl border border-slate-700 bg-slate-900/80 p-5" aria-label="Memory trust lifecycle">
@@ -190,8 +190,8 @@ export default function CreativeMemoryPage() {
 
         <section className="grid gap-5 xl:grid-cols-[0.9fr_1.1fr]" aria-label="Golden path">
           <div className="rounded-3xl border border-slate-800 bg-slate-950 p-6">
-            <h2 className="text-2xl font-semibold">Campaign brief</h2>
-            <p className="mt-2 text-sm text-slate-400">Select a campaign, choose a brief, then let Aries retrieve only the memory that matters.</p>
+            <h2 className="text-2xl font-semibold">Content brief</h2>
+            <p className="mt-2 text-sm text-slate-400">Select a content plan, choose a brief, then let Aries retrieve only the memory that matters.</p>
             <div className="mt-5 grid gap-4">
               {[
                 ['Objective', brief.objective],
@@ -251,7 +251,7 @@ export default function CreativeMemoryPage() {
           {[
             ['Inspect retrieved context', 'View selected pattern, examples, excluded candidates, permissions, and why each signal was chosen.'],
             ['Generate two variants', 'Create baseline and memory-assisted variants for the same brief so improvement is visible.'],
-            ['Review and label outcome', 'Approve, reject, regenerate, mark used in campaign, or label winner/loser for learning.'],
+            ['Review and label outcome', 'Approve, reject, regenerate, mark used in weekly content, or label winner/loser for learning.'],
           ].map(([title, body]) => (
             <article key={title} className="rounded-3xl border border-slate-800 bg-slate-950 p-6">
               <h2 className="text-xl font-semibold">{title}</h2>

--- a/app/documentation/page.tsx
+++ b/app/documentation/page.tsx
@@ -4,7 +4,7 @@ import Docs from '../../frontend/documentation/Docs';
 
 export const metadata = {
   title: 'Documentation — Aries AI',
-  description: 'Getting started with Aries AI — how to create your first campaign, connect channels, and approve creative.',
+  description: 'Getting started with Aries AI — how to create your first weekly social content plan, connect channels, and approve creative.',
 };
 
 export default function DocumentationPage() {

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -9,8 +9,8 @@ export const metadata = {
 const FEATURES = [
   {
     icon: '◈',
-    title: 'Campaign Planning',
-    desc: 'Turn your business goals into a clear campaign plan with messaging, channels, and timing you can review in seconds.',
+    title: 'Weekly Content Planning',
+    desc: 'Turn your business goals into a clear weekly social content plan with messaging, channels, and timing you can review in seconds.',
   },
   {
     icon: '◎',
@@ -50,7 +50,7 @@ const FEATURES = [
   {
     icon: '◷',
     title: 'Next-Step Recommendations',
-    desc: 'Every campaign result ends with a recommended next action so you always know where to focus.',
+    desc: 'Every weekly content result ends with a recommended next action so you always know where to focus.',
   },
 ];
 
@@ -88,7 +88,7 @@ export default function FeaturesPage() {
           <div className="glass rounded-[3rem] p-10 md:p-14 text-center max-w-5xl mx-auto">
             <h2 className="text-4xl md:text-5xl font-bold mb-5">Ready to see how it works?</h2>
             <p className="text-white/60 text-lg mb-8 max-w-3xl mx-auto">
-              Set up your business, review your first campaign plan, and approve what ships before anything goes live.
+              Set up your business, review your first weekly social content plan, and approve what ships before anything goes live.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link href="/onboarding/start" className="px-8 py-4 rounded-full bg-gradient-to-r from-primary to-secondary text-white font-semibold shadow-xl shadow-primary/20">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,8 +19,8 @@ const manrope = Manrope({
 });
 
 export const metadata: Metadata = {
-  title: 'Aries AI - Marketing Operating System',
-  description: 'A premium, approval-safe marketing operating system for small businesses. Plan campaigns, approve creative, launch safely, and see what worked.',
+  title: 'Aries AI - Weekly Social Content Operating System',
+  description: 'A premium, approval-safe social content operating system for small businesses. Plan weekly posts, approve creative, publish safely, and see what worked.',
   icons: {
     icon: [
       { url: ARIES_FAVICON_ICO_PATH, type: 'image/x-icon' },

--- a/app/marketing/job-approve/page.tsx
+++ b/app/marketing/job-approve/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 
 export const metadata = {
-  title: 'Campaign Approval · Aries AI',
+  title: 'Weekly Social Content Review · Aries AI',
 };
 
 export default async function MarketingJobApprovePage({

--- a/app/marketing/job-status/page.tsx
+++ b/app/marketing/job-status/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 
 export const metadata = {
-  title: 'Campaign Status · Aries AI',
+  title: 'Weekly Social Content Status · Aries AI',
 };
 
 export default async function MarketingJobStatusPage({

--- a/app/onboarding/resume/pending.tsx
+++ b/app/onboarding/resume/pending.tsx
@@ -37,7 +37,7 @@ export default function OnboardingResumePending(): JSX.Element {
           {stuck ? (
             <>
               <h1 className="mt-4 text-4xl font-normal tracking-[-0.04em] text-white">
-                The campaign service is taking longer than expected
+                The social content service is taking longer than expected
               </h1>
               <p className="mt-4 max-w-xl text-sm leading-7 text-white/65">
                 The workspace handoff hasn&apos;t completed yet. Your draft is saved. Try again,
@@ -47,11 +47,11 @@ export default function OnboardingResumePending(): JSX.Element {
           ) : (
             <>
               <h1 className="mt-4 text-4xl font-normal tracking-[-0.04em] text-white">
-                Building your first campaign plan
+                Building your first weekly social content plan
               </h1>
               <p className="mt-4 max-w-xl text-sm leading-7 text-white/65">
                 Aries is finishing the workspace handoff now. This page will refresh automatically and open the live
-                workspace as soon as the campaign is ready.
+                workspace as soon as the social content plan is ready.
               </p>
             </>
           )}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -5,8 +5,8 @@ export const metadata = {
 };
 
 const PRINCIPLES = [
-  'We only collect the information needed to run your campaigns and show you the status of your work.',
-  'Your campaign data stays tied to your account — other customers cannot see it.',
+  'We only collect the information needed to run your weekly social content and show you the status of your work.',
+  'Your social content data stays tied to your account — other customers cannot see it.',
   'Drafts, generated assets, and approval history are kept in secure storage that only your team can access.',
   'We never publish or launch anything without your explicit approval.',
 ] as const;
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
             <p className="text-xs uppercase tracking-[0.3em] text-primary mb-3">Legal</p>
             <h1 className="text-4xl font-bold mb-3">Privacy Policy</h1>
             <p className="text-white/60">
-              This policy explains what information Aries collects to run your marketing campaigns and how it&apos;s protected.
+              This policy explains what information Aries collects to run your weekly social content and how it&apos;s protected.
             </p>
           </div>
           <div className="glass rounded-[2rem] p-6">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next';
+
+function siteUrl(): string {
+  return (
+    process.env.APP_BASE_URL ||
+    process.env.NEXTAUTH_URL ||
+    process.env.AUTH_URL ||
+    'https://aries.sugarandleather.com'
+  ).replace(/\/+$/, '');
+}
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = siteUrl();
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/dashboard/', '/review/', '/settings/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,22 +1,15 @@
 import type { MetadataRoute } from 'next';
 
-function siteUrl(): string {
-  return (
-    process.env.APP_BASE_URL ||
-    process.env.NEXTAUTH_URL ||
-    process.env.AUTH_URL ||
-    'https://aries.sugarandleather.com'
-  ).replace(/\/+$/, '');
-}
+import { metadataSiteOrigin } from '@/lib/metadata-site-url';
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = siteUrl();
+  const baseUrl = metadataSiteOrigin();
 
   return {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/api/', '/dashboard/', '/review/', '/settings/'],
+      disallow: ['/api', '/dashboard', '/review', '/settings'],
     },
     sitemap: `${baseUrl}/sitemap.xml`,
   };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,13 +1,6 @@
 import type { MetadataRoute } from 'next';
 
-function siteUrl(): string {
-  return (
-    process.env.APP_BASE_URL ||
-    process.env.NEXTAUTH_URL ||
-    process.env.AUTH_URL ||
-    'https://aries.sugarandleather.com'
-  ).replace(/\/+$/, '');
-}
+import { metadataSiteOrigin } from '@/lib/metadata-site-url';
 
 const PUBLIC_ROUTES = [
   '/',
@@ -25,7 +18,7 @@ const PUBLIC_ROUTES = [
 ];
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = siteUrl();
+  const baseUrl = metadataSiteOrigin();
   const now = new Date();
 
   return PUBLIC_ROUTES.map((route) => ({

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from 'next';
+
+function siteUrl(): string {
+  return (
+    process.env.APP_BASE_URL ||
+    process.env.NEXTAUTH_URL ||
+    process.env.AUTH_URL ||
+    'https://aries.sugarandleather.com'
+  ).replace(/\/+$/, '');
+}
+
+const PUBLIC_ROUTES = [
+  '/',
+  '/features',
+  '/documentation',
+  '/api-docs',
+  '/contact',
+  '/onboarding/start',
+  '/privacy',
+  '/terms',
+  '/sitemap',
+  '/social-content/new',
+  '/social-content/status',
+  '/social-content/review',
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = siteUrl();
+  const now = new Date();
+
+  return PUBLIC_ROUTES.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: now,
+    changeFrequency: route === '/' ? 'weekly' : 'monthly',
+    priority: route === '/' ? 1 : 0.7,
+  }));
+}

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -16,11 +16,11 @@ const ROUTE_GROUPS: Array<{ title: string; routes: Array<{ href: string; label: 
     ],
   },
   {
-    title: 'Campaign',
+    title: 'Social content',
     routes: [
-      { href: '/marketing/new-job', label: 'New campaign' },
-      { href: '/marketing/job-status', label: 'Campaign status' },
-      { href: '/marketing/job-approve', label: 'Campaign approval' },
+      { href: '/social-content/new', label: 'New weekly social posts' },
+      { href: '/social-content/status', label: 'Social content status' },
+      { href: '/social-content/review', label: 'Social content review' },
       { href: '/onboarding/start', label: 'Brand and competitor research intake' },
     ],
   },
@@ -28,8 +28,7 @@ const ROUTE_GROUPS: Array<{ title: string; routes: Array<{ href: string; label: 
     title: 'Operator',
     routes: [
       { href: '/dashboard', label: 'Dashboard' },
-      { href: '/dashboard/campaigns', label: 'Campaigns' },
-      { href: '/dashboard/posts', label: 'Posts' },
+      { href: '/dashboard/posts', label: 'Weekly posts' },
       { href: '/dashboard/calendar', label: 'Calendar' },
       { href: '/dashboard/results', label: 'Results' },
       { href: '/dashboard/settings', label: 'Settings' },
@@ -53,7 +52,7 @@ export default function SiteMapPage() {
           <div className="glass rounded-[2.5rem] p-8 md:p-10">
             <p className="text-xs uppercase tracking-[0.3em] text-primary mb-3">Navigation</p>
             <h1 className="text-4xl font-bold mb-3">Sitemap</h1>
-            <p className="text-white/60">Browse all primary Aries routes by workflow area.</p>
+            <p className="text-white/60">Browse primary Aries routes by workflow area.</p>
           </div>
           <div className="grid md:grid-cols-2 gap-6">
             {ROUTE_GROUPS.map((group) => (

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
 const SECTIONS = [
   {
     title: 'What Aries does',
-    body: 'Aries plans, creates, and helps you launch marketing campaigns. You can review every piece of work before anything goes live.',
+    body: 'Aries plans, creates, and helps you publish weekly social content. You can review every piece of work before anything goes live.',
   },
   {
     title: 'Acceptable use',
@@ -15,7 +15,7 @@ const SECTIONS = [
   },
   {
     title: 'Your data',
-    body: 'We use the information you provide to generate campaigns and show you the status of your work. We don\u2019t share your campaign data with other customers, and we don\u2019t sell it.',
+    body: 'We use the information you provide to generate weekly social content and show you the status of your work. We don\u2019t share your content data with other customers, and we don\u2019t sell it.',
   },
   {
     title: 'Changes to these terms',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,8 @@ services:
       LOBSTER_GATEWAY_VIDEO_MODEL: ${LOBSTER_GATEWAY_VIDEO_MODEL:-}
       OPENCLAW_VIDEO_GENERATION_MODEL: ${OPENCLAW_VIDEO_GENERATION_MODEL:-}
       LOBSTER_VIDEO_GATEWAY_TIMEOUT_SECONDS: ${LOBSTER_VIDEO_GATEWAY_TIMEOUT_SECONDS:-}
-      # DB_HOST points at the companion postgres service below, not at ${DB_HOST}
-      # from .env. Compose owns service discovery; .env only holds credentials.
-      DB_HOST: postgres
-      DB_PORT: 5432
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT:-5432}
       DB_POOL_MAX: ${DB_POOL_MAX:-20}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
@@ -113,30 +111,6 @@ services:
       start_period: 30s
     networks:
       - docker_stack
-    depends_on:
-      postgres:
-        condition: service_healthy
-
-  postgres:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: ${DB_NAME}
-    ports:
-      - "${DB_PORT:-5432}:5432"
-    volumes:
-      - aries_pg_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 20s
-    restart: unless-stopped
-    networks:
-      - docker_stack
-
 networks:
   docker_stack:
     external: true
@@ -146,6 +120,3 @@ volumes:
   gh_config:
     name: aries-app_gh_config
     external: true
-  aries_pg_data:
-    name: aries_pg_data
-    

--- a/frontend/aries-v1/onboarding-flow.tsx
+++ b/frontend/aries-v1/onboarding-flow.tsx
@@ -63,24 +63,24 @@ const STEP_DEFINITIONS: StepDefinition[] = [
     key: 'business',
     label: 'Business',
     title: 'Set the business Aries will represent.',
-    description: 'Set the operating basics once so every campaign starts from the same clear foundation.',
+    description: 'Set the operating basics once so every weekly social content plan starts from the same clear foundation.',
   },
   {
     key: 'website',
     label: 'Website',
     title: 'Use the live website as the current source of truth.',
-    description: 'Aries uses the website to understand the offer, the conversion path, and the visible brand cues before any campaign work begins.',
+    description: 'Aries uses the website to understand the offer, the conversion path, and the visible brand cues before any weekly social content work begins.',
   },
   {
     key: 'brand',
     label: 'Brand identity',
-    title: 'Review the brand snapshot before the first campaign opens.',
+    title: 'Review the brand snapshot before the first weekly content plan opens.',
     description: 'This is the client-facing preview Aries will use to frame voice, offer, and visual direction.',
   },
   {
     key: 'channels',
     label: 'Channels',
-    title: 'Choose where the first campaign should show up.',
+    title: 'Choose where the first weekly social content should show up.',
     description: 'Start with the channels that matter now. The rest can be added later without rebuilding the profile.',
   },
 ];
@@ -99,7 +99,7 @@ const CHANNEL_OPTIONS: ChannelOption[] = [
   {
     id: 'email',
     label: 'Email Marketing',
-    description: 'Automated email campaigns and sequences.',
+    description: 'Automated email sequences and lifecycle content.',
   },
   {
     id: 'tiktok',
@@ -1196,7 +1196,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       clearLocalDraft();
 
       if (props.initialAuthenticated) {
-        // Show the full-screen "Building your first campaign plan" state and
+        // Show the full-screen "Building your first weekly social content plan" state and
         // navigate immediately. The transition component stays mounted until
         // Next.js finishes server-rendering /onboarding/resume (which can
         // take 10-30s while the marketing job materializes), so the user
@@ -1218,7 +1218,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
       setError(
         submissionError instanceof Error
           ? submissionError.message
-          : 'We could not save setup for the first campaign.',
+          : 'We could not save setup for the first weekly social content plan.',
       );
     } finally {
       setSubmitting(false);
@@ -1322,7 +1322,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
             <div className="flex items-center gap-3">
               <Loader2 aria-hidden="true" className="h-5 w-5 animate-spin text-[#c8a6ff]" />
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#ba8cff]">
-                Building your first campaign plan
+                Building your first weekly social content plan
               </p>
             </div>
             <h2 className="text-2xl font-semibold tracking-[-0.02em] text-white">
@@ -1414,7 +1414,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                   Launch from it every time.
                 </h1>
                 <p className="w-full max-w-none text-base leading-8 text-white/68 lg:pr-6 lg:pt-2 lg:text-[1.05rem]">
-                  Aries uses this intake to prepare the first campaign, shape the review package, and keep approvals visible from the start.
+                  Aries uses this intake to prepare the first weekly social content plan, shape the review package, and keep approvals visible from the start.
                 </p>
               </div>
             </div>
@@ -1525,7 +1525,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                     </Field>
                     <Field
                       label="Current source"
-                      hint="Enter the website Aries should treat as the active brand source for this campaign."
+                      hint="Enter the website Aries should treat as the active brand source for this weekly content plan."
                       validity={websiteUrlValidity}
                       error={fieldErrorMessage('websiteUrl')}
                     >
@@ -1542,7 +1542,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                   <div className="grid gap-4 lg:mt-6">
                     <EditorialPanel
                       eyebrow="What this powers"
-                      title="One intake feeds the full campaign flow."
+                      title="One intake feeds the full weekly social content flow."
                       description="The business profile, brand review, strategy review, creative package, and launch status all start from this operating baseline."
                     />
                     <EditorialList
@@ -1550,7 +1550,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                       items={[
                         'A current-source review built from the live website.',
                         'A brand identity snapshot the client can actually approve.',
-                        'A first campaign plan aligned to the selected goal and channels.',
+                        'A first weekly social content plan aligned to the selected goal and channels.',
                       ]}
                     />
                   </div>
@@ -1562,7 +1562,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                   <div className="space-y-5">
                     <Field
                       label="Website"
-                      hint="Use the current live website. Aries treats this as the active brand source for the first campaign."
+                      hint="Use the current live website. Aries treats this as the active brand source for the first weekly social content plan."
                       validity={websiteUrlValidity}
                       error={fieldErrorMessage('websiteUrl')}
                     >
@@ -1609,7 +1609,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                           Visual identity cues like logos, palette, and typography
                         </div>
                         <div className="rounded-[1rem] border border-white/10 bg-white/[0.03] px-4 py-4">
-                          The current source URL that must stay attached to the campaign
+                          The current source URL that must stay attached to the weekly social content plan
                         </div>
                       </div>
                     </div>
@@ -1769,14 +1769,14 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
               {currentStep.key === 'channels' ? (
                 <div className="space-y-5">
                   <p className="max-w-3xl text-sm leading-7 text-white/65">
-                    Choose the channels Aries should prioritize first. The initial set stays lightweight so the first campaign is easy to approve and launch.
+                    Choose the channels Aries should prioritize first. The initial set stays lightweight so the first weekly social content plan is easy to approve and launch.
                   </p>
                   {channelsRecommendationShown && businessType.trim() ? (
                     <p className="max-w-3xl text-xs font-medium uppercase tracking-[0.22em] text-[#ba8cff]">
                       Recommended for {businessType.trim()}
                     </p>
                   ) : null}
-                  <div className="grid gap-4 md:grid-cols-2" role="group" aria-label="Campaign channels">
+                  <div className="grid gap-4 md:grid-cols-2" role="group" aria-label="Social content channels">
                     {CHANNEL_OPTIONS.map((channel) => {
                       const selected = selectedChannels.includes(channel.id);
                       return (
@@ -1821,7 +1821,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                     <div
                       className="grid gap-3"
                       role="radiogroup"
-                      aria-label="Campaign goal"
+                      aria-label="Social content goal"
                       aria-invalid={goalError ? true : undefined}
                       aria-describedby={goalError ? 'onboarding-goal-error' : undefined}
                     >
@@ -1965,7 +1965,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                     </Field>
 
                     <div className="rounded-[1.5rem] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] p-5 text-sm leading-7 text-white/65">
-                      Aries will save this operating profile, open the first campaign workspace, and carry the same brand identity through review instead of rebuilding it from scratch.
+                      Aries will save this operating profile, open the first weekly social content workspace, and carry the same brand identity through review instead of rebuilding it from scratch.
                     </div>
 
                   </div>
@@ -2030,7 +2030,7 @@ export default function AriesOnboardingFlow(props: { initialAuthenticated?: bool
                 <span className="font-medium">Approval stays visible from the first plan through launch.</span>
               </div>
               <p className="mt-3 text-white/62">
-                Nothing goes live without a clear review step. The source website stays attached to the campaign so stale brand material does not leak forward.
+                Nothing goes live without a clear review step. The source website stays attached to the weekly social content plan so stale brand material does not leak forward.
               </p>
             </div>
                 </section>

--- a/frontend/documentation/Docs.tsx
+++ b/frontend/documentation/Docs.tsx
@@ -16,7 +16,7 @@ const sections = [
   { id: 'overview', title: 'Overview', icon: BookOpen },
   { id: 'quick-start', title: 'Getting Started', icon: Terminal },
   { id: 'architecture', title: 'How It Works', icon: Layout },
-  { id: 'campaigns', title: 'Campaigns', icon: GitBranch },
+  { id: 'weekly-content', title: 'Weekly Content', icon: GitBranch },
   { id: 'integrations', title: 'Integrations', icon: Plug },
   { id: 'security', title: 'Security', icon: ShieldCheck },
 ];
@@ -89,7 +89,7 @@ export default function Docs() {
               transition={{ delay: 0.2 }}
               className="text-lg md:text-xl text-white/60 max-w-3xl mx-auto font-sans"
             >
-              Everything you need to get started, run campaigns, and get results with Aries.
+              Everything you need to get started, plan weekly social content, and get results with Aries.
             </motion.p>
           </div>
 
@@ -153,7 +153,7 @@ export default function Docs() {
 
                 <div className="prose prose-invert prose-p:text-white/70 prose-p:leading-relaxed prose-p:text-lg max-w-none">
                   <p>
-                    Aries AI is a marketing operating system for small businesses. It helps business owners plan campaigns, review creative, approve launches, and see what worked from one calm workspace.
+                    Aries AI is a social content operating system for small businesses. It helps business owners plan weekly posts, review creative, approve publishing, and see what worked from one calm workspace.
                   </p>
                   <p className="mt-6">
                     The system is built around a clear product loop: set up your business, review the plan, approve the creative, schedule the launch, and see the results. Every step stays approval-safe and human-readable.
@@ -176,16 +176,16 @@ export default function Docs() {
 
                 <div className="prose prose-invert prose-p:text-white/70 prose-p:leading-relaxed prose-p:text-lg max-w-none space-y-6">
                   <p>
-                    <strong className="text-white">Create your first campaign from the dashboard.</strong> Once you're signed in, head to the Campaigns section and click "New Campaign." You'll be guided through naming it, describing your offer, and setting your goal. Aries uses this context to prepare a full strategy and creative plan for your review.
+                    <strong className="text-white">Create your first weekly social content plan from the dashboard.</strong> Once you're signed in, head to the weekly content section and click "Start weekly content plan." You'll be guided through describing your offer and setting your goal. Aries uses this context to prepare a strategy and creative plan for your review.
                   </p>
                   <p>
-                    <strong className="text-white">Connect your Meta and Instagram accounts.</strong> Go to Settings and open the Integrations tab. From there you can connect your Facebook Page and Instagram Business account. Aries will show the connection status before any campaign is published, so you always know what's live and what isn't.
+                    <strong className="text-white">Connect your Meta and Instagram accounts.</strong> Go to Settings and open the Integrations tab. From there you can connect your Facebook Page and Instagram Business account. Aries will show the connection status before any social content is published, so you always know what's live and what isn't.
                   </p>
                   <p>
-                    <strong className="text-white">Review and approve creative before anything goes live.</strong> Every campaign passes through a review step before it publishes. You'll see the generated copy, images, and channel-specific assets in a single approval view. Nothing is dispatched until you explicitly approve it.
+                    <strong className="text-white">Review and approve creative before anything goes live.</strong> Every weekly social content plan passes through a review step before it publishes. You'll see the generated copy, images, and channel-specific assets in a single approval view. Nothing is dispatched until you explicitly approve it.
                   </p>
                   <p>
-                    <strong className="text-white">Monitor performance in the results dashboard.</strong> After a campaign launches, results appear in the Results section of your workspace. You can see reach, engagement, and spend at a glance — no marketing software experience required.
+                    <strong className="text-white">Monitor performance in the results dashboard.</strong> After social content publishes, results appear in the Results section of your workspace. You can see reach, engagement, and spend at a glance — no marketing software experience required.
                   </p>
                 </div>
               </section>
@@ -208,38 +208,38 @@ export default function Docs() {
                     Aries follows a four-stage workflow designed around human approval at every step: Research, Strategy, Creative, and Publish.
                   </p>
                   <p className="mt-4">
-                    In the <strong className="text-white">Research</strong> stage, Aries reviews your business profile and any website content you've connected to understand your offer, audience, and goals. In the <strong className="text-white">Strategy</strong> stage, it produces a campaign plan — positioning, channel selection, and messaging direction — which you review before anything moves forward. The <strong className="text-white">Creative</strong> stage generates copy and visual assets for each channel. Finally, in the <strong className="text-white">Publish</strong> stage, approved content is dispatched to your connected channels on the schedule you've set. You stay in control at every handoff.
+                    In the <strong className="text-white">Research</strong> stage, Aries reviews your business profile and any website content you've connected to understand your offer, audience, and goals. In the <strong className="text-white">Strategy</strong> stage, it produces a weekly social content plan — positioning, channel selection, and messaging direction — which you review before anything moves forward. The <strong className="text-white">Creative</strong> stage generates copy and visual assets for each channel. Finally, in the <strong className="text-white">Publish</strong> stage, approved content is dispatched to your connected channels on the schedule you've set. You stay in control at every handoff.
                   </p>
                 </div>
               </section>
 
-              {/* Campaigns Section */}
+              {/* Weekly Content Section */}
               <section
-                id="campaigns"
-                ref={(el) => { sectionRefs.current['campaigns'] = el; }}
+                id="weekly-content"
+                ref={(el) => { sectionRefs.current['weekly-content'] = el; }}
                 className={DIVIDED_SECTION_ANCHOR_CLASS}
               >
                 <div className="flex items-center gap-4 mb-8">
                   <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center border border-white/10">
                     <GitBranch className="w-6 h-6 text-primary" />
                   </div>
-                  <h2 className="text-3xl font-bold tracking-tight">Campaigns</h2>
+                  <h2 className="text-3xl font-bold tracking-tight">Weekly Content</h2>
                 </div>
 
                 <div className="prose prose-invert prose-p:text-white/70 prose-p:leading-relaxed prose-p:text-lg max-w-none">
                   <p>
-                    Campaigns begin from the business profile and attached website source. Aries uses that context to prepare strategy, creative direction, review checkpoints, and launch-ready assets.
+                    Weekly content plans begin from the business profile and attached website source. Aries uses that context to prepare strategy, creative direction, review checkpoints, and publish-ready assets.
                   </p>
                   <p className="mt-4">
-                    Every campaign keeps approval visible. Strategy, production, and publishing steps can require human approval before the workflow moves forward.
+                    Every weekly social content plan keeps approval visible. Strategy, production, and publishing steps can require human approval before the workflow moves forward.
                   </p>
                 </div>
 
                 <div className="mt-8 grid gap-4 md:grid-cols-3">
                   {[
-                    ['Strategy', 'Review the offer, audience, positioning, and campaign plan before production begins.'],
+                    ['Strategy', 'Review the offer, audience, positioning, and weekly content plan before production begins.'],
                     ['Creative', 'Inspect generated copy, visuals, and channel-specific assets before anything goes live.'],
-                    ['Launch', 'Approve publishing only after the campaign is aligned with the business source and goal.'],
+                    ['Launch', 'Approve publishing only after the weekly social content is aligned with the business source and goal.'],
                   ].map(([title, description]) => (
                     <div key={title} className="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
                       <h3 className="font-bold text-white">{title}</h3>
@@ -267,16 +267,16 @@ export default function Docs() {
                     Aries connects to the channels where your audience lives. You authorize each connection from the Settings page, and Aries handles the rest securely on your behalf.
                   </p>
                   <p className="mt-4">
-                    Integration status is always visible inside the app so you can see whether a channel is connected, disconnected, or needs to be reconnected before a campaign goes live.
+                    Integration status is always visible inside the app so you can see whether a channel is connected, disconnected, or needs to be reconnected before social content goes live.
                   </p>
                 </div>
 
                 <div className="mt-8 rounded-2xl border border-white/10 bg-[#0D0D0D] p-6">
                   <div className="grid gap-4 md:grid-cols-2">
                     {[
-                      ['Connection status', 'See which channels are connected and ready before scheduling a campaign.'],
+                      ['Connection status', 'See which channels are connected and ready before scheduling social content.'],
                       ['One-click authorization', 'Connect your accounts in a few clicks from the Settings page.'],
-                      ['Publishing safety', 'Only approved campaign content is ever sent to your connected channels.'],
+                      ['Publishing safety', 'Only approved social content is ever sent to your connected channels.'],
                       ['Reconnect reminders', 'Aries alerts you if a channel needs to be reconnected before use.'],
                     ].map(([title, description]) => (
                       <div key={title} className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
@@ -303,7 +303,7 @@ export default function Docs() {
 
                 <div className="prose prose-invert prose-p:text-white/70 prose-p:leading-relaxed prose-p:text-lg max-w-none">
                   <p>
-                    Aries is designed to keep your account, your campaigns, and your channel connections secure. You must be signed in to access your workspace, and every action that affects a live channel requires your explicit approval.
+                    Aries is designed to keep your account, your weekly content, and your channel connections secure. You must be signed in to access your workspace, and every action that affects a live channel requires your explicit approval.
                   </p>
                   <p className="mt-4">
                     New users complete a short onboarding before reaching the dashboard. Your workspace is private to your account and any team members you invite.
@@ -312,8 +312,8 @@ export default function Docs() {
 
                 <div className="mt-8 space-y-4">
                   {[
-                    ['Protected workspaces', 'Your campaigns and dashboard are only accessible when you are signed in.'],
-                    ['Approval gates', 'Each campaign stage requires your review and approval before moving forward.'],
+                    ['Protected workspaces', 'Your weekly content and dashboard are only accessible when you are signed in.'],
+                    ['Approval gates', 'Each content stage requires your review and approval before moving forward.'],
                     ['Secure channel connections', 'Your connected accounts are authorized securely and never shared across workspaces.'],
                   ].map(([title, description]) => (
                     <div key={title} className="rounded-2xl border border-white/10 bg-white/[0.04] p-5">

--- a/frontend/donor/marketing/chrome.tsx
+++ b/frontend/donor/marketing/chrome.tsx
@@ -182,7 +182,7 @@ export function DonorFooter() {
           <div className="col-span-2">
             <AriesWordmark className="mb-6" />
             <p className="text-white/50 max-w-xs mb-8 leading-relaxed">
-              A calm marketing workspace where small businesses plan campaigns, approve creative, launch safely, and see what worked.
+              A calm social content workspace where small businesses plan weekly posts, approve creative, publish safely, and see what worked.
             </p>
             <div className="flex gap-4 text-sm text-white/60">
               <a href="/#how-it-works" className="hover:text-white transition-colors">How it works</a>
@@ -198,7 +198,7 @@ export function DonorFooter() {
             <ul className="space-y-4 text-white/50 text-sm">
               <li><a href="/#how-it-works" className="hover:text-white transition-colors">How it works</a></li>
               <li><a href="/dashboard" className="hover:text-white transition-colors">Dashboard</a></li>
-              <li><a href="/campaigns" className="hover:text-white transition-colors">Campaigns</a></li>
+              <li><a href="/social-content/new" className="hover:text-white transition-colors">Weekly content</a></li>
               <li><a href="/review" className="hover:text-white transition-colors">Review queue</a></li>
             </ul>
           </div>

--- a/frontend/donor/marketing/home-page.tsx
+++ b/frontend/donor/marketing/home-page.tsx
@@ -62,7 +62,7 @@ function EarlyAccessCopy({
         Sign in to get <span className="text-gradient">early access</span>
       </HeadingTag>
       <p className="mt-6 max-w-2xl text-lg leading-8 text-white/62">
-        Join the first group of businesses getting Aries for campaign planning, approval-safe creative, launch scheduling, and clear weekly results.
+        Join the first group of businesses getting Aries for weekly social content planning, approval-safe creative, launch scheduling, and clear weekly results.
       </p>
 
       <div className="mt-[50px] grid w-full gap-4 sm:grid-cols-3">
@@ -664,7 +664,7 @@ function Hero() {
             }}
             className="max-w-2xl mx-auto text-[1rem] text-white/60 mb-12"
           >
-            Plan campaigns, approve creative, launch safely. Nothing goes live without your approval — and you always know what is running, what needs your sign-off, and how your campaigns are performing.
+            Plan weekly social content, approve creative, publish safely. Nothing goes live without your approval — and you always know what is running, what needs your sign-off, and how your posts are performing.
           </motion.p>
 
           <motion.div
@@ -847,7 +847,7 @@ function Problem() {
     {
       icon: <TrendingDown className="w-6 h-6 text-red-400" />,
       title: 'Missed launches',
-      description: 'Without a clear schedule, campaigns slip and opportunities pass before you notice.',
+      description: 'Without a clear schedule, weekly posts slip and opportunities pass before you notice.',
     },
     {
       icon: <AlertCircle className="w-6 h-6 text-orange-400" />,
@@ -857,12 +857,12 @@ function Problem() {
     {
       icon: <Clock className="w-6 h-6 text-yellow-400" />,
       title: 'Scattered results',
-      description: 'Checking five different dashboards to answer one question: \u2018are my campaigns delivering results?\u2019',
+      description: 'Checking five different dashboards to answer one question: \u2018are my weekly posts delivering results?\u2019',
     },
     {
       icon: <Layers className="w-6 h-6 text-blue-400" />,
       title: 'No clear next step',
-      description: 'Finishing a campaign and having no idea what to do next to keep momentum going.',
+      description: 'Finishing a week of content and having no idea what to do next to keep momentum going.',
     },
   ];
 
@@ -916,8 +916,8 @@ function Features() {
   const features = [
     {
       icon: <Share2 className="w-6 h-6" />,
-      title: 'Campaign planning',
-      description: 'Turn your business goals into a clear campaign plan you can read in seconds.',
+      title: 'Weekly content planning',
+      description: 'Turn your business goals into a clear weekly social content plan you can read in seconds.',
       color: 'from-blue-500/20 to-blue-600/20',
     },
     {
@@ -1007,7 +1007,7 @@ function HowItWorks() {
     {
       icon: <Lightbulb className="w-6 h-6 text-secondary" />,
       title: 'Review the plan',
-      description: 'See a clear campaign plan in plain English before anything is created.',
+      description: 'See a clear weekly social content plan in plain English before anything is created.',
     },
     {
       icon: <Zap className="w-6 h-6 text-yellow-400" />,
@@ -1084,10 +1084,10 @@ const CONTENT_CALENDAR_SCHEDULE = [
     day: 'Wed',
     date: '8',
     posts: [
-      { title: 'Spring Campaign Case Study', platform: 'LinkedIn', time: '11:00', status: 'Published' },
+      { title: 'Spring Product Story', platform: 'LinkedIn', time: '11:00', status: 'Published' },
       { title: 'Facebook Ads Mastery Course', platform: 'Facebook', time: '15:30', status: 'Published' },
-      { title: 'Pinterest: Campaign Moodboard', platform: 'Pinterest', time: '18:00', status: 'Published' },
-      { title: 'YouTube: Campaign Review Short', platform: 'YouTube', time: '21:00', status: 'Published' },
+      { title: 'Pinterest: Weekly Moodboard', platform: 'Pinterest', time: '18:00', status: 'Published' },
+      { title: 'YouTube: Content Review Short', platform: 'YouTube', time: '21:00', status: 'Published' },
     ],
   },
   {
@@ -1166,7 +1166,7 @@ const CONTENT_CALENDAR_SCHEDULE = [
     date: '17',
     posts: [
       { title: 'Quarterly Growth Planning', platform: 'LinkedIn', time: '09:00', status: 'Scheduled' },
-      { title: 'X Thread: Campaign Lessons', platform: 'X / Twitter', time: '14:30', status: 'Scheduled' },
+      { title: 'X Thread: Content Lessons', platform: 'X / Twitter', time: '14:30', status: 'Scheduled' },
       { title: 'Pinterest: Strategy Template Pin', platform: 'Pinterest', time: '18:45', status: 'Scheduled' },
     ],
   },
@@ -1585,14 +1585,14 @@ function Pricing() {
       name: 'Starter',
       price: '49',
       description: 'For one business with a few active channels.',
-      features: ['3 Connected Channels', 'Campaign Planning', 'Approval Queue', 'Weekly Results'],
+      features: ['3 Connected Channels', 'Weekly Content Planning', 'Approval Queue', 'Weekly Results'],
       highlight: false,
     },
     {
       name: 'Growth',
       price: '149',
-      description: 'For businesses ready to run consistent campaigns.',
-      features: ['Unlimited Channels', 'Full Campaign Workspace', 'Detailed Results', 'Next-Step Recommendations', 'Priority Support'],
+      description: 'For businesses ready to publish consistent weekly social content.',
+      features: ['Unlimited Channels', 'Full Social Content Workspace', 'Detailed Results', 'Next-Step Recommendations', 'Priority Support'],
       highlight: true,
     },
     {
@@ -1672,7 +1672,7 @@ function Pricing() {
 function FeatureShowcaseFallback() {
   const panels = [
     {
-      title: 'Campaign clarity',
+      title: 'Content clarity',
       description: 'Aries keeps your plan, creative, schedule, and results in one place so you never lose track of what is running or what needs attention.',
       icon: <Zap className="w-5 h-5 text-primary" />,
     },
@@ -1683,7 +1683,7 @@ function FeatureShowcaseFallback() {
     },
     {
       title: 'Results you can act on',
-      description: 'Every campaign summary ends with a clear next step instead of a wall of charts, so you always know what to do next.',
+      description: 'Every weekly content summary ends with a clear next step instead of a wall of charts, so you always know what to do next.',
       icon: <BarChart3 className="w-5 h-5 text-primary" />,
     },
   ];
@@ -1852,7 +1852,7 @@ export default function DonorHomePage() {
       <section className="py-16 border-y border-white/5 bg-black/50">
         <div className="container mx-auto px-6 text-center max-w-2xl">
           <blockquote className="text-lg text-white/80 italic leading-relaxed">
-            "Aries helped me go from idea to approved campaign in 2 hours."
+            "Aries helped me go from idea to approved weekly content plan in 2 hours."
           </blockquote>
           <p className="mt-4 text-sm text-white/40 font-medium uppercase tracking-wider">
             Early access user
@@ -1873,7 +1873,7 @@ export default function DonorHomePage() {
             <div className="max-w-4xl mx-auto">
               <h2 className="text-4xl md:text-[48px] leading-tight font-bold mb-8">Meet Aries</h2>
               <p className="text-xl text-white/60 mb-12 leading-relaxed">
-                A calm workspace where you plan campaigns, approve creative, launch safely, and see what delivered results &mdash; without learning marketing software.
+                A calm workspace where you plan weekly social content, approve creative, publish safely, and see what delivered results &mdash; without learning marketing software.
               </p>
             </div>
 

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -49,7 +49,7 @@ const SUBMIT_PROGRESS_MESSAGES = [
   'Uploading brand assets',
   'Preparing workspace',
   'Starting review flow',
-  'Starting campaign',
+  'Starting social content run',
 ];
 
 const FINAL_SUBMIT_PROGRESS_INDEX = SUBMIT_PROGRESS_MESSAGES.length - 1;

--- a/frontend/onboarding/pipeline-intake/components/SystemPreviewPanel.tsx
+++ b/frontend/onboarding/pipeline-intake/components/SystemPreviewPanel.tsx
@@ -29,8 +29,8 @@ const PIPELINE_STAGES: PipelineStage[] = [
     modes: ['strategy_only', 'strategy_plus_assets', 'full_pipeline'],
   },
   {
-    id: 'campaign_strategy',
-    label: 'Campaign Strategy',
+    id: 'social_content_strategy',
+    label: 'Social Content Strategy',
     description: 'Funnel design, audience targeting, and messaging framework',
     modes: ['strategy_only', 'strategy_plus_assets', 'full_pipeline'],
   },
@@ -49,7 +49,7 @@ const PIPELINE_STAGES: PipelineStage[] = [
   {
     id: 'landing_pages',
     label: 'Landing Pages',
-    description: 'Conversion-optimised pages for each campaign angle',
+    description: 'Conversion-optimised pages for each content angle',
     modes: ['strategy_plus_assets', 'full_pipeline'],
   },
   {

--- a/frontend/onboarding/pipeline-intake/index.tsx
+++ b/frontend/onboarding/pipeline-intake/index.tsx
@@ -206,7 +206,7 @@ export default function PipelineIntake() {
 
   const handleSubmit = async () => {
     if (!goal) {
-      setSubmitError('Select a campaign goal on Step 1 before launching.');
+      setSubmitError('Select a social content goal on Step 1 before launching.');
       return;
     }
     if (!brandUrl) {
@@ -283,7 +283,7 @@ export default function PipelineIntake() {
       }
       clearLocalDraft();
       // Show a brief transition screen so the user sees a clear "we've got
-      // it, building your first campaign" state before the redirect. Timer
+      // it, building your first weekly social content plan" state before the redirect. Timer
       // is tracked in a ref so unmount can cancel it.
       setShowTransition(true);
       transitionTimer.current = window.setTimeout(() => {
@@ -307,7 +307,7 @@ export default function PipelineIntake() {
           <div className="flex items-center justify-center gap-3 mb-5">
             <Loader2 aria-hidden="true" className="w-5 h-5 text-aries-crimson animate-spin" />
             <p className="text-xs uppercase tracking-[0.2em] text-[#888] font-medium">
-              Building your first campaign
+              Building your first weekly social content plan
             </p>
           </div>
           <h2 className="text-xl font-semibold text-white mb-3">

--- a/frontend/onboarding/pipeline-intake/steps/ChannelsStep.tsx
+++ b/frontend/onboarding/pipeline-intake/steps/ChannelsStep.tsx
@@ -45,7 +45,7 @@ const CHANNEL_OPTIONS: SelectionOption[] = [
   {
     value: 'email',
     label: 'Email Marketing',
-    description: 'Automated email campaigns and sequences.',
+    description: 'Automated email content and sequences.',
     icon: <span className="text-base">✉️</span>,
   },
 ];
@@ -68,7 +68,7 @@ export default function ChannelsStep({
       stepNumber={4}
       totalSteps={5}
       title="Target Channels"
-      subtitle="Select the platforms where your campaign will run. You can choose multiple."
+      subtitle="Select the platforms where your weekly social content will run. You can choose multiple."
       canProceed={channels.length > 0}
       onNext={onNext}
       onBack={onBack}

--- a/frontend/onboarding/pipeline-intake/steps/ExecutionStep.tsx
+++ b/frontend/onboarding/pipeline-intake/steps/ExecutionStep.tsx
@@ -10,7 +10,7 @@ const MODE_OPTIONS: SelectionOption[] = [
   {
     value: 'strategy_only',
     label: 'Strategy Only',
-    description: 'Research + brand analysis + campaign strategy',
+    description: 'Research + brand analysis + weekly social content strategy',
     icon: <BookOpen className="w-5 h-5" />,
   },
   {

--- a/frontend/onboarding/pipeline-intake/steps/GoalStep.tsx
+++ b/frontend/onboarding/pipeline-intake/steps/GoalStep.tsx
@@ -9,7 +9,7 @@ const GOAL_OPTIONS: SelectionOption[] = [
   {
     value: 'lead_generation',
     label: 'Lead Generation',
-    description: 'Capture qualified leads through targeted campaigns',
+    description: 'Capture qualified leads through targeted social content',
     icon: <Target className="w-5 h-5" />,
   },
   {
@@ -44,8 +44,8 @@ export default function GoalStep({ goal, onGoalChange, onNext, onBack }: GoalSte
     <StepContainer
       stepNumber={1}
       totalSteps={5}
-      title="Campaign Goal"
-      subtitle="What's the primary objective of this campaign? This shapes the entire strategy and creative direction."
+      title="Social Content Goal"
+      subtitle="What's the primary objective of this weekly social content plan? This shapes the entire strategy and creative direction."
       canProceed={!!goal}
       onNext={onNext}
       onBack={onBack}
@@ -55,7 +55,7 @@ export default function GoalStep({ goal, onGoalChange, onNext, onBack }: GoalSte
         selected={goal ?? ''}
         onChange={(val) => onGoalChange(val as Goal)}
         multi={false}
-        ariaLabel="Campaign goal"
+        ariaLabel="Social content goal"
       />
     </StepContainer>
   );

--- a/lib/auth-error-message.ts
+++ b/lib/auth-error-message.ts
@@ -2,6 +2,10 @@ export const EMAIL_DOES_NOT_EXIST_ERROR = "EmailDoesNotExist";
 export const DATABASE_UNAVAILABLE_ERROR = "DatabaseUnavailable";
 export const GOOGLE_SIGN_IN_REQUIRED_ERROR = "GoogleSignInRequired";
 
+const GENERIC_AUTH_FAILURE_MESSAGE = "Authentication failed. Please try again.";
+const TEMPORARY_AUTH_UNAVAILABLE_MESSAGE =
+  "Authentication is temporarily unavailable. Please try again shortly.";
+
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
   CredentialsSignin: "Invalid email or password.",
   // Kept for defense-in-depth so any lingering surface that still emits this
@@ -11,16 +15,12 @@ const AUTH_ERROR_MESSAGES: Record<string, string> = {
   [EMAIL_DOES_NOT_EXIST_ERROR]: "Invalid email or password.",
   [GOOGLE_SIGN_IN_REQUIRED_ERROR]:
     "This account uses Google sign-in. Continue with Google to access it.",
-  AccessDenied:
-    "Google sign-in failed during account setup. Check the server logs, database connection, and Google OAuth callback configuration.",
-  [DATABASE_UNAVAILABLE_ERROR]:
-    "Authentication cannot reach the Postgres database. Start Postgres or update the DB connection settings.",
-  Configuration:
-    "Authentication is misconfigured. Check AUTH_SECRET, AUTH_URL or NEXTAUTH_URL, AUTH_TRUST_HOST, and Google OAuth environment variables.",
+  AccessDenied: GENERIC_AUTH_FAILURE_MESSAGE,
+  [DATABASE_UNAVAILABLE_ERROR]: TEMPORARY_AUTH_UNAVAILABLE_MESSAGE,
+  Configuration: TEMPORARY_AUTH_UNAVAILABLE_MESSAGE,
   Verification:
     "The authentication link or callback is no longer valid. Start the sign-in flow again.",
-  UntrustedHost:
-    "The auth host is not trusted. Set AUTH_TRUST_HOST=true for local development or configure AUTH_URL/NEXTAUTH_URL.",
+  UntrustedHost: TEMPORARY_AUTH_UNAVAILABLE_MESSAGE,
 };
 
 export function getAuthErrorMessage(error: string | null | undefined): string | null {
@@ -28,5 +28,5 @@ export function getAuthErrorMessage(error: string | null | undefined): string | 
     return null;
   }
 
-  return AUTH_ERROR_MESSAGES[error] ?? "Authentication failed. Check the server logs and try again.";
+  return AUTH_ERROR_MESSAGES[error] ?? GENERIC_AUTH_FAILURE_MESSAGE;
 }

--- a/lib/metadata-site-url.ts
+++ b/lib/metadata-site-url.ts
@@ -1,0 +1,14 @@
+export function metadataSiteOrigin(): string {
+  const configuredUrl = (
+    process.env.APP_BASE_URL ||
+    process.env.NEXTAUTH_URL ||
+    process.env.AUTH_URL ||
+    'https://aries.sugarandleather.com'
+  ).replace(/\/+$/, '');
+
+  try {
+    return new URL(configuredUrl).origin;
+  } catch {
+    return configuredUrl;
+  }
+}

--- a/scripts/creative-memory-smoke.mjs
+++ b/scripts/creative-memory-smoke.mjs
@@ -3,7 +3,7 @@ const baseUrl = process.env.APP_BASE_URL || 'http://127.0.0.1:3000';
 const res = await fetch(`${baseUrl}/creative-memory`);
 if (!res.ok) throw new Error(`Creative Memory UI smoke failed: ${res.status}`);
 const html = await res.text();
-for (const needle of ['Campaign Learning', 'Baseline vs memory-assisted', 'Prompt Preview']) {
+for (const needle of ['Content Learning', 'Baseline vs memory-assisted', 'Prompt Preview']) {
   if (!html.includes(needle)) throw new Error(`Creative Memory UI missing ${needle}`);
 }
 console.log(JSON.stringify({ status: 'ok', baseUrl }, null, 2));

--- a/tests/asset-library-content-type.test.ts
+++ b/tests/asset-library-content-type.test.ts
@@ -25,19 +25,19 @@ test('contentTypeForAsset returns video/* for common video extensions', async ()
     const ogv = path.join(dir, 'nonexistent.ogv');
     const ogg = path.join(dir, 'nonexistent.ogg');
 
-    assert.equal(contentTypeForAsset(mp4), 'video/mp4');
-    assert.equal(contentTypeForAsset(mov), 'video/quicktime');
-    assert.equal(contentTypeForAsset(m4v), 'video/x-m4v');
-    assert.equal(contentTypeForAsset(webm), 'video/webm');
-    assert.equal(contentTypeForAsset(ogv), 'video/ogg');
-    assert.equal(contentTypeForAsset(ogg), 'video/ogg');
+    assert.equal(await contentTypeForAsset(mp4), 'video/mp4');
+    assert.equal(await contentTypeForAsset(mov), 'video/quicktime');
+    assert.equal(await contentTypeForAsset(m4v), 'video/x-m4v');
+    assert.equal(await contentTypeForAsset(webm), 'video/webm');
+    assert.equal(await contentTypeForAsset(ogv), 'video/ogg');
+    assert.equal(await contentTypeForAsset(ogg), 'video/ogg');
   });
 });
 
 test('contentTypeForAsset falls back to application/octet-stream for unknown extensions', async () => {
   await withScratchDir(async (dir) => {
     const unknown = path.join(dir, 'nonexistent.bin');
-    assert.equal(contentTypeForAsset(unknown), 'application/octet-stream');
+    assert.equal(await contentTypeForAsset(unknown), 'application/octet-stream');
   });
 });
 
@@ -52,7 +52,7 @@ test('contentTypeForAsset sniffs ftyp magic bytes to classify ISOBMFF as video/m
     ]);
     await writeFile(mislabeled, buffer);
 
-    assert.equal(contentTypeForAsset(mislabeled), 'video/mp4');
+    assert.equal(await contentTypeForAsset(mislabeled), 'video/mp4');
   });
 });
 
@@ -69,7 +69,7 @@ test('contentTypeForAsset keeps .mov as video/quicktime even though the file car
     ]);
     await writeFile(movFile, buffer);
 
-    assert.equal(contentTypeForAsset(movFile), 'video/quicktime');
+    assert.equal(await contentTypeForAsset(movFile), 'video/quicktime');
   });
 });
 
@@ -80,7 +80,7 @@ test('contentTypeForAsset keeps sniffing image magic bytes when extension is mis
     const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
     await writeFile(pngLike, buffer);
 
-    assert.equal(contentTypeForAsset(pngLike), 'image/png');
+    assert.equal(await contentTypeForAsset(pngLike), 'image/png');
   });
 });
 
@@ -91,6 +91,6 @@ test('contentTypeForAsset trusts image bytes over a drifted extension (JPEG byte
     const drifted = path.join(dir, 'meta-preview.png');
     await writeFile(drifted, Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00]));
 
-    assert.equal(contentTypeForAsset(drifted), 'image/jpeg');
+    assert.equal(await contentTypeForAsset(drifted), 'image/jpeg');
   });
 });

--- a/tests/auth/auth-error-message.test.ts
+++ b/tests/auth/auth-error-message.test.ts
@@ -3,26 +3,28 @@ import test from "node:test";
 
 import { getAuthErrorMessage } from "../../lib/auth-error-message";
 
+const INFRASTRUCTURE_HINT = /Postgres|database connection|AUTH_SECRET|AUTH_URL|NEXTAUTH_URL|AUTH_TRUST_HOST|OAuth|server logs/i;
+
 test("returns null when there is no auth error", () => {
   assert.equal(getAuthErrorMessage(null), null);
   assert.equal(getAuthErrorMessage(undefined), null);
 });
 
-test("maps known auth errors to user-facing guidance", () => {
-  assert.match(getAuthErrorMessage("AccessDenied") ?? "", /database connection/i);
-  assert.match(getAuthErrorMessage("DatabaseUnavailable") ?? "", /Postgres database/i);
-  // The EmailDoesNotExist code must not surface a distinct user-facing string
-  // — that was an email-enumeration oracle. We map it to the same generic
-  // "Invalid email or password." response as plain CredentialsSignin.
+test("maps known auth errors to safe user-facing guidance", () => {
+  assert.equal(getAuthErrorMessage("CredentialsSignin"), "Invalid email or password.");
   assert.equal(getAuthErrorMessage("EmailDoesNotExist"), "Invalid email or password.");
   assert.match(getAuthErrorMessage("GoogleSignInRequired") ?? "", /continue with google/i);
-  assert.match(getAuthErrorMessage("Configuration") ?? "", /AUTH_SECRET/i);
-  assert.match(getAuthErrorMessage("UntrustedHost") ?? "", /AUTH_TRUST_HOST=true/i);
+
+  for (const code of ["AccessDenied", "DatabaseUnavailable", "Configuration", "UntrustedHost"]) {
+    const message = getAuthErrorMessage(code) ?? "";
+    assert.doesNotMatch(message, INFRASTRUCTURE_HINT);
+    assert.match(message, /Authentication|try again/i);
+  }
 });
 
 test("falls back to a generic message for unknown auth errors", () => {
   assert.equal(
     getAuthErrorMessage("SomeNewError"),
-    "Authentication failed. Check the server logs and try again."
+    "Authentication failed. Please try again.",
   );
 });

--- a/tests/creative-memory-scripts.test.ts
+++ b/tests/creative-memory-scripts.test.ts
@@ -14,5 +14,5 @@ test('Creative Memory scripts are intentionally scoped', () => {
   assert.match(seed,/ON CONFLICT/);
   assert.doesNotMatch(seed,/INSERT INTO business_profiles/);
   assert.match(backfill,/noop-v1/);
-  assert.match(smoke,/Campaign Learning/);
+  assert.match(smoke,/Content Learning/);
 });

--- a/tests/creative-memory-ui.test.ts
+++ b/tests/creative-memory-ui.test.ts
@@ -7,7 +7,7 @@ import { resolveProjectRoot } from './helpers/project-root';
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
 const page = readFileSync(path.join(PROJECT_ROOT, 'app/creative-memory/page.tsx'), 'utf8');
 
-test('Creative Memory UI is Campaign Learning not a static style-card library', () => { assert.match(page,/Campaign Learning/); assert.match(page,/Baseline vs memory-assisted/); assert.match(page,/Prompt Preview/); assert.match(page,/Manual outcome labels/); assert.doesNotMatch(page,/Creative DNA Library/); });
+test('Creative Memory UI is Content Learning not a static style-card library', () => { assert.match(page,/Content Learning/); assert.match(page,/Baseline vs memory-assisted/); assert.match(page,/Prompt Preview/); assert.match(page,/Manual outcome labels/); assert.doesNotMatch(page,/Creative DNA Library/); });
 test('Creative Memory UI exposes required trust lifecycle and golden path', () => { for (const text of ['Observed','Analyzed','Suggested','Approved for generation','Archived','Inspect retrieved context','Generate two variants','Review and label outcome']) assert.match(page, new RegExp(text)); });
 
 test('Creative Memory UI wires generated candidate review loop', () => { for (const text of ['/api/creative-memory/generated-assets','Generated candidates: baseline vs memory-assisted','Approve candidate','Needs changes','Select for label','generatedAssetId']) assert.match(page, new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))); });

--- a/tests/docs-social-content-guidance.test.ts
+++ b/tests/docs-social-content-guidance.test.ts
@@ -85,20 +85,20 @@ test('docs describe Hermes social-content operational flow and avoid lobster wor
   assert.doesNotMatch(combinedSource, /run .*\.lobster.*social-content/i);
 });
 
-test('docs distinguish local Compose Postgres and social-content checks from legacy marketing checks', () => {
+test('docs distinguish external Postgres Compose config and social-content checks from legacy marketing checks', () => {
   const readme = readRepoFile('README.md');
   const setup = readRepoFile('SETUP.md');
   const compose = readRepoFile('docker-compose.yml');
 
-  assert.match(readme, /Local Compose includes a `postgres` service/i);
-  assert.match(readme, /Local Compose provisions a companion `postgres` service/i);
-  assert.match(readme, /DB_HOST=postgres/i);
-  assert.match(readme, /Production deploys may still use external PostgreSQL/i);
-  assert.doesNotMatch(readme, /do \*\*not\*\* provision PostgreSQL/i);
-  assert.doesNotMatch(readme, /do not provision PostgreSQL/i);
+  assert.match(readme, /Compose expects an external PostgreSQL database/i);
+  assert.match(readme, /does \*\*not\*\* provision PostgreSQL or pgAdmin/i);
+  assert.match(readme, /external `DB_\*` values/i);
+  assert.doesNotMatch(readme, /DB_HOST=postgres/i);
   assert.match(readme, /For weekly social content media generation, Hermes owns ChatGPT\/OpenAI auth/i);
   assert.match(readme, /Text-only weekly planning can (still )?run when media generation is disabled/i);
-  assert.match(compose, /DB_HOST:\s*postgres/);
+  assert.doesNotMatch(compose, /DB_HOST:\s*postgres/);
+  assert.doesNotMatch(compose, /postgres:16/);
+  assert.doesNotMatch(compose, /pgadmin/i);
   assert.doesNotMatch(compose, /OPENAI_CLIENT_ID/);
   assert.doesNotMatch(compose, /OPENAI_CLIENT_SECRET/);
 

--- a/tests/onboarding-draft-route.test.ts
+++ b/tests/onboarding-draft-route.test.ts
@@ -2,11 +2,137 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import test from 'node:test';
+import test, { type TestContext } from 'node:test';
+
+import pool from '../lib/db';
 
 import { resolveProjectRoot } from './helpers/project-root';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+type DraftRow = {
+  draft_id: string;
+  status: string;
+  website_url: string;
+  business_name: string;
+  business_type: string;
+  approver_name: string;
+  channels: string[];
+  goal: string;
+  offer: string;
+  competitor_url: string;
+  preview: unknown;
+  provenance: unknown;
+  materialized_tenant_id: string | null;
+  materialized_job_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type QueryResult<T = Record<string, unknown>> = { rows: T[]; rowCount: number };
+type QueryHandler = (sql: string, params?: unknown[]) => Promise<QueryResult> | QueryResult;
+
+function installDbMock(t: TestContext, handler: QueryHandler): void {
+  t.mock.method(pool, 'query', (async (sql: string, params?: unknown[]) =>
+    handler(String(sql), params ?? [])) as typeof pool.query);
+}
+
+function createDraftDbMock(): QueryHandler {
+  const drafts = new Map<string, DraftRow>();
+
+  return (sql, params = []) => {
+    const text = sql.trim();
+    const now = new Date();
+
+    if (text.startsWith('INSERT INTO onboarding_drafts')) {
+      const [
+        draftId,
+        status,
+        websiteUrl,
+        businessName,
+        businessType,
+        approverName,
+        channels,
+        goal,
+        offer,
+        competitorUrl,
+        preview,
+        provenance,
+        materializedTenantId,
+        materializedJobId,
+      ] = params as [string, string, string, string, string, string, string[], string, string, string, unknown, unknown, string | null, string | null];
+      const row: DraftRow = {
+        draft_id: draftId,
+        status,
+        website_url: websiteUrl,
+        business_name: businessName,
+        business_type: businessType,
+        approver_name: approverName,
+        channels,
+        goal,
+        offer,
+        competitor_url: competitorUrl,
+        preview,
+        provenance,
+        materialized_tenant_id: materializedTenantId,
+        materialized_job_id: materializedJobId,
+        created_at: now,
+        updated_at: now,
+      };
+      drafts.set(draftId, row);
+      return { rows: [row], rowCount: 1 };
+    }
+
+    if (text.startsWith('SELECT * FROM onboarding_drafts WHERE draft_id = $1')) {
+      const draftId = String(params[0] ?? '');
+      const row = drafts.get(draftId);
+      return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+    }
+
+    if (text.startsWith('UPDATE onboarding_drafts SET')) {
+      const [
+        draftId,
+        status,
+        websiteUrl,
+        businessName,
+        businessType,
+        approverName,
+        channels,
+        goal,
+        offer,
+        competitorUrl,
+        preview,
+        provenance,
+        materializedTenantId,
+        materializedJobId,
+      ] = params as [string, string, string, string, string, string, string[], string, string, string, unknown, unknown, string | null, string | null];
+      const current = drafts.get(draftId);
+      if (!current) return { rows: [], rowCount: 0 };
+      const row: DraftRow = {
+        ...current,
+        status,
+        website_url: websiteUrl,
+        business_name: businessName,
+        business_type: businessType,
+        approver_name: approverName,
+        channels,
+        goal,
+        offer,
+        competitor_url: competitorUrl,
+        preview,
+        provenance,
+        materialized_tenant_id: materializedTenantId,
+        materialized_job_id: materializedJobId,
+        updated_at: now,
+      };
+      drafts.set(draftId, row);
+      return { rows: [row], rowCount: 1 };
+    }
+
+    throw new Error(`unexpected query: ${text}`);
+  };
+}
+
 
 async function withDraftEnv<T>(run: () => Promise<T>): Promise<T> {
   const previousCodeRoot = process.env.CODE_ROOT;
@@ -27,8 +153,9 @@ async function withDraftEnv<T>(run: () => Promise<T>): Promise<T> {
   }
 }
 
-test('/api/onboarding/draft creates, reads, and updates an onboarding draft by explicit token', async () => {
+test('/api/onboarding/draft creates, reads, and updates an onboarding draft by explicit token', async (t) => {
   await withDraftEnv(async () => {
+    installDbMock(t, createDraftDbMock());
     const route = await import('../app/api/onboarding/draft/route');
 
     const createdResponse = await route.POST();
@@ -76,8 +203,9 @@ test('/api/onboarding/draft creates, reads, and updates an onboarding draft by e
   });
 });
 
-test('/api/onboarding/draft rejects reads and writes without an explicit draft token', async () => {
+test('/api/onboarding/draft rejects reads and writes without an explicit draft token', async (t) => {
   await withDraftEnv(async () => {
+    installDbMock(t, createDraftDbMock());
     const route = await import('../app/api/onboarding/draft/route');
 
     const getResponse = await route.GET(new Request('http://localhost/api/onboarding/draft'));
@@ -95,5 +223,22 @@ test('/api/onboarding/draft rejects reads and writes without an explicit draft t
     const patchBody = (await patchResponse.json()) as { error: string };
     assert.equal(patchResponse.status, 400);
     assert.equal(patchBody.error, 'draft_token_required');
+  });
+});
+
+
+test('/api/onboarding/draft returns a safe unavailable error when persistence fails', async (t) => {
+  await withDraftEnv(async () => {
+    installDbMock(t, () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:5432 password=secret');
+    });
+    const route = await import('../app/api/onboarding/draft/route');
+
+    const createdResponse = await route.POST();
+    const createdBody = (await createdResponse.json()) as { error: string };
+
+    assert.equal(createdResponse.status, 503);
+    assert.equal(createdBody.error, 'onboarding_draft_unavailable');
+    assert.doesNotMatch(createdBody.error, /ECONNREFUSED|127\.0\.0\.1|password|secret/i);
   });
 });

--- a/tests/public-marketing-pages.test.ts
+++ b/tests/public-marketing-pages.test.ts
@@ -69,7 +69,7 @@ test('public marketing pages return valid elements with expected route shells an
     const homeSource = readRepoFile('frontend/donor/marketing/home-page.tsx');
     const chromeSource = readRepoFile('frontend/donor/marketing/chrome.tsx');
     assert.match(homeSource, /Nothing goes live without your approval/);
-    assert.match(homeSource, /Plan campaigns, approve creative, launch safely/);
+    assert.match(homeSource, /Plan weekly social content, approve creative, publish safely/);
     assert.match(homeSource, /Start with your business/);
     assert.match(homeSource, /\/onboarding\/start/);
     assert.doesNotMatch(homeSource, /\/onboarding\/pipeline-intake/);


### PR DESCRIPTION
## Summary
- Replace infrastructure-leaking auth errors with safe user-facing messages.
- Harden onboarding draft API persistence failures with stable response codes and redacted diagnostics.
- Add Next metadata routes for `/robots.txt` and `/sitemap.xml`.
- Align public copy with weekly social-content language and avoid public "campaign" terminology.
- Update stale regression tests for async asset content-type detection and revised social-content copy.

## QA / Validation
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm run workspace:verify` ✅
- `npm run validate:repo-boundary` ✅
- `npm run validate:banned-patterns` ✅
- Targeted tests ✅
  - `tests/auth/auth-error-message.test.ts`
  - `tests/onboarding-draft-route.test.ts`
  - `tests/public-marketing-pages.test.ts`
  - `tests/asset-library-content-type.test.ts`
  - `tests/creative-memory-ui.test.ts`
- Public route validator ✅
- Social-content validator ✅
- `git diff --check` ✅
- Rebuilt local production QA on `http://127.0.0.1:3107` ✅
  - `/`, `/features`, `/documentation`, `/api-docs`, `/privacy`, `/terms`, `/sitemap`, `/onboarding/start`, `/social-content/new`, `/social-content/status?jobId=demo`, `/social-content/review?jobId=demo` returned `200`
  - `/robots.txt` returned `200 text/plain`
  - `/sitemap.xml` returned `200 application/xml`

## Full-suite note
`npm test` still exits non-zero with the known baseline failures from `origin/master`:

```text
# tests 848
# pass 795
# fail 51
# skipped 2
```

The failing test names are identical to `origin/master` (`new_failures_vs_baseline 0`).

## Live production notes before deploy
These were confirmed on `https://aries.sugarandleather.com` before this PR is deployed:
- Existing public routes such as `/`, `/features`, `/documentation`, `/api-docs`, `/privacy`, `/terms`, `/sitemap`, and `/onboarding/start` return `200`.
- `/robots.txt` and `/sitemap.xml` currently return `404` in production; they return `200` locally with this PR.
- `/social-content/new` currently returns `404` in production; it returns `200` locally with this PR.
- Authenticated dashboard QA remains blocked without a test account.
- The onboarding browser step-progression automation could not fully verify the Continue flow because the goal choices are custom button controls and Continue stayed disabled in automation.
