### PR TITLE
fix(ci): repair deploy workflow YAML indentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,13 +118,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-       - name: Publish exact deploy image
-         env:
-           TARGET_IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
-           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-           DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }}
-           PUBLISH_SHA_ONLY: "1"
-         run: |
+      - name: Publish exact deploy image
+        env:
+          TARGET_IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }}
+          PUBLISH_SHA_ONLY: "1"
+        run: |
           set -euo pipefail
           if [[ ! "${TARGET_IMAGE_TAG}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Skipping image publish for non-SHA tag ${TARGET_IMAGE_TAG}; assuming it already exists."


### PR DESCRIPTION
## Summary
- Fixes invalid indentation in the Deploy workflow around the exact-SHA image publish step.
- Restores valid YAML parsing so workflow_dispatch can be used for exact-SHA deploy recovery after PR #269.

## Test Plan
- python3 - <<'PY'
from pathlib import Path
import yaml
with Path('.github/workflows/deploy.yml').open() as f:
    yaml.safe_load(f)
print('deploy.yml YAML parses')
PY
- git diff --check

Recovery context: PR #269 merge SHA e84b7ce63b1b3828fca5767501038b3272fbe62b could not be dispatched through Deploy because the workflow file was invalid.