### PR TITLE
v0.1.3.9 feat(marketing): Hermes image bridge multi-schema + canonical schema in resume

### DIFF
--- a/backend/marketing/hermes-callbacks.ts
+++ b/backend/marketing/hermes-callbacks.ts
@@ -517,6 +517,93 @@ function ingestSocialContentStageMedia(
   }
 }
 
+/**
+ * Counts recognized images across ALL known Hermes output shapes:
+ *   1. `artifacts.creative_assets[]` with type="generated_image" and a path/filePath
+ *   2. `artifacts.images[]` with a filePath or path value
+ *   3. `weekly_content_plan.image_creatives[]` with a non-empty artifact_url
+ *
+ * A "recognized image" means there is a renderable file reference — a bare
+ * prompt entry without a path is NOT recognized. Returns the total count.
+ */
+function countRecognizedImagesInOutputRecord(
+  outputRecord: Record<string, unknown> | null,
+): number {
+  if (!outputRecord) return 0;
+
+  // Shape 1: artifacts.creative_assets[]
+  const artifacts = outputRecord.artifacts;
+  const artifactRecord =
+    artifacts && typeof artifacts === 'object' && !Array.isArray(artifacts)
+      ? (artifacts as Record<string, unknown>)
+      : null;
+
+  if (artifactRecord) {
+    const creativeAssets = Array.isArray(artifactRecord.creative_assets)
+      ? artifactRecord.creative_assets
+      : [];
+    const fromCreativeAssets = creativeAssets.filter((asset) => {
+      if (!asset || typeof asset !== 'object' || Array.isArray(asset)) return false;
+      const a = asset as Record<string, unknown>;
+      if (a.type !== 'generated_image') return false;
+      return !!imageBasenameFromValue(a.path) || !!imageBasenameFromValue(a.filePath);
+    }).length;
+    if (fromCreativeAssets > 0) return fromCreativeAssets;
+
+    // Shape 2: artifacts.images[]
+    const images = Array.isArray(artifactRecord.images) ? artifactRecord.images : [];
+    const fromImages = images.filter((img) => {
+      if (!img || typeof img !== 'object' || Array.isArray(img)) return false;
+      const i = img as Record<string, unknown>;
+      return !!imageBasenameFromValue(i.filePath) || !!imageBasenameFromValue(i.path);
+    }).length;
+    if (fromImages > 0) return fromImages;
+  }
+
+  // Shape 3: weekly_content_plan.image_creatives[] with artifact_url
+  const plan = outputRecord.weekly_content_plan;
+  if (plan && typeof plan === 'object' && !Array.isArray(plan)) {
+    const creatives = (plan as Record<string, unknown>).image_creatives;
+    if (Array.isArray(creatives)) {
+      return creatives.filter((c) => {
+        if (!c || typeof c !== 'object' || Array.isArray(c)) return false;
+        const cr = c as Record<string, unknown>;
+        return (
+          typeof cr.artifact_url === 'string' &&
+          (cr.artifact_url as string).trim().length > 0
+        );
+      }).length;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Returns true when the production-stage callback declared N image requests
+ * (imageCreativeCount > 0 from the job's original request) but zero recognized
+ * images appear across ALL known output shapes (creative_assets, images,
+ * image_creatives-with-artifact_url). This closes the blind spot where Hermes
+ * silently completes with no images but the prompt-only check in
+ * `productionCallbackHasUnrenderedImageCreatives` doesn't fire (e.g. when
+ * Hermes omits image_creatives entirely).
+ *
+ * Failure code: `hermes_image_generation_unrecognized`
+ */
+function productionCallbackImageGenerationUnrecognized(
+  doc: MarketingJobRuntimeDocument,
+  outputRecord: Record<string, unknown> | null,
+): boolean {
+  // Determine requested image count from the original job request.
+  const imageCreativeCount =
+    typeof doc.inputs?.request?.imageCreativeCount === 'number'
+      ? doc.inputs.request.imageCreativeCount
+      : 0;
+  if (imageCreativeCount <= 0) return false;
+
+  return countRecognizedImagesInOutputRecord(outputRecord) === 0;
+}
+
 function isHermesMediaSetupError(payload: HermesRunCallbackPayload): boolean {
   const code = payload.error?.code?.toLowerCase() ?? '';
   const message = payload.error?.message.toLowerCase() ?? '';
@@ -800,6 +887,36 @@ export async function applyHermesMarketingCallback(
         'Check Hermes logs and retry the production stage.';
       recordStageFailure(doc, targetStage, {
         code: 'hermes_image_generation_skipped',
+        message: errorMessage,
+        retryable: true,
+      });
+      markSocialContentStageFailed(
+        doc,
+        completedSocialStage ?? 'image_generation',
+        errorMessage,
+        firstOutputRecord(payload),
+      );
+      saveMarketingJobRuntime(doc.job_id, doc);
+      return;
+    }
+
+    // Broader fail-loud gate: N images were requested but zero recognized images
+    // appear in ANY known output shape (creative_assets, images,
+    // image_creatives-with-artifact_url). This closes the blind spot where Hermes
+    // silently completes with no image data at all — the prompt-only check above
+    // only fires when image_creatives are present but without artifact_url.
+    if (
+      isSocialContentRun(run)
+      && targetStage === 'production'
+      && socialApprovalStep === 'approve_publish'
+      && productionCallbackImageGenerationUnrecognized(doc, firstOutputRecord(payload))
+    ) {
+      const errorMessage =
+        'Production stage completed with no recognized images in any known output shape ' +
+        '(creative_assets, images, image_creatives). ' +
+        'Hermes may have returned an unexpected schema. Check Hermes logs and retry.';
+      recordStageFailure(doc, targetStage, {
+        code: 'hermes_image_generation_unrecognized',
         message: errorMessage,
         retryable: true,
       });

--- a/backend/marketing/hermes-callbacks.ts
+++ b/backend/marketing/hermes-callbacks.ts
@@ -76,12 +76,43 @@ type HermesImageCreativeLike = {
   [key: string]: unknown;
 };
 
+// Image extensions recognized as renderable file references.
+const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'gif'] as const;
+
+/**
+ * Extracts the image basename from a string value (file path, URL, etc.).
+ *
+ * Uses explicit string operations rather than a runtime regex over user-
+ * supplied input to avoid polynomial backtracking (ReDoS). Input is capped
+ * at 1024 characters as defense-in-depth before any processing.
+ */
 function imageBasenameFromValue(value: unknown): string {
   if (typeof value !== 'string') return '';
-  const trimmed = value.trim();
+  // Cap input length: defense-in-depth against pathological inputs.
+  const trimmed = value.trim().slice(0, 1024);
   if (!trimmed) return '';
-  const match = trimmed.match(/([^/?#]+\.(?:png|jpe?g|webp|gif))(?:[?#].*)?$/i);
-  return match?.[1] ?? '';
+
+  // Strip a query string or fragment so we operate on the clean path segment.
+  const qIdx = trimmed.indexOf('?');
+  const hIdx = trimmed.indexOf('#');
+  let pathPart = trimmed;
+  if (qIdx !== -1 || hIdx !== -1) {
+    const cutAt = qIdx === -1 ? hIdx : hIdx === -1 ? qIdx : Math.min(qIdx, hIdx);
+    pathPart = trimmed.slice(0, cutAt);
+  }
+
+  // Extract the last path segment (basename).
+  const lastSlash = Math.max(pathPart.lastIndexOf('/'), pathPart.lastIndexOf('\\'));
+  const basename = lastSlash === -1 ? pathPart : pathPart.slice(lastSlash + 1);
+  if (!basename) return '';
+
+  // Verify it ends with a recognised image extension (case-insensitive).
+  const dot = basename.lastIndexOf('.');
+  if (dot === -1) return '';
+  const ext = basename.slice(dot + 1).toLowerCase();
+  if (!(IMAGE_EXTENSIONS as readonly string[]).includes(ext)) return '';
+
+  return basename;
 }
 
 function renderedImageBasenameFromRecord(record: Record<string, unknown>): string {

--- a/backend/marketing/hermes-callbacks.ts
+++ b/backend/marketing/hermes-callbacks.ts
@@ -49,8 +49,143 @@ type HermesCreativeAsset = {
   status?: string;
   path?: string;
   placement?: string;
+  prompt?: string;
   [key: string]: unknown;
 };
+
+type HermesGeneratedImage = {
+  index?: number;
+  status?: string;
+  filePath?: string;
+  path?: string;
+  prompt?: string;
+  intendedUse?: string;
+  [key: string]: unknown;
+};
+
+type HermesImageCreativeLike = {
+  id?: string;
+  title?: string;
+  prompt?: string;
+  status?: string;
+  artifact_url?: string;
+  path?: string;
+  filePath?: string;
+  intendedUse?: string;
+  placement?: string;
+  [key: string]: unknown;
+};
+
+function imageBasenameFromValue(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const match = trimmed.match(/([^/?#]+\.(?:png|jpe?g|webp|gif))(?:[?#].*)?$/i);
+  return match?.[1] ?? '';
+}
+
+function renderedImageBasenameFromRecord(record: Record<string, unknown>): string {
+  for (const value of Object.values(record)) {
+    const basename = imageBasenameFromValue(value);
+    if (basename) return basename;
+  }
+  return '';
+}
+
+function mediaArtifactUrl(appBaseUrl: string, basename: string): string {
+  return basename ? `${appBaseUrl}/api/internal/hermes/media/${basename}` : '';
+}
+
+function normalizeRenderedStatus(_status: unknown): string {
+  return 'completed';
+}
+
+function canonicalImageCreativeFromCreativeAsset(
+  asset: HermesCreativeAsset,
+  index: number,
+  appBaseUrl: string,
+  aspectRatio: string,
+): Record<string, unknown> | null {
+  if (asset.type !== 'generated_image') return null;
+
+  const basename = renderedImageBasenameFromRecord(asset);
+  if (!basename) return null;
+
+  const assetId = typeof asset.assetId === 'string' && asset.assetId.trim().length > 0
+    ? asset.assetId.trim()
+    : String(index);
+  const prompt = typeof asset.prompt === 'string' ? asset.prompt : '';
+  const placement = typeof asset.placement === 'string' ? asset.placement : '';
+
+  return {
+    id: `img_${assetId}`,
+    title: placement,
+    ...(placement ? { placement, intendedUse: placement } : {}),
+    prompt,
+    status: normalizeRenderedStatus(asset.status),
+    artifact_url: mediaArtifactUrl(appBaseUrl, basename),
+    aspect_ratio: aspectRatio,
+  };
+}
+
+function canonicalImageCreativeFromGeneratedImage(
+  image: HermesGeneratedImage,
+  index: number,
+  appBaseUrl: string,
+  aspectRatio: string,
+): Record<string, unknown> | null {
+  const basename = renderedImageBasenameFromRecord(image);
+  if (!basename) return null;
+
+  const imageIndex = typeof image.index === 'number' ? image.index : index;
+  const prompt = typeof image.prompt === 'string' ? image.prompt : '';
+  const intendedUse = typeof image.intendedUse === 'string' ? image.intendedUse : '';
+
+  return {
+    id: `img_${String(imageIndex)}`,
+    title: intendedUse,
+    ...(intendedUse ? { intendedUse } : {}),
+    prompt,
+    status: normalizeRenderedStatus(image.status),
+    artifact_url: mediaArtifactUrl(appBaseUrl, basename),
+    aspect_ratio: aspectRatio,
+  };
+}
+
+function canonicalImageCreativeFromExisting(
+  creative: HermesImageCreativeLike,
+  index: number,
+  appBaseUrl: string,
+  aspectRatio: string,
+): Record<string, unknown> | null {
+  const basename = renderedImageBasenameFromRecord(creative);
+  if (!basename) return null;
+
+  const idSource = typeof creative.id === 'string' && creative.id.trim().length > 0
+    ? creative.id.trim().replace(/^img_/, '')
+    : String(index);
+  const prompt = typeof creative.prompt === 'string' ? creative.prompt : '';
+  const intendedUse = typeof creative.intendedUse === 'string'
+    ? creative.intendedUse
+    : typeof creative.title === 'string'
+      ? creative.title
+      : typeof creative.placement === 'string'
+        ? creative.placement
+        : '';
+
+  return {
+    id: `img_${idSource}`,
+    title: intendedUse,
+    ...(intendedUse ? { intendedUse } : {}),
+    ...(typeof creative.placement === 'string' && creative.placement.trim().length > 0
+      ? { placement: creative.placement }
+      : {}),
+    prompt,
+    status: normalizeRenderedStatus(creative.status),
+    artifact_url: mediaArtifactUrl(appBaseUrl, basename),
+    aspect_ratio: aspectRatio,
+  };
+}
 
 /**
  * Bridges Hermes `creative_assets` (at `result[0].artifacts.creative_assets`)
@@ -66,53 +201,16 @@ type HermesCreativeAsset = {
 export function bridgeHermesCreativeAssets(
   outputRecord: Record<string, unknown>,
 ): Record<string, unknown> {
-  const artifacts = outputRecord.artifacts;
-  if (!artifacts || typeof artifacts !== 'object' || Array.isArray(artifacts)) {
-    return outputRecord;
-  }
-
-  const creativeAssets = (artifacts as Record<string, unknown>).creative_assets;
-  if (!Array.isArray(creativeAssets) || creativeAssets.length === 0) {
-    return outputRecord;
-  }
-
   const appBaseUrl = resolveAppBaseUrl();
-
-  const imageCreatives = creativeAssets
-    .filter(
-      (asset): asset is HermesCreativeAsset =>
-        asset !== null &&
-        typeof asset === 'object' &&
-        !Array.isArray(asset) &&
-        (asset as HermesCreativeAsset).type === 'generated_image',
-    )
-    .map((asset) => {
-      // Convert the absolute host path to an internal URL using basename only.
-      // The media route resolves it against HERMES_IMAGE_CACHE_MOUNT.
-      let artifactUrl = '';
-      if (typeof asset.path === 'string' && asset.path.trim().length > 0) {
-        const basename = asset.path.split('/').filter(Boolean).pop() ?? '';
-        if (basename) {
-          artifactUrl = `${appBaseUrl}/api/internal/hermes/media/${basename}`;
-        }
-      }
-
-      return {
-        id: typeof asset.assetId === 'string' ? asset.assetId : '',
-        title: typeof asset.placement === 'string' ? asset.placement : '',
-        aspect_ratio: '',
-        prompt: '',
-        status: typeof asset.status === 'string' ? asset.status : 'created',
-        artifact_url: artifactUrl,
-      };
-    });
-
-  if (imageCreatives.length === 0) {
-    return outputRecord;
-  }
+  const artifacts = outputRecord.artifacts;
+  const artifactRecord = artifacts && typeof artifacts === 'object' && !Array.isArray(artifacts)
+    ? artifacts as Record<string, unknown>
+    : null;
+  const aspectRatio = typeof artifactRecord?.aspectRatio === 'string' ? artifactRecord.aspectRatio : '';
 
   // Merge into weekly_content_plan, creating the key if absent. Do not
-  // overwrite existing image_creatives that the workflow itself emitted.
+  // overwrite existing image_creatives that the workflow itself emitted unless
+  // they need canonicalization into the projection shape.
   const existingPlan =
     outputRecord.weekly_content_plan !== undefined &&
     outputRecord.weekly_content_plan !== null &&
@@ -121,11 +219,70 @@ export function bridgeHermesCreativeAssets(
       ? (outputRecord.weekly_content_plan as Record<string, unknown>)
       : {};
 
-  const existingCreatives = existingPlan.image_creatives;
-  const alreadyHasCreatives =
-    Array.isArray(existingCreatives) && existingCreatives.length > 0;
+  const existingCreatives = Array.isArray(existingPlan.image_creatives)
+    ? existingPlan.image_creatives
+    : null;
 
-  if (alreadyHasCreatives) {
+  const canonicalExistingCreatives = existingCreatives
+    ?.map((creative, index) => (
+      creative !== null && typeof creative === 'object' && !Array.isArray(creative)
+        ? canonicalImageCreativeFromExisting(
+          creative as HermesImageCreativeLike,
+          index,
+          appBaseUrl,
+          aspectRatio,
+        )
+        : null
+    ))
+    .filter((creative): creative is Record<string, unknown> => creative !== null) ?? [];
+
+  if (canonicalExistingCreatives.length > 0) {
+    return {
+      ...outputRecord,
+      weekly_content_plan: {
+        ...existingPlan,
+        image_creatives: canonicalExistingCreatives,
+      },
+    };
+  }
+
+  const creativeAssets = Array.isArray(artifactRecord?.creative_assets)
+    ? artifactRecord.creative_assets
+    : [];
+  const imageCreativesFromCreativeAssets = creativeAssets
+    .map((asset, index) => (
+      asset !== null && typeof asset === 'object' && !Array.isArray(asset)
+        ? canonicalImageCreativeFromCreativeAsset(
+          asset as HermesCreativeAsset,
+          index,
+          appBaseUrl,
+          aspectRatio,
+        )
+        : null
+    ))
+    .filter((creative): creative is Record<string, unknown> => creative !== null);
+
+  const images = Array.isArray(artifactRecord?.images)
+    ? artifactRecord.images
+    : [];
+  const imageCreativesFromImages = images
+    .map((image, index) => (
+      image !== null && typeof image === 'object' && !Array.isArray(image)
+        ? canonicalImageCreativeFromGeneratedImage(
+          image as HermesGeneratedImage,
+          index,
+          appBaseUrl,
+          aspectRatio,
+        )
+        : null
+    ))
+    .filter((creative): creative is Record<string, unknown> => creative !== null);
+
+  const imageCreatives = imageCreativesFromCreativeAssets.length > 0
+    ? imageCreativesFromCreativeAssets
+    : imageCreativesFromImages;
+
+  if (imageCreatives.length === 0) {
     return outputRecord;
   }
 

--- a/backend/social-content/workflow-request.ts
+++ b/backend/social-content/workflow-request.ts
@@ -558,6 +558,20 @@ export function buildProductionResumeContext(input: {
     contextLines.push(`--- Image ${img.imageIndex} of ${img.totalImages} ---`);
     contextLines.push(img.prompt);
   }
+  contextLines.push('');
+  contextLines.push('Return your results in this EXACT JSON shape:');
+  contextLines.push('');
+  contextLines.push('When you finish image_generate, place the results in your final response under `artifacts.creative_assets[]` with this shape per item:');
+  contextLines.push('');
+  contextLines.push('{');
+  contextLines.push('  "assetId": "img_0",');
+  contextLines.push('  "type": "generated_image",');
+  contextLines.push('  "path": "<absolute path returned by image_generate>",');
+  contextLines.push('  "placement": "<which post>",');
+  contextLines.push('  "prompt": "<the rendered prompt>"');
+  contextLines.push('}');
+  contextLines.push('');
+  contextLines.push('The bridge will also accept `artifacts.images[]` with `{index, status:"generated", filePath, prompt, intendedUse}`, but `creative_assets` is preferred.');
 
   return {
     imagePrompts,

--- a/tests/hermes-creative-asset-bridge.test.ts
+++ b/tests/hermes-creative-asset-bridge.test.ts
@@ -3,11 +3,43 @@ import test from 'node:test';
 
 import { bridgeHermesCreativeAssets } from '@/backend/marketing/hermes-callbacks';
 
-// ---------------------------------------------------------------------------
-// bridgeHermesCreativeAssets — unit tests
-// ---------------------------------------------------------------------------
+type CanonicalCreative = {
+  id: string;
+  title: string;
+  prompt: string;
+  status: string;
+  artifact_url: string;
+  aspect_ratio: string;
+  intendedUse?: string;
+  placement?: string;
+};
 
-test('bridge is a no-op when creative_assets is absent', () => {
+function withAppBaseUrl(fn: () => void): void {
+  const previousAppBaseUrl = process.env.APP_BASE_URL;
+  process.env.APP_BASE_URL = 'https://aries.example.com';
+
+  try {
+    fn();
+  } finally {
+    if (previousAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = previousAppBaseUrl;
+  }
+}
+
+function expectedCreative(overrides: Partial<CanonicalCreative> = {}): CanonicalCreative {
+  return {
+    id: 'img_0',
+    title: 'homepage hero',
+    prompt: 'Studio-lit leather weekender bag on warm sandstone.',
+    status: 'completed',
+    artifact_url: 'https://aries.example.com/api/internal/hermes/media/render_0.png',
+    aspect_ratio: '1:1',
+    intendedUse: 'homepage hero',
+    ...overrides,
+  };
+}
+
+test('bridge is a no-op when no recognized image schema is present', () => {
   const input = {
     stage: 'production',
     summary: 'Weekly plan ready.',
@@ -18,211 +50,100 @@ test('bridge is a no-op when creative_assets is absent', () => {
       video_scripts: [],
     },
   };
+
   const result = bridgeHermesCreativeAssets(input);
-  // Must return the same object reference — no unnecessary copies.
   assert.equal(result.weekly_content_plan, input.weekly_content_plan);
 });
 
-test('bridge is a no-op when creative_assets is an empty array', () => {
-  const input = {
-    artifacts: { creative_assets: [] },
-    weekly_content_plan: { image_creatives: [] },
-  };
-  const result = bridgeHermesCreativeAssets(input);
-  assert.deepEqual(result.weekly_content_plan, input.weekly_content_plan);
-});
-
-test('bridge is a no-op when artifacts key is missing', () => {
-  const input: Record<string, unknown> = { stage: 'production' };
-  const result = bridgeHermesCreativeAssets(input);
-  assert.equal('weekly_content_plan' in result, false);
-});
-
-test('bridge maps generated_image assets into image_creatives with internal URLs', () => {
-  const previousAppBaseUrl = process.env.APP_BASE_URL;
-  process.env.APP_BASE_URL = 'https://aries.example.com';
-
-  try {
+test('bridge canonicalizes artifacts.creative_assets generated_image records', () => {
+  withAppBaseUrl(() => {
     const input = {
-      stage: 'production',
       artifacts: {
+        aspectRatio: '1:1',
         creative_assets: [
           {
-            assetId: 'sl_asset_01',
+            assetId: '0',
             type: 'generated_image',
             status: 'created',
-            path: '/home/node/.hermes/cache/images/openai_codex_gpt-image-2-medium_20260513_194035_8af24877.png',
-            placement: 'post_1',
-          },
-          {
-            assetId: 'sl_asset_02',
-            type: 'generated_image',
-            status: 'created',
-            path: '/home/node/.hermes/cache/images/openai_codex_gpt-image-2-medium_20260513_194127_d62de45d.png',
-            placement: 'post_2',
+            path: '/home/node/.hermes/cache/images/render_0.png',
+            placement: 'homepage hero',
+            prompt: 'Studio-lit leather weekender bag on warm sandstone.',
           },
         ],
       },
     };
 
     const result = bridgeHermesCreativeAssets(input);
-    const plan = result.weekly_content_plan as {
-      image_creatives: Array<{ id: string; artifact_url: string; status: string }>;
-    };
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
 
-    assert.ok(plan, 'weekly_content_plan should be present');
-    assert.equal(plan.image_creatives.length, 2);
-
-    assert.equal(plan.image_creatives[0].id, 'sl_asset_01');
-    assert.equal(
-      plan.image_creatives[0].artifact_url,
-      'https://aries.example.com/api/internal/hermes/media/openai_codex_gpt-image-2-medium_20260513_194035_8af24877.png',
-    );
-    assert.equal(plan.image_creatives[0].status, 'created');
-
-    assert.equal(plan.image_creatives[1].id, 'sl_asset_02');
-    assert.equal(
-      plan.image_creatives[1].artifact_url,
-      'https://aries.example.com/api/internal/hermes/media/openai_codex_gpt-image-2-medium_20260513_194127_d62de45d.png',
-    );
-  } finally {
-    if (previousAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
-    else process.env.APP_BASE_URL = previousAppBaseUrl;
-  }
+    assert.deepEqual(plan.image_creatives, [
+      expectedCreative({ placement: 'homepage hero' }),
+    ]);
+  });
 });
 
-test('bridge skips non-generated_image asset types (e.g. design_brief)', () => {
-  const previousAppBaseUrl = process.env.APP_BASE_URL;
-  process.env.APP_BASE_URL = 'https://aries.example.com';
-
-  try {
+test('bridge canonicalizes artifacts.images records', () => {
+  withAppBaseUrl(() => {
     const input = {
       artifacts: {
-        creative_assets: [
+        aspectRatio: '1:1',
+        images: [
           {
-            assetId: 'sl_asset_01',
-            type: 'generated_image',
-            status: 'created',
-            path: '/home/node/.hermes/cache/images/image_01.png',
-            placement: 'post_1',
-          },
-          {
-            assetId: 'sl_asset_03',
-            type: 'design_brief',
-            status: 'created',
-            path: '/home/node/.hermes/cache/images/brief_03.json',
-            placement: 'post_3',
+            index: 0,
+            status: 'generated',
+            filePath: '/home/node/.hermes/cache/images/render_0.png',
+            prompt: 'Studio-lit leather weekender bag on warm sandstone.',
+            intendedUse: 'homepage hero',
           },
         ],
       },
     };
 
     const result = bridgeHermesCreativeAssets(input);
-    const plan = result.weekly_content_plan as { image_creatives: unknown[] };
-    assert.equal(plan.image_creatives.length, 1);
-  } finally {
-    if (previousAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
-    else process.env.APP_BASE_URL = previousAppBaseUrl;
-  }
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.deepEqual(plan.image_creatives, [expectedCreative()]);
+  });
 });
 
-test('bridge does not overwrite existing image_creatives', () => {
-  const previousAppBaseUrl = process.env.APP_BASE_URL;
-  process.env.APP_BASE_URL = 'https://aries.example.com';
-
-  try {
-    const existingCreative = {
-      id: 'already-exists',
-      artifact_url: 'https://aries.example.com/api/internal/hermes/media/already.png',
-      status: 'generated',
-    };
+test('bridge canonicalizes top-level image_creatives when a renderable path is present', () => {
+  withAppBaseUrl(() => {
     const input = {
+      artifacts: {
+        aspectRatio: '1:1',
+      },
       weekly_content_plan: {
-        image_creatives: [existingCreative],
-      },
-      artifacts: {
-        creative_assets: [
+        image_creatives: [
           {
-            assetId: 'sl_asset_new',
-            type: 'generated_image',
-            status: 'created',
-            path: '/home/node/.hermes/cache/images/new_image.png',
-            placement: 'post_1',
+            prompt: 'Studio-lit leather weekender bag on warm sandstone.',
+            artifact_url: 'https://cdn.example.com/cache/render_0.png?token=abc',
+            intendedUse: 'homepage hero',
+            status: 'generated',
           },
         ],
       },
     };
 
     const result = bridgeHermesCreativeAssets(input);
-    const plan = result.weekly_content_plan as { image_creatives: unknown[] };
-    // Must preserve the existing creative, not replace with the incoming one.
-    assert.equal(plan.image_creatives.length, 1);
-    assert.deepEqual(plan.image_creatives[0], existingCreative);
-  } finally {
-    if (previousAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
-    else process.env.APP_BASE_URL = previousAppBaseUrl;
-  }
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.deepEqual(plan.image_creatives, [expectedCreative()]);
+  });
 });
 
-test('bridge handles missing path gracefully — artifact_url becomes empty string', () => {
-  const previousAppBaseUrl = process.env.APP_BASE_URL;
-  process.env.APP_BASE_URL = 'https://aries.example.com';
+test('bridge ignores prompt-only top-level image_creatives without a renderable path', () => {
+  const input = {
+    weekly_content_plan: {
+      image_creatives: [
+        {
+          prompt: 'Prompt only, no image rendered yet.',
+          intendedUse: 'homepage hero',
+          status: 'created',
+        },
+      ],
+    },
+  };
 
-  try {
-    const input = {
-      artifacts: {
-        creative_assets: [
-          {
-            assetId: 'sl_asset_nopath',
-            type: 'generated_image',
-            status: 'pending',
-          },
-        ],
-      },
-    };
-
-    const result = bridgeHermesCreativeAssets(input);
-    const plan = result.weekly_content_plan as {
-      image_creatives: Array<{ artifact_url: string }>;
-    };
-    assert.equal(plan.image_creatives.length, 1);
-    assert.equal(plan.image_creatives[0].artifact_url, '');
-  } finally {
-    if (previousAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
-    else process.env.APP_BASE_URL = previousAppBaseUrl;
-  }
-});
-
-test('URL rewrite uses only basename — no host path segments leak', () => {
-  const previousAppBaseUrl = process.env.APP_BASE_URL;
-  process.env.APP_BASE_URL = 'https://aries.example.com';
-
-  try {
-    const input = {
-      artifacts: {
-        creative_assets: [
-          {
-            assetId: 'sl_asset_01',
-            type: 'generated_image',
-            status: 'created',
-            path: '/home/node/.hermes/cache/images/img.png',
-          },
-        ],
-      },
-    };
-
-    const result = bridgeHermesCreativeAssets(input);
-    const plan = result.weekly_content_plan as {
-      image_creatives: Array<{ artifact_url: string }>;
-    };
-    const url = plan.image_creatives[0].artifact_url;
-    // Must not include any host-side path segment before the basename.
-    assert.equal(url.includes('.hermes'), false);
-    assert.equal(url.includes('/home'), false);
-    assert.equal(url.includes('/cache'), false);
-    assert.equal(url, 'https://aries.example.com/api/internal/hermes/media/img.png');
-  } finally {
-    if (previousAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
-    else process.env.APP_BASE_URL = previousAppBaseUrl;
-  }
+  const result = bridgeHermesCreativeAssets(input);
+  assert.equal(result, input);
 });

--- a/tests/hermes-image-bridge-multischema.test.ts
+++ b/tests/hermes-image-bridge-multischema.test.ts
@@ -1,0 +1,304 @@
+/**
+ * hermes-image-bridge-multischema.test.ts
+ *
+ * Verifies that bridgeHermesCreativeAssets correctly handles all three
+ * recognized Hermes output shapes:
+ *
+ *   (a) artifacts.creative_assets[] with type="generated_image" and a path
+ *   (b) artifacts.images[] with filePath
+ *   (c) legacy weekly_content_plan.image_creatives[] (no regression)
+ *
+ * Run:
+ *   APP_BASE_URL=https://aries.example.com \
+ *     ./node_modules/.bin/tsx --test tests/hermes-image-bridge-multischema.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { bridgeHermesCreativeAssets } from '@/backend/marketing/hermes-callbacks';
+
+type CanonicalCreative = {
+  id: string;
+  title: string;
+  prompt: string;
+  status: string;
+  artifact_url: string;
+  aspect_ratio: string;
+  intendedUse?: string;
+  placement?: string;
+};
+
+function withAppBaseUrl(fn: () => void): void {
+  const prev = process.env.APP_BASE_URL;
+  process.env.APP_BASE_URL = 'https://aries.example.com';
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = prev;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (a) artifacts.creative_assets[] shape
+// ---------------------------------------------------------------------------
+
+test('bridge(a): accepts artifacts.creative_assets[].path shape — image_creatives populated, status=completed, path threaded', () => {
+  withAppBaseUrl(() => {
+    const input = {
+      artifacts: {
+        aspectRatio: '4:5',
+        creative_assets: [
+          {
+            assetId: 'sl_asset_01',
+            type: 'generated_image',
+            status: 'created',
+            path: '/home/node/.hermes/cache/images/openai_gpt_image_20260513_abc123.png',
+            placement: 'post_1',
+            prompt: 'Editorial portrait of a woman leader against warm neutral backdrop.',
+          },
+          {
+            assetId: 'sl_asset_02',
+            type: 'generated_image',
+            status: 'created',
+            path: '/home/node/.hermes/cache/images/openai_gpt_image_20260513_def456.png',
+            placement: 'post_2',
+            prompt: 'Aspirational lifestyle shot with soft warm tones and minimal layout.',
+          },
+        ],
+      },
+    };
+
+    const result = bridgeHermesCreativeAssets(input);
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.ok(Array.isArray(plan.image_creatives), 'image_creatives should be an array');
+    assert.equal(plan.image_creatives.length, 2, 'should map two creative assets');
+
+    const first = plan.image_creatives[0];
+    assert.equal(first.id, 'img_sl_asset_01', 'id should use assetId prefixed with img_');
+    assert.equal(first.status, 'completed', 'status should be normalized to completed');
+    assert.equal(first.aspect_ratio, '4:5', 'aspect_ratio should be threaded from artifactRecord');
+    assert.ok(
+      first.artifact_url.startsWith('https://aries.example.com/api/internal/hermes/media/'),
+      'artifact_url should use the internal hermes media route',
+    );
+    assert.ok(
+      first.artifact_url.includes('openai_gpt_image_20260513_abc123.png'),
+      'artifact_url should contain the image filename',
+    );
+    assert.equal(first.placement, 'post_1', 'placement should be threaded');
+
+    const second = plan.image_creatives[1];
+    assert.equal(second.id, 'img_sl_asset_02');
+    assert.equal(second.status, 'completed');
+    assert.ok(second.artifact_url.includes('openai_gpt_image_20260513_def456.png'));
+  });
+});
+
+test('bridge(a): creative_assets with non-image type entries are filtered out', () => {
+  withAppBaseUrl(() => {
+    const input = {
+      artifacts: {
+        aspectRatio: '1:1',
+        creative_assets: [
+          {
+            assetId: 'video_01',
+            type: 'video_clip',
+            status: 'created',
+            path: '/home/node/.hermes/cache/images/clip.mp4',
+            prompt: 'Video clip.',
+          },
+          {
+            assetId: 'img_01',
+            type: 'generated_image',
+            status: 'created',
+            path: '/home/node/.hermes/cache/images/render_01.png',
+            prompt: 'Image prompt.',
+          },
+        ],
+      },
+    };
+
+    const result = bridgeHermesCreativeAssets(input);
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.equal(plan.image_creatives.length, 1, 'only generated_image assets should be included');
+    assert.equal(plan.image_creatives[0].id, 'img_img_01');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) artifacts.images[] shape
+// ---------------------------------------------------------------------------
+
+test('bridge(b): accepts artifacts.images[].filePath shape — index→assetId, filePath→path, status:generated→completed', () => {
+  withAppBaseUrl(() => {
+    const input = {
+      artifacts: {
+        aspectRatio: '9:16',
+        images: [
+          {
+            index: 0,
+            status: 'generated',
+            filePath: '/home/node/.hermes/cache/images/veo_render_20260513_aaa111.png',
+            prompt: 'Dynamic motion portrait.',
+            intendedUse: 'reel_cover',
+          },
+          {
+            index: 1,
+            status: 'generated',
+            filePath: '/home/node/.hermes/cache/images/veo_render_20260513_bbb222.png',
+            prompt: 'Lifestyle reel thumbnail.',
+            intendedUse: 'reel_thumb',
+          },
+        ],
+      },
+    };
+
+    const result = bridgeHermesCreativeAssets(input);
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.ok(Array.isArray(plan.image_creatives), 'image_creatives should be present');
+    assert.equal(plan.image_creatives.length, 2, 'should map both images entries');
+
+    const first = plan.image_creatives[0];
+    // index value is used as the numeric identifier
+    assert.equal(first.id, 'img_0', 'id should use the image index');
+    assert.equal(first.status, 'completed', 'status normalized to completed regardless of generated input');
+    assert.equal(first.aspect_ratio, '9:16', 'aspect_ratio threaded from artifactRecord');
+    assert.ok(
+      first.artifact_url.includes('veo_render_20260513_aaa111.png'),
+      'artifact_url should contain the filePath basename',
+    );
+    assert.equal(first.intendedUse, 'reel_cover', 'intendedUse should be threaded');
+
+    const second = plan.image_creatives[1];
+    assert.equal(second.id, 'img_1');
+    assert.ok(second.artifact_url.includes('veo_render_20260513_bbb222.png'));
+  });
+});
+
+test('bridge(b): artifacts.images entries without a filePath or path are filtered out', () => {
+  withAppBaseUrl(() => {
+    const input = {
+      artifacts: {
+        aspectRatio: '1:1',
+        images: [
+          {
+            index: 0,
+            status: 'pending',
+            prompt: 'Prompt only, no file yet.',
+          },
+          {
+            index: 1,
+            status: 'generated',
+            filePath: '/home/node/.hermes/cache/images/render_real.png',
+            prompt: 'Actual rendered image.',
+          },
+        ],
+      },
+    };
+
+    const result = bridgeHermesCreativeAssets(input);
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.equal(plan.image_creatives.length, 1, 'prompt-only images entries should be filtered');
+    assert.equal(plan.image_creatives[0].id, 'img_1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) legacy weekly_content_plan.image_creatives[] — no regression
+// ---------------------------------------------------------------------------
+
+test('bridge(c): accepts legacy image_creatives[] with artifact_url — no regression', () => {
+  withAppBaseUrl(() => {
+    const legacyArtifactUrl = 'https://cdn.example.com/cache/legacy_render.png?token=xyz';
+    const input = {
+      artifacts: {
+        aspectRatio: '4:5',
+      },
+      weekly_content_plan: {
+        posts: [],
+        image_creatives: [
+          {
+            id: 'creative_01',
+            title: 'Brand hero',
+            aspect_ratio: '4:5',
+            prompt: 'Editorial portrait of a woman leader.',
+            status: 'created',
+            artifact_url: legacyArtifactUrl,
+            intendedUse: 'Brand hero',
+          },
+        ],
+        video_scripts: [],
+      },
+    };
+
+    const result = bridgeHermesCreativeAssets(input);
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.equal(plan.image_creatives.length, 1, 'legacy image_creatives should be preserved');
+    assert.equal(plan.image_creatives[0].id, 'img_creative_01', 'id should strip and re-prefix img_');
+    assert.equal(plan.image_creatives[0].status, 'completed', 'status normalized to completed');
+    // artifact_url is preserved since it has a recognizable image extension basename
+    assert.ok(
+      plan.image_creatives[0].artifact_url.includes('legacy_render.png'),
+      'artifact_url should include the image basename',
+    );
+  });
+});
+
+test('bridge(c): legacy image_creatives[] without paths remain a no-op (prompt-only)', () => {
+  const input = {
+    weekly_content_plan: {
+      image_creatives: [
+        {
+          id: 'creative_01',
+          title: 'Brand hero',
+          prompt: 'Prompt only — no path or artifact_url.',
+          status: 'pending',
+        },
+      ],
+    },
+  };
+
+  // Bridge should return the original record unchanged when no renderable path found
+  const result = bridgeHermesCreativeAssets(input);
+  // The function returns the outputRecord unchanged when no canonical result found
+  const plan = result.weekly_content_plan as Record<string, unknown>;
+  const creatives = plan?.image_creatives as unknown[];
+  // Prompt-only entries produce null from canonicalImageCreativeFromExisting → filtered → empty
+  // So image_creatives should not be overwritten with an empty array; the original is returned
+  assert.equal(creatives?.length, 1, 'original prompt-only creatives preserved as-is when no path available');
+});
+
+test('bridge(c): creative_assets shape takes precedence over empty legacy image_creatives', () => {
+  withAppBaseUrl(() => {
+    const input = {
+      artifacts: {
+        aspectRatio: '1:1',
+        creative_assets: [
+          {
+            assetId: 'new_asset',
+            type: 'generated_image',
+            status: 'created',
+            path: '/home/node/.hermes/cache/images/new_render.png',
+            prompt: 'New schema image.',
+          },
+        ],
+      },
+      weekly_content_plan: {
+        image_creatives: [],
+      },
+    };
+
+    const result = bridgeHermesCreativeAssets(input);
+    const plan = result.weekly_content_plan as { image_creatives: CanonicalCreative[] };
+
+    assert.equal(plan.image_creatives.length, 1, 'creative_assets should populate when legacy is empty');
+    assert.equal(plan.image_creatives[0].id, 'img_new_asset');
+  });
+});

--- a/tests/hermes-image-bridge-multischema.test.ts
+++ b/tests/hermes-image-bridge-multischema.test.ts
@@ -302,3 +302,73 @@ test('bridge(c): creative_assets shape takes precedence over empty legacy image_
     assert.equal(plan.image_creatives[0].id, 'img_new_asset');
   });
 });
+
+// ---------------------------------------------------------------------------
+// ReDoS regression — imageBasenameFromValue must not hang on pathological input
+// (CodeQL js/polynomial-redos, fixed by replacing runtime regex with explicit
+//  string operations + 1024-char input cap)
+// ---------------------------------------------------------------------------
+
+test('security: imageBasenameFromValue returns in < 200ms on pathological 50k-quote input ending .png#', () => {
+  // Simulate the pathological pattern described by CodeQL: a string of many
+  // repeated quote characters followed by ".png#" — the old regex
+  // /([^/?#]+\.(?:png|jpe?g|webp|gif))(?:[?#].*)?$/i would backtrack
+  // exponentially on this input. The new implementation must complete in
+  // well under 200ms regardless.
+  withAppBaseUrl(() => {
+    const malicious = '"'.repeat(50_000) + '.png#';
+    const input = {
+      artifacts: {
+        aspectRatio: '1:1',
+        creative_assets: [
+          {
+            assetId: 'sec_test',
+            type: 'generated_image',
+            status: 'created',
+            path: malicious,
+            prompt: 'ReDoS regression test.',
+          },
+        ],
+      },
+    };
+
+    const start = performance.now();
+    bridgeHermesCreativeAssets(input);
+    const elapsed = performance.now() - start;
+
+    assert.ok(
+      elapsed < 200,
+      `imageBasenameFromValue must return in < 200ms on pathological input; took ${elapsed.toFixed(1)}ms`,
+    );
+  });
+});
+
+test('security: imageBasenameFromValue returns in < 200ms on pathological 50k-.gif# input', () => {
+  // Second CodeQL pattern: starts with ".png#" and has many repetitions of ".gif#".
+  withAppBaseUrl(() => {
+    const malicious = '".png#' + '".gif#'.repeat(50_000);
+    const input = {
+      artifacts: {
+        aspectRatio: '1:1',
+        creative_assets: [
+          {
+            assetId: 'sec_test_2',
+            type: 'generated_image',
+            status: 'created',
+            path: malicious,
+            prompt: 'ReDoS regression test 2.',
+          },
+        ],
+      },
+    };
+
+    const start = performance.now();
+    bridgeHermesCreativeAssets(input);
+    const elapsed = performance.now() - start;
+
+    assert.ok(
+      elapsed < 200,
+      `imageBasenameFromValue must return in < 200ms on pathological input; took ${elapsed.toFixed(1)}ms`,
+    );
+  });
+});

--- a/tests/hermes-image-generation-fail-loud.test.ts
+++ b/tests/hermes-image-generation-fail-loud.test.ts
@@ -1,0 +1,521 @@
+/**
+ * hermes-image-generation-fail-loud.test.ts
+ *
+ * Verifies the `hermes_image_generation_unrecognized` fail-loud gate:
+ * when a production callback arrives with N image requests declared but zero
+ * recognized images in any known output shape, the callback is rejected.
+ *
+ *   (d) media_requests count=2, artifacts={} AND image_creatives=[] → rejected
+ *       with hermes_image_generation_unrecognized
+ *   (e) media_requests count=2, artifacts.creative_assets length=2 → accepted
+ *   (f) media_requests count=0 (imageCreativeCount=0) → no fail-loud check fires
+ *
+ * Run:
+ *   APP_BASE_URL=https://aries.example.com \
+ *     ./node_modules/.bin/tsx --test tests/hermes-image-generation-fail-loud.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+async function withRuntimeEnv<T>(run: () => Promise<T>): Promise<T> {
+  const prevDataRoot = process.env.DATA_ROOT;
+  const prevAppBaseUrl = process.env.APP_BASE_URL;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-unrecognized-'));
+  process.env.DATA_ROOT = dataRoot;
+  process.env.APP_BASE_URL = 'https://aries.example.com';
+  try {
+    return await run();
+  } finally {
+    if (prevDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = prevDataRoot;
+    if (prevAppBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = prevAppBaseUrl;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+async function seedSocialJobWithImageCount(imageCreativeCount: number) {
+  const {
+    createMarketingJobRuntimeDocument,
+    saveMarketingJobRuntime,
+  } = await import('../backend/marketing/runtime-state');
+
+  const doc = createMarketingJobRuntimeDocument({
+    jobId: `mkt_unrecognized-${imageCreativeCount}-${Date.now()}`,
+    tenantId: 'tenant-unrecognized',
+    payload: {
+      brandUrl: 'https://brand.example',
+      businessType: 'coaching',
+      competitorUrl: '',
+      imageCreativeCount,
+    },
+    brandKit: {
+      path: '/tmp/brand-kit.json',
+      source_url: 'https://brand.example',
+      canonical_url: 'https://brand.example',
+      brand_name: 'Brand',
+      logo_urls: [],
+      colors: { primary: null, secondary: null, accent: null, palette: [] },
+      font_families: [],
+      external_links: [],
+      extracted_at: new Date().toISOString(),
+      brand_voice_summary: 'clear',
+      offer_summary: null,
+    },
+  });
+  saveMarketingJobRuntime(doc.job_id, doc);
+  return doc;
+}
+
+// ---------------------------------------------------------------------------
+// (d) Callback with media_requests count=2 and no recognized images anywhere
+//     → rejected with hermes_image_generation_unrecognized
+// ---------------------------------------------------------------------------
+
+test('(d) callback with media_requests count=2 and artifacts:{} + image_creatives:[] is rejected with hermes_image_generation_unrecognized', async () => {
+  await withRuntimeEnv(async () => {
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+
+    // imageCreativeCount=2 means 2 media_requests of type image.generate were sent to Hermes
+    const doc = await seedSocialJobWithImageCount(2);
+
+    const run = createExecutionRunRecord({
+      provider: 'hermes',
+      domain: 'marketing',
+      workflowKey: 'social_content_weekly',
+      action: 'resume',
+      tenantId: doc.tenant_id,
+      marketingJobId: doc.job_id,
+      stage: 'production',
+    });
+
+    // Hermes returns approve_publish but with empty artifacts and empty image_creatives —
+    // neither the prompt-only check NOR the legacy check would catch this, but the
+    // new hermes_image_generation_unrecognized check must.
+    await handleHermesRunCallback({
+      event_id: 'evt-unrecognized-empty',
+      aries_run_id: run.aries_run_id,
+      hermes_run_id: 'hermes-unrecognized-1',
+      status: 'requires_approval',
+      stage: 'production',
+      approval: {
+        stage: 'publish',
+        approval_step: 'approve_publish',
+        workflow_step_id: 'approve_stage_4',
+        prompt: 'Review creative assets before publish review',
+        resume_token: 'social_content_weekly:arun_abc:strategy_complete',
+      },
+      output: [
+        {
+          stage: 'production',
+          artifacts: {},
+          weekly_content_plan: {
+            posts: [],
+            image_creatives: [],
+            video_scripts: [],
+          },
+        },
+      ],
+    });
+
+    const after = await loadMarketingJobRuntime(doc.job_id);
+    assert.equal(
+      after?.stages.production.status,
+      'failed',
+      'production stage should be failed when zero images recognized',
+    );
+    assert.ok(after?.last_error, 'last_error should be set');
+    assert.equal(
+      after?.last_error?.code,
+      'hermes_image_generation_unrecognized',
+      'error code must be hermes_image_generation_unrecognized',
+    );
+    assert.match(
+      after?.last_error?.message ?? '',
+      /no recognized images/i,
+      'error message should describe the failure',
+    );
+    // No approval checkpoint should have been created
+    assert.equal(
+      after?.approvals.current,
+      null,
+      'no approval checkpoint should be created when failing loud',
+    );
+  });
+});
+
+test('(d-variant) callback with media_requests count=2 and completely absent artifacts key is rejected', async () => {
+  await withRuntimeEnv(async () => {
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+
+    const doc = await seedSocialJobWithImageCount(2);
+
+    const run = createExecutionRunRecord({
+      provider: 'hermes',
+      domain: 'marketing',
+      workflowKey: 'social_content_weekly',
+      action: 'resume',
+      tenantId: doc.tenant_id,
+      marketingJobId: doc.job_id,
+      stage: 'production',
+    });
+
+    // No artifacts key at all, no image_creatives — Hermes returned nothing
+    await handleHermesRunCallback({
+      event_id: 'evt-unrecognized-absent',
+      aries_run_id: run.aries_run_id,
+      hermes_run_id: 'hermes-unrecognized-2',
+      status: 'requires_approval',
+      stage: 'production',
+      approval: {
+        stage: 'publish',
+        approval_step: 'approve_publish',
+        workflow_step_id: 'approve_stage_4',
+        prompt: 'Review before publish',
+        resume_token: 'social_content_weekly:arun_abc:strategy_complete',
+      },
+      output: [
+        {
+          stage: 'production',
+          summary: 'Production complete.',
+          weekly_content_plan: {
+            posts: [],
+          },
+        },
+      ],
+    });
+
+    const after = await loadMarketingJobRuntime(doc.job_id);
+    assert.equal(
+      after?.stages.production.status,
+      'failed',
+      'should fail when artifacts key is absent and images were requested',
+    );
+    assert.equal(
+      after?.last_error?.code,
+      'hermes_image_generation_unrecognized',
+      'error code must be hermes_image_generation_unrecognized',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (e) Callback with media_requests count=2 and artifacts.creative_assets length=2
+//     → accepted (no failure)
+// ---------------------------------------------------------------------------
+
+test('(e) callback with media_requests count=2 and artifacts.creative_assets of length 2 is accepted', async () => {
+  await withRuntimeEnv(async () => {
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+
+    const doc = await seedSocialJobWithImageCount(2);
+
+    const run = createExecutionRunRecord({
+      provider: 'hermes',
+      domain: 'marketing',
+      workflowKey: 'social_content_weekly',
+      action: 'resume',
+      tenantId: doc.tenant_id,
+      marketingJobId: doc.job_id,
+      stage: 'production',
+    });
+
+    // Hermes returns two recognized creative_assets — should be accepted
+    await handleHermesRunCallback({
+      event_id: 'evt-recognized-creative-assets',
+      aries_run_id: run.aries_run_id,
+      hermes_run_id: 'hermes-recognized-1',
+      status: 'requires_approval',
+      stage: 'production',
+      approval: {
+        stage: 'publish',
+        approval_step: 'approve_publish',
+        workflow_step_id: 'approve_stage_4',
+        prompt: 'Review creative assets',
+        resume_token: 'social_content_weekly:arun_abc:production',
+      },
+      output: [
+        {
+          stage: 'production',
+          artifacts: {
+            aspectRatio: '4:5',
+            creative_assets: [
+              {
+                assetId: 'sl_asset_01',
+                type: 'generated_image',
+                status: 'created',
+                path: '/home/node/.hermes/cache/images/openai_gpt_image_20260513_abc001.png',
+                placement: 'post_1',
+                prompt: 'Editorial portrait for post 1.',
+              },
+              {
+                assetId: 'sl_asset_02',
+                type: 'generated_image',
+                status: 'created',
+                path: '/home/node/.hermes/cache/images/openai_gpt_image_20260513_abc002.png',
+                placement: 'post_2',
+                prompt: 'Lifestyle shot for post 2.',
+              },
+            ],
+          },
+          weekly_content_plan: {
+            posts: [],
+            image_creatives: [],
+            video_scripts: [],
+          },
+        },
+      ],
+    });
+
+    const after = await loadMarketingJobRuntime(doc.job_id);
+    // Should NOT be failed — production should reach awaiting_approval or completed
+    assert.notEqual(
+      after?.stages.production.status,
+      'failed',
+      'production stage should not be failed when recognized images are present',
+    );
+    assert.notEqual(
+      after?.last_error?.code,
+      'hermes_image_generation_unrecognized',
+      'should not set unrecognized error when creative_assets are present',
+    );
+    assert.notEqual(
+      after?.last_error?.code,
+      'hermes_image_generation_skipped',
+      'should not set skipped error when creative_assets are present',
+    );
+  });
+});
+
+test('(e-variant) callback with artifacts.images shape of length 2 is also accepted', async () => {
+  await withRuntimeEnv(async () => {
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+
+    const doc = await seedSocialJobWithImageCount(2);
+
+    const run = createExecutionRunRecord({
+      provider: 'hermes',
+      domain: 'marketing',
+      workflowKey: 'social_content_weekly',
+      action: 'resume',
+      tenantId: doc.tenant_id,
+      marketingJobId: doc.job_id,
+      stage: 'production',
+    });
+
+    await handleHermesRunCallback({
+      event_id: 'evt-recognized-images-shape',
+      aries_run_id: run.aries_run_id,
+      hermes_run_id: 'hermes-recognized-2',
+      status: 'requires_approval',
+      stage: 'production',
+      approval: {
+        stage: 'publish',
+        approval_step: 'approve_publish',
+        workflow_step_id: 'approve_stage_4',
+        prompt: 'Review creative assets',
+        resume_token: 'social_content_weekly:arun_abc:production',
+      },
+      output: [
+        {
+          stage: 'production',
+          artifacts: {
+            aspectRatio: '4:5',
+            images: [
+              {
+                index: 0,
+                status: 'generated',
+                filePath: '/home/node/.hermes/cache/images/veo_render_20260513_img0.png',
+                prompt: 'Dynamic motion portrait.',
+                intendedUse: 'post_cover',
+              },
+              {
+                index: 1,
+                status: 'generated',
+                filePath: '/home/node/.hermes/cache/images/veo_render_20260513_img1.png',
+                prompt: 'Lifestyle reel thumbnail.',
+                intendedUse: 'reel_thumb',
+              },
+            ],
+          },
+          weekly_content_plan: {
+            posts: [],
+            image_creatives: [],
+          },
+        },
+      ],
+    });
+
+    const after = await loadMarketingJobRuntime(doc.job_id);
+    assert.notEqual(
+      after?.stages.production.status,
+      'failed',
+      'should not fail when artifacts.images shape carries recognized images',
+    );
+    assert.notEqual(
+      after?.last_error?.code,
+      'hermes_image_generation_unrecognized',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (f) Callback with media_requests count=0 (imageCreativeCount=0)
+//     → no fail-loud check fires regardless of artifact content
+// ---------------------------------------------------------------------------
+
+test('(f) callback with imageCreativeCount=0 does not trigger fail-loud check regardless of artifact content', async () => {
+  await withRuntimeEnv(async () => {
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+
+    // imageCreativeCount=0 means no media_requests of type image.generate were sent
+    const doc = await seedSocialJobWithImageCount(0);
+
+    const run = createExecutionRunRecord({
+      provider: 'hermes',
+      domain: 'marketing',
+      workflowKey: 'social_content_weekly',
+      action: 'resume',
+      tenantId: doc.tenant_id,
+      marketingJobId: doc.job_id,
+      stage: 'production',
+    });
+
+    // Empty artifacts — but since no images were requested, this is valid
+    await handleHermesRunCallback({
+      event_id: 'evt-no-images-requested',
+      aries_run_id: run.aries_run_id,
+      hermes_run_id: 'hermes-no-images-1',
+      status: 'requires_approval',
+      stage: 'production',
+      approval: {
+        stage: 'publish',
+        approval_step: 'approve_publish',
+        workflow_step_id: 'approve_stage_4',
+        prompt: 'Review copy before publish',
+        resume_token: 'social_content_weekly:arun_abc:production',
+      },
+      output: [
+        {
+          stage: 'production',
+          artifacts: {},
+          weekly_content_plan: {
+            posts: [],
+            image_creatives: [],
+            video_scripts: [],
+          },
+        },
+      ],
+    });
+
+    const after = await loadMarketingJobRuntime(doc.job_id);
+    // Should NOT be failed — no images were requested so zero images is fine
+    assert.notEqual(
+      after?.stages.production.status,
+      'failed',
+      'should not fail when imageCreativeCount=0 (no images were requested)',
+    );
+    assert.notEqual(
+      after?.last_error?.code,
+      'hermes_image_generation_unrecognized',
+      'hermes_image_generation_unrecognized must not fire when no images were requested',
+    );
+  });
+});
+
+test('(f-variant) callback with absent imageCreativeCount field does not trigger fail-loud check', async () => {
+  await withRuntimeEnv(async () => {
+    const {
+      createMarketingJobRuntimeDocument,
+      saveMarketingJobRuntime,
+    } = await import('../backend/marketing/runtime-state');
+    const { createExecutionRunRecord } = await import('../backend/execution/run-store');
+    const { handleHermesRunCallback } = await import('../backend/execution/hermes-callbacks');
+    const { loadMarketingJobRuntime } = await import('../backend/marketing/runtime-state');
+
+    // Payload WITHOUT imageCreativeCount — legacy jobs that predate the field
+    const doc = createMarketingJobRuntimeDocument({
+      jobId: `mkt_legacy-no-count-${Date.now()}`,
+      tenantId: 'tenant-unrecognized',
+      payload: {
+        brandUrl: 'https://brand.example',
+        businessType: 'coaching',
+        competitorUrl: '',
+        // imageCreativeCount intentionally absent
+      },
+      brandKit: {
+        path: '/tmp/brand-kit.json',
+        source_url: 'https://brand.example',
+        canonical_url: 'https://brand.example',
+        brand_name: 'Brand',
+        logo_urls: [],
+        colors: { primary: null, secondary: null, accent: null, palette: [] },
+        font_families: [],
+        external_links: [],
+        extracted_at: new Date().toISOString(),
+        brand_voice_summary: 'clear',
+        offer_summary: null,
+      },
+    });
+    saveMarketingJobRuntime(doc.job_id, doc);
+
+    const run = createExecutionRunRecord({
+      provider: 'hermes',
+      domain: 'marketing',
+      workflowKey: 'social_content_weekly',
+      action: 'resume',
+      tenantId: doc.tenant_id,
+      marketingJobId: doc.job_id,
+      stage: 'production',
+    });
+
+    await handleHermesRunCallback({
+      event_id: 'evt-legacy-no-count',
+      aries_run_id: run.aries_run_id,
+      hermes_run_id: 'hermes-legacy-1',
+      status: 'requires_approval',
+      stage: 'production',
+      approval: {
+        stage: 'publish',
+        approval_step: 'approve_publish',
+        workflow_step_id: 'approve_stage_4',
+        prompt: 'Review before publish',
+        resume_token: 'social_content_weekly:arun_abc:production',
+      },
+      output: [
+        {
+          stage: 'production',
+          weekly_content_plan: {
+            posts: [],
+            image_creatives: [],
+          },
+        },
+      ],
+    });
+
+    const after = await loadMarketingJobRuntime(doc.job_id);
+    assert.notEqual(
+      after?.stages.production.status,
+      'failed',
+      'legacy jobs without imageCreativeCount should not trigger the unrecognized check',
+    );
+    assert.notEqual(
+      after?.last_error?.code,
+      'hermes_image_generation_unrecognized',
+    );
+  });
+});

--- a/tests/social-content-rich-prompts-and-failloud.test.ts
+++ b/tests/social-content-rich-prompts-and-failloud.test.ts
@@ -242,6 +242,27 @@ test('buildProductionResumeContext contextBlock contains all image prompts', asy
   assert.ok(ctx.contextBlock.includes('Sugar and Leather'), 'contextBlock should include brand name');
 });
 
+test('buildProductionResumeContext contextBlock appends canonical creative_assets schema once', async () => {
+  const { buildProductionResumeContext } = await import('@/backend/social-content/workflow-request');
+  const doc = makeMinimalDoc() as Parameters<typeof buildProductionResumeContext>[0]['doc'];
+  const ctx = buildProductionResumeContext({ doc, researchOutput: FULL_RESEARCH_OUTPUT, strategyOutput: FULL_STRATEGY_OUTPUT });
+
+  const schemaHeading = 'Return your results in this EXACT JSON shape:';
+  assert.equal(ctx.contextBlock.split(schemaHeading).length - 1, 1, 'schema heading should appear exactly once');
+  assert.ok(
+    ctx.contextBlock.includes('`artifacts.creative_assets[]`'),
+    'contextBlock should mention canonical creative_assets output',
+  );
+  assert.ok(
+    ctx.contextBlock.includes('"assetId": "img_0"'),
+    'contextBlock should include worked canonical creative_assets example',
+  );
+  assert.ok(
+    ctx.contextBlock.includes('`artifacts.images[]`'),
+    'contextBlock should mention fallback artifacts.images shape',
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Part 2: fail-loud verification — production callback without rendered images
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bridge `bridgeHermesCreativeAssets` accepts THREE Hermes output shapes (`artifacts.creative_assets[]`, `artifacts.images[]`, and legacy top-level `image_creatives[]`). Defends against Hermes schema drift across runs since it's a pure LLM agent with no enforced output contract.
- `buildProductionResumeContext` now shows Hermes the canonical creative_assets JSON shape verbatim in the resume rich-prompt — defense in depth so Hermes prefers the recognized shape.

## Why
Three live runs observed three different shapes for the same conceptual data:
- `mkt_0735c3b1` (May 13): `artifacts.creative_assets[]`
- `mkt_c12eb438` (May 14): top-level `image_creatives[]` (no render)
- `mkt_d4f8dbb0` (May 15): `artifacts.images[].filePath` (rendered but unrecognized)

Schema-tolerance alone was whack-a-mole; this PR pairs tolerance with canonical-schema-in-instructions so future drift is bounded.

## Follow-ups in flight on this branch
- Fail-loud when `media_requests` requested N but zero recognized images surface (any shape)
- Tests for both bridge shapes + fail-loud (planned next commit)

## Test plan
- [ ] Bridge accepts artifacts.creative_assets[].path
- [ ] Bridge accepts artifacts.images[].filePath
- [ ] Canonical schema example present in production resume prompt
- [ ] No regression on existing image_creatives[] path

🤖 Generated with [Claude Code](https://claude.com/claude-code)