### PR TITLE
ci: bump deploy workflow actions past Node 20 deprecation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,20 +103,20 @@ jobs:
           echo "image_ref=${image_ref}" >> "${GITHUB_OUTPUT}"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_WORKFLOW_TOKEN || github.token }}
 
       - name: Checkout deploy source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
         with:
           ref: ${{ steps.resolve.outputs.checkout_ref }}
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Publish exact deploy image
         env:

--- a/.github/workflows/issue-agent-fix.yml
+++ b/.github/workflows/issue-agent-fix.yml
@@ -31,7 +31,7 @@ jobs:
       (github.event.action == 'labeled' && github.event.label.name == 'agent:fix')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -44,7 +44,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- bump deploy workflow actions off the Node 20-based majors
- move sibling workflow checkout steps to actions/checkout v5.0.1 as well
- keep checkout on v5.0.1 (not v6) to avoid the newer credential-persistence behavior shift while still clearing the Node 20 cutoff

## Validation
- parsed all workflow YAML files successfully with python/yaml
- confirmed the self-hosted runner is on Actions Runner 2.334.0, which satisfies the v2.327.1+ minimum for these Node 24 action releases
- `npm run workspace:verify` is not worktree-safe today; in this worktree it fails because it hardcodes `/home/node/aries-app` as the canonical root
