### PR TITLE
fix(partners): apply DB schema on start + decouple outbox from delivery config

### DIFF
--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -6,7 +6,7 @@ import bcrypt from 'bcryptjs';
 import { enqueuePartnerAttribution } from '@/backend/partners/outbox';
 import { ensureUserJourneySchema } from '@/lib/auth-user-journey';
 import pool from '@/lib/db';
-import { partnerAttributionDeliveryConfigured } from '@/lib/partner-attribution-env';
+import { partnerAttributionEnabled } from '@/lib/partner-attribution-env';
 import { PARTNER_REF_COOKIE_NAME, parsePartnerRefCookie } from '@/lib/partner-ref-cookie';
 
 export async function userExists(email: string): Promise<boolean> {
@@ -74,7 +74,7 @@ export async function registerUserAction(formData: any) {
       const userId = String(userResult.rows[0].id);
       const emailDomain = typeof email === 'string' && email.includes('@') ? email.split('@')[1] : null;
 
-      if (partnerRef && partnerAttributionDeliveryConfigured()) {
+      if (partnerRef && partnerAttributionEnabled()) {
         await enqueuePartnerAttribution(client, {
           userId,
           refCode: partnerRef,
@@ -87,7 +87,11 @@ export async function registerUserAction(formData: any) {
 
       await client.query('COMMIT');
 
-      if (partnerRef && partnerAttributionDeliveryConfigured()) {
+      // Always consume the cookie when a valid ref was parsed and a user
+      // was created — independent of whether the outbox row got written.
+      // The cookie is single-use intent; persisting it would let a second
+      // signup from the same browser silently re-attribute to a stale ref.
+      if (partnerRef) {
         cookieStore.delete(PARTNER_REF_COOKIE_NAME);
       }
 

--- a/auth.ts
+++ b/auth.ts
@@ -22,7 +22,7 @@ import {
   normalizeEmail,
   tenantClaimsErrorRedirect,
 } from "./lib/auth-tenant-membership";
-import { partnerAttributionDeliveryConfigured } from "./lib/partner-attribution-env";
+import { partnerAttributionEnabled } from "./lib/partner-attribution-env";
 import { PARTNER_REF_COOKIE_NAME, parsePartnerRefCookie } from "./lib/partner-ref-cookie";
 
 const authRuntime = resolveAuthRuntimeConfig(process.env);
@@ -192,7 +192,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                 role?: string | null;
               };
 
-              if (partnerRef && partnerAttributionDeliveryConfigured()) {
+              if (partnerRef && partnerAttributionEnabled()) {
                 await enqueuePartnerAttribution(client, {
                   userId: String(authenticatedUser.id),
                   refCode: partnerRef,
@@ -208,7 +208,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               throw insertErr;
             }
 
-            if (partnerRef && partnerAttributionDeliveryConfigured()) {
+            // Cookie is single-use intent; clear whenever we parsed a valid
+            // ref and successfully created the user, regardless of whether
+            // the outbox row got written (delivery config can be partial).
+            if (partnerRef) {
               cookieStore.delete(PARTNER_REF_COOKIE_NAME);
             }
           }

--- a/backend/partners/outbox.ts
+++ b/backend/partners/outbox.ts
@@ -1,7 +1,10 @@
 import type { Pool, PoolClient } from 'pg';
 
 import { postAriesSignup, type AriesSignupPayload, type VmsPostResult } from '@/backend/partners/vms-client';
-import { partnerAttributionDeliveryConfigured } from '@/lib/partner-attribution-env';
+import {
+  partnerAttributionDeliveryConfigured,
+  partnerAttributionEnabled,
+} from '@/lib/partner-attribution-env';
 
 export type PartnerAttributionEnqueueInput = {
   userId: string;
@@ -12,11 +15,18 @@ export type PartnerAttributionEnqueueInput = {
   domain?: string | null;
 };
 
+/**
+ * Capture the partner-attribution intent at signup time. Only gated on the
+ * light feature flag — we want the row written even if the VMS delivery
+ * config (base URL + webhook secret) isn't set yet, so a later config fix
+ * delivers the backlog instead of silently losing attributions. The worker
+ * checks the full delivery config at drain time.
+ */
 export async function enqueuePartnerAttribution(
   client: PoolClient,
   input: PartnerAttributionEnqueueInput,
 ): Promise<void> {
-  if (!partnerAttributionDeliveryConfigured()) {
+  if (!partnerAttributionEnabled()) {
     return;
   }
 

--- a/scripts/start-runtime.mjs
+++ b/scripts/start-runtime.mjs
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import cluster from 'node:cluster';
 import os from 'node:os';
 import path from 'node:path';
@@ -35,6 +35,27 @@ const runtimeEnv = {
   NODE_ENV: process.env.NODE_ENV || 'production',
   PORT: String(parsedPort),
 };
+
+// Apply DB schema before forking any workers. init-db.js uses `CREATE TABLE
+// IF NOT EXISTS` / `ALTER ... IF NOT EXISTS`, so this is idempotent and safe
+// to re-run on every container start. We block here because feature code
+// (e.g. partner_attribution_outbox enqueue) assumes the schema exists; if
+// init-db fails we don't want to fork workers and serve traffic that will
+// roll back transactions.
+const skipInit = (process.env.ARIES_SKIP_DB_INIT ?? '').trim().toLowerCase();
+if (skipInit !== '1' && skipInit !== 'true') {
+  const initDbPath = path.join(projectRoot, 'scripts', 'init-db.js');
+  const initResult = spawnSync(process.execPath, [initDbPath], {
+    stdio: 'inherit',
+    env: runtimeEnv,
+  });
+  if (initResult.status !== 0) {
+    console.error(
+      `[runtime] init-db.js exited with code=${String(initResult.status)} signal=${String(initResult.signal ?? '')}; refusing to start workers`,
+    );
+    process.exit(1);
+  }
+}
 
 if (processManager === 'cluster') {
   startClusterRuntime();

--- a/tests/partner-outbox.test.ts
+++ b/tests/partner-outbox.test.ts
@@ -48,8 +48,34 @@ test('enqueuePartnerAttribution inserts when delivery is configured', async () =
   assert.ok(statements.some((s) => s.includes('INSERT INTO partner_attribution_outbox')));
 });
 
-test('enqueuePartnerAttribution is a no-op when delivery is not configured', async () => {
+test('enqueuePartnerAttribution still inserts when feature enabled but VMS delivery not yet configured', async () => {
+  // This is the load-bearing outbox semantic: capture intent at signup time
+  // even if the VMS base URL / webhook secret isn't propagated to this env
+  // yet. The worker picks up the backlog once delivery is configured. The
+  // previous behaviour silently dropped attributions on deploys that
+  // shipped PARTNER_ATTRIBUTION_ENABLED=true ahead of VMS_WEBHOOK_SECRET.
   delete process.env.VMS_WEBHOOK_SECRET;
+  let inserted = false;
+  const client = {
+    async query(sql: string) {
+      if (sql.includes('INSERT INTO partner_attribution_outbox')) {
+        inserted = true;
+      }
+      return { rowCount: 1, rows: [] };
+    },
+  } as unknown as PoolClient;
+
+  await enqueuePartnerAttribution(client, {
+    userId: '1',
+    refCode: 'ref9',
+    name: 'N',
+    email: 'e@x.com',
+  });
+  assert.equal(inserted, true);
+});
+
+test('enqueuePartnerAttribution is a no-op when the feature flag itself is disabled', async () => {
+  delete process.env.PARTNER_ATTRIBUTION_ENABLED;
   let called = false;
   const client = {
     async query() {
@@ -65,6 +91,23 @@ test('enqueuePartnerAttribution is a no-op when delivery is not configured', asy
     email: 'e@x.com',
   });
   assert.equal(called, false);
+});
+
+test('drainPartnerAttributionOutboxOnce skips when VMS delivery is not configured', async () => {
+  delete process.env.VMS_WEBHOOK_SECRET;
+  let queried = false;
+  const client = {
+    async query() {
+      queried = true;
+      return { rowCount: 0, rows: [] };
+    },
+  } as unknown as PoolClient;
+
+  const n = await drainPartnerAttributionOutboxOnce(client, async () => ({ ok: true, status: 201 }));
+  assert.equal(n, 0);
+  // The worker MUST NOT open a transaction or pick rows when it can't deliver
+  // them; backlog stays in `pending` for the next tick after config lands.
+  assert.equal(queried, false);
 });
 
 test('drainPartnerAttributionOutboxOnce marks delivered on 201', async () => {


### PR DESCRIPTION
## Summary
- Fix three load-bearing bugs in #295's partner-attribution implementation that together left the feature silently dead in prod and primed a signup-breaking failure for the day `VMS_WEBHOOK_SECRET` lands in the env.
- Make this PR an alternative to closing #296 (the panic-revert). Once this lands, #296 can be closed without merging.

## The bugs (and why they happened together)

### 1. `partner_attribution_outbox` table never created in prod (would break signups)
`scripts/init-db.js` only runs when a developer manually invokes `npm run db:init`. There's no Dockerfile entrypoint, no `start-runtime.mjs` hook, no `.github/workflows/deploy.yml` step. When `VMS_WEBHOOK_SECRET` is eventually set in prod, every signup with a partner ref cookie would `INSERT INTO partner_attribution_outbox` on a table that doesn't exist → the user-creation transaction rolls back → signup fails.

**Fix:** `scripts/start-runtime.mjs` now `spawnSync`s `init-db.js` before forking any workers. Refuses to start workers on non-zero exit. `ARIES_SKIP_DB_INIT=1` available for explicit opt-out.

### 2. `enqueuePartnerAttribution` silently dropped writes when delivery wasn't fully configured
The enqueue gate was `partnerAttributionDeliveryConfigured()` — `PARTNER_ATTRIBUTION_ENABLED && VMS_BASE_URL && VMS_WEBHOOK_SECRET`. If the feature flag flipped on in an env that didn't yet have the secret, every signup silently no-op'd. No log, no metric, no error. That's the exact failure mode an outbox is supposed to prevent.

**Fix:** enqueue is now gated only on the light `partnerAttributionEnabled()` check. The worker keeps the strict delivery check at drain time. Rows written before the secret lands get delivered once it does.

### 3. Cookie not cleared when enqueue was skipped (compounding attribution drift)
The `cookieStore.delete(PARTNER_REF_COOKIE_NAME)` call sat inside the same `partnerAttributionDeliveryConfigured()` conditional. So when the gate skipped the enqueue (bug #2), the 90-day cookie persisted. Two signups from the same browser would both silently no-op. Then when delivery config landed, the third signup would attribute to a stale ref.

**Fix:** cookie is cleared whenever a valid ref was parsed and a user was created, regardless of delivery state. Single-use intent semantics.

## How these bugs masked each other in prod
PR #295 deployed → table didn't exist (bug 1). But `VMS_WEBHOOK_SECRET` was unset in prod, so bug 2 silently no-op'd every enqueue, which prevented bug 1 from being triggered. Feature appeared to work (no errors logged) while doing nothing. The bomb would have detonated the moment someone set the secret.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run verify` — 20/20 tests pass (outbox suite extended with two new regressions: enqueue still writes when feature on but VMS not configured; worker still skips drain when delivery not configured)
- [ ] After merge: confirm `init-db.js` runs in the deploy logs of the first deployment; query `\d partner_attribution_outbox` on prod DB to confirm schema is present.
- [ ] After merge: set `VMS_WEBHOOK_SECRET` in prod env. Signup through `https://aries.sugarandleather.com/signup?ref=<real-partner-code>`. Confirm an outbox row appears with `status='delivered'` within ~30s.

## Related
- Closes #296 (panic-revert no longer needed — fixing forward).
- Built on top of #295.