### PR TITLE
v0.1.11.3 feat(marketing): replace native date inputs with month/day dropdowns + auto year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.1.11.3 — feat(marketing): replace native date inputs with month/day dropdowns + auto year
+
+Two pain points with the v0.1.11.2 native `<input type="date">` fields:
+
+1. **Chrome automation input corruption.** Browser automation agents (pair-agent at read+write scope, no JS exec) fill date inputs via simulated keypresses. Chrome reads chars per MM/DD/YYYY segment — "2026-06-14" becomes "0004-02-06". The React-native-setter workaround requires JS exec, which those agents don't have.
+
+2. **Year navigation overhead.** One-off campaigns overwhelmingly happen within the current year. Native date pickers force operators through year selection on every use.
+
+**Solution: `MonthDayPicker` component** (`frontend/marketing/month-day-picker.tsx`). Two `<select>` dropdowns (Month, Day) that browser automation can interact with reliably via click + select. Hidden year state defaults to `currentYear`. A third Year dropdown appears **only when today is within 30 days of Dec 31** (so a December operator can schedule a January campaign), offering `[currentYear, currentYear+1]`.
+
+Day options recompute on month/year change; if the selected day exceeds the new month's max (e.g. day=31 then switch to April), the day clears and `onChange` emits `''`. `onChange` emits `''` until both month and day are set, then emits `YYYY-MM-DD` with zero-padded fields.
+
+Server-side year-range and past-date validation from v0.1.11.2 is preserved unchanged — the component prevents bad-year input by construction but the server remains the source of truth.
+
+12 new tests in `tests/month-day-picker.test.ts` cover: emit contract, leap-year day count, day clamping on month change, year-selector visibility (hidden June, visible Dec), year default, value prop parsing, and zero-padding.
+
 ## v0.1.11.2 — fix(marketing): one-off dashboard window + date input hardening
 
 Live QA against v0.1.11.1 caught two further bugs in the one_off_campaign flow. Both are display/validation bugs; no schema changes or pipeline changes are required.

--- a/frontend/marketing/month-day-picker.tsx
+++ b/frontend/marketing/month-day-picker.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+
+export interface MonthDayPickerProps {
+  value: string;
+  onChange: (next: string) => void;
+  ariaLabel: string;
+  invalid?: boolean;
+  /** Override today's date — test-only. */
+  _today?: Date;
+}
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function daysInMonth(year: number, month: number): number {
+  // month is 1-based; new Date(year, month, 0) gives last day of that month
+  return new Date(year, month, 0).getDate();
+}
+
+export function isNearYearEnd(today: Date): boolean {
+  const month = today.getMonth(); // 0-based
+  const day = today.getDate();
+  // Within 30 days of Dec 31: month=11 (Dec), or month=10 (Nov) day >= 1 when
+  // Nov 30 + 30 days would reach Dec 30. Simpler: compute days until Dec 31.
+  const currentYear = today.getFullYear();
+  const dec31 = new Date(currentYear, 11, 31);
+  const msPerDay = 1000 * 60 * 60 * 24;
+  const daysUntilYearEnd = Math.round((dec31.getTime() - today.getTime()) / msPerDay);
+  return daysUntilYearEnd <= 30;
+}
+
+function parseValue(value: string): { month: number; day: number; year: number } | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const year = parseInt(value.slice(0, 4), 10);
+  const month = parseInt(value.slice(5, 7), 10);
+  const day = parseInt(value.slice(8, 10), 10);
+  if (month < 1 || month > 12 || day < 1) return null;
+  return { year, month, day };
+}
+
+const selectClassName =
+  'rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-primary/50';
+const selectInvalidClassName =
+  'rounded-2xl border border-red-500/50 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-red-500/70';
+
+export function MonthDayPicker({ value, onChange, ariaLabel, invalid, _today }: MonthDayPickerProps) {
+  const today = _today ?? new Date();
+  const currentYear = today.getFullYear();
+  const showYearSelector = isNearYearEnd(today);
+
+  const parsed = useMemo(() => parseValue(value), [value]);
+
+  const [selectedMonth, setSelectedMonth] = useState<number>(parsed?.month ?? 0);
+  const [selectedDay, setSelectedDay] = useState<number>(parsed?.day ?? 0);
+  const [selectedYear, setSelectedYear] = useState<number>(parsed?.year ?? currentYear);
+
+  // Sync from incoming value prop when it changes externally
+  const lastValueRef = React.useRef(value);
+  if (value !== lastValueRef.current) {
+    lastValueRef.current = value;
+    const p = parseValue(value);
+    if (p) {
+      if (p.month !== selectedMonth) setSelectedMonth(p.month);
+      if (p.day !== selectedDay) setSelectedDay(p.day);
+      if (p.year !== selectedYear) setSelectedYear(p.year);
+    } else if (value === '') {
+      setSelectedMonth(0);
+      setSelectedDay(0);
+      setSelectedYear(currentYear);
+    }
+  }
+
+  const maxDay = selectedMonth > 0 ? daysInMonth(selectedYear, selectedMonth) : 31;
+
+  function emit(month: number, day: number, year: number) {
+    if (month > 0 && day > 0) {
+      const mm = String(month).padStart(2, '0');
+      const dd = String(day).padStart(2, '0');
+      onChange(`${year}-${mm}-${dd}`);
+    } else {
+      onChange('');
+    }
+  }
+
+  function handleMonthChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const month = parseInt(e.target.value, 10);
+    setSelectedMonth(month);
+    const max = month > 0 ? daysInMonth(selectedYear, month) : 31;
+    let day = selectedDay;
+    if (day > max) {
+      day = 0;
+      setSelectedDay(0);
+    }
+    emit(month, day, selectedYear);
+  }
+
+  function handleDayChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const day = parseInt(e.target.value, 10);
+    setSelectedDay(day);
+    emit(selectedMonth, day, selectedYear);
+  }
+
+  function handleYearChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const year = parseInt(e.target.value, 10);
+    setSelectedYear(year);
+    const max = selectedMonth > 0 ? daysInMonth(year, selectedMonth) : 31;
+    let day = selectedDay;
+    if (day > max) {
+      day = 0;
+      setSelectedDay(0);
+    }
+    emit(selectedMonth, day, year);
+  }
+
+  const className = invalid ? selectInvalidClassName : selectClassName;
+
+  return (
+    <fieldset aria-label={ariaLabel} className="flex gap-2">
+      <select
+        aria-label="Month"
+        aria-invalid={invalid}
+        value={selectedMonth}
+        onChange={handleMonthChange}
+        className={className}
+      >
+        <option value={0}>Month</option>
+        {MONTHS.map((name, i) => (
+          <option key={name} value={i + 1}>{name}</option>
+        ))}
+      </select>
+
+      <select
+        aria-label="Day"
+        aria-invalid={invalid}
+        value={selectedDay}
+        onChange={handleDayChange}
+        className={className}
+      >
+        <option value={0}>Day</option>
+        {Array.from({ length: maxDay }, (_, i) => i + 1).map((d) => (
+          <option key={d} value={d}>{d}</option>
+        ))}
+      </select>
+
+      {showYearSelector ? (
+        <select
+          aria-label="Year"
+          aria-invalid={invalid}
+          value={selectedYear}
+          onChange={handleYearChange}
+          className={className}
+        >
+          <option value={currentYear}>{currentYear}</option>
+          <option value={currentYear + 1}>{currentYear + 1}</option>
+        </select>
+      ) : null}
+    </fieldset>
+  );
+}
+
+export default MonthDayPicker;

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -9,6 +9,7 @@ import { isValidWebsiteUrl } from '@/lib/api/marketing';
 import { validateCanonicalCompetitorUrl } from '@/lib/marketing-competitor';
 import { useMarketingJobCreate, type UseMarketingJobCreateOptions } from '@/hooks/use-marketing-job-create';
 import StatusBadge from '../components/status-badge';
+import { MonthDayPicker } from './month-day-picker';
 
 function isErrorResult(value: unknown): value is MarketingApiError {
   return typeof (value as MarketingApiError)?.error === 'string';
@@ -88,15 +89,6 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
   const [milestoneDate, setMilestoneDate] = useState('');
   const [milestoneLabel, setMilestoneLabel] = useState('');
 
-  // UX hints only — server enforces the real rules. Use browser local time so
-  // the native date picker greys out obviously invalid dates.
-  const todayStr = new Date().toLocaleDateString('en-CA');
-  const maxDateStr = (() => {
-    const d = new Date();
-    d.setFullYear(d.getFullYear() + 5);
-    return d.toLocaleDateString('en-CA');
-  })();
-
   useEffect(() => {
     if (!submitting) {
       setSubmitProgress({ stepIndex: 0, dotCount: 0 });
@@ -154,19 +146,9 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
       const trimmedMilestoneDate = milestoneDate.trim();
       const trimmedMilestoneLabel = milestoneLabel.trim();
       const errors: Record<string, string> = {};
-      const currentYear = new Date().getFullYear();
-      const checkDateYear = (value: string, field: string): void => {
-        if (!value) return;
-        const y = parseInt(value.slice(0, 4), 10);
-        if (isNaN(y) || y < currentYear || y > currentYear + 5) {
-          errors[field] = `Date must be a current or near-future year (between ${currentYear} and ${currentYear + 5}).`;
-        }
-      };
       if (!trimmedOneOffName) errors['oneOff.name'] = 'Campaign name is required.';
       if (!trimmedCampaignEndDate) errors['oneOff.campaignEndDate'] = 'Campaign end date is required.';
-      checkDateYear(trimmedCampaignEndDate, 'oneOff.campaignEndDate');
       if (!trimmedOneOffCta) errors['oneOff.cta'] = 'CTA is required.';
-      if (trimmedMilestoneDate) checkDateYear(trimmedMilestoneDate, 'oneOff.milestoneDate');
       if (trimmedMilestoneDate && !trimmedMilestoneLabel) {
         errors['oneOff.milestoneLabel'] = 'Add a label for this date (e.g. "Sale ends" or "Doors open").';
       }
@@ -485,18 +467,15 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                     ) : null}
                   </Field>
                   <Field label="Campaign end date" required>
-                    <input
-                      type="date"
+                    <MonthDayPicker
                       value={campaignEndDate}
-                      onChange={(e) => setCampaignEndDate(e.target.value)}
-                      min={todayStr}
-                      max={maxDateStr}
-                      aria-invalid={oneOffFieldError('oneOff.campaignEndDate') ? true : undefined}
-                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-primary/50"
+                      onChange={setCampaignEndDate}
+                      ariaLabel="Campaign end date"
+                      invalid={!!oneOffFieldError('oneOff.campaignEndDate')}
                     />
                     <p className="mt-2 text-xs text-white/45">Aries stops publishing past end-of-day in your timezone.</p>
                     {oneOffFieldError('oneOff.campaignEndDate') ? (
-                      <p className="mt-2 text-sm text-red-300">{marketingCreate.fieldErrors['oneOff.campaignEndDate']}</p>
+                      <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.campaignEndDate')}</p>
                     ) : null}
                   </Field>
                   <Field label="Call to action" required>
@@ -530,17 +509,14 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                         ) : null}
                       </Field>
                       <Field label="Milestone date">
-                        <input
-                          type="date"
+                        <MonthDayPicker
                           value={milestoneDate}
-                          onChange={(e) => setMilestoneDate(e.target.value)}
-                          min={todayStr}
-                          max={maxDateStr}
-                          aria-invalid={oneOffFieldError('oneOff.milestoneDate') ? true : undefined}
-                          className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-primary/50"
+                          onChange={setMilestoneDate}
+                          ariaLabel="Milestone date"
+                          invalid={!!oneOffFieldError('oneOff.milestoneDate')}
                         />
                         {oneOffFieldError('oneOff.milestoneDate') ? (
-                          <p className="mt-2 text-sm text-red-300">{marketingCreate.fieldErrors['oneOff.milestoneDate']}</p>
+                          <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.milestoneDate')}</p>
                         ) : null}
                       </Field>
                     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-platform-bootstrap-runtime",
-  "version": "0.1.11.2",
+  "version": "0.1.11.3",
   "description": "Next.js application for weekly social content automation: connect platforms, generate and review a week of content, and publish on a schedule.",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/month-day-picker.test.ts
+++ b/tests/month-day-picker.test.ts
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+
+import { MonthDayPicker, isNearYearEnd } from '../frontend/marketing/month-day-picker';
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// --- Pure date-math unit tests ---
+
+test('isNearYearEnd: June 15 → false (far from year end)', () => {
+  const year = new Date().getFullYear();
+  assert.equal(isNearYearEnd(new Date(`${year}-06-15`)), false);
+});
+
+test('isNearYearEnd: Dec 10 → true (within 30 days of Dec 31)', () => {
+  const year = new Date().getFullYear();
+  assert.equal(isNearYearEnd(new Date(`${year}-12-10`)), true);
+});
+
+test('isNearYearEnd: Dec 1 → true (30 days before Dec 31)', () => {
+  const year = new Date().getFullYear();
+  assert.equal(isNearYearEnd(new Date(`${year}-12-01`)), true);
+});
+
+test('isNearYearEnd: Nov 30 → false (31 days before Dec 31)', () => {
+  const year = new Date().getFullYear();
+  assert.equal(isNearYearEnd(new Date(`${year}-11-30`)), false);
+});
+
+// --- Rendered component tests using react-test-renderer ---
+
+test('emits empty string until both month AND day are selected', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  const emitted: string[] = [];
+
+  let root!: import('react-test-renderer').ReactTestRenderer;
+  await act(async () => {
+    root = create(
+      React.createElement(MonthDayPicker, {
+        value: '',
+        onChange: (v: string) => emitted.push(v),
+        ariaLabel: 'Test date',
+      }),
+    );
+    await flushMicrotasks();
+  });
+
+  const selects = root.root.findAllByType('select');
+  const monthSelect = selects.find((s) => s.props['aria-label'] === 'Month');
+  assert.ok(monthSelect, 'Month select not found');
+
+  // Select month only — should emit ''
+  await act(async () => {
+    monthSelect!.props.onChange({ target: { value: '6' } });
+    await flushMicrotasks();
+  });
+  assert.equal(emitted[emitted.length - 1], '');
+
+  // Now also select day — should emit a full date
+  const daySelect = root.root.findAllByType('select').find((s) => s.props['aria-label'] === 'Day');
+  assert.ok(daySelect, 'Day select not found');
+  await act(async () => {
+    daySelect!.props.onChange({ target: { value: '14' } });
+    await flushMicrotasks();
+  });
+  const last = emitted[emitted.length - 1];
+  assert.match(last, /^\d{4}-06-14$/);
+});
+
+test('Feb has 29 days in leap year 2024, 28 days in non-leap 2025', () => {
+  // Verify via daysInMonth logic: new Date(year, 2, 0).getDate()
+  assert.equal(new Date(2024, 2, 0).getDate(), 29, 'leap year Feb should have 29 days');
+  assert.equal(new Date(2025, 2, 0).getDate(), 28, 'non-leap year Feb should have 28 days');
+});
+
+test('changing month from March to April when day=31 clears day and emits empty', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  const emitted: string[] = [];
+
+  let root!: import('react-test-renderer').ReactTestRenderer;
+  await act(async () => {
+    root = create(
+      React.createElement(MonthDayPicker, {
+        value: '',
+        onChange: (v: string) => emitted.push(v),
+        ariaLabel: 'Test date',
+      }),
+    );
+    await flushMicrotasks();
+  });
+
+  const getSelects = () => root.root.findAllByType('select');
+  const monthSelect = () => getSelects().find((s) => s.props['aria-label'] === 'Month')!;
+  const daySelect = () => getSelects().find((s) => s.props['aria-label'] === 'Day')!;
+
+  // Select March (month=3)
+  await act(async () => {
+    monthSelect().props.onChange({ target: { value: '3' } });
+    await flushMicrotasks();
+  });
+
+  // Select day 31
+  await act(async () => {
+    daySelect().props.onChange({ target: { value: '31' } });
+    await flushMicrotasks();
+  });
+  assert.match(emitted[emitted.length - 1]!, /^\d{4}-03-31$/);
+
+  // Switch to April (max 30 days) — day 31 should be cleared
+  await act(async () => {
+    monthSelect().props.onChange({ target: { value: '4' } });
+    await flushMicrotasks();
+  });
+  assert.equal(emitted[emitted.length - 1], '', 'day 31 in April should clear and emit empty string');
+});
+
+test('year selector is HIDDEN when _today is June 15', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  const currentYear = new Date().getFullYear();
+  const june15 = new Date(`${currentYear}-06-15T12:00:00`);
+
+  let root!: import('react-test-renderer').ReactTestRenderer;
+  await act(async () => {
+    root = create(
+      React.createElement(MonthDayPicker, {
+        value: '',
+        onChange: () => {},
+        ariaLabel: 'Test date',
+        _today: june15,
+      }),
+    );
+    await flushMicrotasks();
+  });
+
+  const selects = root.root.findAllByType('select');
+  const yearSelect = selects.find((s) => s.props['aria-label'] === 'Year');
+  assert.equal(yearSelect, undefined, 'Year selector should not be present in June');
+});
+
+test('year selector is VISIBLE when _today is Dec 10 with two options', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  const currentYear = new Date().getFullYear();
+  const dec10 = new Date(`${currentYear}-12-10T12:00:00`);
+
+  let root!: import('react-test-renderer').ReactTestRenderer;
+  await act(async () => {
+    root = create(
+      React.createElement(MonthDayPicker, {
+        value: '',
+        onChange: () => {},
+        ariaLabel: 'Test date',
+        _today: dec10,
+      }),
+    );
+    await flushMicrotasks();
+  });
+
+  const selects = root.root.findAllByType('select');
+  const yearSelect = selects.find((s) => s.props['aria-label'] === 'Year');
+  assert.ok(yearSelect, 'Year selector should be present in December');
+
+  const options = yearSelect!.props.children as React.ReactElement[];
+  assert.ok(Array.isArray(options), 'Year select should have option children');
+  assert.equal(options.length, 2, 'Year select should have exactly 2 options');
+});
+
+test('year selector defaults to currentYear when shown', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  const currentYear = new Date().getFullYear();
+  const dec15 = new Date(`${currentYear}-12-15T12:00:00`);
+
+  let root!: import('react-test-renderer').ReactTestRenderer;
+  await act(async () => {
+    root = create(
+      React.createElement(MonthDayPicker, {
+        value: '',
+        onChange: () => {},
+        ariaLabel: 'Test date',
+        _today: dec15,
+      }),
+    );
+    await flushMicrotasks();
+  });
+
+  const selects = root.root.findAllByType('select');
+  const yearSelect = selects.find((s) => s.props['aria-label'] === 'Year');
+  assert.ok(yearSelect, 'Year selector should be present');
+  assert.equal(yearSelect!.props.value, currentYear, 'Year selector should default to currentYear');
+});
+
+test('incoming value "2026-06-14" populates month=6 (June), day=14', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  let root!: import('react-test-renderer').ReactTestRenderer;
+  await act(async () => {
+    root = create(
+      React.createElement(MonthDayPicker, {
+        value: '2026-06-14',
+        onChange: () => {},
+        ariaLabel: 'Test date',
+      }),
+    );
+    await flushMicrotasks();
+  });
+
+  const selects = root.root.findAllByType('select');
+  const monthSelect = selects.find((s) => s.props['aria-label'] === 'Month');
+  const daySelect = selects.find((s) => s.props['aria-label'] === 'Day');
+
+  assert.ok(monthSelect, 'Month select not found');
+  assert.ok(daySelect, 'Day select not found');
+  assert.equal(monthSelect!.props.value, 6, 'Month should be 6 (June)');
+  assert.equal(daySelect!.props.value, 14, 'Day should be 14');
+});
+
+test('emitted date string zero-pads month and day ("2026-06-04" not "2026-6-4")', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  const emitted: string[] = [];
+
+  let root!: import('react-test-renderer').ReactTestRenderer;
+  await act(async () => {
+    root = create(
+      React.createElement(MonthDayPicker, {
+        value: '',
+        onChange: (v: string) => emitted.push(v),
+        ariaLabel: 'Test date',
+      }),
+    );
+    await flushMicrotasks();
+  });
+
+  const selects = root.root.findAllByType('select');
+  const monthSelect = selects.find((s) => s.props['aria-label'] === 'Month')!;
+  const daySelect = selects.find((s) => s.props['aria-label'] === 'Day')!;
+
+  await act(async () => {
+    monthSelect.props.onChange({ target: { value: '6' } });
+    await flushMicrotasks();
+  });
+  await act(async () => {
+    daySelect.props.onChange({ target: { value: '4' } });
+    await flushMicrotasks();
+  });
+
+  const last = emitted[emitted.length - 1];
+  assert.match(last!, /^\d{4}-06-04$/, 'Month and day must be zero-padded');
+});


### PR DESCRIPTION
## Problems solved

**1. Chrome automation input corruption.**
Native `<input type="date">` fills via simulated keypresses are corrupted by Chrome's per-segment MM/DD/YYYY parsing — "2026-06-14" arrives as "0004-02-06". The React-native-setter workaround requires JS exec, which the pair-agent at read+write scope doesn't have. This corrupted value slipped past the YYYY-MM-DD regex and caused v0.1.11.2's server hardening to become the last line of defense instead of a belt-and-suspenders backstop.

**2. Year selection overhead.**
One-off campaigns overwhelmingly happen within the current year. Native date pickers force operators through year navigation on every use.

## Solution: `MonthDayPicker` component

New file: `frontend/marketing/month-day-picker.tsx`

- Two `<select>` dropdowns (Month, Day) that browser automation can interact with reliably via click + select — no JS exec required.
- Hidden year state, defaults to `currentYear`.
- **Year boundary logic:** a third Year `<select>` appears **only when today is within 30 days of Dec 31**, offering `[currentYear, currentYear+1]`. This handles the December-operator-scheduling-January case without cluttering the common-case UI.
- Day options recompute when month or year changes. If the selected day exceeds the new month's max (e.g. day=31 then switch to April which has 30), the day clears and `onChange` emits `''`.
- `onChange` emits `''` until both month and day are set. Once both are set, emits `YYYY-MM-DD` with zero-padded month and day.
- Incoming `value` prop (`YYYY-MM-DD`) populates the dropdowns on mount and on prop change — handles the edit-existing-campaign case.

## What didn't change

- Server-side year-range and past-date validation from v0.1.11.2 is **preserved unchanged** — the component prevents bad-year input by construction but the server remains the source of truth.
- Weekly campaign path is untouched.
- No new dependencies.

## Tests

12 new tests in `tests/month-day-picker.test.ts` (Node built-in runner + react-test-renderer, matching existing patterns):

- Emits `''` until both month and day selected
- Leap-year (2024) Feb has 29 days; non-leap (2025) has 28
- Day clamping: day=31 → switch to April → day clears, emits `''`
- Year selector hidden when `_today` = June 15
- Year selector visible when `_today` = Dec 10, with two options
- Year selector defaults to currentYear when shown
- Incoming value `"2026-06-14"` populates month=6, day=14
- Emitted string zero-pads month and day

**Verification:** 38/38 regression suite pass, typecheck clean, banned-patterns clean.

Prior PR: #443 (v0.1.11.2 date hardening)

🤖 Generated with [Claude Code](https://claude.ai/code)