### PR TITLE
chore(compose): pass ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK to container (#302 rollout)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,12 @@ LOG_LEVEL=info
 # LOBSTER_STAGE2_CACHE_DIR=/data/lobster-stage2-cache
 # LOBSTER_STAGE3_CACHE_DIR=/data/lobster-stage3-cache
 # LOBSTER_STAGE4_CACHE_DIR=/data/lobster-stage4-cache
+
+# PR #302 migration gate. Set to 1 to allow READ from the legacy
+# <cacheRoot>/<runId>/... layout that predates tenant-scoped paths. New
+# writes always go to <cacheRoot>/<tenantId>/<runId>/... regardless of
+# this flag. Remove after one full pipeline cycle has soaked per tenant.
+# ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1
 # LOBSTER_MEDIA_GATEWAY_ENABLED=1
 # LOBSTER_MEDIA_GATEWAY_ALLOW_DIRECT_FALLBACK=1
 # LOBSTER_MEDIA_GATEWAY_SHARED_ROOTS=/tmp:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       ARIES_EXECUTION_PROVIDER: ${ARIES_EXECUTION_PROVIDER:-hermes}
       ARIES_MARKETING_EXECUTION_PROVIDER: ${ARIES_MARKETING_EXECUTION_PROVIDER:-hermes}
+      # Migration gate for PR #302 stage-cache tenant-prefix work. Enables
+      # READS from the legacy <cacheRoot>/<runId>/... layout during the
+      # one-pipeline-cycle soak period. New writes always go to the
+      # tenant-scoped path regardless. Remove after migration completes.
+      ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: ${ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK:-}
       OPENCLAW_GATEWAY_URL: ${OPENCLAW_GATEWAY_URL}
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
       OPENCLAW_SESSION_KEY: ${OPENCLAW_SESSION_KEY:-main}


### PR DESCRIPTION
## Summary

Companion to PR #302. Wires the \`ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK\` migration gate through docker-compose so the host's .env value reaches the runtime.

Without this passthrough, setting the var in the host .env is a no-op — docker-compose only forwards env vars that are explicitly named in the \`environment:\` block.

## Coordination with the host

Host .env on aries.sugarandleather.com has been set to \`ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1\` in lockstep with this commit. Once this lands and redeploys, the container picks up the value and legacy on-disk caches at \`<cacheRoot>/<runId>/...\` remain readable during the soak period. New writes from #302's code always go to \`<cacheRoot>/<tenantId>/<runId>/...\` regardless.

## Removal

Remove this passthrough + the host .env value after one full pipeline cycle has soaked per tenant. Tracked TODO in \`backend/marketing/artifact-store.ts\`.

## Test plan

- [x] \`docker-compose config\` would show the var in the env section (this is just a passthrough; no logic to test)
- [ ] Post-merge deploy verification: \`docker exec aries-app-aries-app-1 env | grep STAGE_CACHE\` returns \`ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)