### PR TITLE
fix: reap stalled marketing jobs by stage timeout

### DIFF
--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -18,11 +18,13 @@ const MARKETING_RUNTIME_SCHEMA_VERSION = '1.0.0';
 export type MarketingStage = 'research' | 'strategy' | 'production' | 'publish';
 export type MarketingJobState = 'queued' | 'running' | 'approval_required' | 'completed' | 'failed' | 'needs_connection';
 /**
- * `failed_stale` is reserved for the manual stale-run reaper script
+ * `failed_stale` is reserved for the stale-run reaper script
  * (`scripts/reap-stale-runs.ts`). The reaper sets it when an in-flight run has
- * been silent past `STALE_RUN_REAPER_THRESHOLD_MS` (default 30 minutes — twice
- * the marketing workflow timeout). It is never produced by the orchestrator
- * or callback handlers; existing code paths treat it identically to `failed`.
+ * exceeded the allowed silence window for its current stage (defaults:
+ * research 10m, strategy 5m, production 90m, publish 30m; optional global
+ * override `STALE_RUN_REAPER_THRESHOLD_MS`). It is never produced by the
+ * orchestrator or callback handlers; existing code paths treat it identically
+ * to `failed`.
  */
 export type MarketingJobStatus =
   | 'pending'
@@ -202,9 +204,10 @@ export type MarketingJobRuntimeDocument = {
   soft_cancel_requested_at?: string | null;
   /** Optional machine-readable reason set when a non-orchestrator process
    * forces the run into a terminal failed status. Currently only used by
-   * the manual stale-run reaper (`scripts/reap-stale-runs.ts`), which sets
-   * `'stale_run_reaper'` when a submitted/running run has been silent past
-   * the staleness threshold. Treated as advisory metadata. */
+   * the stale-run reaper (`scripts/reap-stale-runs.ts`), which sets
+   * `'marketing_job_stalled'` when a submitted/running run has been silent
+   * past the staleness threshold for its current stage. Treated as advisory
+   * metadata. */
   failure_reason?: string | null;
 };
 

--- a/backend/marketing/stale-run-reaper.ts
+++ b/backend/marketing/stale-run-reaper.ts
@@ -16,12 +16,24 @@ const KNOWN_SCHEMA_NAMES = new Set([
   'job_runtime_state_schema',
 ]);
 
-const STALE_REAPER_FAILURE_REASON = 'stale_run_reaper';
+const STALE_REAPER_FAILURE_REASON = 'marketing_job_stalled';
 const STALE_REAPER_ERROR_MESSAGE =
-  'Run marked failed by the stale-run reaper after exceeding the silence threshold without a Hermes callback.';
+  'Marketing job stalled without progress and was failed by the stale-run reaper.';
 
 const DEFAULT_MARKETING_WORKFLOW_TIMEOUT_MS = 15 * 60 * 1000;
 const DEFAULT_STALE_THRESHOLD_MS = DEFAULT_MARKETING_WORKFLOW_TIMEOUT_MS * 2;
+const DEFAULT_STAGE_THRESHOLD_MS: Readonly<Record<MarketingStage, number>> = {
+  research: 10 * 60 * 1000,
+  strategy: 5 * 60 * 1000,
+  production: 90 * 60 * 1000,
+  publish: 30 * 60 * 1000,
+};
+const STAGE_THRESHOLD_ENV_BY_STAGE: Readonly<Record<MarketingStage, string>> = {
+  research: 'STALE_RUN_REAPER_RESEARCH_THRESHOLD_MS',
+  strategy: 'STALE_RUN_REAPER_STRATEGY_THRESHOLD_MS',
+  production: 'STALE_RUN_REAPER_PRODUCTION_THRESHOLD_MS',
+  publish: 'STALE_RUN_REAPER_PUBLISH_THRESHOLD_MS',
+};
 
 const IN_FLIGHT_STATES: ReadonlySet<MarketingJobState> = new Set([
   'queued',
@@ -48,8 +60,9 @@ export type StaleRunCandidate = {
   state: MarketingJobState;
   status: MarketingJobStatus;
   stage: MarketingStage;
-  updatedAt: string;
+  progressAt: string;
   silentMs: number;
+  thresholdMs: number;
   filePath: string;
   mutated: boolean;
 };
@@ -61,15 +74,44 @@ export type StaleRunReaperReport = {
   skipped: number;
   errors: number;
   thresholdMs: number;
+  thresholdsByStage: Record<MarketingStage, number>;
   dryRun: boolean;
 };
 
-export function staleRunReaperThresholdMs(): number {
+function parsePositiveInt(value: string | undefined): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function staleRunReaperGlobalThresholdOverrideMs(): number | null {
+  return parsePositiveInt(process.env.STALE_RUN_REAPER_THRESHOLD_MS);
+}
+
+export function staleRunReaperThresholdMs(stage?: MarketingStage): number {
+  const globalOverride = staleRunReaperGlobalThresholdOverrideMs();
+  if (globalOverride !== null) return globalOverride;
+  if (stage) {
+    return (
+      parsePositiveInt(process.env[STAGE_THRESHOLD_ENV_BY_STAGE[stage]]) ??
+      DEFAULT_STAGE_THRESHOLD_MS[stage]
+    );
+  }
   const raw = process.env.STALE_RUN_REAPER_THRESHOLD_MS?.trim();
   if (!raw) return DEFAULT_STALE_THRESHOLD_MS;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_STALE_THRESHOLD_MS;
   return parsed;
+}
+
+export function staleRunReaperThresholdsByStage(): Record<MarketingStage, number> {
+  return {
+    research: staleRunReaperThresholdMs('research'),
+    strategy: staleRunReaperThresholdMs('strategy'),
+    production: staleRunReaperThresholdMs('production'),
+    publish: staleRunReaperThresholdMs('publish'),
+  };
 }
 
 function isKnownSchema(value: unknown): boolean {
@@ -125,6 +167,51 @@ function parseTimestampMs(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function pushTimestampMs(values: number[], value: unknown): void {
+  const parsed = parseTimestampMs(value);
+  if (parsed !== null) values.push(parsed);
+}
+
+function latestProgressTimestamp(parsed: Record<string, unknown>, stage: MarketingStage): number | null {
+  const timestamps: number[] = [];
+  pushTimestampMs(timestamps, parsed.updated_at);
+
+  const stages = parsed.stages;
+  const stageRecord =
+    stages && typeof stages === 'object' && !Array.isArray(stages)
+      ? ((stages as Record<string, unknown>)[stage] as Record<string, unknown> | undefined)
+      : undefined;
+  if (stageRecord && typeof stageRecord === 'object' && !Array.isArray(stageRecord)) {
+    pushTimestampMs(timestamps, stageRecord.started_at);
+    pushTimestampMs(timestamps, stageRecord.completed_at);
+    pushTimestampMs(timestamps, stageRecord.failed_at);
+  }
+
+  const approvals = parsed.approvals;
+  const currentApproval =
+    approvals && typeof approvals === 'object' && !Array.isArray(approvals)
+      ? ((approvals as Record<string, unknown>).current as Record<string, unknown> | null | undefined)
+      : null;
+  if (
+    currentApproval &&
+    typeof currentApproval === 'object' &&
+    !Array.isArray(currentApproval) &&
+    asMarketingStage(currentApproval.stage) === stage
+  ) {
+    pushTimestampMs(timestamps, currentApproval.requested_at);
+  }
+
+  const history = Array.isArray(parsed.history) ? parsed.history : [];
+  for (const entry of history) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    if (asMarketingStage((entry as Record<string, unknown>).stage) !== stage) continue;
+    pushTimestampMs(timestamps, (entry as Record<string, unknown>).at);
+  }
+
+  if (timestamps.length === 0) return null;
+  return Math.max(...timestamps);
+}
+
 function isTerminalDoc(state: MarketingJobState, status: MarketingJobStatus): boolean {
   if (state === 'completed' || state === 'failed' || state === 'needs_connection') return true;
   if (status === 'completed' || status === 'failed' || status === 'needs_connection') return true;
@@ -164,7 +251,6 @@ function logWarn(message: string, fields?: Record<string, unknown>): void {
 function applyStaleMarker(
   doc: MarketingJobRuntimeDocument,
   candidate: StaleRunCandidate,
-  thresholdMs: number,
   nowIso: string,
 ): void {
   const stage = candidate.stage;
@@ -177,8 +263,8 @@ function applyStaleMarker(
       previous_state: candidate.state,
       previous_status: candidate.status,
       silent_ms: candidate.silentMs,
-      threshold_ms: thresholdMs,
-      previous_updated_at: candidate.updatedAt,
+      threshold_ms: candidate.thresholdMs,
+      previous_progress_at: candidate.progressAt,
     },
     at: nowIso,
   };
@@ -198,7 +284,7 @@ function applyStaleMarker(
       state: 'failed',
       status: 'failed_stale',
       stage,
-      note: `stale-run reaper marked job failed after ${candidate.silentMs} ms of silence`,
+      note: `stale-run reaper marked job failed after ${candidate.silentMs} ms without ${stage} progress`,
     });
   }
   doc.updated_at = nowIso;
@@ -209,6 +295,7 @@ export async function runStaleRunReaper(
 ): Promise<StaleRunReaperReport> {
   const dataRoot = path.normalize(options.dataRoot);
   const root = path.join(dataRoot, MARKETING_JOBS_SUBDIR);
+  const thresholdsByStage = staleRunReaperThresholdsByStage();
   const thresholdMs = options.thresholdMs ?? staleRunReaperThresholdMs();
   const now = options.now ?? (() => new Date());
   const report: StaleRunReaperReport = {
@@ -218,6 +305,7 @@ export async function runStaleRunReaper(
     skipped: 0,
     errors: 0,
     thresholdMs,
+    thresholdsByStage,
     dryRun: options.dryRun,
   };
 
@@ -300,16 +388,17 @@ export async function runStaleRunReaper(
       continue;
     }
 
-    const updatedAtMs = parseTimestampMs(parsed.updated_at);
-    if (updatedAtMs === null) {
+    const progressAtMs = latestProgressTimestamp(parsed, stage);
+    if (progressAtMs === null) {
       report.skipped += 1;
-      logWarn('runtime doc missing parseable updated_at; skipping', { jobId, filePath });
+      logWarn('runtime doc missing parseable progress timestamp; skipping', { jobId, filePath, stage });
       continue;
     }
 
+    const candidateThresholdMs = options.thresholdMs ?? thresholdsByStage[stage];
     const nowMs = now().getTime();
-    const silentMs = nowMs - updatedAtMs;
-    if (silentMs <= thresholdMs) {
+    const silentMs = nowMs - progressAtMs;
+    if (silentMs <= candidateThresholdMs) {
       report.skipped += 1;
       continue;
     }
@@ -320,8 +409,9 @@ export async function runStaleRunReaper(
       state,
       status,
       stage,
-      updatedAt: asString(parsed.updated_at),
+      progressAt: new Date(progressAtMs).toISOString(),
       silentMs,
+      thresholdMs: candidateThresholdMs,
       filePath,
       mutated: false,
     };
@@ -334,7 +424,7 @@ export async function runStaleRunReaper(
         status,
         stage,
         silent_ms: silentMs,
-        threshold_ms: thresholdMs,
+        threshold_ms: candidateThresholdMs,
         filePath,
       });
       report.candidates.push(candidate);
@@ -343,7 +433,7 @@ export async function runStaleRunReaper(
 
     try {
       const doc = parsed as unknown as MarketingJobRuntimeDocument;
-      applyStaleMarker(doc, candidate, thresholdMs, new Date(nowMs).toISOString());
+      applyStaleMarker(doc, candidate, new Date(nowMs).toISOString());
       await writeFile(filePath, JSON.stringify(doc, null, 2));
       candidate.mutated = true;
       report.mutated += 1;
@@ -353,7 +443,9 @@ export async function runStaleRunReaper(
         tenantId,
         previous_state: state,
         previous_status: status,
+        stage,
         silent_ms: silentMs,
+        threshold_ms: candidateThresholdMs,
         filePath,
       });
     } catch (err) {
@@ -374,6 +466,7 @@ export async function runStaleRunReaper(
     skipped: report.skipped,
     errors: report.errors,
     threshold_ms: thresholdMs,
+    thresholds_by_stage: thresholdsByStage,
   });
 
   return report;

--- a/backend/marketing/stale-run-reaper.ts
+++ b/backend/marketing/stale-run-reaper.ts
@@ -73,7 +73,11 @@ export type StaleRunReaperReport = {
   mutated: number;
   skipped: number;
   errors: number;
-  thresholdMs: number;
+  /**
+   * The global override threshold (ms) passed explicitly by the caller (e.g. --threshold-ms).
+   * Null when no override was provided and filtering ran per-stage via thresholdsByStage.
+   */
+  thresholdMs: number | null;
   thresholdsByStage: Record<MarketingStage, number>;
   dryRun: boolean;
 };
@@ -295,8 +299,18 @@ export async function runStaleRunReaper(
 ): Promise<StaleRunReaperReport> {
   const dataRoot = path.normalize(options.dataRoot);
   const root = path.join(dataRoot, MARKETING_JOBS_SUBDIR);
-  const thresholdsByStage = staleRunReaperThresholdsByStage();
-  const thresholdMs = options.thresholdMs ?? staleRunReaperThresholdMs();
+  // When a caller-supplied override is present, apply it uniformly across all stages so that
+  // report.thresholdsByStage reflects what filtering actually used (not stale env defaults).
+  const thresholdsByStage: Record<MarketingStage, number> = options.thresholdMs
+    ? {
+        research: options.thresholdMs,
+        strategy: options.thresholdMs,
+        production: options.thresholdMs,
+        publish: options.thresholdMs,
+      }
+    : staleRunReaperThresholdsByStage();
+  // thresholdMs is the explicit override, or null when filtering ran per-stage.
+  const thresholdMs: number | null = options.thresholdMs ?? null;
   const now = options.now ?? (() => new Date());
   const report: StaleRunReaperReport = {
     scanned: 0,
@@ -395,7 +409,7 @@ export async function runStaleRunReaper(
       continue;
     }
 
-    const candidateThresholdMs = options.thresholdMs ?? thresholdsByStage[stage];
+    const candidateThresholdMs = thresholdsByStage[stage];
     const nowMs = now().getTime();
     const silentMs = nowMs - progressAtMs;
     if (silentMs <= candidateThresholdMs) {
@@ -465,7 +479,7 @@ export async function runStaleRunReaper(
     mutated: report.mutated,
     skipped: report.skipped,
     errors: report.errors,
-    threshold_ms: thresholdMs,
+    ...(thresholdMs !== null ? { threshold_ms_override: thresholdMs } : {}),
     thresholds_by_stage: thresholdsByStage,
   });
 

--- a/scripts/automations/manifest.mjs
+++ b/scripts/automations/manifest.mjs
@@ -87,6 +87,16 @@ export const automationJobs = [
     purpose: 'Scan Aries runtime and automation health, normalize failures into the runtime incident log, and announce the concise detection/resolution summary.',
   },
   {
+    id: 'aries-marketing-stale-run-reaper',
+    name: 'Aries marketing stale-run reaper',
+    cron: '*/5 * * * *',
+    tz: 'America/Los_Angeles',
+    message:
+      `Work in ${repoRoot}. Run npx tsx scripts/reap-stale-runs.ts --apply. Return only the final summary line plus any candidate lines if mutated > 0.`,
+    purpose:
+      'Sweep marketing runtime docs every 5 minutes and mark stalled running/approval jobs as failed_stale once they exceed the current-stage timeout window.',
+  },
+  {
     id: 'aries-runtime-error-repair-loop',
     name: 'Aries runtime error repair loop',
     cron: '10,40 * * * *',

--- a/scripts/reap-stale-runs.ts
+++ b/scripts/reap-stale-runs.ts
@@ -4,6 +4,7 @@ import { resolveDataRoot } from '@/lib/runtime-paths';
 import {
   runStaleRunReaper,
   staleRunReaperThresholdMs,
+  staleRunReaperThresholdsByStage,
   type StaleRunReaperReport,
 } from '@/backend/marketing/stale-run-reaper';
 
@@ -66,9 +67,13 @@ function parseArgs(argv: string[]): CliArgs {
 }
 
 function summarize(report: StaleRunReaperReport): string {
+  const thresholdSummary = report.thresholdsByStage
+    ? `research:${report.thresholdsByStage.research},strategy:${report.thresholdsByStage.strategy},production:${report.thresholdsByStage.production},publish:${report.thresholdsByStage.publish}`
+    : String(report.thresholdMs);
   const lines = [
     `mode=${report.dryRun ? 'dry-run' : 'apply'}`,
     `threshold_ms=${report.thresholdMs}`,
+    `thresholds_by_stage=${thresholdSummary}`,
     `scanned=${report.scanned}`,
     `candidates=${report.candidates.length}`,
     `mutated=${report.mutated}`,
@@ -94,9 +99,17 @@ async function main(): Promise<number> {
 
   const dataRoot = args.dataRoot ?? resolveDataRoot();
   const thresholdMs = args.thresholdMs ?? staleRunReaperThresholdMs();
+  const thresholdsByStage = args.thresholdMs
+    ? {
+        research: args.thresholdMs,
+        strategy: args.thresholdMs,
+        production: args.thresholdMs,
+        publish: args.thresholdMs,
+      }
+    : staleRunReaperThresholdsByStage();
 
   process.stdout.write(
-    `[reap-stale-runs] starting mode=${args.dryRun ? 'dry-run' : 'apply'} dataRoot=${dataRoot} threshold_ms=${thresholdMs}\n`,
+    `[reap-stale-runs] starting mode=${args.dryRun ? 'dry-run' : 'apply'} dataRoot=${dataRoot} threshold_ms=${thresholdMs} thresholds_by_stage=${JSON.stringify(thresholdsByStage)}\n`,
   );
 
   const report = await runStaleRunReaper({

--- a/scripts/reap-stale-runs.ts
+++ b/scripts/reap-stale-runs.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import { resolveDataRoot } from '@/lib/runtime-paths';
 import {
   runStaleRunReaper,
-  staleRunReaperThresholdMs,
   staleRunReaperThresholdsByStage,
   type StaleRunReaperReport,
 } from '@/backend/marketing/stale-run-reaper';
@@ -11,8 +10,16 @@ import {
 const USAGE = `Usage: tsx scripts/reap-stale-runs.ts [--apply] [--dry-run] [--data-root <path>] [--threshold-ms <int>]
 
 Sweeps marketing-job runtime documents under DATA_ROOT/generated/draft/marketing-jobs
-and marks runs that have been silent past STALE_RUN_REAPER_THRESHOLD_MS (default
-30 minutes — twice the marketing workflow timeout) as failed_stale.
+and marks runs that have been silent past their per-stage timeout as failed_stale.
+
+Per-stage defaults (overridable via env vars):
+  research:   10 min  (STALE_RUN_REAPER_RESEARCH_THRESHOLD_MS)
+  strategy:    5 min  (STALE_RUN_REAPER_STRATEGY_THRESHOLD_MS)
+  production: 90 min  (STALE_RUN_REAPER_PRODUCTION_THRESHOLD_MS)
+  publish:    30 min  (STALE_RUN_REAPER_PUBLISH_THRESHOLD_MS)
+
+--threshold-ms <int>  Override all per-stage thresholds with a single value (ms).
+                      When omitted, per-stage thresholds (env or defaults above) apply.
 
 Defaults to --dry-run. Pass --apply to mutate runtime docs. Never deletes files.
 Idempotent: a second --apply finds zero candidates because reaped runs land in
@@ -67,12 +74,10 @@ function parseArgs(argv: string[]): CliArgs {
 }
 
 function summarize(report: StaleRunReaperReport): string {
-  const thresholdSummary = report.thresholdsByStage
-    ? `research:${report.thresholdsByStage.research},strategy:${report.thresholdsByStage.strategy},production:${report.thresholdsByStage.production},publish:${report.thresholdsByStage.publish}`
-    : String(report.thresholdMs);
+  const thresholdSummary = `research:${report.thresholdsByStage.research},strategy:${report.thresholdsByStage.strategy},production:${report.thresholdsByStage.production},publish:${report.thresholdsByStage.publish}`;
   const lines = [
     `mode=${report.dryRun ? 'dry-run' : 'apply'}`,
-    `threshold_ms=${report.thresholdMs}`,
+    ...(report.thresholdMs !== null ? [`threshold_ms_override=${report.thresholdMs}`] : []),
     `thresholds_by_stage=${thresholdSummary}`,
     `scanned=${report.scanned}`,
     `candidates=${report.candidates.length}`,
@@ -98,8 +103,10 @@ async function main(): Promise<number> {
   }
 
   const dataRoot = args.dataRoot ?? resolveDataRoot();
-  const thresholdMs = args.thresholdMs ?? staleRunReaperThresholdMs();
-  const thresholdsByStage = args.thresholdMs
+  // When --threshold-ms is supplied, runStaleRunReaper will apply it uniformly across all stages
+  // and reflect that in report.thresholdsByStage. Let the reaper derive the effective per-stage
+  // map so that what we log here matches what report.thresholdsByStage will contain.
+  const effectiveThresholdsByStage = args.thresholdMs
     ? {
         research: args.thresholdMs,
         strategy: args.thresholdMs,
@@ -109,13 +116,13 @@ async function main(): Promise<number> {
     : staleRunReaperThresholdsByStage();
 
   process.stdout.write(
-    `[reap-stale-runs] starting mode=${args.dryRun ? 'dry-run' : 'apply'} dataRoot=${dataRoot} threshold_ms=${thresholdMs} thresholds_by_stage=${JSON.stringify(thresholdsByStage)}\n`,
+    `[reap-stale-runs] starting mode=${args.dryRun ? 'dry-run' : 'apply'} dataRoot=${dataRoot}${args.thresholdMs !== undefined ? ` threshold_ms_override=${args.thresholdMs}` : ''} thresholds_by_stage=${JSON.stringify(effectiveThresholdsByStage)}\n`,
   );
 
   const report = await runStaleRunReaper({
     dataRoot,
     dryRun: args.dryRun,
-    thresholdMs,
+    thresholdMs: args.thresholdMs,
   });
 
   process.stdout.write(`[reap-stale-runs] ${summarize(report)}\n`);

--- a/tests/reap-stale-runs.test.ts
+++ b/tests/reap-stale-runs.test.ts
@@ -470,6 +470,75 @@ test('skips runtime docs missing any parseable progress timestamp', async () => 
   });
 });
 
+test('--threshold-ms override propagates into report.thresholdsByStage and report.thresholdMs', async () => {
+  await withScratch(async (dataRoot) => {
+    const now = new Date('2026-05-06T12:00:00.000Z');
+    const staleAt = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString();
+    const doc = makeRuntimeDoc({
+      jobId: 'job-override-propagation',
+      tenantId: 'tenant-1',
+      state: 'running',
+      status: 'running',
+      updatedAtIso: staleAt,
+      stage: 'production',
+    });
+    await writeRuntimeDoc(dataRoot, doc);
+
+    const overrideMs = 45 * 60 * 1000; // 45 minutes
+    const report = await runStaleRunReaper({
+      dataRoot,
+      dryRun: true,
+      now: () => now,
+      thresholdMs: overrideMs,
+    });
+
+    // report.thresholdMs must reflect the explicit override, not null
+    assert.equal(report.thresholdMs, overrideMs, 'report.thresholdMs must equal the override');
+
+    // report.thresholdsByStage must use the override for every stage, not env/default values
+    assert.equal(report.thresholdsByStage.research, overrideMs, 'research threshold must equal override');
+    assert.equal(report.thresholdsByStage.strategy, overrideMs, 'strategy threshold must equal override');
+    assert.equal(report.thresholdsByStage.production, overrideMs, 'production threshold must equal override');
+    assert.equal(report.thresholdsByStage.publish, overrideMs, 'publish threshold must equal override');
+
+    // The production job is 2 hours stale — well past 45 min override — so it should be a candidate
+    assert.equal(report.candidates.length, 1, 'stale job should be candidate with override threshold');
+    assert.equal(report.candidates[0]!.thresholdMs, overrideMs, 'candidate.thresholdMs must equal override');
+  });
+});
+
+test('without --threshold-ms override, report.thresholdMs is null and thresholdsByStage reflects per-stage defaults', async () => {
+  await withScratch(async (dataRoot) => {
+    // Clean env to ensure defaults apply
+    const savedEnvKeys = [
+      'STALE_RUN_REAPER_THRESHOLD_MS',
+      'STALE_RUN_REAPER_RESEARCH_THRESHOLD_MS',
+      'STALE_RUN_REAPER_STRATEGY_THRESHOLD_MS',
+      'STALE_RUN_REAPER_PRODUCTION_THRESHOLD_MS',
+      'STALE_RUN_REAPER_PUBLISH_THRESHOLD_MS',
+    ] as const;
+    const saved: Record<string, string | undefined> = {};
+    for (const key of savedEnvKeys) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+
+    try {
+      const report = await runStaleRunReaper({ dataRoot, dryRun: true });
+
+      assert.equal(report.thresholdMs, null, 'report.thresholdMs must be null when no override');
+      assert.equal(report.thresholdsByStage.research, 10 * 60 * 1000);
+      assert.equal(report.thresholdsByStage.strategy, 5 * 60 * 1000);
+      assert.equal(report.thresholdsByStage.production, 90 * 60 * 1000);
+      assert.equal(report.thresholdsByStage.publish, 30 * 60 * 1000);
+    } finally {
+      for (const key of savedEnvKeys) {
+        if (saved[key] !== undefined) process.env[key] = saved[key];
+      }
+    }
+  });
+});
+
 test('ignores files with unknown schema_name', async () => {
   await withScratch(async (dataRoot) => {
     const dir = path.join(dataRoot, 'generated', 'draft', 'marketing-jobs');

--- a/tests/reap-stale-runs.test.ts
+++ b/tests/reap-stale-runs.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test';
 import {
   runStaleRunReaper,
   staleRunReaperThresholdMs,
+  staleRunReaperThresholdsByStage,
 } from '../backend/marketing/stale-run-reaper';
 
 type RuntimeDocStub = {
@@ -130,6 +131,40 @@ test('staleRunReaperThresholdMs honors env override', () => {
   }
 });
 
+test('staleRunReaperThresholdsByStage defaults to per-stage windows', () => {
+  const prior = {
+    global: process.env.STALE_RUN_REAPER_THRESHOLD_MS,
+    research: process.env.STALE_RUN_REAPER_RESEARCH_THRESHOLD_MS,
+    strategy: process.env.STALE_RUN_REAPER_STRATEGY_THRESHOLD_MS,
+    production: process.env.STALE_RUN_REAPER_PRODUCTION_THRESHOLD_MS,
+    publish: process.env.STALE_RUN_REAPER_PUBLISH_THRESHOLD_MS,
+  };
+  delete process.env.STALE_RUN_REAPER_THRESHOLD_MS;
+  delete process.env.STALE_RUN_REAPER_RESEARCH_THRESHOLD_MS;
+  delete process.env.STALE_RUN_REAPER_STRATEGY_THRESHOLD_MS;
+  delete process.env.STALE_RUN_REAPER_PRODUCTION_THRESHOLD_MS;
+  delete process.env.STALE_RUN_REAPER_PUBLISH_THRESHOLD_MS;
+  try {
+    assert.deepEqual(staleRunReaperThresholdsByStage(), {
+      research: 10 * 60 * 1000,
+      strategy: 5 * 60 * 1000,
+      production: 90 * 60 * 1000,
+      publish: 30 * 60 * 1000,
+    });
+  } finally {
+    if (prior.global === undefined) delete process.env.STALE_RUN_REAPER_THRESHOLD_MS;
+    else process.env.STALE_RUN_REAPER_THRESHOLD_MS = prior.global;
+    if (prior.research === undefined) delete process.env.STALE_RUN_REAPER_RESEARCH_THRESHOLD_MS;
+    else process.env.STALE_RUN_REAPER_RESEARCH_THRESHOLD_MS = prior.research;
+    if (prior.strategy === undefined) delete process.env.STALE_RUN_REAPER_STRATEGY_THRESHOLD_MS;
+    else process.env.STALE_RUN_REAPER_STRATEGY_THRESHOLD_MS = prior.strategy;
+    if (prior.production === undefined) delete process.env.STALE_RUN_REAPER_PRODUCTION_THRESHOLD_MS;
+    else process.env.STALE_RUN_REAPER_PRODUCTION_THRESHOLD_MS = prior.production;
+    if (prior.publish === undefined) delete process.env.STALE_RUN_REAPER_PUBLISH_THRESHOLD_MS;
+    else process.env.STALE_RUN_REAPER_PUBLISH_THRESHOLD_MS = prior.publish;
+  }
+});
+
 test('reaper returns empty report when marketing-jobs dir is missing', async () => {
   await withScratch(async (dataRoot) => {
     const report = await runStaleRunReaper({ dataRoot, dryRun: true });
@@ -175,6 +210,69 @@ test('dry-run identifies a stale running run without mutating the file', async (
   });
 });
 
+test('uses stage-specific thresholds and reaps a job stalled after research completed but never advanced', async () => {
+  await withScratch(async (dataRoot) => {
+    const now = new Date('2026-05-06T12:00:00.000Z');
+    const elevenMinutesAgo = new Date(now.getTime() - 11 * 60 * 1000).toISOString();
+    const productionFresh = new Date(now.getTime() - 11 * 60 * 1000).toISOString();
+
+    const stalledResearch = makeRuntimeDoc({
+      jobId: 'job-research-stalled',
+      tenantId: 'tenant-1',
+      state: 'running',
+      status: 'running',
+      updatedAtIso: elevenMinutesAgo,
+      stage: 'research',
+    });
+    (stalledResearch.stages.research as Record<string, unknown>).status = 'completed';
+    (stalledResearch.stages.research as Record<string, unknown>).completed_at = elevenMinutesAgo;
+    stalledResearch.history.push({
+      at: elevenMinutesAgo,
+      state: 'running',
+      status: 'running',
+      stage: 'research',
+      note: 'research completed from Hermes callback',
+    });
+    await writeRuntimeDoc(dataRoot, stalledResearch);
+
+    const freshProduction = makeRuntimeDoc({
+      jobId: 'job-production-not-stale',
+      tenantId: 'tenant-1',
+      state: 'running',
+      status: 'running',
+      updatedAtIso: productionFresh,
+      stage: 'production',
+    });
+    freshProduction.stages.production = {
+      stage: 'production',
+      status: 'in_progress',
+      started_at: productionFresh,
+      completed_at: null,
+      failed_at: null,
+      run_id: null,
+      summary: null,
+      primary_output: null,
+      outputs: {},
+      artifacts: [],
+      errors: [],
+    };
+    await writeRuntimeDoc(dataRoot, freshProduction);
+
+    const report = await runStaleRunReaper({
+      dataRoot,
+      dryRun: false,
+      now: () => now,
+    });
+
+    assert.equal(report.scanned, 2);
+    assert.equal(report.candidates.length, 1, 'only the research-stalled job is reaped');
+    assert.equal(report.candidates[0]!.jobId, 'job-research-stalled');
+    assert.equal(report.candidates[0]!.stage, 'research');
+    assert.equal(report.candidates[0]!.thresholdMs, 10 * 60 * 1000);
+    assert.ok(report.skipped >= 1, 'production job is skipped because 11 minutes is below the 90 minute production threshold');
+  });
+});
+
 test('apply mutates the doc to failed_stale and is idempotent on re-run', async () => {
   await withScratch(async (dataRoot) => {
     const now = new Date('2026-05-06T12:00:00.000Z');
@@ -202,10 +300,10 @@ test('apply mutates the doc to failed_stale and is idempotent on re-run', async 
     const after = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
     assert.equal(after.state, 'failed', 'state moved to failed');
     assert.equal(after.status, 'failed_stale', 'status moved to failed_stale');
-    assert.equal(after.failure_reason, 'stale_run_reaper');
+    assert.equal(after.failure_reason, 'marketing_job_stalled');
     const lastError = after.last_error as Record<string, unknown> | null;
     assert.ok(lastError, 'last_error populated');
-    assert.equal(lastError!.code, 'stale_run_reaper');
+    assert.equal(lastError!.code, 'marketing_job_stalled');
     assert.equal(lastError!.stage, 'production');
 
     const history = after.history as Array<{ note: string; state: string; status: string }>;
@@ -224,7 +322,7 @@ test('apply mutates the doc to failed_stale and is idempotent on re-run', async 
 
     const afterSecond = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
     assert.equal(afterSecond.status, 'failed_stale', 'status remains failed_stale after re-run');
-    assert.equal(afterSecond.failure_reason, 'stale_run_reaper');
+    assert.equal(afterSecond.failure_reason, 'marketing_job_stalled');
   });
 });
 
@@ -314,7 +412,7 @@ test('reaps approval_required runs (still in-flight)', async () => {
 
     const after = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
     assert.equal(after.status, 'failed_stale');
-    assert.equal(after.failure_reason, 'stale_run_reaper');
+    assert.equal(after.failure_reason, 'marketing_job_stalled');
   });
 });
 
@@ -329,7 +427,7 @@ test('skips already-reaped docs even on a forced re-scan with old timestamps', a
       status: 'failed_stale',
       updatedAtIso: stale,
     });
-    doc.failure_reason = 'stale_run_reaper';
+    doc.failure_reason = 'marketing_job_stalled';
     await writeRuntimeDoc(dataRoot, doc);
 
     const report = await runStaleRunReaper({
@@ -343,7 +441,7 @@ test('skips already-reaped docs even on a forced re-scan with old timestamps', a
   });
 });
 
-test('skips runtime docs missing parseable updated_at', async () => {
+test('skips runtime docs missing any parseable progress timestamp', async () => {
   await withScratch(async (dataRoot) => {
     const now = new Date('2026-05-06T12:00:00.000Z');
     const doc = makeRuntimeDoc({
@@ -354,6 +452,10 @@ test('skips runtime docs missing parseable updated_at', async () => {
       updatedAtIso: '2026-05-06T11:00:00.000Z',
     });
     doc.updated_at = 'not-a-date';
+    (doc.stages.research as Record<string, unknown>).started_at = 'not-a-date';
+    (doc.stages.research as Record<string, unknown>).completed_at = 'not-a-date';
+    (doc.stages.research as Record<string, unknown>).failed_at = 'not-a-date';
+    doc.history = [{ at: 'not-a-date', state: 'running', status: 'running', stage: 'research', note: 'bad timestamp' }];
     await writeRuntimeDoc(dataRoot, doc);
 
     const report = await runStaleRunReaper({
@@ -362,7 +464,7 @@ test('skips runtime docs missing parseable updated_at', async () => {
       now: () => now,
       thresholdMs: 30 * 60 * 1000,
     });
-    assert.equal(report.candidates.length, 0, 'unparseable timestamp must not produce a candidate');
+    assert.equal(report.candidates.length, 0, 'unparseable progress timestamps must not produce a candidate');
     assert.equal(report.mutated, 0);
     assert.ok(report.skipped >= 1);
   });


### PR DESCRIPTION
## Bug Description

Marketing jobs could remain in `running` forever after stage progress stopped, leaving zombie rows like `mkt_e6d7d734` in the dashboard. The existing stale-run reaper only existed as a manual script with a single silence threshold, so stalled in-flight jobs were not being swept automatically or classified with a stage-aware failure.

## Root Cause

1. The stale-run reaper was not registered in the automation cron manifest, so nothing invoked it automatically.
2. The reaper used one global threshold keyed only off runtime-document silence, instead of current-stage progress windows and a structured stalled-job failure code.

## Fix

- add stage-aware stale thresholds (research 10m, strategy 5m, production 90m, publish 30m) with optional env overrides
- derive the latest progress timestamp from runtime doc state, stage timestamps, approval timestamps, and stage history before reaping
- mark stalled jobs as `failed_stale` with `failure_reason`/`last_error.code = marketing_job_stalled`
- register a 5-minute automation cron entry to run `scripts/reap-stale-runs.ts --apply`
- expand regression coverage for stage-specific reaping and zombie-after-research behavior

## How to Verify

1. Run `npx tsx --test tests/reap-stale-runs.test.ts`
2. Run `npm run verify`
3. Optionally run `npx tsx scripts/reap-stale-runs.ts --dry-run --data-root /home/node/data` to inspect live candidates

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

## Risk Assessment

Low — changes are isolated to the stale-run reaper path, its CLI/reporting surface, and cron registration for the existing sweep script.
