### PR TITLE
fix(hermes-port): require approval after every weekly social-content stage

### DIFF
--- a/app/social-content/layout.tsx
+++ b/app/social-content/layout.tsx
@@ -1,8 +1,18 @@
 import type { ReactNode } from 'react';
 
+import AppShellLayout from '@/frontend/app-shell/layout';
 import { enforceOnboardingGate } from '@/lib/onboarding-gate-server';
 
+// QA 2026-05-13: the legacy /social-content/{new,status,review} URLs are
+// still linked from campaign workspaces (campaign-workspace-state.ts
+// ISSUE-009 fallback action). Without the shell, users land here with no
+// global nav and get stuck. Wrap the segment so legacy surfaces inherit
+// the same chrome as /dashboard/*.
 export default async function SocialContentSegmentLayout({ children }: { children: ReactNode }) {
   await enforceOnboardingGate();
-  return <>{children}</>;
+  return (
+    <AppShellLayout currentRouteId="campaigns" loginRedirectPath="/social-content">
+      {children}
+    </AppShellLayout>
+  );
 }

--- a/backend/marketing/ports/hermes.ts
+++ b/backend/marketing/ports/hermes.ts
@@ -335,12 +335,20 @@ export class HermesMarketingPort implements MarketingExecutionPort {
     }
 
     if (!response.ok) {
+      const responseBody = await response.text().catch(() => '');
+      console.error('[hermes-port] gateway-rejected', {
+        status: response.status,
+        aries_run_id: run.aries_run_id,
+        response_body: responseBody.slice(0, 1000),
+        payload_keys: Object.keys(payload),
+        idempotency_key_present: idempotencyKey.length > 0,
+      });
       const message = `Hermes gateway returned HTTP ${response.status} on /v1/runs.`;
       markSubmissionFailed(run.aries_run_id, 'hermes_gateway_request_failed', message);
       return gatewayErrorResult(
         'hermes_gateway_request_failed',
         message,
-        { status: response.status, aries_run_id: run.aries_run_id },
+        { status: response.status, aries_run_id: run.aries_run_id, body: responseBody.slice(0, 200) },
         workflowKey,
       );
     }

--- a/backend/marketing/ports/hermes.ts
+++ b/backend/marketing/ports/hermes.ts
@@ -970,6 +970,28 @@ export class HermesMarketingPort implements MarketingExecutionPort {
   }
 
   private instructions(workflowKey: string): string {
+    if (workflowKey === SOCIAL_CONTENT_WEEKLY_WORKFLOW_KEY) {
+      // QA 2026-05-13: weekly social content is an approval-gated 4-stage
+      // pipeline. Each stage (research → strategy → production → publish)
+      // returns to the dashboard for operator review before the next stage
+      // fires. The default-permissive instruction (status:"completed" with an
+      // optional requires_approval) regressed Hermes into emitting
+      // status:"completed" after research, which Aries treats as
+      // pipeline-done — bypassing the brand/strategy/creative review gates.
+      // Encode the contract explicitly so the gate fires after every stage.
+      return [
+        'You are the Aries marketing execution agent driving the weekly social content pipeline.',
+        'Reply with a single strict JSON object only — no prose, no markdown fences.',
+        'This is an approval-gated 4-stage pipeline: research → strategy → production → publish.',
+        'After completing the research stage, return status "requires_approval" with approval.stage="brand", approval.workflowStepId="strategy", approval.prompt="Review research findings before strategy starts", approval.resumeToken set, and output:[{stage:"research", ...artifacts}].',
+        'After completing the strategy stage on resume, return status "requires_approval" with approval.stage="strategy", approval.workflowStepId="production", approval.prompt="Review strategy before production starts", and output:[{stage:"strategy", ...artifacts}].',
+        'After completing the production stage on resume, return status "requires_approval" with approval.stage="creative", approval.workflowStepId="publish", approval.prompt="Review creative assets before publish review", and output:[{stage:"production", ...artifacts}].',
+        'After completing the publish stage on resume, return status "requires_approval" with approval.stage="publish", approval.workflowStepId="publish_review", approval.prompt="Approve to publish the weekly social content", and output:[{stage:"publish", ...artifacts}].',
+        'Only return status "completed" after the publish-review approval has been granted on the final resume call.',
+        `Required schema when returning a checkpoint: {"ok":true,"status":"requires_approval","workflowKey":"${workflowKey}","approval":{"stage":"...","workflowStepId":"...","prompt":"...","resumeToken":"..."},"output":[{...}]}.`,
+        `Required schema when terminal: {"ok":true,"status":"completed","workflowKey":"${workflowKey}","output":[{...}]}.`,
+      ].join(' ');
+    }
     return [
       'You are the Aries marketing execution agent.',
       'Reply with a single strict JSON object only — no prose, no markdown fences.',


### PR DESCRIPTION
## Summary
- Weekly social content is an approval-gated 4-stage pipeline (research → strategy → production → publish); each stage should return to the dashboard for operator review before the next fires
- Hermes was returning \`status:\"completed\"\` after research, which the callback handler treated as pipeline-done — no checkpoint, no fan-out, no advance
- Encode the multi-stage approval contract explicitly in the instructions sent to Hermes so each stage returns \`requires_approval\` with the right stage / next workflowStepId / prompt / resumeToken

## Evidence
Fresh prod campaign \`mkt_24852670-7094-45a6-a6df-1ba70a4654ee\` (after the prior key + diagnostic fixes):

\`\`\`
10:38:43 — Social content accepted
10:38:47 — Research completed
[no brand-review checkpoint, no strategy stage fired]
\`\`\`

Callback payload from Hermes carried \`status:\"completed\"\` with \`output:[{stage:\"research\"}]\` and nothing else — the permissive instruction let Hermes treat research as the whole job.

## Behavior
- \`SOCIAL_CONTENT_WEEKLY_WORKFLOW_KEY\` workflows get explicit per-stage approval instructions
- All other workflows (brand_campaign etc.) keep the existing permissive instruction — no behavior change

## Test plan
- [x] typecheck
- [x] lint
- [ ] Post-deploy: start a fresh weekly social content run, verify brandReview checkpoint appears on dashboard after research, approve, verify strategy fires, repeat through publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)