### PR TITLE
fix(prd): gate /api/oauth/refresh on getTenantContext (§20 invariant 4)

### DIFF
--- a/app/api/oauth/[provider]/refresh/route.ts
+++ b/app/api/oauth/[provider]/refresh/route.ts
@@ -1,13 +1,44 @@
-import { oauthRefresh } from '../../../../../backend/integrations/refresh';
+import { NextResponse } from 'next/server';
+
+import { oauthRefresh } from '@/backend/integrations/refresh';
+import { getTenantContext } from '@/lib/tenant-context';
+
+// PRD §20 invariant 4: tenant IDs are derived server-side; clients and
+// callbacks do not decide tenant access. Prior to this gate the route
+// trusted `body.tenant_id` and would trigger an OAuth token refresh for
+// any tenant id any caller supplied. The session-derived tenantId now
+// overrides whatever the body claims; the body-level `tenant_id` field
+// is dropped.
+
+type RefreshBody = {
+  token_expires_in_seconds?: number;
+  refresh_expires_in_seconds?: number;
+};
 
 export async function POST(req: Request, { params }: { params: Promise<{ provider: string }> }) {
   const { provider } = await params;
-  let body: { tenant_id?: string; token_expires_in_seconds?: number; refresh_expires_in_seconds?: number } = {};
-  try { body = await req.json(); } catch {}
-  const result = await oauthRefresh(provider, body.tenant_id, {
+
+  let tenantContext;
+  try {
+    tenantContext = await getTenantContext();
+  } catch {
+    return NextResponse.json({ error: 'Authentication required.' }, { status: 403 });
+  }
+
+  let body: RefreshBody = {};
+  try {
+    body = (await req.json()) as RefreshBody;
+  } catch {
+    // empty body is allowed; only the override fields are read
+  }
+
+  const result = await oauthRefresh(provider, tenantContext.tenantId, {
     token_expires_in_seconds: body.token_expires_in_seconds,
-    refresh_expires_in_seconds: body.refresh_expires_in_seconds
+    refresh_expires_in_seconds: body.refresh_expires_in_seconds,
   });
   const status = result.broker_status === 'ok' ? 200 : 400;
-  return new Response(JSON.stringify(result), { status, headers: { 'content-type': 'application/json' } });
+  return new Response(JSON.stringify(result), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
 }

--- a/tests/prd-invariants/inv-04-tenant-derived-server-side.test.ts
+++ b/tests/prd-invariants/inv-04-tenant-derived-server-side.test.ts
@@ -30,12 +30,6 @@ const ALLOWLIST = new Set<string>([
   // server-side sidecar is the only legitimate caller; the secret-bearer is
   // the tenant authority.
   'app/api/internal/publishing/scheduled-dispatch/route.ts',
-  // FIXME-PRD-INV-04 (next-PR gap): /api/oauth/[provider]/refresh reads
-  // body.tenant_id without an auth gate.  The invariant suite surfaced this;
-  // follow-up PR adds verifyInternalCallbackRequest (or session-based
-  // getTenantContext if the surface is user-facing) and removes this
-  // allowlist entry.  Tracked in PR-body "Deferred from invariant suite".
-  'app/api/oauth/[provider]/refresh/route.ts',
 ]);
 
 test('no app/api route reads tenant id directly from the request body', () => {


### PR DESCRIPTION
## Summary

Closes the gap surfaced by the §20 invariant suite in PR #467: the route at `app/api/oauth/[provider]/refresh/route.ts` previously trusted `body.tenant_id` with **no auth gate at all** and would trigger an OAuth token refresh for any tenant id any caller supplied.

Now the route resolves `tenantId` from the session via `getTenantContext()` and ignores any body-level `tenant_id`. Unauthenticated callers get a `403 Authentication required.` instead of a successful refresh.

## Why this matters

PRD §20 invariant 4: *"Tenant IDs are derived server-side; clients and callbacks do not decide tenant access."* The invariant test (`inv-04-tenant-derived-server-side`) flagged this route with a `FIXME-PRD-INV-04` allowlist entry in PR #467. This PR removes the allowlist entry so the suite enforces the contract from here on.

## What changed

- `app/api/oauth/[provider]/refresh/route.ts` — wraps with `getTenantContext()`, drops body-level `tenant_id`, returns `403` on auth failure, uses `NextResponse` and the `@/` path alias for consistency with sibling tenant-gated routes (e.g. `app/api/business/profile/route.ts`).
- `tests/prd-invariants/inv-04-tenant-derived-server-side.test.ts` — removes the `FIXME-PRD-INV-04` allowlist entry; the suite now enforces the gate.

## Deferred follow-ups (out of scope here)

Sibling routes under `app/api/oauth/[provider]/` share the same no-auth-gate shape and need similar treatment. Each ships as its own PR per the one-slice-per-PR rule:
- `app/api/oauth/[provider]/disconnect/route.ts` — same `body.tenant_id` shape via `handleOauthDisconnectHttp`
- `app/api/oauth/[provider]/start/route.ts` — same shape via `handleIntegrationsConnect`
- `app/api/oauth/meta/select-page/route.ts` — needs inspection

These are not currently flagged by the invariant suite because they read `tenant_id` inside the handler functions, not the route file. The suite's pattern can be tightened to chase that one-hop indirection — a separate gap to file.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run verify` — 8/8 steps pass, including the §20 invariant suite with the allowlist entry removed
- [x] Existing oauth-refresh test files (15 tests) all pass — they cover `oauthRefresh()` directly, not the HTTP route, so behavior is unchanged for in-process callers
- [ ] Live verification: confirm an unauthenticated `POST /api/oauth/meta/refresh` returns 403 in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
