### PR TITLE
fix(ops): structure Hermes kanban GC summary log

### DIFF
--- a/scripts/hermes-kanban-gc-worker.ts
+++ b/scripts/hermes-kanban-gc-worker.ts
@@ -24,8 +24,8 @@ type CommandResult = {
 };
 
 type GcReport = {
-  tasksArchived: number;
-  workspacesDeleted: number;
+  archived: number;
+  workspacesRemoved: number;
   errors: number;
 };
 
@@ -148,13 +148,13 @@ async function archiveTasks(taskIds: string[]): Promise<number> {
 }
 
 async function runGcOnce(): Promise<GcReport> {
-  const report: GcReport = { tasksArchived: 0, workspacesDeleted: 0, errors: 0 };
+  const report: GcReport = { archived: 0, workspacesRemoved: 0, errors: 0 };
   const retentionDays = resolveRetentionDays();
 
   try {
     const tasks = await listDoneTasks();
     const candidates = selectArchiveCandidates(tasks, retentionDays, Math.floor(Date.now() / 1000));
-    report.tasksArchived = await archiveTasks(candidates);
+    report.archived = await archiveTasks(candidates);
   } catch (error) {
     report.errors += 1;
     console.error('[hermes-kanban-gc] archive phase failed', error);
@@ -163,7 +163,7 @@ async function runGcOnce(): Promise<GcReport> {
   try {
     const gcResult = await runHermes(['kanban', 'gc']);
     const gcOutput = `${gcResult.stdout}\n${gcResult.stderr}`;
-    report.workspacesDeleted = parseWorkspaceDeleteCount(gcOutput);
+    report.workspacesRemoved = parseWorkspaceDeleteCount(gcOutput);
   } catch (error) {
     report.errors += 1;
     console.error('[hermes-kanban-gc] gc phase failed', error);
@@ -182,7 +182,11 @@ async function tick(): Promise<void> {
   try {
     const report = await runGcOnce();
     console.log(
-      `[hermes-kanban-gc] tasks_archived=${report.tasksArchived} workspaces_deleted=${report.workspacesDeleted} errors_n=${report.errors}`,
+      `[hermes-kanban-gc] summary ${JSON.stringify({
+        archived: report.archived,
+        workspaces_removed: report.workspacesRemoved,
+        errors: report.errors,
+      })}`,
     );
   } catch (error) {
     console.error('[hermes-kanban-gc] tick failed', error);

--- a/tests/hermes-kanban-gc-worker.test.ts
+++ b/tests/hermes-kanban-gc-worker.test.ts
@@ -61,7 +61,7 @@ process.exit(3);
 
   assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`);
   assert.match(result.stdout, /\[hermes-kanban-gc\] starting; interval=1000000ms retention_days=7/);
-  assert.match(result.stdout, /tasks_archived=1 workspaces_deleted=3 errors_n=0/);
+  assert.match(result.stdout, /\[hermes-kanban-gc\] summary \{"archived":1,"workspaces_removed":3,"errors":0\}/);
   assert.deepEqual(
     readFileSync(logPath, 'utf8')
       .trim()


### PR DESCRIPTION
## Summary\n- change Hermes kanban GC tick summaries to the requested structured log shape: `[hermes-kanban-gc] summary {\"archived\":N,\"workspaces_removed\":M,\"errors\":E}`\n- keep the existing archive/delete behavior and runtime wiring intact\n- update targeted worker test coverage for the structured summary log\n\n## Tests\n- `APP_BASE_URL=https://aries.example.com npx tsx --test tests/hermes-kanban-gc-worker.test.ts tests/deploy-manifest-parity.test.ts`\n\nNote: `npm run workspace:verify` currently fails in this checkout because the git root resolves to /home/node/docker-stack/aries-app while the repo verifier expects /home/node/aries-app.\n