### PR TITLE
fix(marketing): add tenant segment to stage cache paths (PRD audit Finding 1)

### DIFF
--- a/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
@@ -255,7 +255,13 @@ export async function handleGetMarketingJobAsset(
     return assetNotFoundResponse(jobId, assetId, 'asset_descriptor_missing');
   }
 
-  const buffer = await readMarketingAssetWithinAllowedRoots(asset.filePath);
+  // Always pass the runtime doc's tenant_id (not the caller's tenant context)
+  // so cross-tenant boundary checks fire even on public-mode reads where the
+  // caller may not have a tenant. The runtime doc's tenant_id already passed
+  // the requiresTenantContext check above for authenticated reads.
+  const buffer = await readMarketingAssetWithinAllowedRoots(asset.filePath, {
+    tenantId: runtimeDoc.tenant_id,
+  });
   if (!buffer) {
     return assetNotFoundResponse(jobId, assetId, 'asset_file_missing');
   }

--- a/app/materials/[jobId]/[assetId]/page.tsx
+++ b/app/materials/[jobId]/[assetId]/page.tsx
@@ -92,7 +92,9 @@ export default async function MaterialsViewerPage({
   // reach identical to the API's — a malformed or out-of-root filePath in
   // the runtime doc cannot coerce the viewer into reading an arbitrary
   // file on disk.
-  const rawBuffer = await readMarketingAssetWithinAllowedRoots(asset.filePath);
+  const rawBuffer = await readMarketingAssetWithinAllowedRoots(asset.filePath, {
+    tenantId: runtimeDoc.tenant_id,
+  });
   if (!rawBuffer) {
     notFound();
   }

--- a/backend/marketing/artifact-collector.ts
+++ b/backend/marketing/artifact-collector.ts
@@ -36,7 +36,17 @@ function cacheRoot(envKey: string, fallbackFolder: string): string {
   return process.env[envKey]?.trim() || path.join(tmpdir(), fallbackFolder);
 }
 
-function stepPayloadPath(stage: 1 | 2 | 3 | 4, runId: string, stepName: string): string {
+function stepPayloadPath(
+  stage: 1 | 2 | 3 | 4,
+  runId: string,
+  stepName: string,
+  tenantId: string,
+): string {
+  if (!tenantId) {
+    // Fail closed: callers that lost the tenant context must not surface a
+    // shared-root cache path.
+    throw new Error(`stepPayloadPath requires a non-empty tenantId (stage=${stage}, run=${runId})`);
+  }
   const root =
     stage === 1
       ? cacheRoot('LOBSTER_STAGE1_CACHE_DIR', 'lobster-stage1-cache')
@@ -45,7 +55,7 @@ function stepPayloadPath(stage: 1 | 2 | 3 | 4, runId: string, stepName: string):
         : stage === 3
           ? cacheRoot('LOBSTER_STAGE3_CACHE_DIR', 'lobster-stage3-cache')
           : cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache');
-  return path.join(root, runId, `${stepName}.json`);
+  return path.join(root, tenantId, runId, `${stepName}.json`);
 }
 
 async function readJsonIfExists(filePath: string): Promise<Record<string, unknown> | null> {
@@ -251,8 +261,9 @@ export async function collectResearchStageArtifacts(
   primaryOutput: Record<string, unknown> | null,
 ): Promise<StageCapture> {
   const runId = (await resolveRunId(primaryOutput, facts.runtimeDoc, 1)) || facts.runId;
-  const compilePath = runId ? stepPayloadPath(1, runId, 'ads_analyst_compile') : '';
-  const extractorPath = runId ? stepPayloadPath(1, runId, 'meta_ads_extractor') : '';
+  const tenantId = stringValue(facts.runtimeDoc?.tenant_id);
+  const compilePath = runId && tenantId ? stepPayloadPath(1, runId, 'ads_analyst_compile', tenantId) : '';
+  const extractorPath = runId && tenantId ? stepPayloadPath(1, runId, 'meta_ads_extractor', tenantId) : '';
   const [compile, extractor] = await Promise.all([
     facts.stagePayload('research', 'ads_analyst_compile'),
     facts.stagePayload('research', 'meta_ads_extractor'),
@@ -315,16 +326,17 @@ export async function collectStrategyReviewArtifacts(
     facts.stagePayload('strategy', 'strategy_review_preview'),
   ]);
   const runId = (await resolveRunId(primaryOutput, runtimeDoc, 2)) || facts.runId || null;
+  const tenantId = stringValue(runtimeDoc?.tenant_id);
   const websitePath =
     stringValue(asRecord(primaryOutput)?.validated_website_analysis_path) ||
     validatedDocs?.paths.websiteAnalysis ||
-    (runId ? stepPayloadPath(2, runId, 'website_brand_analysis') : '');
+    (runId && tenantId ? stepPayloadPath(2, runId, 'website_brand_analysis', tenantId) : '');
   const brandProfilePath =
     stringValue(asRecord(primaryOutput)?.validated_brand_profile_path) ||
     validatedDocs?.paths.brandProfile ||
     null;
-  const plannerPath = runId ? stepPayloadPath(2, runId, 'campaign_planner') : '';
-  const reviewPath = runId ? stepPayloadPath(2, runId, 'strategy_review_preview') : '';
+  const plannerPath = runId && tenantId ? stepPayloadPath(2, runId, 'campaign_planner', tenantId) : '';
+  const reviewPath = runId && tenantId ? stepPayloadPath(2, runId, 'strategy_review_preview', tenantId) : '';
   const rawRunWebsite = websiteStep || (websitePath ? await facts.jsonAtPath(websitePath) : null);
   const runWebsite = sourceMatchedRecord(
     rawRunWebsite,
@@ -426,9 +438,10 @@ export async function collectProductionReviewArtifacts(
     facts.stagePayload('production', 'veo_video_generator'),
   ]);
   const runId = (await resolveRunId(primaryOutput, runtimeDoc, 3)) || facts.runId || null;
-  const reviewPath = runId ? stepPayloadPath(3, runId, 'production_review_preview') : '';
-  const finalizePath = runId ? stepPayloadPath(3, runId, 'creative_director_finalize') : '';
-  const videoPath = runId ? stepPayloadPath(3, runId, 'veo_video_generator') : '';
+  const tenantId = stringValue(runtimeDoc?.tenant_id);
+  const reviewPath = runId && tenantId ? stepPayloadPath(3, runId, 'production_review_preview', tenantId) : '';
+  const finalizePath = runId && tenantId ? stepPayloadPath(3, runId, 'creative_director_finalize', tenantId) : '';
+  const videoPath = runId && tenantId ? stepPayloadPath(3, runId, 'veo_video_generator', tenantId) : '';
   const review = reviewStep || (reviewPath ? await facts.jsonAtPath(reviewPath) : null);
   const video = videoStep || (videoPath ? await facts.jsonAtPath(videoPath) : null);
   const jobId = runtimeDoc?.job_id || stringValue(primaryOutput?.job_id) || null;
@@ -512,8 +525,9 @@ export async function collectPublishReviewArtifacts(
     preflightStep?.runId ||
     reviewStep?.runId ||
     null;
-  const preflightPath = preflightStep?.path || (runId ? stepPayloadPath(4, runId, 'performance_marketer_preflight') : '');
-  const reviewPath = reviewStep?.path || (runId ? stepPayloadPath(4, runId, 'launch_review_preview') : '');
+  const tenantId = stringValue(runtimeDoc?.tenant_id);
+  const preflightPath = preflightStep?.path || (runId && tenantId ? stepPayloadPath(4, runId, 'performance_marketer_preflight', tenantId) : '');
+  const reviewPath = reviewStep?.path || (runId && tenantId ? stepPayloadPath(4, runId, 'launch_review_preview', tenantId) : '');
   const preflight = preflightStep?.payload || (preflightPath ? await readJsonIfExists(preflightPath) : null);
   const resolvedPublishReview = runtimeDoc ? await resolvePublishReviewBundle(runtimeDoc) : { reviewPayload: null, reviewBundle: null };
   // In docker setups, the lobster step cache lives on the gateway host (a different
@@ -680,9 +694,13 @@ export async function collectPublishReviewArtifacts(
   };
 }
 
-export async function collectPublishFinalizeArtifacts(primaryOutput: Record<string, unknown> | null): Promise<StageCapture> {
+export async function collectPublishFinalizeArtifacts(
+  primaryOutput: Record<string, unknown> | null,
+  runtimeDoc?: MarketingJobRuntimeDocument | null,
+): Promise<StageCapture> {
   const runId = await resolveRunId(primaryOutput);
-  const summaryPath = runId ? stepPayloadPath(4, runId, 'performance_marketer_summary') : '';
+  const tenantId = stringValue(runtimeDoc?.tenant_id);
+  const summaryPath = runId && tenantId ? stepPayloadPath(4, runId, 'performance_marketer_summary', tenantId) : '';
   const summaryPayload = summaryPath ? await readJsonIfExists(summaryPath) : null;
   const publisherSteps = [
     'meta_ads_publisher',
@@ -698,9 +716,9 @@ export async function collectPublishFinalizeArtifacts(primaryOutput: Record<stri
     payloadPath: string;
     payload: Record<string, unknown>;
   }> = [];
-  if (runId) {
+  if (runId && tenantId) {
     for (const stepName of publisherSteps) {
-      const payloadPath = stepPayloadPath(4, runId, stepName);
+      const payloadPath = stepPayloadPath(4, runId, stepName, tenantId);
       const payload = await readJsonIfExists(payloadPath);
       if (payload) {
         publisherPayloads.push({ stepName, payloadPath, payload });

--- a/backend/marketing/artifact-store.ts
+++ b/backend/marketing/artifact-store.ts
@@ -25,9 +25,53 @@ function uniqueStrings(values: Array<string | null | undefined>): string[] {
   return Array.from(new Set(values.map((value) => stringValue(value)).filter(Boolean)));
 }
 
+/**
+ * Returns the base directory that holds stage cache runs for a given stage,
+ * before tenant scoping. Prefer `stageCacheRootForTenant` at call sites that
+ * have a tenant in scope; this raw root remains exported for inference
+ * fallbacks that scan the directory tree (the inference layer applies the
+ * tenant filter itself).
+ */
 export function stageCacheRoot(stage: MarketingArtifactStageNumber): string {
   const config = STAGE_CACHE_DEFAULTS[stage];
   return stringValue(process.env[config.envKey]) || path.join(tmpdir(), config.folder);
+}
+
+/**
+ * Tenant-scoped stage cache root: `<cacheRoot>/<tenantId>`.
+ *
+ * Two tenants targeting the same competitor (e.g. nike.com) used to collide
+ * on `<cacheRoot>/<runId>/<step>.json` because runId derives from a slug of
+ * the competitor URL. Inserting `<tenantId>` as a path segment makes the
+ * filesystem layout itself tenant-isolated, complementing the runId
+ * inference check in stage-artifact-resolution.ts.
+ *
+ * Fails closed when tenantId is empty/whitespace — background workers that
+ * cannot resolve a tenant must not silently fall back to a shared root.
+ */
+export function stageCacheRootForTenant(
+  stage: MarketingArtifactStageNumber,
+  tenantId: string,
+): string {
+  const normalized = stringValue(tenantId);
+  if (!normalized) {
+    throw new Error(
+      `stageCacheRootForTenant requires a non-empty tenantId (stage=${stage})`,
+    );
+  }
+  return path.join(stageCacheRoot(stage), normalized);
+}
+
+/**
+ * Legacy fallback read gate. When set to "1", reads will fall back to the
+ * pre-tenant-segment layout `<cacheRoot>/<runId>/<step>.json` if the tenant-
+ * scoped path misses. Writes are NEVER routed to the legacy layout.
+ *
+ * TODO(stage-cache-tenant-prefix): remove this gate after the next full
+ * pipeline cycle for all tenants has populated tenant-scoped caches.
+ */
+export function legacyStageCacheReadFallbackEnabled(): boolean {
+  return stringValue(process.env.ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK) === '1';
 }
 
 export function hostOutputMount(): string {

--- a/backend/marketing/asset-read.ts
+++ b/backend/marketing/asset-read.ts
@@ -2,13 +2,34 @@ import { readFile, realpath } from 'node:fs/promises';
 import path from 'node:path';
 
 import { resolveDataRoot } from '@/lib/runtime-paths';
-import { generatedAssetCandidates, marketingAssetRoots } from './artifact-store';
+import { generatedAssetCandidates, marketingAssetRoots, stageCacheRoot } from './artifact-store';
 
 const INGEST_SUBDIR = 'ingested-assets';
 
 export type ReadMarketingAssetOptions = {
   tenantId?: string;
 };
+
+/**
+ * Returns the set of subtrees whose first segment under the root is the
+ * owning tenantId. Two families are currently tenant-scoped on disk:
+ *
+ *   1. `DATA_ROOT/ingested-assets/<tenantId>/...`  (user-uploaded media)
+ *   2. `<stageCacheRoot>/<tenantId>/<runId>/...`   (per-stage Lobster cache)
+ *
+ * Paths outside these subtrees are not tenant-scoped (workflow specs, repo
+ * source, raw Lobster output logs) and must NOT be rejected here — that
+ * would block legitimate reads.
+ */
+function tenantScopedRoots(): string[] {
+  return [
+    path.join(path.normalize(resolveDataRoot()), INGEST_SUBDIR),
+    path.normalize(stageCacheRoot(1)),
+    path.normalize(stageCacheRoot(2)),
+    path.normalize(stageCacheRoot(3)),
+    path.normalize(stageCacheRoot(4)),
+  ];
+}
 
 function tenantPrefixViolates(
   candidate: string,
@@ -17,16 +38,20 @@ function tenantPrefixViolates(
   if (tenantId === undefined) {
     return false;
   }
-  const ingestRoot = path.join(path.normalize(resolveDataRoot()), INGEST_SUBDIR);
-  const rel = path.relative(ingestRoot, candidate);
-  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
-    return false;
+  for (const tenantRoot of tenantScopedRoots()) {
+    const rel = path.relative(tenantRoot, candidate);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+      continue;
+    }
+    const segments = rel.split(path.sep).filter(Boolean);
+    if (segments.length === 0) {
+      continue;
+    }
+    if (segments[0] !== tenantId) {
+      return true;
+    }
   }
-  const segments = rel.split(path.sep).filter(Boolean);
-  if (segments.length === 0) {
-    return false;
-  }
-  return segments[0] !== tenantId;
+  return false;
 }
 
 /**

--- a/backend/marketing/asset-read.ts
+++ b/backend/marketing/asset-read.ts
@@ -21,7 +21,7 @@ export type ReadMarketingAssetOptions = {
  * source, raw Lobster output logs) and must NOT be rejected here — that
  * would block legitimate reads.
  */
-function tenantScopedRoots(): string[] {
+function tenantScopedRootCandidates(): string[] {
   return [
     path.join(path.normalize(resolveDataRoot()), INGEST_SUBDIR),
     path.normalize(stageCacheRoot(1)),
@@ -31,14 +31,35 @@ function tenantScopedRoots(): string[] {
   ];
 }
 
-function tenantPrefixViolates(
+/**
+ * Resolve each tenant-scoped root to its realpath when possible so the
+ * tenant-prefix check below operates in the same coordinate system as the
+ * resolved candidate. Without this, a symlinked DATA_ROOT or
+ * LOBSTER_STAGE*_CACHE_DIR makes `path.relative(normalizedRoot, realpathCandidate)`
+ * start with `..` and the check silently skips that subtree, leaving a
+ * false-negative on the cross-tenant boundary.
+ *
+ * Roots that do not exist on disk yet (fresh deploy, no cache populated)
+ * fall back to the normalized path — realpath of a missing dir throws, and
+ * a non-existent root can't host a cross-tenant read anyway.
+ */
+async function resolvedTenantScopedRoots(): Promise<string[]> {
+  return Promise.all(
+    tenantScopedRootCandidates().map((root) =>
+      realpath(root).catch(() => root),
+    ),
+  );
+}
+
+async function tenantPrefixViolates(
   candidate: string,
   tenantId: string | undefined,
-): boolean {
+): Promise<boolean> {
   if (tenantId === undefined) {
     return false;
   }
-  for (const tenantRoot of tenantScopedRoots()) {
+  const tenantRoots = await resolvedTenantScopedRoots();
+  for (const tenantRoot of tenantRoots) {
     const rel = path.relative(tenantRoot, candidate);
     if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
       continue;
@@ -117,7 +138,7 @@ export async function readMarketingAssetWithinAllowedRoots(
         // different tenantId (or an empty one) must be denied even if the
         // path is otherwise within trusted roots — that's the cross-tenant
         // boundary this helper enforces.
-        if (tenantPrefixViolates(resolvedCandidate, options.tenantId)) {
+        if (await tenantPrefixViolates(resolvedCandidate, options.tenantId)) {
           continue;
         }
         return await readFile(resolvedCandidate);

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -343,7 +343,15 @@ function stageLogRoot(stage: 1 | 2 | 3 | 4): string {
   return resolveCodePath('lobster', 'output', 'logs', '{runId}', stageFolder);
 }
 
-function stepPayloadPath(stage: 1 | 2 | 3 | 4, runId: string, stepName: string): string {
+function stepPayloadPath(
+  stage: 1 | 2 | 3 | 4,
+  runId: string,
+  stepName: string,
+  tenantId: string,
+): string {
+  if (!tenantId) {
+    throw new Error(`stepPayloadPath requires a non-empty tenantId (stage=${stage}, run=${runId})`);
+  }
   const root =
     stage === 1
       ? cacheRoot('LOBSTER_STAGE1_CACHE_DIR', 'lobster-stage1-cache')
@@ -352,7 +360,7 @@ function stepPayloadPath(stage: 1 | 2 | 3 | 4, runId: string, stepName: string):
         : stage === 3
           ? cacheRoot('LOBSTER_STAGE3_CACHE_DIR', 'lobster-stage3-cache')
           : cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache');
-  const primary = path.join(root, runId, `${stepName}.json`);
+  const primary = path.join(root, tenantId, runId, `${stepName}.json`);
   if (existsSync(primary)) {
     return primary;
   }

--- a/backend/marketing/publish-review.ts
+++ b/backend/marketing/publish-review.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import type { MarketingJobFacts } from './job-facts';
 import type { MarketingJobRuntimeDocument, MarketingVideoStageArtifact } from './runtime-state';
 import { readMarketingStageStepPayload } from './stage-artifact-resolution';
+import { legacyStageCacheReadFallbackEnabled } from './artifact-store';
 import {
   ARTIFACT_INCOMPLETE_TEXT,
   ARTIFACT_UNAVAILABLE_TEXT,
@@ -126,9 +127,26 @@ type PublishStepPayloadCandidate = {
 };
 
 async function readExactPublishStepPayload(runtimeDoc: MarketingJobRuntimeDocument, stepName: string, runId: string): Promise<PublishStepPayloadCandidate | null> {
-  const cachePath = path.join(cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache'), runId, `${stepName}.json`);
-  const cached = await readJsonIfExists(cachePath);
-  if (cached) {
+  const tenantId = stringValue(runtimeDoc.tenant_id);
+  if (!tenantId) {
+    // Fail closed when there's no tenant; stage cache reads must never
+    // cross-trust a shared root.
+    return null;
+  }
+
+  const stage4CacheRoot = cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache');
+  const tenantScopedCandidates = [
+    path.join(stage4CacheRoot, tenantId, runId, `${stepName}.json`),
+  ];
+  if (legacyStageCacheReadFallbackEnabled()) {
+    tenantScopedCandidates.push(path.join(stage4CacheRoot, runId, `${stepName}.json`));
+  }
+
+  for (const cachePath of tenantScopedCandidates) {
+    const cached = await readJsonIfExists(cachePath);
+    if (!cached) {
+      continue;
+    }
     try {
       return {
         runId,
@@ -226,7 +244,13 @@ async function collectFallbackPublishStepPayloadCandidates(
   const candidates: PublishStepPayloadCandidate[] = [];
   const seenPaths = new Set<string>();
 
-  const cacheDir = cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache');
+  const tenantId = stringValue(runtimeDoc.tenant_id);
+  if (!tenantId) {
+    // Inference fallback must not scan a shared cache root across tenants.
+    return [];
+  }
+
+  const cacheDir = path.join(cacheRoot('LOBSTER_STAGE4_CACHE_DIR', 'lobster-stage4-cache'), tenantId);
   if (existsSync(cacheDir)) {
     for (const entry of await readdir(cacheDir)) {
       if (!entry.startsWith(`${prefix}-`)) {

--- a/backend/marketing/stage-artifact-resolution.ts
+++ b/backend/marketing/stage-artifact-resolution.ts
@@ -2,7 +2,12 @@ import { existsSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
-import { lobsterOutputRoots, stageCacheRoot } from './artifact-store';
+import {
+  legacyStageCacheReadFallbackEnabled,
+  lobsterOutputRoots,
+  stageCacheRoot,
+  stageCacheRootForTenant,
+} from './artifact-store';
 import type { MarketingJobRuntimeDocument, MarketingStage } from './runtime-state';
 
 export type MarketingArtifactStageNumber = 1 | 2 | 3 | 4;
@@ -120,13 +125,26 @@ export async function inferMarketingStageRunId(
     return null;
   }
 
+  const tenantId = stringValue(runtimeDoc.tenant_id);
+  if (!tenantId) {
+    // Fail closed: without a tenant we cannot safely surface a cached runId,
+    // because the inference fallback keys off a competitor URL slug that
+    // can collide across tenants.
+    return null;
+  }
+
   const targetTime = stageTimestamp(runtimeDoc, currentStage);
   const candidates: Array<{ runId: string; score: number; mtimeMs: number }> = [];
   const seenRunIds = new Set<string>();
 
-  const cacheRoot = stageCacheRoot(stage);
-  if (existsSync(cacheRoot)) {
-    for (const entry of await readdir(cacheRoot)) {
+  // Scan only the tenant-scoped cache subtree so a sibling tenant's directory
+  // can never surface as a "closest by mtime" candidate. The legacy shared
+  // layout is intentionally skipped here even when the read fallback gate is
+  // on — inference would have no way to verify the legacy entry belongs to
+  // this tenant.
+  const tenantCacheRoot = path.join(stageCacheRoot(stage), tenantId);
+  if (existsSync(tenantCacheRoot)) {
+    for (const entry of await readdir(tenantCacheRoot)) {
       if (!prefixes.some((prefix) => entry.startsWith(`${prefix}-`))) {
         continue;
       }
@@ -134,7 +152,7 @@ export async function inferMarketingStageRunId(
         continue;
       }
       try {
-        const entryPath = path.join(cacheRoot, entry);
+        const entryPath = path.join(tenantCacheRoot, entry);
         const stats = await stat(entryPath);
         if (!stats.isDirectory()) {
           continue;
@@ -195,8 +213,20 @@ export async function readMarketingStageStepPayload(
     await inferMarketingStageRunId(runtimeDoc, stage),
   ]);
 
+  const tenantId = stringValue(runtimeDoc.tenant_id);
+  if (!tenantId) {
+    // Same fail-closed reasoning as inferMarketingStageRunId — a missing
+    // tenant_id on a runtime doc is a programmer error, not a normal state.
+    return {
+      runId: runIds[0] || null,
+      path: null,
+      payload: null,
+      source: 'none',
+    };
+  }
+
   for (const runId of runIds) {
-    const cachePath = path.join(stageCacheRoot(stage), runId, `${stepName}.json`);
+    const cachePath = path.join(stageCacheRootForTenant(stage, tenantId), runId, `${stepName}.json`);
     const cached = await readJsonIfExists(cachePath);
     if (cached) {
       return {
@@ -205,6 +235,22 @@ export async function readMarketingStageStepPayload(
         payload: cached,
         source: 'cache',
       };
+    }
+
+    // Legacy on-disk caches at `<cacheRoot>/<runId>/<step>.json` (no tenant
+    // segment) remain readable as a last resort while operators migrate. New
+    // writes always go to the tenant-scoped path; this branch only reads.
+    if (legacyStageCacheReadFallbackEnabled()) {
+      const legacyCachePath = path.join(stageCacheRoot(stage), runId, `${stepName}.json`);
+      const legacyCached = await readJsonIfExists(legacyCachePath);
+      if (legacyCached) {
+        return {
+          runId,
+          path: legacyCachePath,
+          payload: legacyCached,
+          source: 'cache',
+        };
+      }
     }
 
     for (const outputRoot of lobsterOutputRoots()) {

--- a/tests/marketing-stage-cache-tenant-isolation.test.ts
+++ b/tests/marketing-stage-cache-tenant-isolation.test.ts
@@ -1,0 +1,223 @@
+// Stage cache tenant isolation (PRD audit Finding 1).
+//
+// Verifies that:
+//   1. Stage cache reads and writes are scoped under `<cacheRoot>/<tenantId>`.
+//   2. inferMarketingStageRunId rejects a sibling-tenant runId via the
+//      tenant-scoped scan.
+//   3. readMarketingAssetWithinAllowedRoots denies cross-tenant stage cache
+//      reads when called with the wrong tenantId.
+//   4. The legacy fallback gate (ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1)
+//      allows reads of pre-migration on-disk caches.
+//   5. Writes are NEVER routed to the legacy layout — only reads tolerated.
+//
+// All paths run through tsx --test; this file matches the style of
+// tests/marketing-stage-* peers.
+
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  legacyStageCacheReadFallbackEnabled,
+  stageCacheRoot,
+  stageCacheRootForTenant,
+} from '../backend/marketing/artifact-store';
+import { createMarketingJobRuntimeDocument } from '../backend/marketing/runtime-state';
+import {
+  inferMarketingStageRunId,
+  readMarketingStageStepPayload,
+} from '../backend/marketing/stage-artifact-resolution';
+
+type EnvOverrides = Record<string, string | undefined>;
+
+async function withEnv<T>(overrides: EnvOverrides, run: () => Promise<T>): Promise<T> {
+  const prior: EnvOverrides = {};
+  for (const [k, v] of Object.entries(overrides)) {
+    prior[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [k, v] of Object.entries(prior)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+async function withScratch<T>(run: (ctx: { stage1: string; stage4: string }) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(path.join(tmpdir(), 'aries-stage-cache-iso-'));
+  const stage1 = path.join(root, 'stage1');
+  const stage4 = path.join(root, 'stage4');
+  await mkdir(stage1, { recursive: true });
+  await mkdir(stage4, { recursive: true });
+  try {
+    return await run({ stage1, stage4 });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function makeRuntimeDoc(tenantId: string, jobId: string, competitorUrl: string) {
+  return createMarketingJobRuntimeDocument({
+    jobId,
+    tenantId,
+    payload: { competitorUrl, brandUrl: 'https://brand.example.com' },
+    brandKit: {
+      path: `/tmp/${tenantId}.brand-kit.json`,
+      source_url: 'https://brand.example.com',
+      canonical_url: 'https://brand.example.com',
+      brand_name: 'Brand',
+      logo_urls: [],
+      colors: { primary: '#111', secondary: '#eee', accent: '#c33', palette: ['#111', '#eee', '#c33'] },
+      font_families: ['Inter'],
+      external_links: [],
+      extracted_at: '2026-04-24T00:00:00.000Z',
+      brand_voice_summary: 'Grounded.',
+      offer_summary: 'Audit.',
+    },
+  });
+}
+
+test('stage cache path includes tenant segment', () => {
+  const root = stageCacheRoot(1);
+  const tenantRoot = stageCacheRootForTenant(1, 'tenant-a');
+  assert.equal(tenantRoot, path.join(root, 'tenant-a'));
+});
+
+test('stageCacheRootForTenant fails closed when tenantId is empty', () => {
+  assert.throws(() => stageCacheRootForTenant(1, ''));
+  assert.throws(() => stageCacheRootForTenant(2, '   '));
+});
+
+test('readMarketingStageStepPayload writes go to tenant-scoped path only', async () => {
+  await withScratch(async ({ stage1 }) => {
+    await withEnv({ LOBSTER_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: undefined }, async () => {
+      const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
+      doc.stages.research.run_id = 'nike-com-abc12345';
+
+      // Seed both tenant-scoped (legitimate) and legacy-shared (must NOT match) caches.
+      const tenantDir = path.join(stage1, 'tenant-a', 'nike-com-abc12345');
+      const legacyDir = path.join(stage1, 'nike-com-abc12345');
+      await mkdir(tenantDir, { recursive: true });
+      await mkdir(legacyDir, { recursive: true });
+      await writeFile(path.join(tenantDir, 'step.json'), JSON.stringify({ scope: 'tenant-a' }));
+      await writeFile(path.join(legacyDir, 'step.json'), JSON.stringify({ scope: 'legacy-shared' }));
+
+      const resolution = await readMarketingStageStepPayload(doc, 1, 'step');
+      assert.equal(resolution.source, 'cache');
+      assert.deepEqual(resolution.payload, { scope: 'tenant-a' });
+      assert.ok(resolution.path?.includes(`${path.sep}tenant-a${path.sep}`), `path should be tenant-scoped: ${resolution.path}`);
+    });
+  });
+});
+
+test('inferMarketingStageRunId rejects sibling-tenant runId by tenant-scoped scan', async () => {
+  await withScratch(async ({ stage1 }) => {
+    await withEnv({ LOBSTER_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: undefined }, async () => {
+      // Tenant A and B both target nike.com. Tenant B has a cache run on disk.
+      const tenantBRun = path.join(stage1, 'tenant-b', 'nike-com-bbbbbbbb');
+      await mkdir(tenantBRun, { recursive: true });
+      await writeFile(path.join(tenantBRun, 'step.json'), JSON.stringify({ tenant: 'b' }));
+
+      // Tenant A has no run on disk and no explicit run_id in the runtime doc.
+      const docA = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
+
+      const runIdA = await inferMarketingStageRunId(docA, 1);
+      assert.equal(runIdA, null, 'tenant A inference must NOT surface tenant B run');
+
+      // Sanity: tenant B can find its own.
+      const docB = makeRuntimeDoc('tenant-b', 'job-b', 'https://nike.com');
+      const runIdB = await inferMarketingStageRunId(docB, 1);
+      assert.equal(runIdB, 'nike-com-bbbbbbbb');
+    });
+  });
+});
+
+test('cross-tenant readMarketingAssetWithinAllowedRoots is denied for stage cache subtrees', async () => {
+  await withScratch(async ({ stage1 }) => {
+    const tenantBFile = path.join(stage1, 'tenant-b', 'nike-com-bbbbbbbb', 'step.json');
+    await mkdir(path.dirname(tenantBFile), { recursive: true });
+    await writeFile(tenantBFile, JSON.stringify({ tenant: 'b' }));
+
+    const codeRoot = await mkdtemp(path.join(tmpdir(), 'aries-code-'));
+    const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-data-'));
+    try {
+      await withEnv(
+        {
+          LOBSTER_STAGE1_CACHE_DIR: stage1,
+          DATA_ROOT: dataRoot,
+          CODE_ROOT: codeRoot,
+        },
+        async () => {
+          const { readMarketingAssetWithinAllowedRoots } = await import('../backend/marketing/asset-read');
+
+          const okBytes = await readMarketingAssetWithinAllowedRoots(tenantBFile, { tenantId: 'tenant-b' });
+          assert.ok(okBytes, 'tenant B can read its own stage cache file');
+
+          const denied = await readMarketingAssetWithinAllowedRoots(tenantBFile, { tenantId: 'tenant-a' });
+          assert.equal(denied, null, 'tenant A must be denied a tenant B stage cache path');
+        },
+      );
+    } finally {
+      await rm(codeRoot, { recursive: true, force: true });
+      await rm(dataRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test('legacy fallback gate enables reading pre-migration caches', async () => {
+  await withScratch(async ({ stage1 }) => {
+    // Off by default: legacy cache invisible.
+    await withEnv({ LOBSTER_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: undefined }, async () => {
+      const legacyDir = path.join(stage1, 'nike-com-cccccccc');
+      await mkdir(legacyDir, { recursive: true });
+      await writeFile(path.join(legacyDir, 'step.json'), JSON.stringify({ legacy: true }));
+
+      const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
+      doc.stages.research.run_id = 'nike-com-cccccccc';
+
+      const off = await readMarketingStageStepPayload(doc, 1, 'step');
+      assert.equal(off.source, 'none', 'legacy read must be off by default');
+      assert.equal(legacyStageCacheReadFallbackEnabled(), false);
+    });
+
+    // Gate on: legacy cache visible.
+    await withEnv({ LOBSTER_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: '1' }, async () => {
+      const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
+      doc.stages.research.run_id = 'nike-com-cccccccc';
+
+      const on = await readMarketingStageStepPayload(doc, 1, 'step');
+      assert.equal(on.source, 'cache', 'legacy fallback should surface the legacy cache');
+      assert.deepEqual(on.payload, { legacy: true });
+      assert.equal(legacyStageCacheReadFallbackEnabled(), true);
+    });
+  });
+});
+
+test('legacy fallback never writes to the shared root', async () => {
+  // The codebase has no writer for these caches in TypeScript (Lobster
+  // populates them out-of-band), so this is a structural assertion: the
+  // tenant-scoped path is the only write target we ever construct.
+  await withScratch(async ({ stage1 }) => {
+    await withEnv({ LOBSTER_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: '1' }, async () => {
+      const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
+      doc.stages.research.run_id = 'nike-com-cccccccc';
+
+      // Read a non-existent path with the fallback gate on. No side-effects expected.
+      await readMarketingStageStepPayload(doc, 1, 'absent-step');
+
+      const entries = existsSync(stage1) ? await readdir(stage1) : [];
+      assert.deepEqual(
+        entries.sort(),
+        [],
+        'no implicit directories created at the shared root by a read',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a tenant segment to every Lobster stage cache path so two tenants targeting the same competitor (e.g. nike.com) can't surface each other's cache directories. Three coordinated changes:

1. **Path shape**: `<cacheRoot>/<runId>/<step>.json` becomes `<cacheRoot>/<tenantId>/<runId>/<step>.json`. New `stageCacheRootForTenant(stage, tenantId)` helper throws on empty tenantId — background workers without a tenant fail closed instead of silently falling back to a shared root. Updates `backend/marketing/artifact-store.ts`, `stage-artifact-resolution.ts`, `publish-review.ts`, `artifact-collector.ts`, and `jobs-status.ts`.
2. **Inference**: `inferMarketingStageRunId` now scans only the tenant subtree. A sibling tenant's cache dir can no longer be picked as a closest-by-mtime candidate even when the competitor slug matches.
3. **Asset read**: `tenantPrefixViolates` in `asset-read.ts` is widened to cover the four stage cache subroots in addition to `DATA_ROOT/ingested-assets`. Both `readMarketingAssetWithinAllowedRoots` call sites now pass `{ tenantId: runtimeDoc.tenant_id }`.

Backwards compat: `ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1` enables reads of pre-migration caches at the legacy shared layout. Writes never go there. The gate is documented inline with a TODO to remove after the next full pipeline cycle.

## Test plan

- [x] `npm run typecheck` passes
- [x] `tests/marketing-stage-cache-tenant-isolation.test.ts` — 7/7 pass (tenant-scoped path, fail-closed on empty tenantId, sibling-tenant inference rejection, cross-tenant asset-read denial, legacy gate on/off, no implicit shared-root writes)
- [x] `tests/marketing-publish-stage-gate.test.ts`, `tests/marketing-artifact-store.test.ts`, `tests/marketing-job-facts.test.ts`, `tests/asset-tenant-isolation.test.ts`, `tests/marketing-jobs-cache.test.ts` — 29/29 pass
- [x] `npm run validate:banned-patterns` clean
- [x] `npm run guardrails:agent` passes
- [ ] Soak in staging with `ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1` for one full pipeline cycle, then remove the gate

## Migration

No in-flight `.lobster-stage*-cache` directories were found on the local disk other than test scratch dirs. Production hosts will have populated caches at the legacy layout — set `ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1` on deploy so existing data remains readable while new runs populate the tenant-scoped paths. Remove the gate once all tenants have re-run at least one pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)