### PR TITLE
fix: sanitize Meta page picker tenant errors

### DIFF
--- a/backend/integrations/meta/select-page.ts
+++ b/backend/integrations/meta/select-page.ts
@@ -84,7 +84,7 @@ export async function handleMetaSelectPageHttp(
       {
         status: 'error',
         reason: 'not_authenticated',
-        message: error instanceof Error ? error.message : reason,
+        message: reason,
       },
       401,
     );

--- a/tests/oauth-meta-callback.test.ts
+++ b/tests/oauth-meta-callback.test.ts
@@ -5,6 +5,7 @@ import pool from '../lib/db';
 import { decryptToken } from '../backend/integrations/oauth-crypto';
 import { oauthCallback } from '../backend/integrations/callback';
 import { handleMetaSelectPageHttp } from '../backend/integrations/meta/select-page';
+import { TenantContextError } from '../lib/tenant-context';
 
 const BASE64_KEY = Buffer.alloc(32, 7).toString('base64');
 
@@ -456,6 +457,32 @@ test('meta callback: multi-page returns picker_required and stashes pages in pen
     assert.equal(payload.pages?.length, 3);
     const stashedDelta = payload.pages?.find((p) => p.id === 'page_delta');
     assert.equal(stashedDelta?.instagramBusinessAccountId, null);
+  });
+});
+
+test('handleMetaSelectPageHttp: returns sanitized tenant context errors', async () => {
+  await withEnv(META_ENV, async () => {
+    const req = new Request('https://aries.example.com/api/oauth/meta/select-page', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ state: 'state_auth_error', page_id: 'page_x' }),
+    });
+    const res = await handleMetaSelectPageHttp(req, {
+      tenantContextLoader: async () => {
+        throw new TenantContextError(
+          'tenant_claims_incomplete',
+          'Sensitive tenant lookup failed at stack frame /internal/path.ts:42',
+          ['tenantId'],
+        );
+      },
+    });
+
+    assert.equal(res.status, 401);
+    const body = (await res.json()) as { status: string; reason: string; message?: string };
+    assert.equal(body.status, 'error');
+    assert.equal(body.reason, 'not_authenticated');
+    assert.equal(body.message, 'tenant_claims_incomplete');
+    assert.doesNotMatch(JSON.stringify(body), /Sensitive tenant lookup|internal\/path|stack frame/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Sanitizes Meta page-picker tenant context errors so raw exception text is not returned to clients
- Adds a regression test proving sensitive error strings and stack/path-like details are omitted

## Test Plan
- `npm exec -- tsx --test tests/oauth-meta-callback.test.ts`
- `npm run verify`

Follow-up for CodeQL/Copilot feedback left on merged PR #269.
