### PR TITLE
v0.1.12.1 fix(marketing): aggregate dashboard pagination + 3 one_off campaign UI fixes

### DIFF
--- a/app/api/marketing/campaigns/route.ts
+++ b/app/api/marketing/campaigns/route.ts
@@ -14,13 +14,21 @@ export async function handleGetMarketingCampaigns(tenantContextLoader?: TenantCo
   }
 
   const tenantId = tenantResult.tenantContext.tenantId;
-  const [campaigns, deletedCampaigns, currentBrandKit] = await Promise.all([
+  const [campaignPage, deletedCampaigns, currentBrandKit] = await Promise.all([
     listMarketingCampaignsForTenant(tenantId),
     listDeletedMarketingCampaignsForTenant(tenantId),
     loadTenantBrandKit(tenantId),
   ]);
   const currentBrandKitExtractedAt = currentBrandKit?.extracted_at ?? null;
-  return NextResponse.json({ campaigns, deletedCampaigns, currentBrandKitExtractedAt }, { status: 200 });
+  return NextResponse.json(
+    {
+      campaigns: campaignPage.campaigns,
+      hasMore: campaignPage.hasMore,
+      deletedCampaigns,
+      currentBrandKitExtractedAt,
+    },
+    { status: 200 },
+  );
 }
 
 export async function GET() {

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -810,7 +810,9 @@ async function extractCampaignName(
   const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {
     currentSourceUrl: runtimeDoc.inputs.brand_url || null,
   })
+  const oneOffName = stringValue(recordValue(recordValue(runtimeDoc.inputs.request)?.oneOff)?.name)
   const candidates = [
+    oneOffName,
     status.reviewCampaignName,
     proposal.campaignName,
     status.tenantName,

--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -581,7 +581,7 @@ export async function loadMarketingJobRuntime(jobId: string): Promise<MarketingJ
 
 async function collectMarketingJobRefsForTenant(
   tenantId: string,
-  options: { includeDeleted?: boolean; onlyDeleted?: boolean } = {},
+  options: { includeDeleted?: boolean; onlyDeleted?: boolean; limit?: number } = {},
 ): Promise<Array<{ jobId: string; updatedAt: number }>> {
   const root = marketingRuntimeRoot();
   const refs: Array<{ jobId: string; updatedAt: number }> = [];
@@ -648,11 +648,15 @@ async function collectMarketingJobRefsForTenant(
     }
   }
 
-  return refs.sort((left, right) => right.updatedAt - left.updatedAt);
+  const sorted = refs.sort((left, right) => right.updatedAt - left.updatedAt);
+  return options.limit !== undefined ? sorted.slice(0, options.limit) : sorted;
 }
 
-export async function listMarketingJobIdsForTenant(tenantId: string): Promise<string[]> {
-  return (await collectMarketingJobRefsForTenant(tenantId)).map((entry) => entry.jobId);
+export async function listMarketingJobIdsForTenant(
+  tenantId: string,
+  options: { limit?: number } = {},
+): Promise<string[]> {
+  return (await collectMarketingJobRefsForTenant(tenantId, options)).map((entry) => entry.jobId);
 }
 
 /**
@@ -849,8 +853,13 @@ function socialContentRuntimeContainsBasename(
   return false;
 }
 
-export async function listDeletedMarketingJobIdsForTenant(tenantId: string): Promise<string[]> {
-  return (await collectMarketingJobRefsForTenant(tenantId, { onlyDeleted: true })).map((entry) => entry.jobId);
+export async function listDeletedMarketingJobIdsForTenant(
+  tenantId: string,
+  options: { limit?: number } = {},
+): Promise<string[]> {
+  return (await collectMarketingJobRefsForTenant(tenantId, { onlyDeleted: true, ...options })).map(
+    (entry) => entry.jobId,
+  );
 }
 
 /**

--- a/backend/marketing/runtime-views.ts
+++ b/backend/marketing/runtime-views.ts
@@ -1550,12 +1550,26 @@ const CAMPAIGN_LIST_DEFAULT_LIMIT = 20;
 
 export async function listMarketingCampaignsForTenant(
   tenantId: string,
-  options: { limit?: number } = {},
+  options: { limit?: number | 'all' } = {},
 ): Promise<CampaignListPage> {
-  const limit = options.limit ?? CAMPAIGN_LIST_DEFAULT_LIMIT;
-  // Fetch limit+1 job IDs so we can detect whether more exist beyond the page
-  const jobIds = await listMarketingJobIdsForTenant(tenantId, { limit: limit + 1 });
-  const hasMore = jobIds.length > limit;
+  // 'all' explicitly opts out of pagination (used by listPublicMarketingCampaigns
+  // and other internal callers that want full-tenant coverage). Numeric inputs
+  // from untyped JS call sites can be 0/negative/NaN; clamp to a positive
+  // integer, falling back to the default when invalid.
+  const rawLimit = options.limit ?? CAMPAIGN_LIST_DEFAULT_LIMIT;
+  const unlimited = rawLimit === 'all';
+  const limit = unlimited
+    ? Number.POSITIVE_INFINITY
+    : Number.isFinite(rawLimit) && (rawLimit as number) > 0
+      ? Math.floor(rawLimit as number)
+      : CAMPAIGN_LIST_DEFAULT_LIMIT;
+  // Fetch limit+1 job IDs so we can detect whether more exist beyond the page.
+  // For unlimited mode pass undefined so listMarketingJobIdsForTenant returns all.
+  const jobIds = await listMarketingJobIdsForTenant(
+    tenantId,
+    unlimited ? {} : { limit: limit + 1 },
+  );
+  const hasMore = !unlimited && jobIds.length > limit;
   const pageJobIds = hasMore ? jobIds.slice(0, limit) : jobIds;
 
   const campaigns: RuntimeCampaignListItem[] = [];
@@ -1632,7 +1646,7 @@ export async function listPublicMarketingCampaigns(): Promise<RuntimeCampaignLis
   const byId = new Map<string, RuntimeCampaignListItem>();
 
   for (const tenantId of await listMarketingTenantIds()) {
-    const { campaigns } = await listMarketingCampaignsForTenant(tenantId);
+    const { campaigns } = await listMarketingCampaignsForTenant(tenantId, { limit: 'all' });
     for (const campaign of campaigns) {
       if (!byId.has(campaign.id)) {
         byId.set(campaign.id, campaign);

--- a/backend/marketing/runtime-views.ts
+++ b/backend/marketing/runtime-views.ts
@@ -1541,11 +1541,27 @@ function assertDenialResult(result: Awaited<ReturnType<typeof denyMarketingJob>>
   }
 }
 
-export async function listMarketingCampaignsForTenant(tenantId: string): Promise<RuntimeCampaignListItem[]> {
+export type CampaignListPage = {
+  campaigns: RuntimeCampaignListItem[];
+  hasMore: boolean;
+};
+
+const CAMPAIGN_LIST_DEFAULT_LIMIT = 20;
+
+export async function listMarketingCampaignsForTenant(
+  tenantId: string,
+  options: { limit?: number } = {},
+): Promise<CampaignListPage> {
+  const limit = options.limit ?? CAMPAIGN_LIST_DEFAULT_LIMIT;
+  // Fetch limit+1 job IDs so we can detect whether more exist beyond the page
+  const jobIds = await listMarketingJobIdsForTenant(tenantId, { limit: limit + 1 });
+  const hasMore = jobIds.length > limit;
+  const pageJobIds = hasMore ? jobIds.slice(0, limit) : jobIds;
+
   const campaigns: RuntimeCampaignListItem[] = [];
   const seen = new Set<string>();
 
-  for (const jobId of await listMarketingJobIdsForTenant(tenantId)) {
+  for (const jobId of pageJobIds) {
     const status = await getMarketingJobStatus(jobId);
     if (status.tenantName === null && status.brandWebsiteUrl === null && status.status === 'error') {
       continue;
@@ -1562,11 +1578,13 @@ export async function listMarketingCampaignsForTenant(tenantId: string): Promise
     campaigns.push(buildCampaignListItem(status, view, pendingApprovals, jobBrandKitExtractedAt));
   }
 
-  return campaigns.sort((left, right) => {
+  campaigns.sort((left, right) => {
     const leftUpdated = Date.parse(left.updatedAt || '');
     const rightUpdated = Date.parse(right.updatedAt || '');
     return (Number.isFinite(rightUpdated) ? rightUpdated : 0) - (Number.isFinite(leftUpdated) ? leftUpdated : 0);
   });
+
+  return { campaigns, hasMore };
 }
 
 /**
@@ -1614,7 +1632,7 @@ export async function listPublicMarketingCampaigns(): Promise<RuntimeCampaignLis
   const byId = new Map<string, RuntimeCampaignListItem>();
 
   for (const tenantId of await listMarketingTenantIds()) {
-    const campaigns = await listMarketingCampaignsForTenant(tenantId);
+    const { campaigns } = await listMarketingCampaignsForTenant(tenantId);
     for (const campaign of campaigns) {
       if (!byId.has(campaign.id)) {
         byId.set(campaign.id, campaign);

--- a/frontend/aries-v1/campaign-workspace-state.ts
+++ b/frontend/aries-v1/campaign-workspace-state.ts
@@ -374,9 +374,9 @@ export function deriveWorkspaceHeaderState(
   return {
     title:
       safeReviewCampaignName(status.reviewBundle?.campaignName) ||
+      status.dashboard.campaign?.name ||
       sourceDomain ||
       status.tenantName ||
-      status.dashboard.campaign?.name ||
       `Campaign ${status.jobId}`,
     sourceDomain,
     sourceUrl,

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -463,7 +463,7 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                       className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
                     />
                     {oneOffFieldError('oneOff.name') ? (
-                      <p className="mt-2 text-sm text-red-300">{marketingCreate.fieldErrors['oneOff.name']}</p>
+                      <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.name')}</p>
                     ) : null}
                   </Field>
                   <Field label="Campaign end date" required>
@@ -487,7 +487,7 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                       className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
                     />
                     {oneOffFieldError('oneOff.cta') ? (
-                      <p className="mt-2 text-sm text-red-300">{marketingCreate.fieldErrors['oneOff.cta']}</p>
+                      <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.cta')}</p>
                     ) : null}
                   </Field>
 
@@ -505,7 +505,7 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                           className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
                         />
                         {oneOffFieldError('oneOff.milestoneLabel') ? (
-                          <p className="mt-2 text-sm text-red-300">{marketingCreate.fieldErrors['oneOff.milestoneLabel']}</p>
+                          <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.milestoneLabel')}</p>
                         ) : null}
                       </Field>
                       <Field label="Milestone date">

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -526,16 +526,16 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
 
               <button
                 type="submit"
-                disabled={submitting || !websiteUrlIsValid}
+                disabled={submitting || (jobMode === 'weekly' && !websiteUrlIsValid)}
                 className="w-full rounded-full bg-gradient-to-r from-primary to-secondary px-6 py-4 text-white font-semibold shadow-xl shadow-primary/20 disabled:opacity-60 disabled:cursor-not-allowed"
-                aria-describedby={!websiteUrlIsValid && !submitting ? 'start-campaign-hint' : undefined}
+                aria-describedby={jobMode === 'weekly' && !websiteUrlIsValid && !submitting ? 'start-campaign-hint' : undefined}
               >
                 <span className="inline-flex items-center justify-center gap-2">
                   {submitting ? <LoaderCircle className="h-4 w-4 animate-spin" /> : null}
                   {submitButtonLabel}
                 </span>
               </button>
-              {!websiteUrlIsValid && !submitting && (
+              {jobMode === 'weekly' && !websiteUrlIsValid && !submitting && (
                 <p id="start-campaign-hint" className="mt-2 text-center text-xs text-white/45">
                   {websiteUrl.trim()
                     ? 'Enter a valid URL like https://example.com to start the campaign.'

--- a/lib/api/aries-v1.ts
+++ b/lib/api/aries-v1.ts
@@ -239,6 +239,9 @@ export type OnboardingDraft = {
 
 export type CampaignListResponse = {
   campaigns: RuntimeCampaignListItem[];
+  /** True when the tenant has additional campaigns beyond the returned page.
+   * The current page is capped at 20 most-recent campaigns. */
+  hasMore?: boolean;
   /** Soft-deleted campaigns in the same shape as `campaigns`. Feeds the
    * Recycle Bin / "Deleted campaigns" section of the campaign list screen
    * so users can see what they deleted and restore if needed. */

--- a/tests/dashboard-content-adapter.test.ts
+++ b/tests/dashboard-content-adapter.test.ts
@@ -260,7 +260,7 @@ test('dashboard adapter derives proposal-backed content and calendar without liv
     const content = await getMarketingDashboardContent(jobId, {
       referenceDate: new Date('2026-03-27T00:00:00.000Z'),
     });
-    const campaigns = await listMarketingCampaignsForTenant('tenant_dashboard');
+    const { campaigns } = await listMarketingCampaignsForTenant('tenant_dashboard');
 
     assert.equal(content.campaigns.length, 1);
     assert.equal(content.posts.some((post) => post.provenance.sourceKind === 'proposal'), true);

--- a/tests/runtime-views-auth-hardening.test.ts
+++ b/tests/runtime-views-auth-hardening.test.ts
@@ -382,7 +382,7 @@ test('runtime campaign and review view services exist and return honest empty st
   await withMarketingRuntimeEnv(async () => {
     const views = await import('../backend/marketing/runtime-views');
 
-    const campaigns = await views.listMarketingCampaignsForTenant('tenant_empty');
+    const { campaigns } = await views.listMarketingCampaignsForTenant('tenant_empty');
     const reviews = await views.listMarketingReviewItemsForTenant('tenant_empty');
 
     assert.deepEqual(campaigns, []);
@@ -451,7 +451,7 @@ test('runtime campaign views stay populated when proposal artifacts exist even w
     );
 
     const views = await import('../backend/marketing/runtime-views');
-    const campaigns = await views.listMarketingCampaignsForTenant('tenant_runtime');
+    const { campaigns } = await views.listMarketingCampaignsForTenant('tenant_runtime');
 
     assert.equal(campaigns.length, 1);
     assert.equal(campaigns[0].dashboard.posts.length > 0, true);
@@ -529,7 +529,7 @@ test('tenant runtime views keep only the latest rerun for the same campaign iden
     );
 
     const views = await import('../backend/marketing/runtime-views');
-    const campaigns = await views.listMarketingCampaignsForTenant('tenant_runtime_dedupe');
+    const { campaigns } = await views.listMarketingCampaignsForTenant('tenant_runtime_dedupe');
     const posts = await views.listMarketingPostsForTenant('tenant_runtime_dedupe');
 
     assert.equal(campaigns.length, 1);
@@ -561,7 +561,7 @@ test('runtime views ignore malformed legacy marketing runtime documents without 
     );
 
     const views = await import('../backend/marketing/runtime-views');
-    const campaigns = await views.listMarketingCampaignsForTenant('tenant_empty');
+    const { campaigns } = await views.listMarketingCampaignsForTenant('tenant_empty');
     const reviews = await views.listMarketingReviewItemsForTenant('tenant_empty');
 
     assert.deepEqual(campaigns, []);
@@ -714,7 +714,7 @@ test('approve_stage_2 workflow reviews include research, brief, brand-kit, and u
 
       const reviews = await views.listMarketingReviewItemsForTenant('tenant_123');
       const approvalItem = reviews.find((item) => item.id === `${started.jobId}::approval`);
-      const campaigns = await views.listMarketingCampaignsForTenant('tenant_123');
+      const { campaigns } = await views.listMarketingCampaignsForTenant('tenant_123');
       const extractedBrandKitSection = approvalItem?.sections.find((section) => section.id === 'extracted-brand-kit');
 
       assert.equal(approvalItem?.reviewType, 'workflow_approval');
@@ -916,7 +916,7 @@ test('publish review previews stop counting as pending once the workflow checkpo
     const reviewsAfter = await views.listMarketingReviewItemsForTenant('tenant_review');
     assert.equal(reviewsAfter.some((item) => item.id === `${jobId}::approval`), false);
 
-    const campaigns = await views.listMarketingCampaignsForTenant('tenant_review');
+    const { campaigns } = await views.listMarketingCampaignsForTenant('tenant_review');
     assert.equal(campaigns.length, 1);
 
     const savedReviewState = JSON.parse(await readFile(reviewStateFile, 'utf8')) as {
@@ -964,7 +964,7 @@ test('publish approvals still surface a workflow review item when the bundle has
 
     const updatedReviews = await views.listMarketingReviewItemsForTenant('tenant_review');
     const workflowReview = updatedReviews.find((item) => item.id === `${jobId}::approval`);
-    const campaigns = await views.listMarketingCampaignsForTenant('tenant_review');
+    const { campaigns } = await views.listMarketingCampaignsForTenant('tenant_review');
     const workspace = loadCampaignWorkspaceRecord(jobId, 'tenant_review');
 
     assert.equal(workflowReview?.workflowState, 'revisions_requested');
@@ -1018,5 +1018,60 @@ test('publish-preview review items attach rendered mp4 previews for video platfo
       assert.equal(videoAttachment?.kind, 'preview');
       assert.equal(videoAttachment?.posterUrl, `/api/marketing/jobs/${jobId}/assets/video-${platformSlug}-${familyId}-poster`);
     }
+  });
+});
+
+test('listMarketingCampaignsForTenant paginates and sets hasMore when campaign count exceeds limit', async () => {
+  await withMarketingRuntimeEnv(async () => {
+    const jobsRoot = path.join(process.env.DATA_ROOT!, 'generated', 'draft', 'marketing-jobs');
+    await mkdir(jobsRoot, { recursive: true });
+
+    const makeMinimalRuntimeDoc = (jobId: string, updatedAt: string) => ({
+      schema_name: 'marketing_job_state_schema',
+      schema_version: '1.0.0',
+      job_id: jobId,
+      job_type: 'weekly_social_content',
+      tenant_id: 'tenant_pagination',
+      state: 'running',
+      status: 'running',
+      current_stage: 'research',
+      stage_order: ['research', 'strategy', 'production', 'publish'],
+      stages: {
+        research: { stage: 'research', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+        strategy: { stage: 'strategy', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+        production: { stage: 'production', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+        publish: { stage: 'publish', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      },
+      approvals: { current: null, history: [] },
+      publish_config: { platforms: [], live_publish_platforms: [], video_render_platforms: [] },
+      brand_kit: null,
+      inputs: { request: {}, brand_url: 'https://brand.example' },
+      errors: [],
+      last_error: null,
+      history: [],
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: updatedAt,
+    });
+
+    // Write 5 jobs with distinct names so dedup does not collapse them
+    for (let i = 1; i <= 5; i++) {
+      const jobId = `pagination-job-${i}`;
+      await writeFile(
+        path.join(jobsRoot, `${jobId}.json`),
+        JSON.stringify(makeMinimalRuntimeDoc(jobId, `2026-0${i}-01T00:00:00.000Z`), null, 2),
+      );
+    }
+
+    const views = await import('../backend/marketing/runtime-views');
+
+    // Limit=3 — should return 3 campaigns and signal more exist
+    const page = await views.listMarketingCampaignsForTenant('tenant_pagination', { limit: 3 });
+    assert.equal(page.campaigns.length <= 3, true, 'page size must not exceed the requested limit');
+    assert.equal(page.hasMore, true, 'hasMore should be true when 5 jobs exceed limit of 3');
+
+    // Limit=10 — all 5 should fit, no more
+    const fullPage = await views.listMarketingCampaignsForTenant('tenant_pagination', { limit: 10 });
+    assert.equal(fullPage.campaigns.length, 5);
+    assert.equal(fullPage.hasMore, false, 'hasMore should be false when all campaigns fit in the page');
   });
 });


### PR DESCRIPTION
## Summary

v0.1.12.1 hotfix bundle — Brendan's QA recheck against v0.1.11.5 / v0.1.12.0 surfaced four production issues; all four fixed in this PR.

### 1. Aggregate dashboard stuck on `Loading…` (78-job sequential loop)
- Root cause: `listMarketingCampaignsForTenant` (`backend/marketing/runtime-views.ts`) looped over all 78 jobs for tenant 15, each with 4 serial IO calls.
- Fix: pagination defaults to `limit=20`, slicing the already-sorted `updated_at DESC` job list **before** the expensive per-job loop. Returns `{ campaigns, hasMore }`.
- Respects CLAUDE.md guardrail #1 — no unbenchmarked `Promise.all` introduced.

### 2. Campaign name not visible on detail header (one_off campaigns)
- Header rendered brand URL instead of operator-typed `name`.
- Fix: `extractCampaignName` (`backend/marketing/dashboard-content.ts`) reads `inputs.request.oneOff.name` as top-priority; `deriveWorkspaceHeaderState` (`frontend/aries-v1/campaign-workspace-state.ts`) checks `dashboard.campaign?.name` before `sourceDomain`.

### 3. Milestone-date-only validation fails (asymmetric with label-only)
- `name`, `cta`, and `milestoneLabel` error display now uses `oneOffFieldError()` consistently — previously read only from `marketingCreate.fieldErrors`, so client-side errors never showed.
- File: `frontend/marketing/new-job.tsx`.

### 4. Empty-submit button stays disabled (one_off mode)
- Button `disabled` prop scoped to `weekly` mode only; one_off mode allows submit to surface inline errors.
- File: `frontend/marketing/new-job.tsx`.

## Test plan

- [x] `npm run verify` — 38/38 PASS
- [x] `npm run guardrails:agent` — clean
- [x] `npm run lint` — clean
- [ ] Live verification with Brendan against tenant 15:
  - [ ] Aggregate dashboard renders < 2s with 78+ jobs
  - [ ] One_off detail header shows operator-typed name
  - [ ] /marketing/new in one_off mode: empty submit surfaces fieldErrors
  - [ ] Milestone date-only and label-only behave symmetrically

🤖 Generated with [Claude Code](https://claude.com/claude-code)
