### PR TITLE
fix(api): wrap aries-research callback POST for Next.js 16 route typing

### DIFF
--- a/app/api/internal/aries-research/callback/route.ts
+++ b/app/api/internal/aries-research/callback/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import { verifyInternalCallbackRequest, verifyPlaintextMatchesCallbackTokenHash } from '@/lib/internal-callback-auth';
 import { createMemoryOrchestrator } from '@/backend/memory/orchestrator';
@@ -40,7 +40,7 @@ function deriveJobStatus(
   return 'completed';
 }
 
-export async function POST(req: Request, opts?: { transport?: HonchoTransport }) {
+export async function handleResearchCallback(req: Request, opts?: { transport?: HonchoTransport }) {
   const authResult = verifyInternalCallbackRequest(req);
   if (!authResult.ok) {
     return NextResponse.json({ status: 'error', reason: authResult.reason }, { status: authResult.status });
@@ -119,4 +119,8 @@ export async function POST(req: Request, opts?: { transport?: HonchoTransport })
     ok: true,
     counts: { approved, queued, dropped },
   });
+}
+
+export async function POST(req: NextRequest) {
+  return handleResearchCallback(req);
 }

--- a/tests/memory-research-callback.test.ts
+++ b/tests/memory-research-callback.test.ts
@@ -179,7 +179,7 @@ test('happy path: correct counts, Honcho write for auto-approved only, status be
 
     t.mock.method(pool, 'query', harness.query as typeof pool.query);
 
-    const { POST } = await import('../app/api/internal/aries-research/callback/route');
+    const { handleResearchCallback: POST } = await import('../app/api/internal/aries-research/callback/route');
 
     const req = callbackRequest({
       jobId: job.id,
@@ -206,7 +206,7 @@ test('all 4 findings recorded in aries_research_findings', async (t) => {
 
     t.mock.method(pool, 'query', harness.query as typeof pool.query);
 
-    const { POST } = await import('../app/api/internal/aries-research/callback/route');
+    const { handleResearchCallback: POST } = await import('../app/api/internal/aries-research/callback/route');
 
     await POST(callbackRequest({
       jobId: job.id,
@@ -226,7 +226,7 @@ test('only auto-approved finding reaches Honcho transport', async (t) => {
 
     t.mock.method(pool, 'query', harness.query as typeof pool.query);
 
-    const { POST } = await import('../app/api/internal/aries-research/callback/route');
+    const { handleResearchCallback: POST } = await import('../app/api/internal/aries-research/callback/route');
 
     await POST(callbackRequest({
       jobId: job.id,
@@ -250,7 +250,7 @@ test('job status flips to needs_review when something is queued', async (t) => {
 
     t.mock.method(pool, 'query', harness.query as typeof pool.query);
 
-    const { POST } = await import('../app/api/internal/aries-research/callback/route');
+    const { handleResearchCallback: POST } = await import('../app/api/internal/aries-research/callback/route');
 
     await POST(callbackRequest({
       jobId: job.id,
@@ -271,7 +271,7 @@ test('wrong callback token returns 403', async (t) => {
 
     t.mock.method(pool, 'query', harness.query as typeof pool.query);
 
-    const { POST } = await import('../app/api/internal/aries-research/callback/route');
+    const { handleResearchCallback: POST } = await import('../app/api/internal/aries-research/callback/route');
 
     const res = await POST(callbackRequest({
       jobId: job.id,
@@ -293,7 +293,7 @@ test('unknown jobId returns 404', async (t) => {
 
     t.mock.method(pool, 'query', harness.query as typeof pool.query);
 
-    const { POST } = await import('../app/api/internal/aries-research/callback/route');
+    const { handleResearchCallback: POST } = await import('../app/api/internal/aries-research/callback/route');
 
     const res = await POST(callbackRequest({
       jobId: randomUUID(),
@@ -313,7 +313,7 @@ test('missing INTERNAL_API_SECRET bearer returns 401 or 403', async (t) => {
 
     t.mock.method(pool, 'query', harness.query as typeof pool.query);
 
-    const { POST } = await import('../app/api/internal/aries-research/callback/route');
+    const { handleResearchCallback: POST } = await import('../app/api/internal/aries-research/callback/route');
 
     const res = await POST(callbackRequest({
       jobId: job.id,


### PR DESCRIPTION
## Summary

- **Master is currently un-deployable.** Deploy workflow run 25664538264 (commit 113b9a9) failed with a TypeScript build error caused by the `POST` handler in `app/api/internal/aries-research/callback/route.ts` accepting a custom second argument (`opts?: { transport?: HonchoTransport }`). Next.js 16's `RouteHandlerConfig` type constraint requires the second parameter to be `{ params: Promise<{}> }`, making any other shape a type error.
- Renamed the internal implementation to `handleResearchCallback(req, opts?)` — signature and transport-injection semantics are unchanged.
- Added a thin `export async function POST(req: NextRequest)` wrapper that satisfies the Next.js runtime typing and delegates to `handleResearchCallback`.
- Updated `tests/memory-research-callback.test.ts` to import `handleResearchCallback` directly (aliased as `POST` locally) so all transport-injection test cases continue to work without modification.

## Verification

- `npm run typecheck` — passes (previously errored)
- `npm run verify` — passes (full regression gate)

## Sibling route scan

```
grep -rn "export async function POST.*opts" app/api/
grep -rn "export async function POST.*transport" app/api/
```

Only `app/api/internal/aries-research/callback/route.ts` matched. No other routes have this antipattern — no additional cleanup needed.

## Test plan

- [ ] Typecheck passes locally (`npm run typecheck`)
- [ ] `npm run verify` passes
- [ ] Deploy workflow re-runs successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)