### PR TITLE
fix(deploy): amd64-only build + force apt IPv4 to unbreak self-hosted deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,6 +124,9 @@ jobs:
           GHCR_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           DEFAULT_BRANCH_NAME: ${{ github.event.repository.default_branch }}
           PUBLISH_SHA_ONLY: "1"
+          # Production runs amd64 only. Skip arm64 to avoid QEMU emulation cost
+          # (10-20x slower) on x86_64 self-hosted runners.
+          PLATFORMS: linux/amd64
         run: |
           set -euo pipefail
           if [[ ! "${TARGET_IMAGE_TAG}" =~ ^[0-9a-f]{40}$ ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV DATA_ROOT=/data
 ENV HOME=/home/node
 
 RUN set -eux; \
+  echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4; \
   apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \


### PR DESCRIPTION
## Summary
- `publish-image.sh` defaults `PLATFORMS` to `linux/amd64,linux/arm64`. On the x86_64 self-hosted runner that arrived in this repo today, arm64 builds via QEMU added ~15 minutes per deploy with no production benefit. Pin `PLATFORMS=linux/amd64` in the publish step.
- The runner host has no working IPv6 route. `apt-get update` inside the build container tries IPv6 first, times out on `deb.debian.org` `InRelease` fetches, and falls back — burning ~5 minutes per `apt-get update`. Drop `/etc/apt/apt.conf.d/99force-ipv4` in the runner stage so apt skips IPv6 unconditionally.

## Test plan
- [ ] Land this PR; observe Deploy workflow time drops from ~30 min to ~3-5 min.
- [ ] Confirm container reaches v0.1.2.4 with `HONCHO_WRITE_PUBLISH_ENABLED=true` and `HONCHO_WRITE_APPROVALS_ENABLED=true` in env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)