### PR TITLE
fix: ingest video render artifacts from Hermes cache

### DIFF
--- a/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/assets/[assetId]/handler.ts
@@ -113,24 +113,32 @@ async function resolveVideoAssetPath(jobId: string, assetId: string): Promise<{ 
   const isPoster = assetId.endsWith('-poster');
   const baseName = assetId.replace(/^video-/, '').replace(/-poster$/, '');
   const videosRoot = path.resolve(resolveDraftRoot(), 'jobs', jobId, 'videos');
-  const requestedPath = path.resolve(videosRoot, `${baseName}${isPoster ? '.jpg' : '.mp4'}`);
+  const requestedPaths = isPoster
+    ? ['.jpg', '.jpeg', '.png', '.webp'].map((ext) => path.resolve(videosRoot, `${baseName}-poster${ext}`))
+    : [path.resolve(videosRoot, `${baseName}.mp4`)];
 
-  if (!baseName || !isWithinRoot(videosRoot, requestedPath)) {
+  if (!baseName || requestedPaths.some((candidate) => !isWithinRoot(videosRoot, candidate))) {
     return invalidVideoAssetResponse();
   }
 
   const resolvedVideosRoot = await realpath(videosRoot).catch(() => videosRoot);
-  const resolvedPath = await realpath(requestedPath).catch((error: unknown) => {
-    if (
-      error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      (error.code === 'ENOENT' || error.code === 'ENOTDIR')
-    ) {
-      return null;
+  let resolvedPath: string | null = null;
+  for (const requestedPath of requestedPaths) {
+    resolvedPath = await realpath(requestedPath).catch((error: unknown) => {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+      ) {
+        return null;
+      }
+      throw error;
+    });
+    if (resolvedPath) {
+      break;
     }
-    throw error;
-  });
+  }
 
   if (!resolvedPath) {
     return assetNotFoundResponse(jobId, assetId, 'asset_file_missing');
@@ -142,7 +150,13 @@ async function resolveVideoAssetPath(jobId: string, assetId: string): Promise<{ 
 
   return {
     filePath: resolvedPath,
-    contentType: isPoster ? 'image/jpeg' : 'video/mp4',
+    contentType: isPoster
+      ? resolvedPath.endsWith('.png')
+        ? 'image/png'
+        : resolvedPath.endsWith('.webp')
+          ? 'image/webp'
+          : 'image/jpeg'
+      : 'video/mp4',
   };
 }
 

--- a/backend/execution/hermes-callbacks.ts
+++ b/backend/execution/hermes-callbacks.ts
@@ -262,9 +262,14 @@ function validateApprovalTransition(
     if (!approvalStep) {
       return { status: 'error', reason: 'approval_stage_mismatch' };
     }
+    // Video render/script approvals occur during the production run stage but
+    // gate the publish gate — they map to 'publish' in the allowlist, not
+    // 'production', so the stage check passes correctly.
     const expectedMarketingStage = approvalStep === 'approve_weekly_plan'
       ? 'strategy'
-      : approvalStep === 'approve_publish'
+      : (approvalStep === 'approve_publish'
+        || approvalStep === 'approve_video_render'
+        || approvalStep === 'approve_video_script')
         ? 'publish'
         : 'production';
     // Explicit per-stage allowlist: each run stage maps to exactly one valid

--- a/backend/marketing/hermes-callbacks.ts
+++ b/backend/marketing/hermes-callbacks.ts
@@ -11,6 +11,7 @@ import {
   reconcileSocialContentIntermediateStages,
   socialContentStageFromCallbackStage,
 } from '@/backend/social-content/runtime-state';
+import { ingestSocialContentVideoRenderOutput } from '@/backend/social-content/media-ingest';
 import type { SocialContentApprovalStep, SocialContentArtifact, SocialContentStage } from '@/backend/social-content/types';
 
 import {
@@ -329,6 +330,23 @@ function productionCallbackHasUnrenderedImageCreatives(
   );
 }
 
+function ingestSocialContentStageMedia(
+  run: ExecutionRunRecord,
+  payload: HermesRunCallbackPayload,
+): void {
+  if (!isSocialContentRun(run) || !run.marketing_job_id || payload.stage !== 'video_render') {
+    return;
+  }
+
+  const result = ingestSocialContentVideoRenderOutput(run.marketing_job_id, payload.output);
+  if (result.skipped.length > 0) {
+    console.warn('[social-content-video-ingest] skipped media during Hermes callback ingest', {
+      jobId: run.marketing_job_id,
+      skipped: result.skipped,
+    });
+  }
+}
+
 function isHermesMediaSetupError(payload: HermesRunCallbackPayload): boolean {
   const code = payload.error?.code?.toLowerCase() ?? '';
   const message = payload.error?.message.toLowerCase() ?? '';
@@ -590,6 +608,7 @@ export async function applyHermesMarketingCallback(
   }
 
   if (payload.status === 'requires_approval') {
+    ingestSocialContentStageMedia(run, payload);
     const socialApprovalStep = isSocialContentRun(run) ? normalizeSocialApprovalStep(payload) : null;
     const completedSocialStage = isSocialContentRun(run)
       ? socialContentStageFromCallbackStage(payload.stage) ?? socialStageForMarketingStage(targetStage)
@@ -670,6 +689,7 @@ export async function applyHermesMarketingCallback(
   }
 
   if (payload.status === 'completed') {
+    ingestSocialContentStageMedia(run, payload);
     const multiStage = extractMultiStageOutputs(payload);
     if (multiStage) {
       for (const stage of STAGE_ORDER) {

--- a/backend/marketing/hermes-callbacks.ts
+++ b/backend/marketing/hermes-callbacks.ts
@@ -330,6 +330,19 @@ function productionCallbackHasUnrenderedImageCreatives(
   );
 }
 
+function summarizeVideoIngestSkips(
+  skipped: Array<{ path: string; reason: 'not_allowed' | 'missing' | 'invalid' }>,
+): { count: number; reasons: Partial<Record<'not_allowed' | 'missing' | 'invalid', number>> } {
+  const reasons: Partial<Record<'not_allowed' | 'missing' | 'invalid', number>> = {};
+  for (const entry of skipped) {
+    reasons[entry.reason] = (reasons[entry.reason] ?? 0) + 1;
+  }
+  return {
+    count: skipped.length,
+    reasons,
+  };
+}
+
 function ingestSocialContentStageMedia(
   run: ExecutionRunRecord,
   payload: HermesRunCallbackPayload,
@@ -342,7 +355,7 @@ function ingestSocialContentStageMedia(
   if (result.skipped.length > 0) {
     console.warn('[social-content-video-ingest] skipped media during Hermes callback ingest', {
       jobId: run.marketing_job_id,
-      skipped: result.skipped,
+      skipped: summarizeVideoIngestSkips(result.skipped),
     });
   }
 }

--- a/backend/social-content/media-ingest.ts
+++ b/backend/social-content/media-ingest.ts
@@ -1,0 +1,206 @@
+import { copyFileSync, existsSync, mkdirSync, realpathSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { resolveDataRoot, resolveDraftRoot } from '@/lib/runtime-paths';
+
+type UnknownRecord = Record<string, unknown>;
+
+type MediaRewrite = {
+  from: string;
+  to: string;
+};
+
+export type SocialContentVideoIngestResult = {
+  rewrites: MediaRewrite[];
+  skipped: Array<{ path: string; reason: 'not_allowed' | 'missing' | 'invalid' }>;
+};
+
+function recordValue(value: unknown): UnknownRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function recordArray(value: unknown): UnknownRecord[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is UnknownRecord => !!entry && typeof entry === 'object' && !Array.isArray(entry))
+    : [];
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function slug(value: string, fallback: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || fallback;
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function sourceRoots(): string[] {
+  const roots = [
+    process.env.HERMES_MEDIA_CACHE_DIR,
+    process.env.HERMES_CACHE_DIR,
+    path.join(homedir(), '.hermes'),
+    path.join(tmpdir(), 'hermes'),
+    resolveDataRoot(),
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => path.resolve(value));
+
+  return Array.from(new Set(roots));
+}
+
+function resolveAllowedSource(filePath: string): { ok: true; resolved: string } | { ok: false; reason: 'not_allowed' | 'missing' | 'invalid' } {
+  const raw = stringValue(filePath);
+  if (!raw || !path.isAbsolute(raw)) {
+    return { ok: false, reason: 'invalid' };
+  }
+
+  const normalized = path.resolve(raw);
+  let resolved: string;
+  try {
+    resolved = realpathSync(normalized);
+  } catch {
+    return existsSync(normalized)
+      ? { ok: false, reason: 'not_allowed' }
+      : { ok: false, reason: 'missing' };
+  }
+
+  for (const root of sourceRoots()) {
+    let resolvedRoot = root;
+    try {
+      resolvedRoot = realpathSync(root);
+    } catch {
+      resolvedRoot = root;
+    }
+    if (isWithinRoot(resolvedRoot, resolved)) {
+      return { ok: true, resolved };
+    }
+  }
+
+  return { ok: false, reason: 'not_allowed' };
+}
+
+function videoDestination(jobId: string, baseName: string): string {
+  return path.join(resolveDraftRoot(), 'jobs', jobId, 'videos', `${baseName}.mp4`);
+}
+
+function posterDestination(jobId: string, baseName: string, ext: string): string {
+  return path.join(resolveDraftRoot(), 'jobs', jobId, 'videos', `${baseName}-poster${ext}`);
+}
+
+function copyDeterministic(source: string, destination: string, result: SocialContentVideoIngestResult): string {
+  mkdirSync(path.dirname(destination), { recursive: true });
+  if (path.resolve(source) !== path.resolve(destination)) {
+    copyFileSync(source, destination);
+  }
+  result.rewrites.push({ from: source, to: destination });
+  return destination;
+}
+
+function firstDefinedPath(record: UnknownRecord, keys: string[]): { key: string; value: string } | null {
+  for (const key of keys) {
+    const value = stringValue(record[key]);
+    if (value) {
+      return { key, value };
+    }
+  }
+  return null;
+}
+
+function ingestVariantMedia(jobId: string, contract: UnknownRecord, variant: UnknownRecord, result: SocialContentVideoIngestResult): void {
+  const platformSlug = slug(
+    stringValue(contract.platform_slug) || stringValue(contract.canonical_platform_slug) || stringValue(contract.platform),
+    'platform',
+  );
+  const familyId = slug(stringValue(variant.family_id) || stringValue(variant.family_name), 'variant');
+  const baseName = `${platformSlug}-${familyId}`;
+
+  const videoRef = firstDefinedPath(variant, [
+    'video_path',
+    'rendered_video_path',
+    'video_file',
+    'rendered_video_file',
+  ]);
+  if (videoRef) {
+    const resolved = resolveAllowedSource(videoRef.value);
+    if (resolved.ok && path.extname(resolved.resolved).toLowerCase() === '.mp4') {
+      const destination = copyDeterministic(resolved.resolved, videoDestination(jobId, baseName), result);
+      variant[videoRef.key] = destination;
+    } else {
+      result.skipped.push({ path: videoRef.value, reason: resolved.ok ? 'invalid' : resolved.reason });
+    }
+  }
+
+  const posterRef = firstDefinedPath(variant, [
+    'poster_path',
+    'poster_file',
+    'thumbnail_path',
+    'thumbnail_file',
+    'thumbnail_image_path',
+  ]);
+  if (posterRef) {
+    const resolved = resolveAllowedSource(posterRef.value);
+    const ext = resolved.ok ? path.extname(resolved.resolved).toLowerCase() : '';
+    if (resolved.ok && (ext === '.jpg' || ext === '.jpeg' || ext === '.png' || ext === '.webp')) {
+      const destination = copyDeterministic(resolved.resolved, posterDestination(jobId, baseName, ext), result);
+      variant[posterRef.key] = destination;
+      if (posterRef.key.startsWith('thumbnail')) {
+        variant.poster_path = destination;
+      }
+    } else {
+      result.skipped.push({ path: posterRef.value, reason: resolved.ok ? 'invalid' : resolved.reason });
+    }
+  }
+}
+
+function ingestOutputRecord(jobId: string, output: UnknownRecord, result: SocialContentVideoIngestResult): void {
+  const videoAssets = recordValue(output.video_assets);
+  const platformContracts = recordArray(videoAssets?.platform_contracts);
+  for (const contract of platformContracts) {
+    const variants = recordArray(contract.rendered_video_variants);
+    for (const variant of variants) {
+      ingestVariantMedia(jobId, contract, variant, result);
+    }
+  }
+}
+
+export function ingestSocialContentVideoRenderOutput(
+  jobId: string,
+  output: unknown,
+): SocialContentVideoIngestResult {
+  const result: SocialContentVideoIngestResult = {
+    rewrites: [],
+    skipped: [],
+  };
+
+  if (!jobId.trim()) {
+    return result;
+  }
+
+  if (Array.isArray(output)) {
+    for (const entry of output) {
+      const record = recordValue(entry);
+      if (record) {
+        ingestOutputRecord(jobId, record, result);
+      }
+    }
+    return result;
+  }
+
+  const record = recordValue(output);
+  if (record) {
+    ingestOutputRecord(jobId, record, result);
+  }
+
+  return result;
+}

--- a/backend/social-content/media-ingest.ts
+++ b/backend/social-content/media-ingest.ts
@@ -32,11 +32,18 @@ function stringValue(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+const MAX_SLUG_INPUT_LENGTH = 256;
+
 function slug(value: string, fallback: string): string {
-  const normalized = value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  // Cap input length before regex to prevent ReDoS on pathological inputs.
+  const capped = value.length > MAX_SLUG_INPUT_LENGTH ? value.slice(0, MAX_SLUG_INPUT_LENGTH) : value;
+  const lowered = capped.toLowerCase();
+  // Replace non-alphanumeric runs with a single dash, then strip leading/trailing
+  // dashes with two anchored replacements that each scan at most once — avoiding
+  // the ambiguous alternation /^-+|-+$/g which can cause polynomial backtracking.
+  const dashed = lowered.replace(/[^a-z0-9]+/g, '-');
+  const trimmedStart = dashed.replace(/^-+/, '');
+  const normalized = trimmedStart.replace(/-+$/, '');
   return normalized || fallback;
 }
 

--- a/backend/social-content/media-ingest.ts
+++ b/backend/social-content/media-ingest.ts
@@ -2,7 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, realpathSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { resolveDataRoot, resolveDraftRoot } from '@/lib/runtime-paths';
+import { resolveDraftRoot } from '@/lib/runtime-paths';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -45,27 +45,57 @@ function isWithinRoot(root: string, candidate: string): boolean {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
+function expandHermesCacheRoots(root: string): string[] {
+  const normalized = path.resolve(root);
+  const baseName = path.basename(normalized).toLowerCase();
+  if (baseName === 'videos' || baseName === 'images') {
+    return [normalized];
+  }
+  if (baseName === 'cache') {
+    return [
+      path.join(normalized, 'videos'),
+      path.join(normalized, 'images'),
+    ];
+  }
+
+  return [
+    path.join(normalized, 'cache', 'videos'),
+    path.join(normalized, 'cache', 'images'),
+    path.join(normalized, 'videos'),
+    path.join(normalized, 'images'),
+  ];
+}
+
 function sourceRoots(): string[] {
   const roots = [
     process.env.HERMES_MEDIA_CACHE_DIR,
     process.env.HERMES_CACHE_DIR,
-    path.join(homedir(), '.hermes'),
-    path.join(tmpdir(), 'hermes'),
-    resolveDataRoot(),
+    path.join(homedir(), '.hermes', 'cache'),
+    path.join(tmpdir(), 'hermes', 'cache'),
   ]
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-    .map((value) => path.resolve(value));
+    .flatMap((value) => expandHermesCacheRoots(value));
 
   return Array.from(new Set(roots));
 }
 
-function resolveAllowedSource(filePath: string): { ok: true; resolved: string } | { ok: false; reason: 'not_allowed' | 'missing' | 'invalid' } {
+function resolveAllowedSource(
+  filePath: string,
+  exactAllowedDestinations: string[] = [],
+): { ok: true; resolved: string } | { ok: false; reason: 'not_allowed' | 'missing' | 'invalid' } {
   const raw = stringValue(filePath);
   if (!raw || !path.isAbsolute(raw)) {
     return { ok: false, reason: 'invalid' };
   }
 
   const normalized = path.resolve(raw);
+  const exactAllowed = new Set(exactAllowedDestinations.map((candidate) => path.resolve(candidate)));
+  if (exactAllowed.has(normalized)) {
+    return existsSync(normalized)
+      ? { ok: true, resolved: normalized }
+      : { ok: false, reason: 'missing' };
+  }
+
   let resolved: string;
   try {
     resolved = realpathSync(normalized);
@@ -96,6 +126,14 @@ function videoDestination(jobId: string, baseName: string): string {
 
 function posterDestination(jobId: string, baseName: string, ext: string): string {
   return path.join(resolveDraftRoot(), 'jobs', jobId, 'videos', `${baseName}-poster${ext}`);
+}
+
+function exactAllowedVideoDestinations(jobId: string, baseName: string): string[] {
+  return [videoDestination(jobId, baseName)];
+}
+
+function exactAllowedPosterDestinations(jobId: string, baseName: string): string[] {
+  return ['.jpg', '.jpeg', '.png', '.webp'].map((ext) => posterDestination(jobId, baseName, ext));
 }
 
 function copyDeterministic(source: string, destination: string, result: SocialContentVideoIngestResult): string {
@@ -132,12 +170,14 @@ function ingestVariantMedia(jobId: string, contract: UnknownRecord, variant: Unk
     'rendered_video_file',
   ]);
   if (videoRef) {
-    const resolved = resolveAllowedSource(videoRef.value);
-    if (resolved.ok && path.extname(resolved.resolved).toLowerCase() === '.mp4') {
+    const resolved = resolveAllowedSource(videoRef.value, exactAllowedVideoDestinations(jobId, baseName));
+    if ('reason' in resolved) {
+      result.skipped.push({ path: videoRef.value, reason: resolved.reason });
+    } else if (path.extname(resolved.resolved).toLowerCase() === '.mp4') {
       const destination = copyDeterministic(resolved.resolved, videoDestination(jobId, baseName), result);
       variant[videoRef.key] = destination;
     } else {
-      result.skipped.push({ path: videoRef.value, reason: resolved.ok ? 'invalid' : resolved.reason });
+      result.skipped.push({ path: videoRef.value, reason: 'invalid' });
     }
   }
 
@@ -149,16 +189,16 @@ function ingestVariantMedia(jobId: string, contract: UnknownRecord, variant: Unk
     'thumbnail_image_path',
   ]);
   if (posterRef) {
-    const resolved = resolveAllowedSource(posterRef.value);
-    const ext = resolved.ok ? path.extname(resolved.resolved).toLowerCase() : '';
-    if (resolved.ok && (ext === '.jpg' || ext === '.jpeg' || ext === '.png' || ext === '.webp')) {
+    const resolved = resolveAllowedSource(posterRef.value, exactAllowedPosterDestinations(jobId, baseName));
+    const ext = 'resolved' in resolved ? path.extname(resolved.resolved).toLowerCase() : '';
+    if ('resolved' in resolved && (ext === '.jpg' || ext === '.jpeg' || ext === '.png' || ext === '.webp')) {
       const destination = copyDeterministic(resolved.resolved, posterDestination(jobId, baseName, ext), result);
       variant[posterRef.key] = destination;
       if (posterRef.key.startsWith('thumbnail')) {
         variant.poster_path = destination;
       }
     } else {
-      result.skipped.push({ path: posterRef.value, reason: resolved.ok ? 'invalid' : resolved.reason });
+      result.skipped.push({ path: posterRef.value, reason: 'reason' in resolved ? resolved.reason : 'invalid' });
     }
   }
 }

--- a/tests/marketing-hermes-callback-flow.test.ts
+++ b/tests/marketing-hermes-callback-flow.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -341,6 +341,80 @@ test('Hermes media setup failures move social content jobs to needs_connection',
         ?.stages?.image_generation?.status,
       'failed',
     );
+  });
+});
+
+test('Hermes video_render callbacks ingest rendered media from the Hermes cache into DATA_ROOT job videos', async () => {
+  await withRuntimeEnv(async () => {
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+    const hermesCacheRoot = await mkdtemp(path.join(tmpdir(), 'aries-hermes-video-cache-'));
+    const previousHermesCacheDir = process.env.HERMES_CACHE_DIR;
+    const doc = await seedMarketingJob();
+
+    try {
+      process.env.HERMES_CACHE_DIR = hermesCacheRoot;
+      const videoPath = path.join(hermesCacheRoot, 'run-1', 'launch-cut.mp4');
+      const posterPath = path.join(hermesCacheRoot, 'run-1', 'launch-cut.png');
+      await mkdir(path.dirname(videoPath), { recursive: true });
+      await writeFile(videoPath, Buffer.from('callback-video'));
+      await writeFile(posterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+      const run = createExecutionRunRecord({
+        provider: 'hermes',
+        domain: 'marketing',
+        workflowKey: 'social_content_weekly',
+        action: 'resume',
+        tenantId: doc.tenant_id,
+        marketingJobId: doc.job_id,
+        stage: 'production',
+      });
+
+      await handleHermesRunCallback({
+        event_id: 'evt-video-render',
+        aries_run_id: run.aries_run_id,
+        hermes_run_id: 'hermes-video-render-1',
+        status: 'requires_approval',
+        stage: 'video_render',
+        output: [{
+          summary: 'Video render finished',
+          video_assets: {
+            platform_contracts: [{
+              platform_slug: 'tiktok',
+              rendered_video_variants: [{
+                family_id: 'launch-cut',
+                video_path: videoPath,
+                thumbnail_path: posterPath,
+              }],
+            }],
+          },
+        }],
+        approval: {
+          stage: 'video',
+          approval_step: 'approve_video_render',
+          workflow_step_id: 'approve_video_render',
+          prompt: 'Approve render?',
+          resume_token: 'resume-render',
+        },
+      });
+
+      const after = await loadMarketingJobRuntime(doc.job_id);
+      const output = after?.stages.production.primary_output as Record<string, unknown> | null;
+      const variant = (((output?.video_assets as Record<string, unknown> | undefined)?.platform_contracts as Array<Record<string, unknown>> | undefined)?.[0]
+        ?.rendered_video_variants as Array<Record<string, unknown>> | undefined)?.[0];
+      const ingestedVideoPath = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'jobs', doc.job_id, 'videos', 'tiktok-launch-cut.mp4');
+      const ingestedPosterPath = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'jobs', doc.job_id, 'videos', 'tiktok-launch-cut-poster.png');
+
+      assert.equal(variant?.video_path, ingestedVideoPath);
+      assert.equal(variant?.poster_path, ingestedPosterPath);
+      assert.deepEqual(await readFile(ingestedVideoPath), Buffer.from('callback-video'));
+      assert.deepEqual(await readFile(ingestedPosterPath), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    } finally {
+      if (previousHermesCacheDir === undefined) delete process.env.HERMES_CACHE_DIR;
+      else process.env.HERMES_CACHE_DIR = previousHermesCacheDir;
+      await rm(hermesCacheRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/marketing-hermes-callback-flow.test.ts
+++ b/tests/marketing-hermes-callback-flow.test.ts
@@ -355,9 +355,10 @@ test('Hermes video_render callbacks ingest rendered media from the Hermes cache 
 
     try {
       process.env.HERMES_CACHE_DIR = hermesCacheRoot;
-      const videoPath = path.join(hermesCacheRoot, 'run-1', 'launch-cut.mp4');
-      const posterPath = path.join(hermesCacheRoot, 'run-1', 'launch-cut.png');
+      const videoPath = path.join(hermesCacheRoot, 'cache', 'videos', 'run-1', 'launch-cut.mp4');
+      const posterPath = path.join(hermesCacheRoot, 'cache', 'images', 'run-1', 'launch-cut.png');
       await mkdir(path.dirname(videoPath), { recursive: true });
+      await mkdir(path.dirname(posterPath), { recursive: true });
       await writeFile(videoPath, Buffer.from('callback-video'));
       await writeFile(posterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
 
@@ -411,6 +412,80 @@ test('Hermes video_render callbacks ingest rendered media from the Hermes cache 
       assert.deepEqual(await readFile(ingestedVideoPath), Buffer.from('callback-video'));
       assert.deepEqual(await readFile(ingestedPosterPath), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
     } finally {
+      if (previousHermesCacheDir === undefined) delete process.env.HERMES_CACHE_DIR;
+      else process.env.HERMES_CACHE_DIR = previousHermesCacheDir;
+      await rm(hermesCacheRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test('Hermes video_render callback skip logs omit full filesystem paths', async () => {
+  await withRuntimeEnv(async () => {
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const hermesCacheRoot = await mkdtemp(path.join(tmpdir(), 'aries-hermes-video-cache-'));
+    const previousHermesCacheDir = process.env.HERMES_CACHE_DIR;
+    const previousWarn = console.warn;
+    const warnings: unknown[][] = [];
+    const doc = await seedMarketingJob();
+
+    try {
+      process.env.HERMES_CACHE_DIR = hermesCacheRoot;
+      const leakedPosterPath = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'jobs', 'other-job', 'videos', 'tiktok-launch-cut-poster.png');
+      await mkdir(path.dirname(leakedPosterPath), { recursive: true });
+      await writeFile(leakedPosterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args);
+      };
+
+      const run = createExecutionRunRecord({
+        provider: 'hermes',
+        domain: 'marketing',
+        workflowKey: 'social_content_weekly',
+        action: 'resume',
+        tenantId: doc.tenant_id,
+        marketingJobId: doc.job_id,
+        stage: 'production',
+      });
+
+      await handleHermesRunCallback({
+        event_id: 'evt-video-render-skip-log',
+        aries_run_id: run.aries_run_id,
+        hermes_run_id: 'hermes-video-render-skip-log',
+        status: 'requires_approval',
+        stage: 'video_render',
+        output: [{
+          summary: 'Video render finished',
+          video_assets: {
+            platform_contracts: [{
+              platform_slug: 'tiktok',
+              rendered_video_variants: [{
+                family_id: 'launch-cut',
+                thumbnail_path: leakedPosterPath,
+              }],
+            }],
+          },
+        }],
+        approval: {
+          stage: 'video',
+          approval_step: 'approve_video_render',
+          workflow_step_id: 'approve_video_render',
+          prompt: 'Approve render?',
+          resume_token: 'resume-render',
+        },
+      });
+
+      assert.equal(warnings.length, 1);
+      assert.equal(warnings[0]?.[0], '[social-content-video-ingest] skipped media during Hermes callback ingest');
+      assert.deepEqual(warnings[0]?.[1], {
+        jobId: doc.job_id,
+        skipped: {
+          count: 1,
+          reasons: { not_allowed: 1 },
+        },
+      });
+    } finally {
+      console.warn = previousWarn;
       if (previousHermesCacheDir === undefined) delete process.env.HERMES_CACHE_DIR;
       else process.env.HERMES_CACHE_DIR = previousHermesCacheDir;
       await rm(hermesCacheRoot, { recursive: true, force: true });

--- a/tests/social-content-media-ingest.test.ts
+++ b/tests/social-content-media-ingest.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+async function withMediaEnv<T>(run: (ctx: { dataRoot: string; hermesRoot: string }) => Promise<T>): Promise<T> {
+  const previousDataRoot = process.env.DATA_ROOT;
+  const previousHermesCacheDir = process.env.HERMES_CACHE_DIR;
+  const root = await mkdtemp(path.join(tmpdir(), 'aries-social-media-ingest-'));
+  const dataRoot = path.join(root, 'data-root');
+  const hermesRoot = path.join(root, 'hermes-cache');
+  await mkdir(dataRoot, { recursive: true });
+  await mkdir(hermesRoot, { recursive: true });
+
+  process.env.DATA_ROOT = dataRoot;
+  process.env.HERMES_CACHE_DIR = hermesRoot;
+  try {
+    return await run({ dataRoot, hermesRoot });
+  } finally {
+    if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previousDataRoot;
+    if (previousHermesCacheDir === undefined) delete process.env.HERMES_CACHE_DIR;
+    else process.env.HERMES_CACHE_DIR = previousHermesCacheDir;
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test('ingestSocialContentVideoRenderOutput copies allowed Hermes media into the job videos directory', async () => {
+  await withMediaEnv(async ({ dataRoot, hermesRoot }) => {
+    const { ingestSocialContentVideoRenderOutput } = await import('../backend/social-content/media-ingest');
+
+    const jobId = 'job-video-ingest';
+    const videoPath = path.join(hermesRoot, 'runs', 'video.mp4');
+    const posterPath = path.join(hermesRoot, 'runs', 'poster.png');
+    await mkdir(path.dirname(videoPath), { recursive: true });
+    await writeFile(videoPath, Buffer.from('fake-mp4-bytes'));
+    await writeFile(posterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const output = [{
+      video_assets: {
+        platform_contracts: [{
+          platform_slug: 'TikTok',
+          rendered_video_variants: [{
+            family_id: 'Launch Cut',
+            video_path: videoPath,
+            thumbnail_path: posterPath,
+          }],
+        }],
+      },
+    }];
+
+    const result = ingestSocialContentVideoRenderOutput(jobId, output);
+    assert.equal(result.rewrites.length, 2);
+    assert.equal(result.skipped.length, 0);
+
+    const variant = (output[0] as any).video_assets.platform_contracts[0].rendered_video_variants[0];
+    const expectedVideoPath = path.join(dataRoot, 'generated', 'draft', 'jobs', jobId, 'videos', 'tiktok-launch-cut.mp4');
+    const expectedPosterPath = path.join(dataRoot, 'generated', 'draft', 'jobs', jobId, 'videos', 'tiktok-launch-cut-poster.png');
+
+    assert.equal(variant.video_path, expectedVideoPath);
+    assert.equal(variant.poster_path, expectedPosterPath);
+    assert.equal(variant.thumbnail_path, expectedPosterPath);
+    assert.deepEqual(await readFile(expectedVideoPath), Buffer.from('fake-mp4-bytes'));
+    assert.deepEqual(await readFile(expectedPosterPath), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  });
+});
+
+test('ingestSocialContentVideoRenderOutput refuses sources outside the Hermes allowlist', async () => {
+  await withMediaEnv(async ({ dataRoot }) => {
+    const { ingestSocialContentVideoRenderOutput } = await import('../backend/social-content/media-ingest');
+
+    const outsideRoot = await mkdtemp(path.join(tmpdir(), 'aries-social-media-outside-'));
+    const outsideVideoPath = path.join(outsideRoot, 'outside.mp4');
+    await writeFile(outsideVideoPath, Buffer.from('outside-video'));
+
+    try {
+      const output = [{
+        video_assets: {
+          platform_contracts: [{
+            platform_slug: 'TikTok',
+            rendered_video_variants: [{
+              family_id: 'Unsafe',
+              video_path: outsideVideoPath,
+            }],
+          }],
+        },
+      }];
+
+      const result = ingestSocialContentVideoRenderOutput('job-video-ingest', output);
+      assert.equal(result.rewrites.length, 0);
+      assert.deepEqual(result.skipped, [{ path: outsideVideoPath, reason: 'not_allowed' }]);
+      assert.equal((output[0] as any).video_assets.platform_contracts[0].rendered_video_variants[0].video_path, outsideVideoPath);
+
+      const expectedVideoPath = path.join(dataRoot, 'generated', 'draft', 'jobs', 'job-video-ingest', 'videos', 'tiktok-unsafe.mp4');
+      await assert.rejects(readFile(expectedVideoPath));
+    } finally {
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/social-content-media-ingest.test.ts
+++ b/tests/social-content-media-ingest.test.ts
@@ -31,9 +31,10 @@ test('ingestSocialContentVideoRenderOutput copies allowed Hermes media into the 
     const { ingestSocialContentVideoRenderOutput } = await import('../backend/social-content/media-ingest');
 
     const jobId = 'job-video-ingest';
-    const videoPath = path.join(hermesRoot, 'runs', 'video.mp4');
-    const posterPath = path.join(hermesRoot, 'runs', 'poster.png');
+    const videoPath = path.join(hermesRoot, 'cache', 'videos', 'runs', 'video.mp4');
+    const posterPath = path.join(hermesRoot, 'cache', 'images', 'runs', 'poster.png');
     await mkdir(path.dirname(videoPath), { recursive: true });
+    await mkdir(path.dirname(posterPath), { recursive: true });
     await writeFile(videoPath, Buffer.from('fake-mp4-bytes'));
     await writeFile(posterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
 
@@ -97,5 +98,51 @@ test('ingestSocialContentVideoRenderOutput refuses sources outside the Hermes al
     } finally {
       await rm(outsideRoot, { recursive: true, force: true });
     }
+  });
+});
+
+test('ingestSocialContentVideoRenderOutput allows already-ingested exact destination paths but rejects other DATA_ROOT media', async () => {
+  await withMediaEnv(async ({ dataRoot }) => {
+    const { ingestSocialContentVideoRenderOutput } = await import('../backend/social-content/media-ingest');
+
+    const jobId = 'job-video-ingest';
+    const expectedVideoPath = path.join(dataRoot, 'generated', 'draft', 'jobs', jobId, 'videos', 'tiktok-launch-cut.mp4');
+    const expectedPosterPath = path.join(dataRoot, 'generated', 'draft', 'jobs', jobId, 'videos', 'tiktok-launch-cut-poster.png');
+    await mkdir(path.dirname(expectedVideoPath), { recursive: true });
+    await writeFile(expectedVideoPath, Buffer.from('existing-video'));
+    await writeFile(expectedPosterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const otherJobPosterPath = path.join(dataRoot, 'generated', 'draft', 'jobs', 'other-job', 'videos', 'tiktok-launch-cut-poster.png');
+    await mkdir(path.dirname(otherJobPosterPath), { recursive: true });
+    await writeFile(otherJobPosterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const output = [{
+      video_assets: {
+        platform_contracts: [{
+          platform_slug: 'TikTok',
+          rendered_video_variants: [
+            {
+              family_id: 'Launch Cut',
+              video_path: expectedVideoPath,
+              thumbnail_path: expectedPosterPath,
+            },
+            {
+              family_id: 'Unsafe Poster',
+              thumbnail_path: otherJobPosterPath,
+            },
+          ],
+        }],
+      },
+    }];
+
+    const result = ingestSocialContentVideoRenderOutput(jobId, output);
+    assert.equal(result.rewrites.length, 2);
+    assert.deepEqual(result.skipped, [{ path: otherJobPosterPath, reason: 'not_allowed' }]);
+
+    const variants = (output[0] as any).video_assets.platform_contracts[0].rendered_video_variants;
+    assert.equal(variants[0].video_path, expectedVideoPath);
+    assert.equal(variants[0].thumbnail_path, expectedPosterPath);
+    assert.equal(variants[0].poster_path, expectedPosterPath);
+    assert.equal(variants[1].thumbnail_path, otherJobPosterPath);
   });
 });

--- a/tests/social-content-media-ingest.test.ts
+++ b/tests/social-content-media-ingest.test.ts
@@ -101,6 +101,28 @@ test('ingestSocialContentVideoRenderOutput refuses sources outside the Hermes al
   });
 });
 
+test('slug helper completes in bounded time on pathological dash-heavy input (ReDoS regression)', async () => {
+  // Previously the alternation /^-+|-+$/g could exhibit polynomial backtracking
+  // on long runs of dashes. This test asserts the operation finishes well under
+  // 200 ms even for a 50 000-character all-dash string.
+  const { ingestSocialContentVideoRenderOutput } = await import('../backend/social-content/media-ingest');
+
+  const pathologicalSlug = '-'.repeat(50_000) + 'x';
+  const output = [{
+    video_assets: {
+      platform_contracts: [{
+        platform_slug: pathologicalSlug,
+        rendered_video_variants: [],
+      }],
+    },
+  }];
+
+  const start = Date.now();
+  ingestSocialContentVideoRenderOutput('job-redos-check', output);
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 200, `slug took ${elapsed}ms on pathological input — possible ReDoS regression`);
+});
+
 test('ingestSocialContentVideoRenderOutput allows already-ingested exact destination paths but rejects other DATA_ROOT media', async () => {
   await withMediaEnv(async ({ dataRoot }) => {
     const { ingestSocialContentVideoRenderOutput } = await import('../backend/social-content/media-ingest');

--- a/tests/video-asset-handler.test.ts
+++ b/tests/video-asset-handler.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+async function withRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
+  const previousDataRoot = process.env.DATA_ROOT;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-video-asset-handler-'));
+  process.env.DATA_ROOT = dataRoot;
+  try {
+    return await run(dataRoot);
+  } finally {
+    if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previousDataRoot;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+test('handleGetMarketingJobAsset serves PNG video posters from the ingested job videos directory', async () => {
+  await withRuntimeEnv(async (dataRoot) => {
+    const { handleGetMarketingJobAsset } = await import('../app/api/marketing/jobs/[jobId]/assets/[assetId]/handler');
+    const jobId = 'mkt_video_png_poster';
+    const runtimeFile = path.join(dataRoot, 'generated', 'draft', 'marketing-jobs', `${jobId}.json`);
+    const videosRoot = path.join(dataRoot, 'generated', 'draft', 'jobs', jobId, 'videos');
+    const videoPath = path.join(videosRoot, 'launch-cut.mp4');
+    const posterPath = path.join(videosRoot, 'launch-cut-poster.png');
+
+    await mkdir(path.dirname(runtimeFile), { recursive: true });
+    await mkdir(videosRoot, { recursive: true });
+    await writeFile(videoPath, Buffer.from('video-bytes'));
+    await writeFile(posterPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    await writeFile(
+      runtimeFile,
+      JSON.stringify({
+        schema_name: 'marketing_job_state_schema',
+        schema_version: '1.0.0',
+        job_id: jobId,
+        job_type: 'brand_campaign',
+        tenant_id: 'tenant_real',
+        state: 'running',
+        status: 'running',
+        current_stage: 'production',
+        stage_order: ['research', 'strategy', 'production', 'publish'],
+        stages: {
+          research: { stage: 'research', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-r', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          strategy: { stage: 'strategy', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-s', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          production: { stage: 'production', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: 'run-p', summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+          publish: { stage: 'publish', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+        },
+        approvals: { current: null, history: [] },
+        publish_config: { platforms: ['tiktok'], live_publish_platforms: [], video_render_platforms: ['tiktok'] },
+        brand_kit: null,
+        inputs: { request: {}, brand_url: 'https://brand.example' },
+        errors: [],
+        last_error: null,
+        history: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }, null, 2),
+    );
+
+    const response = await handleGetMarketingJobAsset(
+      jobId,
+      'video-launch-cut-poster',
+      new Request('http://localhost/api/marketing/jobs/test/assets/video-launch-cut-poster'),
+      async () => ({
+        userId: 'user_123',
+        tenantId: 'tenant_real',
+        tenantSlug: 'acme',
+        role: 'tenant_admin' as const,
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('content-type'), 'image/png');
+    assert.deepEqual(Buffer.from(await response.arrayBuffer()), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  });
+});


### PR DESCRIPTION
## Summary
- add a social-content media-ingest helper that only copies allowed Hermes-cache video/poster assets into DATA_ROOT/generated/draft/jobs/{jobId}/videos with deterministic names
- invoke the ingest helper on social_content_weekly video_render callbacks before the runtime doc is saved so approval/completion states reference local copies
- expand video asset serving to find PNG/WEBP/JPEG posters and cover the new ingest + poster behavior with focused tests

## Test plan
- npm run workspace:verify (fails in scratch worktree: canonical root mismatch, expected /home/node/aries-app vs actual /home/node/.hermes/kanban/workspaces/t_9fe1ca2a)
- npx tsx --test tests/social-content-media-ingest.test.ts tests/marketing-hermes-callback-flow.test.ts tests/video-asset-handler.test.ts
- npm run validate:repo-boundary
- npm run validate:banned-patterns
