### PR TITLE
fix(qa): give /social-content/* legacy routes the global app shell

### DIFF
--- a/app/social-content/layout.tsx
+++ b/app/social-content/layout.tsx
@@ -1,8 +1,18 @@
 import type { ReactNode } from 'react';
 
+import AppShellLayout from '@/frontend/app-shell/layout';
 import { enforceOnboardingGate } from '@/lib/onboarding-gate-server';
 
+// QA 2026-05-13: the legacy /social-content/{new,status,review} URLs are
+// still linked from campaign workspaces (campaign-workspace-state.ts
+// ISSUE-009 fallback action). Without the shell, users land here with no
+// global nav and get stuck. Wrap the segment so legacy surfaces inherit
+// the same chrome as /dashboard/*.
 export default async function SocialContentSegmentLayout({ children }: { children: ReactNode }) {
   await enforceOnboardingGate();
-  return <>{children}</>;
+  return (
+    <AppShellLayout currentRouteId="campaigns" loginRedirectPath="/social-content">
+      {children}
+    </AppShellLayout>
+  );
 }


### PR DESCRIPTION
## Summary
- Users get trapped on `/social-content/status?jobId=...` with no global navigation
- The ISSUE-009 fallback CTA points the campaign workspace at this orphan page
- Wrap the segment layout in `AppShellLayout` so all legacy `/social-content/*` URLs inherit the same nav as `/dashboard/*`

## Reproduction (prod, before fix)
1. Login → `/dashboard/social-content/<campaignId>`
2. Click "View runtime status"
3. Land at `/social-content/status?jobId=...` with only `[Job ID input]` and `[Refresh]` button — no nav, no back link

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Post-deploy: visit `/social-content/status?jobId=...` on prod and confirm the global header (Home, New Campaign, Campaigns, Posts, Calendar, Results) is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)