### PR TITLE
feat(social-content): project weekly dashboard previews

### DIFF
--- a/app/api/marketing/jobs/[jobId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/handler.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { buildSocialContentDashboardProjection } from '@/backend/social-content/dashboard-projection';
 import type { MarketingApprovalSummary, MarketingJobStatusResponse } from '@/backend/marketing/jobs-status';
 import { getMarketingJobStatusCached } from '@/backend/marketing/jobs-status';
 import { loadMarketingJobRuntime } from '@/backend/marketing/runtime-state';
@@ -167,7 +168,7 @@ function socialContentStatusHistory(
   }));
 }
 
-function socialContentDashboard(
+function socialContentCopyDashboard(
   dashboard: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['dashboard'],
   durationDays: number | null,
 ): Awaited<ReturnType<typeof buildCampaignWorkspaceView>>['dashboard'] {
@@ -179,10 +180,10 @@ function socialContentDashboard(
           ...dashboard.campaign,
           name: /^Campaign in progress$/i.test(dashboard.campaign.name)
             ? 'Social content in progress'
-            : dashboard.campaign.name,
+            : replaceCampaignTerms(dashboard.campaign.name, calendarLabel),
           objective: /^Campaign in progress$/i.test(dashboard.campaign.objective)
             ? 'Social content in progress'
-            : dashboard.campaign.objective,
+            : replaceCampaignTerms(dashboard.campaign.objective, calendarLabel),
           summary: replaceCampaignTerms(dashboard.campaign.summary, calendarLabel),
           stageLabel: replaceCampaignTerms(dashboard.campaign.stageLabel, calendarLabel),
         }
@@ -192,8 +193,19 @@ function socialContentDashboard(
       title: replaceCampaignTerms(asset.title, calendarLabel),
       summary: replaceCampaignTerms(asset.summary, calendarLabel),
     })),
+    posts: dashboard.posts.map((post) => ({
+      ...post,
+      title: replaceCampaignTerms(post.title, calendarLabel),
+      summary: replaceCampaignTerms(post.summary, calendarLabel),
+    })),
+    publishItems: dashboard.publishItems.map((item) => ({
+      ...item,
+      title: replaceCampaignTerms(item.title, calendarLabel),
+      summary: replaceCampaignTerms(item.summary, calendarLabel),
+    })),
     calendarEvents: dashboard.calendarEvents.map((event) => ({
       ...event,
+      title: replaceCampaignTerms(event.title, calendarLabel),
       statusLabel: replaceCampaignTerms(event.statusLabel, calendarLabel),
     })),
   };
@@ -203,6 +215,7 @@ function buildResponsePayload(
   dialect: ResponseDialect,
   result: Awaited<ReturnType<typeof getMarketingJobStatusCached>>['payload'],
   workspaceView: Awaited<ReturnType<typeof buildCampaignWorkspaceView>>,
+  runtimeDoc: NonNullable<Awaited<ReturnType<typeof loadMarketingJobRuntime>>>,
 ) {
   const base = {
     jobId: result.jobId,
@@ -259,7 +272,10 @@ function buildResponsePayload(
     social_content_stage_status: base.marketing_stage_status,
     contentBrief: base.campaignBrief,
     statusHistory: socialContentStatusHistory(base.statusHistory, base.durationDays),
-    dashboard: socialContentDashboard(base.dashboard, base.durationDays),
+    dashboard: buildSocialContentDashboardProjection(
+      runtimeDoc,
+      socialContentCopyDashboard(base.dashboard, base.durationDays),
+    ),
   };
 
   return socialPayload;
@@ -291,7 +307,7 @@ export async function handleGetMarketingJobStatus(
     const { payload: result, cacheStatus } = await getMarketingJobStatusCached(tenantResult.tenantContext.tenantId, jobId);
     const workspaceView = await buildCampaignWorkspaceView(jobId);
 
-    return NextResponse.json(buildResponsePayload(dialect, result, workspaceView), {
+    return NextResponse.json(buildResponsePayload(dialect, result, workspaceView, runtimeDoc), {
       status: 200,
       headers: { 'x-cache': cacheStatus },
     });

--- a/backend/social-content/dashboard-projection.ts
+++ b/backend/social-content/dashboard-projection.ts
@@ -1,0 +1,718 @@
+import { createHash } from 'node:crypto';
+
+import type {
+  MarketingDashboardAsset,
+  MarketingDashboardCalendarEvent,
+  MarketingDashboardCampaign,
+  MarketingDashboardCampaignCompatibilityStatus,
+  MarketingDashboardCampaignContent,
+  MarketingDashboardItemStatus,
+  MarketingDashboardPost,
+  MarketingDashboardPublishItem,
+} from '@/backend/marketing/dashboard-content';
+import type { MarketingJobRuntimeDocument } from '@/backend/marketing/runtime-state';
+import { redactTokenLikeString } from '@/backend/social-content/payload';
+import {
+  parseSocialContentWorkflowOutput,
+  readSocialContentRuntimeState,
+  type SocialContentWorkflowProjection,
+} from '@/backend/social-content/runtime-state';
+
+const STATUS_KEYS: MarketingDashboardItemStatus[] = [
+  'draft',
+  'in_review',
+  'ready',
+  'ready_to_publish',
+  'published_to_meta_paused',
+  'scheduled',
+  'live',
+];
+const DASHBOARD_REDACTED_VALUE = '[redacted]';
+const DASHBOARD_SENSITIVE_ASSIGNMENT_PATTERN =
+  /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|clientSecret|api[_-]?key|apiKey|access[_-]?key|accessKey|AWSAccessKeyId|authorization|password|passwd|token|signature|sig|secret|key)\b\s*[:=]\s*(Bearer\s+)?[^\s&;,'"<>]+/gi;
+
+type UnknownRecord = Record<string, unknown>;
+
+type SocialImageCreative = SocialContentWorkflowProjection['weekly_content_plan']['image_creatives'][number];
+type SocialVideoScript = SocialContentWorkflowProjection['weekly_content_plan']['video_scripts'][number];
+type SocialWeeklyPost = SocialContentWorkflowProjection['weekly_content_plan']['posts'][number];
+
+function recordValue(value: unknown): UnknownRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as UnknownRecord) : null;
+}
+
+function stringValue(value: unknown, fallback = ''): string {
+  if (typeof value === 'string') {
+    const redacted = redactTokenLikeString(value).replace(
+      DASHBOARD_SENSITIVE_ASSIGNMENT_PATTERN,
+      (_match, key: string) => `${key}=${DASHBOARD_REDACTED_VALUE}`,
+    );
+    return redacted.trim() || fallback;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return fallback;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function containsTenantId(doc: MarketingJobRuntimeDocument, value: string): boolean {
+  const tenantId = typeof doc.tenant_id === 'string' ? doc.tenant_id.trim() : '';
+  return tenantId.length > 0 && value.includes(tenantId);
+}
+
+function tenantSafeString(doc: MarketingJobRuntimeDocument, value: unknown, fallback = ''): string {
+  const tenantId = typeof doc.tenant_id === 'string' ? doc.tenant_id.trim() : '';
+  const redacted = stringValue(value, fallback);
+  if (!tenantId) return redacted;
+  return redacted.replace(new RegExp(escapeRegExp(tenantId), 'g'), 'tenant');
+}
+
+function publicId(doc: MarketingJobRuntimeDocument, value: unknown, fallback: string): string {
+  const raw = stringValue(value);
+  if (!raw) return fallback;
+  if (containsTenantId(doc, raw)) {
+    return `${fallback}-${safeHash(doc.job_id, raw).slice(0, 8)}`;
+  }
+  return raw;
+}
+
+function safeDashboardUrl(doc: MarketingJobRuntimeDocument, value: unknown): string | null {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (raw) {
+    try {
+      const rawUrl = new URL(raw);
+      if (hasSensitiveQueryParams(rawUrl)) return null;
+    } catch {
+      return null;
+    }
+  }
+  const redacted = stringValue(value);
+  if (!redacted || containsTenantId(doc, redacted)) return null;
+  try {
+    const url = new URL(redacted);
+    if (isPublicHttpUrl(url)) return url.toString();
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function safeImagePreviewUrl(doc: MarketingJobRuntimeDocument, value: unknown): string | null {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (raw) {
+    try {
+      const rawUrl = new URL(raw);
+      if (hasSensitiveQueryParams(rawUrl)) return null;
+    } catch {
+      return null;
+    }
+  }
+  const redacted = stringValue(value);
+  if (!redacted || containsTenantId(doc, redacted)) return null;
+  try {
+    const url = new URL(redacted);
+    if (isPublicHttpUrl(url)) return url.toString();
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function contentTypeForPreviewUrl(previewUrl: string): string {
+  const dataMatch = previewUrl.match(/^data:(image\/[a-z0-9.+-]+);base64,/i);
+  if (dataMatch) return dataMatch[1].toLowerCase();
+  return 'image/png';
+}
+
+function hasSensitiveQueryParams(url: URL): boolean {
+  for (const key of Array.from(url.searchParams.keys())) {
+    const normalized = key.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const compact = key.toLowerCase().replace(/[^a-z0-9]+/g, '');
+    if (
+      normalized.includes('token') ||
+      normalized.includes('secret') ||
+      normalized.includes('password') ||
+      normalized.includes('passwd') ||
+      normalized.includes('signature') ||
+      normalized.includes('credential') ||
+      normalized.includes('authorization') ||
+      normalized === 'sig' ||
+      normalized === 'key' ||
+      normalized === 'api_key' ||
+      normalized.endsWith('_key') ||
+      normalized.includes('policy') ||
+      compact.includes('apikey') ||
+      compact.includes('accesskey') ||
+      compact.includes('awsaccesskeyid')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) return false;
+  const octets = match.slice(1).map((part) => Number.parseInt(part, 10));
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return false;
+  const [first, second] = octets;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function isPublicHttpUrl(url: URL): boolean {
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.+$/g, '');
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  if (url.username || url.password) return false;
+  if (hostname.includes(':')) return false;
+  if (!hostname || hostname === 'localhost' || hostname.endsWith('.localhost') || hostname.endsWith('.local') || hostname.endsWith('.internal')) return false;
+  if (isPrivateIpv4(hostname)) return false;
+  if (hasSensitiveQueryParams(url)) return false;
+  return true;
+}
+
+function tenantSafeDashboardValue<T>(doc: MarketingJobRuntimeDocument, value: T): T {
+  if (typeof value === 'string') return tenantSafeString(doc, value) as T;
+  if (Array.isArray(value)) return value.map((entry) => tenantSafeDashboardValue(doc, entry)) as T;
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, tenantSafeDashboardValue(doc, entry)]),
+    ) as T;
+  }
+  return value;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => redactTokenLikeString(entry).trim())
+    .filter(Boolean);
+}
+
+function requestedJobTypeFromDoc(doc: MarketingJobRuntimeDocument): string {
+  const request = recordValue(doc.inputs?.request);
+  return stringValue(request?.jobType || request?.job_type || 'brand_campaign').toLowerCase();
+}
+
+function latestSocialProjection(runtimeDoc: MarketingJobRuntimeDocument): SocialContentWorkflowProjection | null {
+  const runtime = readSocialContentRuntimeState(runtimeDoc);
+  if (!runtime) return null;
+
+  let summary = '';
+  let windowDays: number | null = null;
+  let posts: SocialContentWorkflowProjection['weekly_content_plan']['posts'] = [];
+  let imageCreatives: SocialContentWorkflowProjection['weekly_content_plan']['image_creatives'] = [];
+  let videoScripts: SocialContentWorkflowProjection['weekly_content_plan']['video_scripts'] = [];
+
+  for (const stage of runtime.stageOrder) {
+    const projection = parseSocialContentWorkflowOutput(runtime.stages[stage]?.output);
+    if (!projection) continue;
+    const plan = projection.weekly_content_plan;
+    if (projection.summary) summary = projection.summary;
+    if (plan.window_days !== null) windowDays = plan.window_days;
+    if (plan.posts.length > 0) posts = plan.posts;
+    if (plan.image_creatives.length > 0) imageCreatives = plan.image_creatives;
+    if (plan.video_scripts.length > 0) videoScripts = plan.video_scripts;
+  }
+
+  const hasProjection = windowDays !== null || posts.length > 0 || imageCreatives.length > 0 || videoScripts.length > 0;
+  if (!hasProjection) return null;
+  return {
+    summary,
+    weekly_content_plan: {
+      window_days: windowDays,
+      posts,
+      image_creatives: imageCreatives,
+      video_scripts: videoScripts,
+    },
+  };
+}
+
+function safeHash(...parts: string[]): string {
+  return createHash('sha256').update(parts.join('\n')).digest('hex');
+}
+
+function publicCampaignId(jobId: string): string {
+  return `social-${safeHash(jobId).slice(0, 12)}`;
+}
+
+function safeHexColor(value: string, fallback: string): string {
+  const normalized = value.trim();
+  if (/^#[0-9a-f]{6}$/i.test(normalized) || /^#[0-9a-f]{3}$/i.test(normalized)) return normalized;
+  return fallback;
+}
+
+function brandPalette(doc: MarketingJobRuntimeDocument): { primary: string; secondary: string; accent: string } {
+  const colors = recordValue(doc.brand_kit?.colors);
+  const palette = stringArray(colors?.palette);
+  const primary = safeHexColor(tenantSafeString(doc, colors?.primary) || palette[0] || '', '#14151f');
+  const secondary = safeHexColor(tenantSafeString(doc, colors?.secondary) || palette[1] || '', '#f3c969');
+  const accent = safeHexColor(tenantSafeString(doc, colors?.accent) || palette[2] || '', '#f8f4ea');
+  return { primary, secondary, accent };
+}
+
+function brandName(doc: MarketingJobRuntimeDocument): string {
+  const request = recordValue(doc.inputs?.request);
+  return (
+    tenantSafeString(doc, request?.businessName) ||
+    tenantSafeString(doc, request?.brandName) ||
+    tenantSafeString(doc, doc.brand_kit?.brand_name) ||
+    'Weekly social content'
+  );
+}
+
+function escapeSvgText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function shortText(value: string, maxLength: number): string {
+  const normalized = redactTokenLikeString(value).replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
+}
+
+function socialPreviewDataUri(input: {
+  doc: MarketingJobRuntimeDocument;
+  creative: SocialImageCreative;
+  index: number;
+  brand: string;
+}): string {
+  const palette = brandPalette(input.doc);
+  const hash = safeHash(input.doc.tenant_id, input.doc.job_id, input.creative.id, input.creative.title, input.creative.prompt);
+  const seedA = Number.parseInt(hash.slice(0, 2), 16);
+  const seedB = Number.parseInt(hash.slice(2, 4), 16);
+  const seedC = Number.parseInt(hash.slice(4, 6), 16);
+  const title = escapeSvgText(shortText(tenantSafeString(input.doc, input.creative.title, `Image creative ${input.index + 1}`), 42));
+  const prompt = escapeSvgText(shortText(tenantSafeString(input.doc, input.creative.prompt), 86));
+  const brand = escapeSvgText(shortText(input.brand, 36));
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1500" viewBox="0 0 1200 1500" role="img" aria-label="${title}">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="${escapeSvgText(palette.primary)}"/>
+      <stop offset="0.58" stop-color="${escapeSvgText(palette.secondary)}"/>
+      <stop offset="1" stop-color="${escapeSvgText(palette.accent)}"/>
+    </linearGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1200" height="1500" fill="url(#bg)"/>
+  <circle cx="${190 + seedA}" cy="${230 + seedB}" r="${150 + (seedC % 90)}" fill="rgba(255,255,255,0.24)" filter="url(#soft)"/>
+  <circle cx="${830 + (seedB % 160)}" cy="${390 + (seedA % 130)}" r="${120 + (seedA % 80)}" fill="rgba(0,0,0,0.18)" filter="url(#soft)"/>
+  <path d="M80 ${930 + (seedB % 130)} C 300 ${760 + (seedC % 160)}, 520 ${1120 - (seedA % 150)}, 1120 ${830 + (seedA % 120)}" stroke="rgba(255,255,255,0.52)" stroke-width="28" fill="none" stroke-linecap="round"/>
+  <rect x="86" y="96" width="1028" height="1308" rx="78" fill="rgba(8,10,18,0.30)" stroke="rgba(255,255,255,0.28)" stroke-width="2"/>
+  <text x="132" y="180" fill="rgba(255,255,255,0.72)" font-family="Inter, Arial, sans-serif" font-size="34" letter-spacing="8">${brand}</text>
+  <text x="132" y="1030" fill="#fff" font-family="Inter, Arial, sans-serif" font-size="82" font-weight="800">${title}</text>
+  <foreignObject x="132" y="1088" width="900" height="190">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Inter, Arial, sans-serif; color: rgba(255,255,255,0.82); font-size: 38px; line-height: 1.22;">${prompt}</div>
+  </foreignObject>
+  <text x="132" y="1328" fill="rgba(255,255,255,0.64)" font-family="Inter, Arial, sans-serif" font-size="28">Unique weekly social content preview ${input.index + 1}</text>
+</svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`;
+}
+
+function platformLabel(platform: string): string {
+  const normalized = platform.trim().toLowerCase();
+  if (normalized === 'meta') return 'Meta';
+  if (normalized === 'instagram') return 'Instagram';
+  if (normalized === 'linkedin') return 'LinkedIn';
+  if (normalized === 'tiktok') return 'TikTok';
+  if (normalized === 'youtube') return 'YouTube';
+  if (normalized === 'x') return 'X';
+  return normalized ? normalized.charAt(0).toUpperCase() + normalized.slice(1) : 'Social';
+}
+
+function normalizeDashboardStatus(value: string, fallback: MarketingDashboardItemStatus): MarketingDashboardItemStatus {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'published' || normalized === 'live') return 'live';
+  if (normalized === 'scheduled') return 'scheduled';
+  if (normalized === 'approved' || normalized === 'ready' || normalized === 'generated') return 'ready';
+  if (normalized === 'needs_review' || normalized === 'in_review') return 'in_review';
+  if (normalized === 'ready_to_publish') return 'ready_to_publish';
+  if (normalized === 'draft') return 'draft';
+  return fallback;
+}
+
+function dayIndex(day: string, fallback: number, windowDays: number): number {
+  const label = day.trim().match(/^day\s*(\d+)$/i) ?? day.trim().match(/^(\d+)$/);
+  if (label) {
+    const parsed = Number.parseInt(label[1], 10);
+    if (Number.isFinite(parsed)) return Math.min(windowDays, Math.max(1, parsed));
+  }
+  return Math.min(windowDays, Math.max(1, fallback));
+}
+
+function startsAt(doc: MarketingJobRuntimeDocument, day: number): string {
+  const parsed = Date.parse(doc.created_at);
+  const source = Number.isFinite(parsed) ? new Date(parsed) : new Date();
+  const start = Date.UTC(source.getUTCFullYear(), source.getUTCMonth(), source.getUTCDate());
+  return new Date(start + (day - 1) * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function provenance(sourceStage: 'runtime' | 'strategy' | 'production' | 'publish') {
+  return {
+    sourceKind: 'creative_output' as const,
+    sourceStage,
+    sourceRunId: null,
+    isDerivedSchedule: true,
+    isPlatformNative: false,
+  };
+}
+
+function emptyCounts(): Record<MarketingDashboardItemStatus, number> {
+  return Object.fromEntries(STATUS_KEYS.map((key) => [key, 0])) as Record<MarketingDashboardItemStatus, number>;
+}
+
+function recountStatuses(input: {
+  posts: MarketingDashboardPost[];
+  publishItems: MarketingDashboardPublishItem[];
+}): Record<MarketingDashboardItemStatus, number> {
+  const counts = emptyCounts();
+  for (const item of [...input.posts, ...input.publishItems]) {
+    counts[item.status] += 1;
+  }
+  return counts;
+}
+
+function compatibilityStatusFor(status: MarketingDashboardItemStatus): MarketingDashboardCampaignCompatibilityStatus {
+  if (status === 'live') return 'live';
+  if (status === 'scheduled') return 'scheduled';
+  if (status === 'published_to_meta_paused' || status === 'ready_to_publish' || status === 'ready') return 'approved';
+  if (status === 'in_review') return 'in_review';
+  return 'draft';
+}
+
+function aggregateCampaignStatus(input: {
+  posts: MarketingDashboardPost[];
+  publishItems: MarketingDashboardPublishItem[];
+}): MarketingDashboardItemStatus {
+  const items = [...input.publishItems, ...input.posts];
+  if (items.some((item) => item.status === 'live')) return 'live';
+  if (items.some((item) => item.status === 'scheduled')) return 'scheduled';
+  if (items.some((item) => item.status === 'published_to_meta_paused')) return 'published_to_meta_paused';
+  if (items.some((item) => item.status === 'ready_to_publish')) return 'ready_to_publish';
+  if (items.some((item) => item.status === 'ready')) return 'ready';
+  if (items.some((item) => item.status === 'in_review')) return 'in_review';
+  return 'draft';
+}
+
+function mergeById<T extends { id: string }>(existing: T[], additions: T[]): T[] {
+  const byId = new Map<string, T>();
+  for (const item of existing) byId.set(item.id, item);
+  for (const item of additions) byId.set(item.id, item);
+  return Array.from(byId.values());
+}
+
+function imageAssetId(doc: MarketingJobRuntimeDocument, creative: SocialImageCreative, index: number): string {
+  return publicId(doc, creative.id, `social-image-${index + 1}`);
+}
+
+function videoScriptAssetId(doc: MarketingJobRuntimeDocument, script: SocialVideoScript, index: number): string {
+  return publicId(doc, script.id, `social-video-script-${index + 1}`);
+}
+
+function createAssets(input: {
+  doc: MarketingJobRuntimeDocument;
+  projection: SocialContentWorkflowProjection;
+  campaignId: string;
+  campaignName: string;
+  objective: string;
+}): MarketingDashboardAsset[] {
+  const imageAssets = input.projection.weekly_content_plan.image_creatives.map((creative, index) => {
+    const id = imageAssetId(input.doc, creative, index);
+    const title = tenantSafeString(input.doc, creative.title) || `Weekly image creative ${index + 1}`;
+    const previewUrl = safeImagePreviewUrl(input.doc, creative.artifact_url) || socialPreviewDataUri({
+      doc: input.doc,
+      creative,
+      index,
+      brand: input.campaignName,
+    });
+    return {
+      id,
+      campaignId: input.campaignId,
+      jobId: input.doc.job_id,
+      type: 'image_ad',
+      title,
+      summary: tenantSafeString(input.doc, creative.prompt) || title,
+      platform: 'social',
+      platformLabel: 'Social content',
+      campaignName: input.campaignName,
+      funnelStage: 'weekly_content',
+      objective: input.objective,
+      destinationUrl: safeDashboardUrl(input.doc, input.doc.inputs?.brand_url),
+      previewUrl,
+      thumbnailUrl: previewUrl,
+      contentType: contentTypeForPreviewUrl(previewUrl),
+      status: normalizeDashboardStatus(creative.status, 'in_review'),
+      createdAt: input.doc.updated_at || input.doc.created_at || null,
+      relatedPostIds: [],
+      relatedPublishItemIds: [],
+      provenance: provenance('production'),
+    } satisfies MarketingDashboardAsset;
+  });
+
+  const scriptAssets = input.projection.weekly_content_plan.video_scripts.map((script, index) => {
+    const id = videoScriptAssetId(input.doc, script, index);
+    const title = tenantSafeString(input.doc, script.title) || `Weekly video script ${index + 1}`;
+    const duration = script.duration_seconds ? `${script.duration_seconds}s` : 'Short-form';
+    return {
+      id,
+      campaignId: input.campaignId,
+      jobId: input.doc.job_id,
+      type: 'script',
+      title,
+      summary: tenantSafeString(input.doc, script.script_markdown) || `${duration} weekly social video script ready for review.`,
+      platform: 'social',
+      platformLabel: 'Social content',
+      campaignName: input.campaignName,
+      funnelStage: 'weekly_content',
+      objective: input.objective,
+      destinationUrl: safeDashboardUrl(input.doc, input.doc.inputs?.brand_url),
+      previewUrl: null,
+      thumbnailUrl: null,
+      contentType: 'text/markdown',
+      status: normalizeDashboardStatus(script.status, 'in_review'),
+      createdAt: input.doc.updated_at || input.doc.created_at || null,
+      relatedPostIds: [],
+      relatedPublishItemIds: [],
+      provenance: provenance('production'),
+    } satisfies MarketingDashboardAsset;
+  });
+
+  return [...imageAssets, ...scriptAssets];
+}
+
+function resolvePostAssetId(doc: MarketingJobRuntimeDocument, post: SocialWeeklyPost, assets: MarketingDashboardAsset[], index: number): string | null {
+  const previewAssets = assets.filter((asset) => asset.type === 'image_ad' && Boolean(asset.previewUrl || asset.thumbnailUrl));
+  const preferred = publicId(doc, post.creative_brief_id, `social-image-${index + 1}`);
+  if (preferred && previewAssets.some((asset) => asset.id === preferred)) return preferred;
+  return previewAssets[index % Math.max(1, previewAssets.length)]?.id ?? null;
+}
+
+function createPosts(input: {
+  doc: MarketingJobRuntimeDocument;
+  projection: SocialContentWorkflowProjection;
+  assets: MarketingDashboardAsset[];
+  campaignId: string;
+  campaignName: string;
+  objective: string;
+}): MarketingDashboardPost[] {
+  return input.projection.weekly_content_plan.posts.map((post, index) => {
+    const platform = (post.platforms.find(Boolean) || 'meta').toLowerCase();
+    const previewAssetId = resolvePostAssetId(input.doc, post, input.assets, index);
+    return {
+      id: `social-post-${index + 1}`,
+      campaignId: input.campaignId,
+      jobId: input.doc.job_id,
+      type: 'platform_post',
+      title: tenantSafeString(input.doc, post.title) || `Weekly social post ${index + 1}`,
+      summary: tenantSafeString(input.doc, post.caption) || tenantSafeString(input.doc, post.post_type) || 'Weekly social post ready for review.',
+      platform,
+      platformLabel: platformLabel(platform),
+      campaignName: input.campaignName,
+      funnelStage: 'weekly_content',
+      objective: input.objective,
+      destinationUrl: safeDashboardUrl(input.doc, input.doc.inputs?.brand_url),
+      previewAssetId,
+      status: normalizeDashboardStatus(post.status, 'in_review'),
+      createdAt: input.doc.updated_at || input.doc.created_at || null,
+      conceptId: previewAssetId,
+      relatedAssetIds: previewAssetId ? [previewAssetId] : [],
+      relatedPublishItemIds: [],
+      provenance: provenance('production'),
+    } satisfies MarketingDashboardPost;
+  });
+}
+
+function createPublishItems(input: {
+  doc: MarketingJobRuntimeDocument;
+  posts: MarketingDashboardPost[];
+  campaignId: string;
+  campaignName: string;
+  objective: string;
+  includePublishQueue: boolean;
+}): MarketingDashboardPublishItem[] {
+  if (!input.includePublishQueue) return [];
+  return input.posts.map((post, index) => ({
+    id: `social-publish-${index + 1}`,
+    campaignId: input.campaignId,
+    jobId: input.doc.job_id,
+    type: post.status === 'live' ? 'live_post' : post.status === 'scheduled' ? 'scheduled_post' : 'publish_package',
+    title: post.title,
+    summary: `Ready to publish on ${post.platformLabel}.`,
+    platform: post.platform,
+    platformLabel: post.platformLabel,
+    campaignName: input.campaignName,
+    funnelStage: 'weekly_content',
+    objective: input.objective,
+    destinationUrl: post.destinationUrl,
+    previewAssetId: post.previewAssetId,
+    status: post.status === 'live' ? 'live' : post.status === 'scheduled' ? 'scheduled' : 'ready_to_publish',
+    createdAt: input.doc.updated_at || input.doc.created_at || null,
+    relatedAssetIds: post.relatedAssetIds,
+    relatedPostIds: [post.id],
+    provenance: provenance('publish'),
+  } satisfies MarketingDashboardPublishItem));
+}
+
+function createCalendarEvents(input: {
+  doc: MarketingJobRuntimeDocument;
+  projection: SocialContentWorkflowProjection;
+  posts: MarketingDashboardPost[];
+  campaignId: string;
+  campaignName: string;
+  objective: string;
+}): MarketingDashboardCalendarEvent[] {
+  const windowDays = input.projection.weekly_content_plan.window_days ?? 7;
+  return input.projection.weekly_content_plan.posts.map((post, index) => {
+    const linkedPost = input.posts[index];
+    const day = dayIndex(post.day, index + 1, windowDays);
+    return {
+      id: `social-calendar-${index + 1}`,
+      campaignId: input.campaignId,
+      jobId: input.doc.job_id,
+      title: linkedPost?.title || `Weekly social post ${index + 1}`,
+      platform: linkedPost?.platform || 'meta',
+      platformLabel: linkedPost?.platformLabel || 'Meta',
+      startsAt: startsAt(input.doc, day),
+      endsAt: null,
+      status: linkedPost?.status || 'in_review',
+      statusLabel: linkedPost?.status || 'in_review',
+      campaignName: input.campaignName,
+      funnelStage: 'weekly_content',
+      objective: input.objective,
+      destinationUrl: linkedPost?.destinationUrl || safeDashboardUrl(input.doc, input.doc.inputs?.brand_url),
+      previewAssetId: linkedPost?.previewAssetId || null,
+      sourcePostId: linkedPost?.id || null,
+      sourcePublishItemId: null,
+      provenance: provenance('runtime'),
+    } satisfies MarketingDashboardCalendarEvent;
+  });
+}
+
+function createCampaign(input: {
+  doc: MarketingJobRuntimeDocument;
+  dashboard: MarketingDashboardCampaignContent;
+  campaignId: string;
+  campaignName: string;
+  objective: string;
+  posts: MarketingDashboardPost[];
+  assets: MarketingDashboardAsset[];
+  publishItems: MarketingDashboardPublishItem[];
+  calendarEvents: MarketingDashboardCalendarEvent[];
+}): MarketingDashboardCampaign | null {
+  const existing = input.dashboard.campaign;
+  const statusCounts = recountStatuses({ posts: input.posts, publishItems: input.publishItems });
+  const campaignStatus = aggregateCampaignStatus({ posts: input.posts, publishItems: input.publishItems });
+  const counts = {
+    posts: input.posts.length,
+    landingPages: existing?.counts.landingPages ?? 0,
+    imageAds: input.assets.filter((asset) => asset.type === 'image_ad').length,
+    videoAds: existing?.counts.videoAds ?? 0,
+    scripts: input.assets.filter((asset) => asset.type === 'script').length,
+    publishItems: input.publishItems.length,
+    proposalConcepts: existing?.counts.proposalConcepts ?? 0,
+    ready: statusCounts.ready,
+    readyToPublish: statusCounts.ready_to_publish,
+    pausedMetaAds: statusCounts.published_to_meta_paused,
+    scheduled: statusCounts.scheduled,
+    live: statusCounts.live,
+  };
+  return {
+    id: input.campaignId,
+    jobId: input.doc.job_id,
+    externalCampaignId: existing?.externalCampaignId && !containsTenantId(input.doc, existing.externalCampaignId) ? existing.externalCampaignId : input.campaignId,
+    name: input.campaignName,
+    objective: input.objective,
+    funnelStage: 'weekly_content',
+    summary: `${input.posts.length} weekly posts with ${input.assets.length} unique image previews.`,
+    stageLabel: 'Weekly social content',
+    status: campaignStatus,
+    compatibilityStatus: compatibilityStatusFor(campaignStatus),
+    campaignWindow: existing?.campaignWindow ?? null,
+    updatedAt: input.doc.updated_at || input.doc.created_at || null,
+    approvalRequired: existing?.approvalRequired ?? false,
+    approvalActionHref: existing?.approvalActionHref,
+    previewPostIds: input.posts.slice(0, 4).map((post) => post.id),
+    previewAssetIds: input.assets.slice(0, 4).map((asset) => asset.id),
+    postIds: input.posts.map((post) => post.id),
+    assetIds: input.assets.map((asset) => asset.id),
+    publishItemIds: input.publishItems.map((item) => item.id),
+    calendarEventIds: input.calendarEvents.map((event) => event.id),
+    counts,
+    provenance: provenance('runtime'),
+  } satisfies MarketingDashboardCampaign;
+}
+
+export function buildSocialContentDashboardProjection(
+  runtimeDoc: MarketingJobRuntimeDocument,
+  dashboard: MarketingDashboardCampaignContent,
+): MarketingDashboardCampaignContent {
+  if (requestedJobTypeFromDoc(runtimeDoc) !== 'weekly_social_content') {
+    return dashboard;
+  }
+  const projection = latestSocialProjection(runtimeDoc);
+  if (!projection) {
+    return dashboard;
+  }
+
+  const runtime = readSocialContentRuntimeState(runtimeDoc);
+  const existingCampaignId = dashboard.campaign?.id || '';
+  const campaignId = existingCampaignId && !containsTenantId(runtimeDoc, existingCampaignId) ? existingCampaignId : publicCampaignId(runtimeDoc.job_id);
+  const campaignName = tenantSafeString(runtimeDoc, dashboard.campaign?.name) || brandName(runtimeDoc);
+  const request = recordValue(runtimeDoc.inputs?.request);
+  const objective =
+    tenantSafeString(runtimeDoc, dashboard.campaign?.objective) ||
+    tenantSafeString(runtimeDoc, request?.primaryGoal) ||
+    tenantSafeString(runtimeDoc, request?.goal) ||
+    'Weekly social content';
+
+  const assets = createAssets({ doc: runtimeDoc, projection, campaignId, campaignName, objective });
+  const posts = createPosts({ doc: runtimeDoc, projection, assets, campaignId, campaignName, objective });
+  const includePublishQueue = runtime?.publishingRequested === true || runtime?.currentStage === 'publish_review' || runtime?.currentStage === 'completed';
+  const publishItems = createPublishItems({ doc: runtimeDoc, posts, campaignId, campaignName, objective, includePublishQueue });
+  const calendarEvents = createCalendarEvents({ doc: runtimeDoc, projection, posts, campaignId, campaignName, objective });
+
+  const mergedAssets = mergeById(dashboard.assets, assets);
+  const mergedPosts = mergeById(dashboard.posts, posts);
+  const mergedPublishItems = mergeById(dashboard.publishItems, publishItems);
+  const mergedCalendarEvents = mergeById(dashboard.calendarEvents, calendarEvents);
+  const campaign = createCampaign({
+    doc: runtimeDoc,
+    dashboard,
+    campaignId,
+    campaignName,
+    objective,
+    posts: mergedPosts,
+    assets: mergedAssets,
+    publishItems: mergedPublishItems,
+    calendarEvents: mergedCalendarEvents,
+  });
+
+  return tenantSafeDashboardValue(runtimeDoc, {
+    campaign,
+    posts: mergedPosts,
+    assets: mergedAssets,
+    publishItems: mergedPublishItems,
+    calendarEvents: mergedCalendarEvents,
+    statuses: {
+      countsByStatus: recountStatuses({
+        posts: mergedPosts,
+        publishItems: mergedPublishItems,
+      }),
+    },
+  });
+}

--- a/tests/social-content-weekly-defaults.test.ts
+++ b/tests/social-content-weekly-defaults.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
+import { buildSocialContentDashboardProjection } from '@/backend/social-content/dashboard-projection';
 import { normalizeWeeklySocialContentPayload } from '@/backend/social-content/payload';
 import { buildSocialContentWeeklyRequest } from '@/backend/social-content/workflow-request';
 import type { SocialContentCalendarEvent } from '@/backend/marketing/jobs-status';
@@ -659,4 +660,225 @@ test('weekly workflow request redacts token-like text and media values', () => {
     'https://assets.example/image.png?width=1024',
     'id_token=[redacted]',
   ]);
+});
+
+test('social content dashboard projection shows unique tenant-safe image previews linked to posts and publish queue', () => {
+  const doc = {
+    tenant_id: 'tenant_dashboard_projection',
+    job_id: 'mkt_dashboard_projection',
+    created_at: '2026-05-06T00:00:00.000Z',
+    updated_at: '2026-05-06T00:00:00.000Z',
+    inputs: {
+      brand_url: 'https://brand.example',
+      request: {
+        jobType: 'weekly_social_content',
+        businessName: 'Bright Studio',
+        primaryGoal: 'Book discovery calls',
+        openaiAccessToken: 'sk-dashboard-secret-should-not-leak',
+      },
+    },
+    brand_kit: {
+      brand_name: 'Bright Studio',
+      colors: {
+        primary: '#14213d',
+        secondary: '#fca311',
+        accent: '#e5e5e5',
+        palette: ['#14213d', '#fca311', '#e5e5e5'],
+      },
+    },
+    social_content_runtime: {
+      stageOrder: ['planning', 'creative_review', 'publish_review'],
+      stages: {
+        planning: {
+          output: {
+            summary: 'Weekly plan ready.',
+            weekly_content_plan: {
+              window_days: 7,
+              posts: [
+                {
+                  day: 'Day 1',
+                  platforms: ['instagram'],
+                  post_type: 'static',
+                  title: 'Founder story',
+                  caption: 'Show the workshop ritual.',
+                  creative_brief_id: 'image-founder-story',
+                  status: 'approved',
+                },
+                {
+                  day: 'Day 4',
+                  platforms: ['meta'],
+                  post_type: 'static',
+                  title: 'Proof carousel',
+                  caption: 'Share outcome proof.',
+                  creative_brief_id: 'image-proof-carousel',
+                  status: 'approved',
+                },
+              ],
+              image_creatives: [
+                {
+                  id: 'image-founder-story',
+                  title: 'Workshop ritual still life',
+                  aspect_ratio: '4:5',
+                  prompt: 'Close-up of leather tools on warm bench, client initials embossed, no generic office.',
+                  status: 'generated',
+                  artifact_url: '',
+                },
+                {
+                  id: 'image-proof-carousel',
+                  title: 'Client proof wall',
+                  aspect_ratio: '4:5',
+                  prompt: 'Editorial wall of handwritten customer notes and product detail, no fake UI screenshot.',
+                  status: 'generated',
+                  artifact_url: '',
+                },
+              ],
+              video_scripts: [],
+            },
+          },
+        },
+      },
+      publishingRequested: true,
+    },
+  } as unknown as MarketingJobRuntimeDocument;
+
+  const dashboard = buildSocialContentDashboardProjection(doc, {
+    campaign: null,
+    posts: [],
+    assets: [],
+    publishItems: [],
+    calendarEvents: [],
+    statuses: {
+      countsByStatus: {
+        draft: 0,
+        in_review: 0,
+        ready: 0,
+        ready_to_publish: 0,
+        published_to_meta_paused: 0,
+        scheduled: 0,
+        live: 0,
+      },
+    },
+  });
+
+  assert.equal(dashboard.assets.length, 2);
+  assert.equal(dashboard.posts.length, 2);
+  assert.equal(dashboard.publishItems.length, 2);
+  assert.equal(dashboard.posts[0].previewAssetId, 'image-founder-story');
+  assert.equal(dashboard.publishItems[0].previewAssetId, 'image-founder-story');
+  assert.equal(dashboard.assets.every((asset) => asset.contentType === 'image/svg+xml'), true);
+  assert.equal(dashboard.statuses.countsByStatus.ready, 2);
+  assert.equal(dashboard.statuses.countsByStatus.ready_to_publish, 2);
+  assert.equal(dashboard.statuses.countsByStatus.in_review, 0);
+  assert.equal(dashboard.assets.every((asset) => asset.previewUrl?.startsWith('data:image/svg+xml;base64,')), true);
+  assert.notEqual(dashboard.assets[0].previewUrl, dashboard.assets[1].previewUrl);
+  const serialized = JSON.stringify(dashboard);
+  assert.equal(serialized.includes('tenant_dashboard_projection'), false);
+  assert.equal(serialized.includes('sk-dashboard-secret-should-not-leak'), false);
+  assert.equal(/generic ai|ai-generated|stock office/i.test(serialized), false);
+});
+
+test('social content dashboard projection keeps rich weekly output when a later stage only reports the window', () => {
+  const doc = {
+    tenant_id: 'tenant_dashboard_partial_stage',
+    job_id: 'mkt_dashboard_partial_stage',
+    created_at: '2026-05-06T00:00:00.000Z',
+    updated_at: '2026-05-06T00:00:00.000Z',
+    inputs: {
+      brand_url: 'https://brand.example',
+      request: {
+        jobType: 'weekly_social_content',
+        businessName: 'Bright Studio',
+      },
+    },
+    brand_kit: {
+      brand_name: 'Bright Studio',
+    },
+    social_content_runtime: {
+      stageOrder: ['planning', 'video_script', 'publish_review'],
+      stages: {
+        planning: {
+          output: {
+            weekly_content_plan: {
+              window_days: 7,
+              posts: [
+                {
+                  day: 'Day 2',
+                  platforms: ['instagram'],
+                  post_type: 'static',
+                  title: 'Studio proof',
+                  caption: 'Show a specific customer result.',
+                  creative_brief_id: 'tenant_dashboard_partial_stage-image',
+                  status: 'approved',
+                },
+              ],
+              image_creatives: [
+                {
+                  id: 'tenant_dashboard_partial_stage-image',
+                  title: 'tenant_dashboard_partial_stage proof detail',
+                  aspect_ratio: '4:5',
+                  prompt: 'Macro detail of the finished product beside handwritten customer notes for tenant_dashboard_partial_stage with apiKey=dashboardTextSecret123.',
+                  status: 'generated',
+                  artifact_url: 'http://localhost./render.png?api_key=abc123',
+                },
+              ],
+              video_scripts: [],
+            },
+          },
+        },
+        video_script: {
+          output: {
+            weekly_content_plan: {
+              video_scripts: [
+                {
+                  id: 'tenant_dashboard_partial_stage-video',
+                  title: 'Weekly proof reel',
+                  duration_seconds: 30,
+                  script_markdown: 'Open on product detail, cut to customer note, close with booking CTA.',
+                  status: 'approved',
+                },
+              ],
+            },
+          },
+        },
+        publish_review: {
+          output: {
+            weekly_content_plan: {
+              window_days: 7,
+            },
+          },
+        },
+      },
+      publishingRequested: true,
+    },
+  } as unknown as MarketingJobRuntimeDocument;
+
+  const dashboard = buildSocialContentDashboardProjection(doc, {
+    campaign: null,
+    posts: [],
+    assets: [],
+    publishItems: [],
+    calendarEvents: [],
+    statuses: {
+      countsByStatus: {
+        draft: 0,
+        in_review: 0,
+        ready: 0,
+        ready_to_publish: 0,
+        published_to_meta_paused: 0,
+        scheduled: 0,
+        live: 0,
+      },
+    },
+  });
+
+  assert.equal(dashboard.posts.length, 1);
+  assert.equal(dashboard.assets.length, 2);
+  assert.equal(dashboard.publishItems.length, 1);
+  assert.equal(dashboard.campaign?.counts.scripts, 1);
+  assert.notEqual(dashboard.assets[0].id, 'tenant_dashboard_partial_stage-image');
+  assert.equal(dashboard.posts[0].previewAssetId, dashboard.assets[0].id);
+  assert.equal(dashboard.assets[0].previewUrl?.startsWith('data:image/svg+xml;base64,'), true);
+  assert.equal(JSON.stringify(dashboard).includes('api_key'), false);
+  assert.equal(JSON.stringify(dashboard).includes('dashboardTextSecret123'), false);
+  assert.equal(JSON.stringify(dashboard).includes('tenant_dashboard_partial_stage'), false);
 });


### PR DESCRIPTION
## Summary
- Project Hermes weekly social-content runtime outputs into the job dashboard as posts, image/script assets, publish items, and calendar events.
- Generate deterministic tenant-safe SVG image previews when Hermes image artifacts are missing or unsafe/internal, with posts and publish queue linked to image preview assets.
- Merge partial staged weekly outputs without erasing earlier posts/images/scripts, sanitize tenant/token-like strings, and keep dashboard status counts aligned with posts + publish items.

## Verification
- npm run typecheck
- APP_BASE_URL=https://aries.example.com npx tsx --test tests/social-content-weekly-defaults.test.ts --test-name-pattern "dashboard projection"
- npm run validate:social-content
- npm run validate:repo-boundary
- npm run validate:banned-patterns
- npm run verify
- Independent reviewer subagent passed