### PR TITLE
fix(init-db): remove stray backticks that broke template literal (prod still 502)

### DIFF
--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -458,12 +458,12 @@ async function initDb() {
         ADD COLUMN IF NOT EXISTS orphaned_at TIMESTAMPTZ;
 
       -- Backfill columns that may be missing on databases provisioned before
-      -- these tables got their full schemas. `CREATE TABLE IF NOT EXISTS`
+      -- these tables got their full schemas. CREATE TABLE IF NOT EXISTS
       -- above is a no-op when the table already exists, so older deployments
       -- end up with stub schemas missing the columns the CREATE INDEX below
       -- requires. ADD COLUMN IF NOT EXISTS is idempotent on fresh tables.
       -- Without these, init-db.js crashes at boot with
-      -- `error: column "post_id" does not exist` and the container restarts
+      -- "error: column post_id does not exist" and the container restarts
       -- forever (observed: PR #297 and PR #298 prod deploys, 2026-05-12).
       ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS post_id BIGINT;
       ALTER TABLE vision_qa_runs ADD COLUMN IF NOT EXISTS creative_id BIGINT;


### PR DESCRIPTION
## Summary

My #299 introduced backticks inside SQL comments. Those comments are inside a JS template literal, so the inner backticks closed the template literal early. Production restart loop now boots with:

```
/app/scripts/init-db.js:383
    await client.query(\`
                       ^
SyntaxError: missing ) after argument list
```

Comments rewritten to use plain text. Verified with \`node --check scripts/init-db.js\` before pushing this time.

## Test plan

- [x] \`node --check scripts/init-db.js\` passes
- [ ] Production responds 200 after this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)