### PR TITLE
fix: restore deploy workflow YAML indentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,13 +118,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-       - name: Publish exact deploy image
-         env:
-           TARGET_IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
-           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-           DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }}
-           PUBLISH_SHA_ONLY: "1"
-         run: |
+      - name: Publish exact deploy image
+        env:
+          TARGET_IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }}
+          PUBLISH_SHA_ONLY: "1"
+        run: |
           set -euo pipefail
           if [[ ! "${TARGET_IMAGE_TAG}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Skipping image publish for non-SHA tag ${TARGET_IMAGE_TAG}; assuming it already exists."


### PR DESCRIPTION
## Summary
- Fixes invalid indentation in `.github/workflows/deploy.yml` introduced on PR #269
- Restores YAML parsing for exact-SHA deploy publishing

## Test Plan
- `python3` YAML parse of `.github/workflows/deploy.yml`
- `npx tsx --test tests/deploy-workflow-self-hosted.regression-015.test.ts`
- `git diff --check origin/master...HEAD`

Follow-up for #269.