### PR TITLE
fix: redact Meta tenant picker errors

### DIFF
--- a/backend/integrations/meta/select-page.ts
+++ b/backend/integrations/meta/select-page.ts
@@ -80,11 +80,12 @@ export async function handleMetaSelectPageHttp(
     tenantContext = await loader();
   } catch (error) {
     const reason = error instanceof TenantContextError ? error.reason : 'tenant_context_required';
+    console.warn('Meta page selection request missing tenant context', error);
     return jsonResponse(
       {
         status: 'error',
         reason: 'not_authenticated',
-        message: error instanceof Error ? error.message : reason,
+        message: reason,
       },
       401,
     );

--- a/tests/oauth-meta-callback.test.ts
+++ b/tests/oauth-meta-callback.test.ts
@@ -5,6 +5,7 @@ import pool from '../lib/db';
 import { decryptToken } from '../backend/integrations/oauth-crypto';
 import { oauthCallback } from '../backend/integrations/callback';
 import { handleMetaSelectPageHttp } from '../backend/integrations/meta/select-page';
+import { TenantContextError } from '../lib/tenant-context';
 
 const BASE64_KEY = Buffer.alloc(32, 7).toString('base64');
 
@@ -465,6 +466,42 @@ test('meta callback: multi-page returns picker_required and stashes pages in pen
     assert.equal(payload.pages?.length, 3);
     const stashedDelta = payload.pages?.find((p) => p.id === 'page_delta');
     assert.equal(stashedDelta?.instagramBusinessAccountId, null);
+  });
+});
+
+test('handleMetaSelectPageHttp: returns sanitized tenant context errors and logs details', async (t) => {
+  await withEnv(META_ENV, async () => {
+    const logged: unknown[] = [];
+    t.mock.method(console, 'warn', (...args: unknown[]) => {
+      logged.push(args);
+    });
+
+    const req = new Request('https://aries.example.com/api/oauth/meta/select-page', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ state: 'state_auth_error', page_id: 'page_x' }),
+    });
+    const res = await handleMetaSelectPageHttp(req, {
+      tenantContextLoader: async () => {
+        throw new TenantContextError(
+          'tenant_claims_incomplete',
+          'Sensitive tenant lookup failed at stack frame /internal/path.ts:42',
+          ['tenantId'],
+        );
+      },
+    });
+
+    assert.equal(res.status, 401);
+    const body = (await res.json()) as { status: string; reason: string; message?: string };
+    assert.deepEqual(body, {
+      status: 'error',
+      reason: 'not_authenticated',
+      message: 'tenant_claims_incomplete',
+    });
+    assert.doesNotMatch(JSON.stringify(body), /Sensitive tenant lookup|internal\/path|stack frame/);
+    assert.equal(logged.length, 1);
+    assert.match(String(logged[0]), /Meta page selection request missing tenant context/);
+    assert.match(String(logged[0]), /Sensitive tenant lookup failed/);
   });
 });
 

--- a/tests/social-content-approve-route.test.ts
+++ b/tests/social-content-approve-route.test.ts
@@ -220,9 +220,10 @@ test('plan approval submits Hermes resume request body', async () => {
       assert.equal(calls[0].body.job_id, jobId);
       assert.equal(calls[0].body.tenant_id, 'tenant-social-approve');
       assert.equal(calls[0].body.callback_url, 'https://aries.example.com/api/internal/hermes/runs');
-      assert.equal(calls[0].body.callback_auth.type, 'internal_api_secret_bearer');
-      assert.equal(calls[0].body.callback_auth.secret_ref, 'INTERNAL_API_SECRET');
-      assert.match(String(calls[0].body.callback_auth.callback_token), /^[0-9a-f]{64}$/);
+      const callbackAuth = calls[0].body.callback_auth as Record<string, unknown>;
+      assert.equal(callbackAuth.type, 'internal_api_secret_bearer');
+      assert.equal(callbackAuth.secret_ref, 'INTERNAL_API_SECRET');
+      assert.match(String(callbackAuth.callback_token), /^[0-9a-f]{64}$/);
       assert.deepEqual(calls[0].body.callback_context, {
         workflow_key: 'social_content_weekly',
         aries_run_id: calls[0].body.aries_run_id,


### PR DESCRIPTION
## Summary
- Redacts Meta page-picker tenant context failures so clients receive only a safe reason code.
- Logs the full tenant-context failure server-side before returning the sanitized 401.
- Adds regression coverage for the sanitized response/logging path.
- Includes a small test type-safety cleanup needed for `npm run typecheck` on current `master`.

Follow-up for Copilot's inline comment on closed PR #272: https://github.com/DeliciousHouse/aries-app/pull/272#discussion_r2887293311

## Test Plan
- `npx tsx --test tests/oauth-meta-callback.test.ts`
- `npx tsx --test tests/oauth-meta-callback.test.ts tests/social-content-approve-route.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run workspace:verify` from canonical `/home/node/aries-app`

Note: `npm run workspace:verify` in the temp worktree correctly fails because it asserts the canonical root is `/home/node/aries-app`; the canonical-root run passes.
