### PR TITLE
fix(social-content): default weekly post count to 7 (was 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Weekly social-content posts now surface on /dashboard/posts and /dashboard/calendar.** Two wiring gaps prevented the content from reaching the dashboard list endpoints. (1) `parseSocialContentWorkflowOutput` only recognised the `weekly_content_plan` (snake_case) key in Hermes production output, but Hermes actually emits `weeklyPlan` (camelCase); it now accepts either. (2) `buildCampaignWorkspaceView` computed the raw dashboard but never applied `buildSocialContentDashboardProjection`, so posts/assets/calendar events synthesised from the social-content runtime were dropped before the list endpoints read the result. Both gaps are now closed and covered by a regression test.
+- **Default weekly post count is now 7 (was 3) to match the "weekly content" product framing.** The new-job form, backend default scope, and workflow request all now default to 7 static posts per week so a fresh run produces a full week of content without the operator needing to manually adjust the count.
 
 ## [0.1.3.1] - 2026-05-13
 

--- a/backend/social-content/defaults.ts
+++ b/backend/social-content/defaults.ts
@@ -3,7 +3,7 @@ export const SOCIAL_CONTENT_WEEKLY_WORKFLOW_VERSION = '2026-05-social-content-we
 
 export const SOCIAL_CONTENT_DEFAULT_SCOPE = {
   window_days: 7,
-  static_post_count: 3,
+  static_post_count: 7,
   image_creative_count: 2,
   video_script_count: 1,
   video_render_count: 0,

--- a/backend/social-content/types.ts
+++ b/backend/social-content/types.ts
@@ -115,7 +115,7 @@ export const DEFAULT_SOCIAL_CONTENT_FORBIDDEN_PATTERNS: string[] = [
 
 export const DEFAULT_SOCIAL_CONTENT_COUNTS = {
   campaignWindowDays: 7 as const,
-  staticPostCount: 3,
+  staticPostCount: 7,
   imageCreativeCount: 2,
   videoScriptCount: 1,
   videoRenderCount: 0,

--- a/frontend/social-content/new-job.tsx
+++ b/frontend/social-content/new-job.tsx
@@ -67,7 +67,7 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
     DEFAULT_FORBIDDEN_VISUAL_PATTERNS.join("\n"),
   );
 
-  const [staticPostCount, setStaticPostCount] = useState(3);
+  const [staticPostCount, setStaticPostCount] = useState(7);
   const [imageCreativeCount, setImageCreativeCount] = useState(2);
   const [videoScriptCount, setVideoScriptCount] = useState(1);
   const [renderVideoAfterApproval, setRenderVideoAfterApproval] = useState(false);

--- a/tests/marketing-execution-port.test.ts
+++ b/tests/marketing-execution-port.test.ts
@@ -214,7 +214,7 @@ test('HermesMarketingPort.runPipeline returns submitted immediately by default',
     assert.equal(embeddedRequest.job_id, 'job_test');
     assert.equal(embeddedRequest.callback_url, 'https://aries.example.com/api/internal/hermes/runs');
     assert.equal(embeddedRequest.input.scope.window_days, 7);
-    assert.equal(embeddedRequest.input.scope.static_post_count, 3);
+    assert.equal(embeddedRequest.input.scope.static_post_count, 7);
     assert.equal(embeddedRequest.input.scope.image_creative_count, 2);
     assert.equal(embeddedRequest.input.scope.video_script_count, 1);
     assert.equal(embeddedRequest.input.scope.video_render_count, 1);

--- a/tests/social-content-new-job-screen.test.ts
+++ b/tests/social-content-new-job-screen.test.ts
@@ -134,7 +134,7 @@ test("social content form submits defaults and navigates to social-content statu
     assert.ok(submitted);
 
     assert.equal(submitted?.get("campaignWindowDays"), "7");
-    assert.equal(submitted?.get("staticPostCount"), "3");
+    assert.equal(submitted?.get("staticPostCount"), "7");
     assert.equal(submitted?.get("imageCreativeCount"), "2");
     assert.equal(submitted?.get("videoScriptCount"), "1");
     assert.equal(submitted?.get("videoRenderCount"), "0");

--- a/tests/social-content-weekly-defaults.test.ts
+++ b/tests/social-content-weekly-defaults.test.ts
@@ -121,7 +121,7 @@ test('weekly workflow request uses default scope counts/channels', () => {
   assert.equal(request.workflow_key, 'social_content_weekly');
   assert.equal(request.workflow_version, '2026-05-social-content-weekly-v1');
   assert.equal(request.input.scope.window_days, 7);
-  assert.equal(request.input.scope.static_post_count, 3);
+  assert.equal(request.input.scope.static_post_count, 7);
   assert.equal(request.input.scope.image_creative_count, 2);
   assert.equal(request.input.scope.video_script_count, 1);
   assert.equal(request.input.scope.video_render_count, 0);
@@ -235,7 +235,7 @@ test('weekly job status defaults to a 7-day calendar and keeps events in range',
     );
 
     assert.equal(status.durationDays, 7);
-    assert.equal(status.plannedPostCount, 4);
+    assert.equal(status.plannedPostCount, 8);
     assert.equal(weeklyEvents.length, status.calendarEvents.length);
     assert.equal(weeklyEvents.every((event) => event.dayIndex >= 1 && event.dayIndex <= 7), true);
     assert.equal(dashboardWeeklyCreativeReadyCount(weeklyEvents), 0);


### PR DESCRIPTION
## Summary

- Default weekly post count changed from 3 → 7 across all three locations: new-job form (`frontend/social-content/new-job.tsx`), backend default scope (`backend/social-content/defaults.ts`), and type constant (`backend/social-content/types.ts`).
- A fresh run now requests 7 static posts from Hermes by default, producing a full week of content without the operator needing to manually adjust the count.

## Test plan

- [x] Four tests updated to reflect new default of 7: new-job form submission assertion, weekly workflow request scope assertion, execution-port request scope assertion, and the `plannedPostCount` default-counts test (moves from 4 to 8 = 7 static + 1 video script)
- [x] `npm run verify` passes all 7 steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)