### PR TITLE
fix(memory): narrow preference-label name redaction behind ARIES_MEMORY_LABEL_REDACTION_V2 flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,9 @@ Required for Hermes-native local/runtime setup: `DB_HOST`, `DB_PORT`, `DB_USER`,
 
 Optional for legacy compatibility only: `OPENCLAW_GATEWAY_URL`, `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_SESSION_KEY`
 
+Optional safety flags:
+- `ARIES_MEMORY_LABEL_REDACTION_V2=1` — switches `scrubPreferenceLabelForHoncho` (`backend/memory/write-events.ts`) from the legacy broad `[A-Z][a-z]+\s+[A-Z][a-z]+` regex to a narrow first-name-denylist heuristic. Preserves creative descriptors like "Bold Minimalist" / "Quiet Luxury" while still scrubbing `<FirstName> <LastName>` pairs. Default OFF (legacy behavior) until rollout. Email redaction is unchanged in both modes.
+
 Required when working on Aries-managed OAuth providers: `OAUTH_TOKEN_ENCRYPTION_KEY`. Weekly social content media generation does not use an Aries-side OpenAI client or secret; Hermes owns media auth and execution.
 
 Local dev defaults:

--- a/TODOS.md
+++ b/TODOS.md
@@ -112,6 +112,8 @@ _Effort revised from M after eng review locked in 7 architecture decisions._
 
 **Context:** Surfaced in post-hoc review of PR #293 (2026-05-11). Drawer placeholder is lowercase so happy-path testing missed it. Consider dropping the name-scrub entirely (this field is not user-authored) or replacing with a stricter signal (e.g. only redact when adjacent to other PII markers).
 
+**Status (2026-05-12, rollout pending):** Narrow first-name-denylist heuristic implemented in `backend/memory/write-events.ts` (`scrubPreferenceLabelForHoncho`) and gated behind env flag `ARIES_MEMORY_LABEL_REDACTION_V2=1`. Default remains the legacy broad regex; flip the flag in production once the team has validated. Regression + behavior tests in `tests/memory-label-redaction.test.ts`. Email redaction unchanged.
+
 **Effort:** XS
 **Priority:** P3
 **Depends on:** None

--- a/backend/memory/write-events.ts
+++ b/backend/memory/write-events.ts
@@ -757,8 +757,10 @@ export function scheduleHermesPublishPerformanceHonchoWrite(input: {
  * patterns ("John Smith") without scrubbing legitimate operator-authored
  * creative descriptors ("Bold Minimalist", "Quiet Luxury", "Dark Academia").
  *
- * Keep entries lower-cased; matching is performed against the first token's
- * lowercased form so casing in the label does not matter.
+ * Keep entries lower-cased. The redactor matches Title-cased tokens
+ * (`[A-Z][a-z]+`) and lowercases the first token before checking it against
+ * this set, so "John Smith" and "Mary Jones" redact but "JOHN SMITH" and
+ * "john smith" do not. Title-case is required by the surrounding regex.
  */
 const COMMON_FIRST_NAMES_V2: ReadonlySet<string> = new Set([
   'john',

--- a/backend/memory/write-events.ts
+++ b/backend/memory/write-events.ts
@@ -752,12 +752,130 @@ export function scheduleHermesPublishPerformanceHonchoWrite(input: {
 // ---------------------------------------------------------------------------
 
 /**
+ * Common first-name denylist used by the v2 narrow redactor. Intentionally small
+ * and high-frequency — the goal is to catch obvious `<FirstName> <LastName>`
+ * patterns ("John Smith") without scrubbing legitimate operator-authored
+ * creative descriptors ("Bold Minimalist", "Quiet Luxury", "Dark Academia").
+ *
+ * Keep entries lower-cased; matching is performed against the first token's
+ * lowercased form so casing in the label does not matter.
+ */
+const COMMON_FIRST_NAMES_V2: ReadonlySet<string> = new Set([
+  'john',
+  'jane',
+  'mary',
+  'michael',
+  'david',
+  'sarah',
+  'james',
+  'robert',
+  'william',
+  'richard',
+  'thomas',
+  'charles',
+  'joseph',
+  'christopher',
+  'daniel',
+  'matthew',
+  'anthony',
+  'mark',
+  'donald',
+  'steven',
+  'paul',
+  'andrew',
+  'joshua',
+  'kenneth',
+  'kevin',
+  'brian',
+  'george',
+  'edward',
+  'ronald',
+  'timothy',
+  'jason',
+  'jeffrey',
+  'ryan',
+  'jacob',
+  'gary',
+  'nicholas',
+  'eric',
+  'jonathan',
+  'stephen',
+  'larry',
+  'justin',
+  'scott',
+  'brandon',
+  'benjamin',
+  'samuel',
+  'frank',
+  'gregory',
+  'patricia',
+  'linda',
+  'barbara',
+  'elizabeth',
+  'jennifer',
+  'maria',
+  'susan',
+  'margaret',
+  'dorothy',
+  'lisa',
+  'nancy',
+  'karen',
+  'betty',
+  'helen',
+  'sandra',
+  'donna',
+  'carol',
+  'ruth',
+  'sharon',
+  'michelle',
+  'laura',
+  'emily',
+  'kimberly',
+  'deborah',
+  'jessica',
+  'shirley',
+  'cynthia',
+  'angela',
+  'melissa',
+  'amy',
+  'rebecca',
+  'virginia',
+  'kathleen',
+  'amanda',
+  'ashley',
+  'stephanie',
+]);
+
+function isLabelRedactionV2Enabled(): boolean {
+  return process.env.ARIES_MEMORY_LABEL_REDACTION_V2 === '1';
+}
+
+/**
  * Redact obvious PII from free-text preference labels before they enter Honcho claims.
+ *
+ * Two modes:
+ *  - Default (legacy): redact any pair of title-cased words via a broad regex.
+ *    This over-scrubs aesthetic descriptors like "Bold Minimalist".
+ *  - v2 (ARIES_MEMORY_LABEL_REDACTION_V2=1): only redact when the first token
+ *    matches a curated denylist of common first names AND the second token is
+ *    a title-cased word. This preserves creative descriptors while still
+ *    catching `<FirstName> <LastName>` style PII.
+ *
+ * Email redaction is unchanged in both modes — that pattern is unambiguous.
+ *
+ * Security note: we do not log raw label values from this function. Callers
+ * that want telemetry should log only the redaction decision flag.
  */
 export function scrubPreferenceLabelForHoncho(label: string | null | undefined): string {
   let s = typeof label === 'string' ? label : '';
   s = s.replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, '[redacted_email]');
-  s = s.replace(/\b[A-Z][a-z]+\s+[A-Z][a-z]+\b/g, '[redacted_name]');
+  if (isLabelRedactionV2Enabled()) {
+    s = s.replace(/\b([A-Z][a-z]+)\s+([A-Z][a-z]+)\b/g, (match, first: string, _second: string) => {
+      return COMMON_FIRST_NAMES_V2.has(first.toLowerCase()) ? '[redacted_name]' : match;
+    });
+  } else {
+    s = s.replace(/\b[A-Z][a-z]+\s+[A-Z][a-z]+\b/g, '[redacted_name]');
+  }
   return s;
 }
 

--- a/tests/memory-label-redaction.test.ts
+++ b/tests/memory-label-redaction.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { scrubPreferenceLabelForHoncho } from '../backend/memory/write-events';
+
+/**
+ * Safely set env vars for the duration of fn, restoring originals on return.
+ * Mirrors the helper used in tests/memory-write-events.test.ts.
+ */
+function withEnv<T>(updates: Record<string, string | undefined>, fn: () => T): T {
+  const original: Record<string, string | undefined> = {};
+  for (const key of Object.keys(updates)) {
+    original[key] = process.env[key];
+    if (updates[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = updates[key]!;
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    for (const key of Object.keys(original)) {
+      if (original[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original[key]!;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Flag OFF — legacy regression behavior must be preserved.
+// ---------------------------------------------------------------------------
+
+test('scrubPreferenceLabelForHoncho (flag OFF) preserves legacy broad name scrub', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: undefined }, () => {
+    // Creative descriptors get scrubbed under the legacy heuristic — this is
+    // the regression we are intentionally locking in until the flag flips.
+    assert.equal(scrubPreferenceLabelForHoncho('Bold Minimalist'), '[redacted_name]');
+    assert.equal(scrubPreferenceLabelForHoncho('Quiet Luxury'), '[redacted_name]');
+    // Real names scrub too.
+    assert.equal(scrubPreferenceLabelForHoncho('John Smith'), '[redacted_name]');
+    // Single tokens always pass through.
+    assert.equal(scrubPreferenceLabelForHoncho('Minimalist'), 'Minimalist');
+  });
+});
+
+test('scrubPreferenceLabelForHoncho (flag OFF, value="0") still uses legacy regex', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: '0' }, () => {
+    assert.equal(scrubPreferenceLabelForHoncho('Bold Minimalist'), '[redacted_name]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flag ON — creative descriptors survive, real-name patterns still scrub.
+// ---------------------------------------------------------------------------
+
+test('scrubPreferenceLabelForHoncho (flag ON) preserves creative descriptors', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: '1' }, () => {
+    const descriptors = [
+      'Bold Minimalist',
+      'Quiet Luxury',
+      'Dark Academia',
+      'Soft Brutalism',
+      'Cottage Core',
+      'Modern Bauhaus',
+    ];
+    for (const label of descriptors) {
+      assert.equal(scrubPreferenceLabelForHoncho(label), label, `expected "${label}" to survive`);
+    }
+  });
+});
+
+test('scrubPreferenceLabelForHoncho (flag ON) still scrubs common first-name + last-name pairs', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: '1' }, () => {
+    assert.equal(scrubPreferenceLabelForHoncho('John Smith'), '[redacted_name]');
+    assert.equal(scrubPreferenceLabelForHoncho('Jane Doe'), '[redacted_name]');
+    assert.equal(scrubPreferenceLabelForHoncho('Michael Jordan'), '[redacted_name]');
+    assert.equal(scrubPreferenceLabelForHoncho('Sarah Connor'), '[redacted_name]');
+  });
+});
+
+test('scrubPreferenceLabelForHoncho (flag ON) is case-insensitive on the first-name token', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: '1' }, () => {
+    // Regex still requires Title-case to match, but the denylist lookup
+    // lowercases the first token so "John" matches "john" in the set.
+    assert.equal(scrubPreferenceLabelForHoncho('John Doe'), '[redacted_name]');
+  });
+});
+
+test('scrubPreferenceLabelForHoncho (flag ON) handles mixed content', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: '1' }, () => {
+    const input = 'Bold Minimalist by John Smith';
+    const output = scrubPreferenceLabelForHoncho(input);
+    assert.equal(output, 'Bold Minimalist by [redacted_name]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Email — always redacted regardless of the flag.
+// ---------------------------------------------------------------------------
+
+test('scrubPreferenceLabelForHoncho redacts emails with flag OFF', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: undefined }, () => {
+    assert.equal(
+      scrubPreferenceLabelForHoncho('contact me at jane@example.com'),
+      'contact me at [redacted_email]',
+    );
+  });
+});
+
+test('scrubPreferenceLabelForHoncho redacts emails with flag ON', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: '1' }, () => {
+    assert.equal(
+      scrubPreferenceLabelForHoncho('ping ops+aries@sugarandleather.com please'),
+      'ping [redacted_email] please',
+    );
+  });
+});
+
+test('scrubPreferenceLabelForHoncho handles null/undefined/non-string input', () => {
+  withEnv({ ARIES_MEMORY_LABEL_REDACTION_V2: '1' }, () => {
+    assert.equal(scrubPreferenceLabelForHoncho(null), '');
+    assert.equal(scrubPreferenceLabelForHoncho(undefined), '');
+    assert.equal(scrubPreferenceLabelForHoncho(''), '');
+    // @ts-expect-error — runtime guard against non-string input
+    assert.equal(scrubPreferenceLabelForHoncho(42), '');
+  });
+});


### PR DESCRIPTION
## Summary

The current `scrubPreferenceLabelForHoncho` heuristic redacts any two title-cased tokens as a "name" before writing preference labels to durable memory. This eats legitimate operator-authored creative descriptors like *Bold Minimalist*, *Quiet Luxury*, *Dark Academia*, *Soft Brutalism*, *Cottage Core* — degrading future retrieval and biasing brand-voice memory.

This PR implements **Batch 4a** from `docs/product/aries-ai-prd-audit.md` (Dimension 7) and the long-standing `TODOS.md` entry.

### Approach: curated first-name denylist (option b)

Replaced the broad `[A-Z][a-z]+\s+[A-Z][a-z]+` heuristic with a curated list of ~80 common first names. A label only redacts as a name when the first token appears in that list AND the second token is a capitalized word. This catches *John Smith* / *Jane Doe* / *Michael Jordan* without scrubbing aesthetic vocabulary that happens to be two title-cased words.

**Why a denylist over an allowlist of descriptors:** option (a) would need indefinite curation as new style vocabulary emerges. Names are a smaller, more stable surface; aesthetic aliases like "Quiet Davis" still won't bypass it unless the first token is a known first name.

### Gated for safe rollout

New behavior is **off by default** behind `ARIES_MEMORY_LABEL_REDACTION_V2=1`. Production behavior is unchanged until a human flips the flag — set it after burn-in on staging.

### What changed

- `backend/memory/write-events.ts` — replaced `scrubPreferenceLabelForHoncho` body; added `COMMON_FIRST_NAMES_V2` and `isLabelRedactionV2Enabled()`.
- `tests/memory-label-redaction.test.ts` *(new, 9 tests)* — covers flag OFF regression, flag ON descriptor survival, name scrubbing, mixed content, email-always-redacted, null/undefined.
- `CLAUDE.md` — documents the new flag under Environment Variables → "Optional safety flags".
- `TODOS.md` — marks the existing TODO as "rollout pending" and links to the test file.

### Behavior matrix

| Input | Flag OFF (default) | Flag ON (v2) |
|---|---|---|
| `Bold Minimalist` | `[redacted_name]` | `Bold Minimalist` |
| `Quiet Luxury` | `[redacted_name]` | `Quiet Luxury` |
| `Dark Academia` | `[redacted_name]` | `Dark Academia` |
| `Soft Brutalism` | `[redacted_name]` | `Soft Brutalism` |
| `Cottage Core` | `[redacted_name]` | `Cottage Core` |
| `John Smith` | `[redacted_name]` | `[redacted_name]` |
| `Jane Doe` | `[redacted_name]` | `[redacted_name]` |
| `Bold Minimalist by John Smith` | `[redacted_name] by [redacted_name]` | `Bold Minimalist by [redacted_name]` |
| `contact jane@example.com` | `contact [redacted_email]` | `contact [redacted_email]` |

Email redaction is unchanged in both modes. No raw label values are logged.

## Test Coverage

9 new tests in `tests/memory-label-redaction.test.ts`. All pass. Full `npm run verify` regression suite passes.

## Test plan

- [x] All 9 new tests pass with flag OFF and flag ON
- [x] `npm run verify` green
- [ ] Burn-in on staging with `ARIES_MEMORY_LABEL_REDACTION_V2=1` to confirm operator-voice descriptors flow into Honcho intact
- [ ] Flip in production after burn-in

Addresses: `docs/product/aries-ai-prd-audit.md` Dimension 7 + `TODOS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)