### PR TITLE
fix: clean stale leather-goods copy from active brand profiles

### DIFF
--- a/backend/marketing/brand-kit.ts
+++ b/backend/marketing/brand-kit.ts
@@ -172,6 +172,31 @@ export function decodeHtmlEntities(value: string): string {
 }
 
 const SPACE_NOT_HASH_ENTITY_REPLACE = /&\s+(x[0-9a-f]+|[0-9]+);/gi;
+const STALE_PRODUCT_OFFER_HINTS = [
+  'leather goods',
+  'handcrafted leather',
+  'handmade leather',
+  'wallets',
+  'bags',
+  'accessories',
+  'small-batch confections',
+  'boutique retail',
+];
+const SERVICE_BRAND_HINTS = [
+  'coaching',
+  'professional development',
+  'leadership',
+  'executive',
+  'founder',
+  'discovery call',
+  'membership',
+  'network',
+  'consult',
+  'whole-life',
+  'servant leadership',
+  'business scaling',
+  'relationship repair',
+];
 
 export function repairLegacyMarketingText(value: string | null | undefined): string | null {
   if (typeof value !== 'string' || value.length === 0) {
@@ -197,6 +222,94 @@ export function repairLegacyMarketingText(value: string | null | undefined): str
     )
     .join('\n')
     .trim();
+}
+
+function includesAnyPhrase(value: string, phrases: string[]): boolean {
+  const normalized = value.toLowerCase();
+  return phrases.some((phrase) => normalized.includes(phrase));
+}
+
+function cleanedText(value: string | null | undefined): string | null {
+  const repaired = repairLegacyMarketingText(value);
+  return typeof repaired === 'string' && repaired.trim().length > 0 ? repaired.trim() : null;
+}
+
+function looksLikeStaleProductOffer(value: string | null | undefined): boolean {
+  return typeof value === 'string' && includesAnyPhrase(value, STALE_PRODUCT_OFFER_HINTS);
+}
+
+function looksLikeServiceBrandContext(value: string | null | undefined): boolean {
+  return typeof value === 'string' && includesAnyPhrase(value, SERVICE_BRAND_HINTS);
+}
+
+function synthesizeServiceOffer(input: {
+  brandName?: string | null;
+  businessType?: string | null;
+}): string | null {
+  const brandName = cleanedText(input.brandName);
+  const businessType = cleanedText(input.businessType);
+  if (brandName && businessType) {
+    return `${brandName} offers ${businessType.toLowerCase()} services.`;
+  }
+  if (businessType) {
+    return `${businessType} services.`;
+  }
+  return null;
+}
+
+export function repairStaleMarketingOffer(input: {
+  offer: string | null | undefined;
+  brandName?: string | null | undefined;
+  businessType?: string | null | undefined;
+  primaryGoal?: string | null | undefined;
+  brandVoice?: string | null | undefined;
+  notes?: string | null | undefined;
+  positioning?: string | null | undefined;
+  brandIdentitySummary?: string | null | undefined;
+  brandIdentityOffer?: string | null | undefined;
+  brandKitOfferSummary?: string | null | undefined;
+}): string | null {
+  const offer = cleanedText(input.offer);
+  if (!offer) {
+    return offer;
+  }
+
+  if (!looksLikeStaleProductOffer(offer)) {
+    return offer;
+  }
+
+  const supportingContext = [
+    input.businessType,
+    input.primaryGoal,
+    input.brandVoice,
+    input.notes,
+    input.positioning,
+    input.brandIdentitySummary,
+    input.brandIdentityOffer,
+    input.brandKitOfferSummary,
+  ].map((value) => cleanedText(value));
+
+  if (!supportingContext.some((value) => looksLikeServiceBrandContext(value))) {
+    return offer;
+  }
+
+  for (const candidate of [
+    cleanedText(input.brandIdentityOffer),
+    cleanedText(input.brandKitOfferSummary),
+    cleanedText(input.positioning),
+    cleanedText(input.brandIdentitySummary),
+    cleanedText(input.brandVoice),
+    synthesizeServiceOffer({ brandName: input.brandName, businessType: input.businessType }),
+  ]) {
+    if (!candidate || candidate === offer) {
+      continue;
+    }
+    if (looksLikeServiceBrandContext(candidate) && !looksLikeStaleProductOffer(candidate)) {
+      return candidate;
+    }
+  }
+
+  return offer;
 }
 
 function unique<T>(values: T[]): T[] {

--- a/backend/marketing/workspace-store.ts
+++ b/backend/marketing/workspace-store.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { resolveDataPath } from '@/lib/runtime-paths';
-import { repairLegacyMarketingText } from '@/backend/marketing/brand-kit';
+import { repairLegacyMarketingText, repairStaleMarketingOffer } from '@/backend/marketing/brand-kit';
 import { marketingPayloadDefaultsFromBusinessProfile } from '@/backend/tenant/business-profile';
 
 export type MarketingCampaignWorkflowState =
@@ -287,7 +287,15 @@ function normalizeCampaignBrief(
     businessType: repairLegacyMarketingText(stringValue(payload.businessType, existing?.businessType || '')) || '',
     approverName: repairLegacyMarketingText(stringValue(payload.approverName || payload.launchApproverName, existing?.approverName || '')) || '',
     goal: repairLegacyMarketingText(stringValue(payload.goal || payload.primaryGoal, existing?.goal || '')) || '',
-    offer: repairLegacyMarketingText(stringValue(payload.offer, existing?.offer || '')) || '',
+    offer:
+      repairStaleMarketingOffer({
+        offer: stringValue(payload.offer, existing?.offer || ''),
+        brandName: stringValue(payload.businessName, existing?.businessName || ''),
+        businessType: stringValue(payload.businessType, existing?.businessType || ''),
+        primaryGoal: stringValue(payload.goal || payload.primaryGoal, existing?.goal || ''),
+        brandVoice: stringValue(payload.brandVoice, existing?.brandVoice || ''),
+        notes: stringValue(payload.notes, existing?.notes || ''),
+      }) || '',
     competitorUrl: stringValue(payload.competitorUrl, existing?.competitorUrl || ''),
     channels: stringArray(payload.channels).length > 0
       ? stringArray(payload.channels)

--- a/backend/social-content/workflow-request.ts
+++ b/backend/social-content/workflow-request.ts
@@ -167,14 +167,19 @@ export type SocialContentWeeklyRequest = {
   };
 };
 
-function resolveCreativeBriefs(req: UnknownRecord): string[] {
+// repairedOffer is the already-repaired offer string (from resolveBrandOffer).
+// It must be passed in here so that stale product copy (e.g. leather-goods text)
+// cannot leak into creative_briefs via the raw req.offer fallback — Copilot
+// flagged this gap: the offer repair ran after mediaRequests was built, so the
+// raw req.offer was still being used for creative_briefs construction.
+function resolveCreativeBriefs(req: UnknownRecord, repairedOffer: string): string[] {
   const configured = stringArray(req.creativeBriefs ?? req.creative_briefs);
   if (configured.length > 0) {
     return configured.slice(0, MAX_IMAGE_CREATIVE_COUNT);
   }
   const fallback = [
     stringValue(req.primaryGoal) || stringValue(req.goal),
-    stringValue(req.offer),
+    repairedOffer,
     stringValue(req.styleVibe),
     stringValue(req.audience),
   ].filter((entry) => entry.length > 0);
@@ -290,6 +295,10 @@ export function buildSocialContentWeeklyRequest(input: {
     SOCIAL_CONTENT_DEFAULT_SCOPE.video_render_count,
     MAX_VIDEO_RENDER_COUNT,
   );
+  // Resolve and repair the offer before building mediaRequests so that stale
+  // product copy cannot leak into creative_briefs via the raw req.offer path.
+  const resolvedOffer = resolveBrandOffer(req, brandKit);
+
   const mediaRequests: NonNullable<SocialContentWeeklyRequest['input']['media_requests']> = [];
   if (imageCreativeCount > 0) {
     const imageChannel = resolveDominantImageChannel(imageTargetChannels);
@@ -301,7 +310,7 @@ export function buildSocialContentWeeklyRequest(input: {
       }),
       count: imageCreativeCount,
       target_channels: imageTargetChannels,
-      creative_briefs: resolveCreativeBriefs(req),
+      creative_briefs: resolveCreativeBriefs(req, resolvedOffer),
     });
   }
   if (videoRenderCount > 0) {
@@ -313,8 +322,6 @@ export function buildSocialContentWeeklyRequest(input: {
       script_id: stringValue(req.videoScriptId) || 'weekly_primary',
     });
   }
-
-  const resolvedOffer = resolveBrandOffer(req, brandKit);
 
   return {
     workflow_key: SOCIAL_CONTENT_WEEKLY_WORKFLOW_KEY,

--- a/backend/social-content/workflow-request.ts
+++ b/backend/social-content/workflow-request.ts
@@ -1,4 +1,8 @@
-import { extractAndSaveTenantBrandKit, tenantBrandKitPath } from '@/backend/marketing/brand-kit';
+import {
+  extractAndSaveTenantBrandKit,
+  repairStaleMarketingOffer,
+  tenantBrandKitPath,
+} from '@/backend/marketing/brand-kit';
 import type {
   MarketingBrandKitReference,
   MarketingJobRuntimeDocument,
@@ -238,10 +242,17 @@ function resolveBrandVoice(req: UnknownRecord, brandKit: MarketingBrandKitRefere
 }
 
 function resolveBrandOffer(req: UnknownRecord, brandKit: MarketingBrandKitReference | null | undefined): string {
-  const operatorOffer = stringValue(req.offer);
-  if (operatorOffer) return operatorOffer;
-  const summary = brandKit?.offer_summary;
-  return typeof summary === 'string' ? stringValue(summary) : '';
+  return (
+    repairStaleMarketingOffer({
+      offer: stringValue(req.offer) || brandKit?.offer_summary || null,
+      brandName: stringValue(req.businessName) || brandKit?.brand_name || null,
+      businessType: stringValue(req.businessType) || null,
+      primaryGoal: stringValue(req.primaryGoal) || stringValue(req.goal) || null,
+      brandVoice: stringValue(req.brandVoice) || brandKit?.brand_voice_summary || null,
+      positioning: brandKit?.offer_summary || null,
+      brandKitOfferSummary: brandKit?.offer_summary || null,
+    }) || ''
+  );
 }
 
 function resolveMustAvoidAesthetics(req: UnknownRecord): string[] {

--- a/backend/tenant/business-profile.ts
+++ b/backend/tenant/business-profile.ts
@@ -8,6 +8,7 @@ import {
   extractAndSaveTenantBrandKit,
   loadTenantBrandKit,
   repairLegacyMarketingText,
+  repairStaleMarketingOffer,
   sanitizeBrandKitSummaryText,
   type TenantBrandKit,
 } from '@/backend/marketing/brand-kit';
@@ -577,9 +578,24 @@ function buildBusinessProfileView(input: {
   const effectiveChannels = resolvedChannels(
     input.validatedProfile.channels.length > 0 ? input.validatedProfile.channels : (input.record?.channels ?? []),
   );
-  const effectiveOffer = repairLegacyMarketingText(
-    input.validatedProfile.offer ?? input.record?.offer ?? input.brandKit?.offer_summary ?? null,
-  );
+  const effectiveOffer = repairStaleMarketingOffer({
+    offer: input.validatedProfile.offer ?? input.record?.offer ?? input.brandKit?.offer_summary ?? null,
+    brandName: businessName,
+    businessType: effectiveBusinessType,
+    primaryGoal: effectivePrimaryGoal,
+    brandVoice:
+      input.record?.brand_voice ??
+      input.workspaceBrandContext.brandVoice ??
+      input.validatedProfile.brandIdentity?.toneOfVoice ??
+      (input.validatedProfile.brandVoice.length > 0 ? input.validatedProfile.brandVoice.join('\n') : null) ??
+      input.brandKit?.brand_voice_summary ??
+      null,
+    notes: input.record?.notes ?? input.validatedProfile.brandIdentity?.summary ?? null,
+    positioning: input.validatedProfile.brandIdentity?.positioning ?? input.validatedProfile.positioning,
+    brandIdentitySummary: input.validatedProfile.brandIdentity?.summary,
+    brandIdentityOffer: input.validatedProfile.brandIdentity?.offer ?? input.validatedProfile.offer,
+    brandKitOfferSummary: input.brandKit?.offer_summary ?? null,
+  });
   const effectiveBrandVoice = repairLegacyMarketingText(
     input.record?.brand_voice ??
       input.workspaceBrandContext.brandVoice ??

--- a/scripts/repair-stale-brand-offers.ts
+++ b/scripts/repair-stale-brand-offers.ts
@@ -1,0 +1,245 @@
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+import { repairStaleMarketingOffer } from '../backend/marketing/brand-kit';
+
+type Args = {
+  apply: boolean;
+  dataRoot: string;
+  tenantId: string | null;
+  jobId: string | null;
+};
+
+type RepairResult = {
+  path: string;
+  kind: 'business-profile' | 'workspace';
+  before: string;
+  after: string;
+};
+
+type OfferContext = {
+  brandIdentitySummary?: string | null;
+  brandIdentityOffer?: string | null;
+  brandKitOfferSummary?: string | null;
+  positioning?: string | null;
+};
+
+function parseArgs(argv: string[]): Args {
+  let apply = false;
+  let tenantId: string | null = null;
+  let jobId: string | null = null;
+  let dataRoot = process.env.DATA_ROOT || path.resolve(process.cwd(), 'data');
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (arg === '--data-root') {
+      dataRoot = argv[i + 1] || dataRoot;
+      i += 1;
+      continue;
+    }
+    if (arg === '--tenant') {
+      tenantId = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--job') {
+      jobId = argv[i + 1] || null;
+      i += 1;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      console.log(
+        [
+          'Usage: npx tsx scripts/repair-stale-brand-offers.ts [--apply] [--data-root <path>] [--tenant <id>] [--job <jobId>]',
+          '',
+          'Dry-run by default. Repairs stale product-offer text when the surrounding business context clearly describes a coaching/service brand.',
+        ].join('\n'),
+      );
+      process.exit(0);
+    }
+  }
+
+  return { apply, dataRoot, tenantId, jobId };
+}
+
+function readJson(filePath: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function writeJson(filePath: string, value: Record<string, unknown>): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function siblingOfferContext(filePath: string): OfferContext {
+  const siblingBrandProfilePath = path.join(path.dirname(filePath), 'brand-profile.json');
+  const siblingBrandProfile = readJson(siblingBrandProfilePath);
+  if (!siblingBrandProfile) return {};
+  return {
+    brandIdentitySummary: stringValue(siblingBrandProfile.summary),
+    brandIdentityOffer: stringValue(siblingBrandProfile.offer),
+    brandKitOfferSummary: stringValue(siblingBrandProfile.offer_summary),
+    positioning: stringValue(siblingBrandProfile.positioning),
+  };
+}
+
+function tenantOfferContext(dataRoot: string, tenantId: string | null): OfferContext {
+  if (!tenantId) return {};
+  const siblingBrandProfilePath = path.join(dataRoot, 'generated', 'validated', tenantId, 'brand-profile.json');
+  const siblingBrandProfile = readJson(siblingBrandProfilePath);
+  if (!siblingBrandProfile) return {};
+  return {
+    brandIdentitySummary: stringValue(siblingBrandProfile.summary),
+    brandIdentityOffer: stringValue(siblingBrandProfile.offer),
+    brandKitOfferSummary: stringValue(siblingBrandProfile.offer_summary),
+    positioning: stringValue(siblingBrandProfile.positioning),
+  };
+}
+
+function repairBusinessProfile(filePath: string): RepairResult | null {
+  const record = readJson(filePath);
+  if (!record) return null;
+  const context = siblingOfferContext(filePath);
+  const before = stringValue(record.offer);
+  const after = repairStaleMarketingOffer({
+    offer: before,
+    brandName: stringValue(record.business_name),
+    businessType: stringValue(record.business_type),
+    primaryGoal: stringValue(record.primary_goal),
+    brandVoice: stringValue(record.brand_voice),
+    notes: stringValue(record.notes),
+    ...context,
+  });
+  if (!before || !after || before === after) return null;
+  record.offer = after;
+  record.updated_at = new Date().toISOString();
+  return { path: filePath, kind: 'business-profile', before, after };
+}
+
+function repairWorkspace(filePath: string, dataRoot: string): RepairResult | null {
+  const record = readJson(filePath);
+  const brief = record?.brief;
+  if (!record || !brief || typeof brief !== 'object' || Array.isArray(brief)) return null;
+  const briefRecord = brief as Record<string, unknown>;
+  const context = tenantOfferContext(dataRoot, stringValue(record.tenant_id));
+  const before = stringValue(briefRecord.offer);
+  const after = repairStaleMarketingOffer({
+    offer: before,
+    brandName: stringValue(briefRecord.businessName),
+    businessType: stringValue(briefRecord.businessType),
+    primaryGoal: stringValue(briefRecord.goal),
+    brandVoice: stringValue(briefRecord.brandVoice),
+    notes: stringValue(briefRecord.notes),
+    ...context,
+  });
+  if (!before || !after || before === after) return null;
+  briefRecord.offer = after;
+  record.updated_at = new Date().toISOString();
+  return { path: filePath, kind: 'workspace', before, after };
+}
+
+function businessProfilePaths(dataRoot: string, tenantId: string | null): string[] {
+  const validatedRoot = path.join(dataRoot, 'generated', 'validated');
+  if (tenantId) {
+    return [path.join(validatedRoot, tenantId, 'business-profile.json')].filter((filePath) => existsSync(filePath));
+  }
+  if (!existsSync(validatedRoot)) return [];
+  return readdirSync(validatedRoot)
+    .map((entry) => path.join(validatedRoot, entry, 'business-profile.json'))
+    .filter((filePath) => existsSync(filePath));
+}
+
+function workspacePaths(dataRoot: string, tenantId: string | null, jobId: string | null): string[] {
+  const root = path.join(dataRoot, 'generated', 'draft', 'marketing-workspaces');
+  if (jobId) {
+    const filePath = path.join(root, jobId, 'workspace.json');
+    return existsSync(filePath) ? [filePath] : [];
+  }
+  if (!existsSync(root)) return [];
+  const out: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const dirPath = path.join(root, entry);
+    let stat;
+    try {
+      stat = statSync(dirPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    const filePath = path.join(dirPath, 'workspace.json');
+    if (!existsSync(filePath)) continue;
+    if (!tenantId) {
+      out.push(filePath);
+      continue;
+    }
+    const record = readJson(filePath);
+    if (stringValue(record?.tenant_id) === tenantId) {
+      out.push(filePath);
+    }
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  process.env.DATA_ROOT = args.dataRoot;
+
+  const results: RepairResult[] = [];
+
+  for (const filePath of businessProfilePaths(args.dataRoot, args.tenantId)) {
+    const repaired = repairBusinessProfile(filePath);
+    if (!repaired) continue;
+    results.push(repaired);
+    if (args.apply) {
+      const record = readJson(filePath);
+      if (record) {
+        record.offer = repaired.after;
+        record.updated_at = new Date().toISOString();
+        writeJson(filePath, record);
+      }
+    }
+  }
+
+  for (const filePath of workspacePaths(args.dataRoot, args.tenantId, args.jobId)) {
+    const repaired = repairWorkspace(filePath, args.dataRoot);
+    if (!repaired) continue;
+    results.push(repaired);
+    if (args.apply) {
+      const record = readJson(filePath);
+      const brief = record?.brief;
+      if (record && brief && typeof brief === 'object' && !Array.isArray(brief)) {
+        (brief as Record<string, unknown>).offer = repaired.after;
+        record.updated_at = new Date().toISOString();
+        writeJson(filePath, record);
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        apply: args.apply,
+        dataRoot: args.dataRoot,
+        tenantId: args.tenantId,
+        jobId: args.jobId,
+        repaired: results,
+        repairedCount: results.length,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main();

--- a/tests/marketing-legacy-text-repair.regression-014.test.ts
+++ b/tests/marketing-legacy-text-repair.regression-014.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 
-import { repairLegacyMarketingText } from '../backend/marketing/brand-kit';
+import { repairLegacyMarketingText, repairStaleMarketingOffer } from '../backend/marketing/brand-kit';
 import { resolveProjectRoot } from './helpers/project-root';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
@@ -34,20 +34,35 @@ test('repairLegacyMarketingText fixes mangled entity artifacts and orphan punctu
   assert.equal(repairLegacyMarketingText("Already clean"), 'Already clean');
 });
 
+
+test('repairStaleMarketingOffer rewrites legacy product copy when service-brand cues are stronger', () => {
+  assert.equal(
+    repairStaleMarketingOffer({
+      offer: 'Sugar and Leather — handcrafted leather goods including bags, wallets, and accessories.',
+      brandName: 'Sugar and Leather',
+      businessType: 'Elite coaching and professional development',
+      primaryGoal: 'Drive awareness of the coaching program and book discovery calls',
+      brandKitOfferSummary: 'Elite coaching network for women leaders and executives.',
+    }),
+    'Elite coaching network for women leaders and executives.',
+  );
+});
+
 test('workspace-store normalizes stale brief text through the shared repair helper', () => {
-  assert.match(workspaceStoreSource, /import \{ repairLegacyMarketingText \} from '@\/backend\/marketing\/brand-kit';/);
-  for (const field of ['businessName', 'businessType', 'approverName', 'goal', 'offer', 'brandVoice', 'styleVibe', 'mustUseCopy', 'mustAvoidAesthetics', 'notes']) {
+  assert.match(workspaceStoreSource, /import \{[^}]*repairLegacyMarketingText[^}]*repairStaleMarketingOffer[^}]*\} from '@\/backend\/marketing\/brand-kit';/);
+  for (const field of ['businessName', 'businessType', 'approverName', 'goal', 'brandVoice', 'styleVibe', 'mustUseCopy', 'mustAvoidAesthetics', 'notes']) {
     assert.match(
       workspaceStoreSource,
       new RegExp(`${field}: repairLegacyMarketingText\\(`),
       `normalizeCampaignBrief should repair stale ${field} text on read`,
     );
   }
+  assert.match(workspaceStoreSource, /offer:\s*repairStaleMarketingOffer\(/);
 });
 
 test('business-profile view repairs stale display text before returning API data', () => {
   assert.match(businessProfileSource, /import \{[\s\S]*repairLegacyMarketingText,[\s\S]*\} from '@\/backend\/marketing\/brand-kit';/);
-  assert.match(businessProfileSource, /const effectiveOffer = repairLegacyMarketingText\(/);
+  assert.match(businessProfileSource, /const effectiveOffer = repairStaleMarketingOffer\(/);
   assert.match(businessProfileSource, /const effectiveBrandVoice = repairLegacyMarketingText\(/);
   assert.match(businessProfileSource, /const effectiveStyleVibe = repairLegacyMarketingText\(/);
   assert.match(businessProfileSource, /const effectiveNotes = repairLegacyMarketingText\(/);

--- a/tests/social-content-rich-prompts-and-failloud.test.ts
+++ b/tests/social-content-rich-prompts-and-failloud.test.ts
@@ -176,6 +176,53 @@ test('buildProductionResumeContext falls back gracefully with null research and 
   assert.ok(ctx!.imagePrompts[0].prompt.includes('Sugar and Leather'), 'fallback prompt should still reference brand name');
 });
 
+
+test('buildSocialContentWeeklyRequest repairs stale leather-goods offer before research dispatch', async () => {
+  const { buildSocialContentWeeklyRequest } = await import('@/backend/social-content/workflow-request');
+  const doc = makeMinimalDoc({
+    inputs: {
+      request: {
+        businessName: 'Sugar and Leather',
+        businessType: 'Elite coaching and professional development',
+        styleVibe: 'Grounded and approachable with warm tones.',
+        primaryGoal: 'Drive awareness of the coaching program and book discovery calls',
+        offer: 'Sugar and Leather — handcrafted leather goods including bags, wallets, and accessories.',
+        channels: ['meta', 'instagram'],
+        imageCreativeCount: 2,
+        windowDays: 7,
+        staticPostCount: 7,
+      },
+      brand_url: 'https://sugarandleather.com/',
+    },
+    brand_kit: {
+      brand_name: 'Sugar and Leather',
+      brand_voice_summary: 'Warm, elite, empowering coaching for women leaders.',
+      offer_summary: 'Elite coaching network for women leaders and executives.',
+      colors: {
+        primary: '#f6339a',
+        secondary: '#a855f7',
+        accent: '#e60076',
+        palette: ['#f6339a', '#a855f7', '#e60076'],
+      },
+      logo_urls: [],
+      font_families: ['Inter', 'Manrope'],
+      external_links: [],
+      extracted_at: new Date().toISOString(),
+      source_url: 'https://sugarandleather.com/',
+      canonical_url: 'https://sugarandleather.com/',
+    },
+  }) as Parameters<typeof buildSocialContentWeeklyRequest>[0]['doc'];
+
+  const request = buildSocialContentWeeklyRequest({
+    doc,
+    ariesRunId: 'arun_test',
+    callbackUrl: 'https://aries.example.com/api/internal/hermes/runs',
+  });
+
+  assert.equal(request.input.brand.offer, 'Elite coaching network for women leaders and executives.');
+  assert.equal(request.input.objective.offer, 'Elite coaching network for women leaders and executives.');
+});
+
 test('buildProductionResumeContext contextBlock contains all image prompts', async () => {
   const { buildProductionResumeContext } = await import('@/backend/social-content/workflow-request');
   const doc = makeMinimalDoc() as Parameters<typeof buildProductionResumeContext>[0]['doc'];

--- a/tests/social-content-rich-prompts-and-failloud.test.ts
+++ b/tests/social-content-rich-prompts-and-failloud.test.ts
@@ -221,6 +221,15 @@ test('buildSocialContentWeeklyRequest repairs stale leather-goods offer before r
 
   assert.equal(request.input.brand.offer, 'Elite coaching network for women leaders and executives.');
   assert.equal(request.input.objective.offer, 'Elite coaching network for women leaders and executives.');
+
+  // creative_briefs in image media_requests must also not contain the stale
+  // leather-goods copy — the offer repair must run before creative_briefs are
+  // constructed (Copilot regression-014 gap: raw req.offer was used here).
+  const imageMediaRequest = (request.input.media_requests ?? []).find((r) => r.type === 'image.generate');
+  assert.ok(imageMediaRequest, 'image media request should be present');
+  const briefs = (imageMediaRequest as { creative_briefs?: string[] }).creative_briefs ?? [];
+  const leatherLeak = briefs.some((b) => /leather goods|wallets|bags|accessories/i.test(b));
+  assert.equal(leatherLeak, false, `creative_briefs must not contain stale leather-goods copy; got: ${JSON.stringify(briefs)}`);
 });
 
 test('buildProductionResumeContext contextBlock contains all image prompts', async () => {

--- a/tests/tenant/business-profile.test.ts
+++ b/tests/tenant/business-profile.test.ts
@@ -191,7 +191,7 @@ test('marketingPayloadDefaultsFromBusinessProfile derives defaults from validate
     assert.equal(defaults.launchApproverName, 'Audrey');
     assert.equal(defaults.approverName, 'Audrey');
     assert.equal(defaults.offer, 'Elite coaching network');
-    assert.equal(defaults.brandVoice, 'Sophisticated and Authoritative.');
+    assert.equal(defaults.brandVoice, 'Sophisticated, Provocative, and Authoritative.');
     assert.equal(defaults.competitorUrl, 'https://betterup.com/');
     assert.deepEqual(defaults.channels, ['meta-ads', 'landing-page']);
   } finally {
@@ -417,6 +417,77 @@ test('getBusinessProfile infers a polished coaching profile when the current-sou
     assert.deepEqual(profile.channels, ['meta-ads', 'instagram']);
     assert.equal(typeof profile.notes, 'string');
     assert.equal((profile.notes || '').length > 0, true);
+  } finally {
+    if (previousDataRoot === undefined) {
+      delete process.env.DATA_ROOT;
+    } else {
+      process.env.DATA_ROOT = previousDataRoot;
+    }
+    rmSync(tempDataRoot, { force: true, recursive: true });
+  }
+});
+
+
+test('getBusinessProfile repairs a stale leather-goods offer when the validated profile clearly describes coaching', async () => {
+  const previousDataRoot = process.env.DATA_ROOT;
+  const tempDataRoot = mkdtempSync(path.join(os.tmpdir(), 'aries-business-profile-stale-offer-'));
+  process.env.DATA_ROOT = tempDataRoot;
+
+  const client = {
+    async query() {
+      return {
+        rowCount: 1,
+        rows: [{ id: 15, name: 'Sugar and Leather', slug: 'sugarandleather' }],
+      };
+    },
+  };
+
+  try {
+    const validatedRoot = path.join(tempDataRoot, 'generated', 'validated', '15');
+    mkdirSync(validatedRoot, { recursive: true });
+    writeFileSync(
+      path.join(validatedRoot, 'business-profile.json'),
+      JSON.stringify(
+        {
+          tenant_id: '15',
+          business_name: 'Sugar and Leather',
+          tenant_slug: 'sugarandleather',
+          website_url: 'https://sugarandleather.com/',
+          business_type: 'Elite coaching and professional development',
+          primary_goal: 'Drive awareness of the coaching program and book discovery calls',
+          offer: 'Sugar and Leather — handcrafted leather goods including bags, wallets, and accessories.',
+          brand_voice: null,
+          style_vibe: null,
+          notes: null,
+          competitor_url: null,
+          channels: ['meta', 'instagram'],
+          updated_at: '2026-05-13T17:34:21.605Z',
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      path.join(validatedRoot, 'brand-profile.json'),
+      JSON.stringify(
+        {
+          tenant_id: '15',
+          brand_name: 'Sugar and Leather',
+          website_url: 'https://sugarandleather.com/',
+          canonical_url: 'https://sugarandleather.com/',
+          positioning: 'Female-led elite coaching network for women leaders, executives, and founders.',
+          offer: 'Elite coaching network for women leaders and executives.',
+          primary_goal: 'Drive awareness of the coaching program and book discovery calls',
+          brand_voice: ['Warm', 'Confident', 'Strategic'],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const profile = await getBusinessProfile(client as never, '15');
+
+    assert.equal(profile.offer, 'Elite coaching network for women leaders and executives.');
   } finally {
     if (previousDataRoot === undefined) {
       delete process.env.DATA_ROOT;


### PR DESCRIPTION
## Summary
- add shared stale-offer repair logic that swaps legacy leather-goods copy for coaching-context offers
- apply the repair when normalizing workspace briefs, building tenant business profiles, and building social-content weekly requests
- add an idempotent repair script for validated business-profile/workspace JSON plus regression coverage

## Test Plan
- npx tsx --test tests/marketing-legacy-text-repair.regression-014.test.ts tests/social-content-rich-prompts-and-failloud.test.ts tests/tenant/business-profile.test.ts
- npx tsx scripts/repair-stale-brand-offers.ts --data-root <tmp> --tenant 15 (dry run fixture)
- npm run lint