### PR TITLE
fix(prd): gate /api/oauth/disconnect on getTenantContext (§20 invariant 1)

### DIFF
--- a/backend/integrations/disconnect.ts
+++ b/backend/integrations/disconnect.ts
@@ -1,6 +1,7 @@
 import { brokerError, isAllowedProvider, type OAuthBrokerError } from './connect';
 import { dbAuditEvent, dbGetConnectionById, dbUpsertConnection } from './oauth-db';
 import { dbRevokeTokensForConnection } from './oauth-tokens-db';
+import { getTenantContext } from '@/lib/tenant-context';
 
 type OAuthDisconnectRequest = {
   connection_id?: string;
@@ -73,6 +74,21 @@ export async function oauthDisconnect(provider: string, payload: OAuthDisconnect
 }
 
 export async function handleOauthDisconnectHttp(req: Request, providerFromPath?: string): Promise<Response> {
+  // PRD §20 invariant 1: Aries owns tenant boundaries.  Previously this route
+  // accepted a connection_id from any caller and disconnected it without
+  // verifying the caller had access to the owning tenant.  Now: resolve the
+  // session-derived tenant, look up the connection, and refuse if the
+  // connection does not belong to the authenticated tenant.
+  let tenantContext;
+  try {
+    tenantContext = await getTenantContext();
+  } catch {
+    return new Response(
+      JSON.stringify({ broker_status: 'error', reason: 'authentication_required' }),
+      { status: 403, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
   let payload: OAuthDisconnectRequest = {};
   try {
     payload = (await req.json()) as OAuthDisconnectRequest;
@@ -82,6 +98,26 @@ export async function handleOauthDisconnectHttp(req: Request, providerFromPath?:
 
   const url = new URL(req.url);
   const provider = (providerFromPath || url.searchParams.get('provider') || '').toLowerCase();
+
+  // Verify the requested connection belongs to the authenticated tenant
+  // before delegating to oauthDisconnect.  Cross-tenant attempts get a 404
+  // (connection_not_found) so we do not leak whether the connection exists.
+  const connectionId = payload.connection_id?.trim();
+  if (connectionId) {
+    const connection = await dbGetConnectionById(connectionId);
+    if (!connection || connection.tenant_id !== tenantContext.tenantId) {
+      return new Response(
+        JSON.stringify({
+          broker_status: 'error',
+          reason: 'connection_not_found',
+          provider,
+          connection_id: connectionId,
+        }),
+        { status: 404, headers: { 'content-type': 'application/json' } },
+      );
+    }
+  }
+
   const result = await oauthDisconnect(provider, payload);
 
   const status =


### PR DESCRIPTION
## Summary

Closes a tenant-boundary gap audited while extending the §20 invariant work in PR #468. Previously `handleOauthDisconnectHttp` accepted a `connection_id` from any caller and disconnected it **without verifying the caller had access to the owning tenant** — any attacker who could guess a UUID could disconnect any tenant's OAuth integration.

## Why this matters

PRD §20 invariant 1: *"Aries owns tenant boundaries, canonical state, approvals, audit, and workflow policy."* This route violated that invariant directly. PR #468 audited the sibling routes during the `/refresh` fix:

| Route | Status before this PR |
|-------|----------------------|
| `/api/oauth/[provider]/start` | Already gated (handleIntegrationsConnect → loadTenantContextOrResponse) |
| `/api/oauth/[provider]/refresh` | **Fixed in #468** (getTenantContext) |
| `/api/oauth/meta/select-page` | Already gated (handleMetaSelectPageHttp → getTenantContext) |
| `/api/oauth/[provider]/disconnect` | **This PR — fixed here** |

## What changed

`backend/integrations/disconnect.ts`:
- Imports `getTenantContext` from `@/lib/tenant-context`
- `handleOauthDisconnectHttp` now resolves the session-derived tenantId at the top of the handler. Missing session → 403 `authentication_required`.
- Before delegating to `oauthDisconnect`, looks up the connection by id and verifies `connection.tenant_id === tenantContext.tenantId`. Cross-tenant attempts return **404 `connection_not_found`** so we do not leak whether the connection exists.

`oauthDisconnect()` itself is unchanged — it remains callable from in-process sweep scripts with their own auth context.

## Threat model addressed

| Attack | Before | After |
|--------|--------|-------|
| Anonymous caller, no session | Disconnect succeeds | 403 |
| Authenticated tenant A, supplies tenant B's connection_id | Disconnect succeeds | 404 |
| Authenticated tenant A, supplies own connection_id | Disconnect succeeds | Disconnect succeeds (unchanged) |
| Authenticated tenant A, invalid connection_id | 404 | 404 (unchanged) |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run verify` — 8/8 steps pass including the §20 invariant suite
- [ ] Live verification: confirm an unauthenticated `POST /api/oauth/meta/disconnect` returns 403 in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
