### PR TITLE
fix(social-content): surface video render URLs in runtime state

### DIFF
--- a/backend/social-content/runtime-state.ts
+++ b/backend/social-content/runtime-state.ts
@@ -40,6 +40,7 @@ type VideoScript = {
   duration_seconds: number | null;
   script_markdown: string;
   status: string;
+  artifact_url: string;
 };
 
 export type SocialContentWeeklyPlan = {
@@ -697,6 +698,42 @@ function parseImageCreatives(value: unknown): ImageCreative[] {
     }));
 }
 
+function firstString(...values: unknown[]): string {
+  for (const value of values) {
+    const normalized = stringValue(value);
+    if (normalized) return normalized;
+  }
+  return '';
+}
+
+function parseVideoArtifactUrl(entry: UnknownRecord): string {
+  const renderedVideo = asRecord(entry.rendered_video);
+  const render = asRecord(entry.render);
+  const asset = asRecord(entry.asset);
+
+  return firstString(
+    entry.artifact_url,
+    entry.url,
+    entry.rendered_video_url,
+    entry.rendered_video_path,
+    entry.video_url,
+    entry.video_path,
+    renderedVideo?.artifact_url,
+    renderedVideo?.url,
+    renderedVideo?.rendered_video_url,
+    renderedVideo?.rendered_video_path,
+    renderedVideo?.video_url,
+    renderedVideo?.video_path,
+    render?.artifact_url,
+    render?.url,
+    render?.rendered_video_url,
+    render?.rendered_video_path,
+    asset?.artifact_url,
+    asset?.url,
+    asset?.path,
+  );
+}
+
 function parseVideoScripts(value: unknown): VideoScript[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -708,6 +745,7 @@ function parseVideoScripts(value: unknown): VideoScript[] {
       duration_seconds: numberValue(entry.duration_seconds),
       script_markdown: stringValue(entry.script_markdown),
       status: stringValue(entry.status),
+      artifact_url: parseVideoArtifactUrl(entry),
     }));
 }
 
@@ -751,7 +789,7 @@ export function socialContentArtifactsFromProjection(
     title: script.title || `Video script ${index + 1}`,
     status: script.status || 'generated',
     summary: script.script_markdown ? script.script_markdown.slice(0, 240) : null,
-    url: null,
+    url: script.artifact_url || null,
     metadata: {
       duration_seconds: script.duration_seconds,
     },

--- a/tests/social-content-weekly-defaults.test.ts
+++ b/tests/social-content-weekly-defaults.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { buildSocialContentDashboardProjection } from '@/backend/social-content/dashboard-projection';
-import { parseSocialContentWorkflowOutput } from '@/backend/social-content/runtime-state';
+import { parseSocialContentWorkflowOutput, socialContentArtifactsFromProjection } from '@/backend/social-content/runtime-state';
 import { normalizeWeeklySocialContentPayload } from '@/backend/social-content/payload';
 import { buildSocialContentWeeklyRequest } from '@/backend/social-content/workflow-request';
 import type { SocialContentCalendarEvent } from '@/backend/marketing/jobs-status';
@@ -919,4 +919,91 @@ test('parseSocialContentWorkflowOutput accepts camelCase weeklyPlan key from Her
   assert.equal(projection!.weekly_content_plan.posts.length, 1);
   assert.equal(projection!.weekly_content_plan.window_days, 7);
   assert.equal(projection!.weekly_content_plan.image_creatives.length, 1);
+});
+
+test('parseSocialContentWorkflowOutput captures rendered video URLs from weekly plan video scripts', () => {
+  const hermesOutput = {
+    summary: 'Rendered weekly plan ready.',
+    weekly_content_plan: {
+      window_days: 7,
+      posts: [],
+      image_creatives: [],
+      video_scripts: [
+        {
+          id: 'video-direct-url',
+          title: 'Rendered direct URL',
+          duration_seconds: 30,
+          script_markdown: 'Direct URL render.',
+          status: 'rendered',
+          artifact_url: 'https://aries.example.com/api/marketing/jobs/job-123/assets/video-direct-url',
+        },
+        {
+          id: 'video-nested-url',
+          title: 'Rendered nested URL',
+          duration_seconds: 15,
+          script_markdown: 'Nested URL render.',
+          status: 'rendered',
+          rendered_video: {
+            url: 'https://aries.example.com/api/marketing/jobs/job-123/assets/video-nested-url',
+          },
+        },
+        {
+          id: 'video-script-only',
+          title: 'Script only',
+          duration_seconds: 10,
+          script_markdown: 'No render yet.',
+          status: 'approved',
+        },
+      ],
+    },
+  };
+
+  const projection = parseSocialContentWorkflowOutput(hermesOutput);
+  assert.notEqual(projection, null);
+  assert.equal(
+    projection!.weekly_content_plan.video_scripts[0].artifact_url,
+    'https://aries.example.com/api/marketing/jobs/job-123/assets/video-direct-url',
+  );
+  assert.equal(
+    projection!.weekly_content_plan.video_scripts[1].artifact_url,
+    'https://aries.example.com/api/marketing/jobs/job-123/assets/video-nested-url',
+  );
+  assert.equal(projection!.weekly_content_plan.video_scripts[2].artifact_url, '');
+});
+
+test('socialContentArtifactsFromProjection surfaces playable video URLs and preserves null for script-only entries', () => {
+  const projection = parseSocialContentWorkflowOutput({
+    summary: 'Rendered weekly plan ready.',
+    weekly_content_plan: {
+      window_days: 7,
+      posts: [],
+      image_creatives: [],
+      video_scripts: [
+        {
+          id: 'video-ready',
+          title: 'Playable render',
+          duration_seconds: 20,
+          script_markdown: 'Playable render.',
+          status: 'rendered',
+          url: 'https://aries.example.com/api/marketing/jobs/job-456/assets/video-ready',
+        },
+        {
+          id: 'video-script-only',
+          title: 'Script only',
+          duration_seconds: 20,
+          script_markdown: 'Still awaiting render.',
+          status: 'approved',
+        },
+      ],
+    },
+  });
+
+  assert.notEqual(projection, null);
+  const artifacts = socialContentArtifactsFromProjection(projection!);
+  assert.equal(artifacts.length, 2);
+  assert.equal(
+    artifacts[0].url,
+    'https://aries.example.com/api/marketing/jobs/job-456/assets/video-ready',
+  );
+  assert.equal(artifacts[1].url, null);
 });


### PR DESCRIPTION
## Summary
- parse video script entries for rendered video asset URLs/paths in addition to the existing script metadata
- surface those video URLs through socialContentArtifactsFromProjection instead of hardcoding null
- add coverage for direct, nested, and missing render URL cases

## Test Plan
- APP_BASE_URL=https://aries.example.com ARIES_EXECUTION_PROVIDER=legacy-openclaw ARIES_MARKETING_EXECUTION_PROVIDER=legacy-openclaw npx tsx --test --test-concurrency=1 tests/social-content-weekly-defaults.test.ts

## Notes
- `npm run workspace:verify` fails in this environment because the git root is `/home/node/docker-stack/aries-app` while the script expects `/home/node/aries-app`.