### PR TITLE
fix(init-db): backfill missing columns before CREATE INDEX (unblock prod deploys)

### DIFF
--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -457,6 +457,27 @@ async function initDb() {
       ALTER TABLE creative_assets
         ADD COLUMN IF NOT EXISTS orphaned_at TIMESTAMPTZ;
 
+      -- Backfill columns that may be missing on databases provisioned before
+      -- these tables got their full schemas. `CREATE TABLE IF NOT EXISTS`
+      -- above is a no-op when the table already exists, so older deployments
+      -- end up with stub schemas missing the columns the CREATE INDEX below
+      -- requires. ADD COLUMN IF NOT EXISTS is idempotent on fresh tables.
+      -- Without these, init-db.js crashes at boot with
+      -- `error: column "post_id" does not exist` and the container restarts
+      -- forever (observed: PR #297 and PR #298 prod deploys, 2026-05-12).
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS post_id BIGINT;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS creative_id BIGINT;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS attempt_number INTEGER NOT NULL DEFAULT 1;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS brand_color_match_score NUMERIC;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS text_legibility_score NUMERIC;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS forbidden_pattern_hits INTEGER;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS brand_violation_score NUMERIC;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS verdict TEXT;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS model_version TEXT;
+      ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS raw_model_output JSONB;
+      ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS post_id BIGINT;
+      ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS target_platforms TEXT[] NOT NULL DEFAULT '{}';
+
       CREATE INDEX IF NOT EXISTS idx_posts_tenant_created ON posts (tenant_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_vision_qa_runs_tenant_post ON vision_qa_runs (tenant_id, post_id);
       CREATE INDEX IF NOT EXISTS idx_scheduled_posts_tenant_scheduled ON scheduled_posts (tenant_id, scheduled_for);


### PR DESCRIPTION
## Summary

Production is currently 502 — both PR #298 (`c93e69e`) and PR #297 (`bce5aa1`) deploys have failed with the same symptom over the past 3 hours. Container starts, init-db.js crashes, container restart-loops forever.

## Root cause

Confirmed via `docker logs aries-app-aries-app-1`:

```
Error initializing database: error: column "post_id" does not exist
    at async initDb (/app/scripts/init-db.js:383:5) {
  routine: 'ComputeIndexAttrs'
}
[runtime] init-db.js exited with code=1 signal=; refusing to start workers
```

PR #298 wired init-db.js to run on every container start. That surfaced a latent issue: production databases provisioned before #269 ("Weekly social content pipeline checkpoint") have stub schemas for `vision_qa_runs` and `scheduled_posts`. `CREATE TABLE IF NOT EXISTS` is a no-op when the tables exist, so older deployments never picked up the `post_id` (and other) columns those tables now need. Init then crashes at `scripts/init-db.js:461` when it tries to `CREATE INDEX ... ON vision_qa_runs (tenant_id, post_id)` — the column doesn't exist on the existing prod table.

## Fix

Add `ALTER TABLE … ADD COLUMN IF NOT EXISTS …` for every column referenced by the CREATE INDEX statements that follow, mirroring the existing pattern at `init-db.js:376-377` (password_resets.attempts) and 450-451 (creative_assets.superseded_by). Idempotent on fresh databases.

Covers `vision_qa_runs.{post_id, creative_id, attempt_number, brand_color_match_score, text_legibility_score, forbidden_pattern_hits, brand_violation_score, verdict, model_version, raw_model_output}` and `scheduled_posts.{post_id, target_platforms}`.

## Test plan

- [x] `npm run typecheck` — clean (no TS changes)
- [ ] Deploy verification: production responds 200 on `/` after this deploys
- [ ] After this lands, re-deploy PR #297's changes by retrying or by a follow-up PR — its code is already on master in `bce5aa1`, so a fresh deploy on top of this hotfix should pick it up too

## Context

The 502 has been live for ~30 minutes as of this PR. Two PRs are blocked by it (#297 just merged, #298 already merged). This is a forward-fix to unblock both — no revert needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)