### PR TITLE
feat(prd): require auth gate on every state-mutating app/api route (§20 invariant 1)

### DIFF
--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -72,6 +72,7 @@ const steps = [
       'tests/prd-invariants/inv-13-workflow-transitions-explicit.test.ts',
       'tests/prd-invariants/inv-14-callbacks-authn-schema-tenant-idemp.test.ts',
       'tests/prd-invariants/inv-15-capability-ports-not-vendor.test.ts',
+      'tests/prd-invariants/inv-01b-state-mutating-routes-auth-gate.test.ts',
     ],
   },
   {

--- a/tests/prd-invariants/inv-01b-state-mutating-routes-auth-gate.test.ts
+++ b/tests/prd-invariants/inv-01b-state-mutating-routes-auth-gate.test.ts
@@ -1,0 +1,235 @@
+// PRD §20 invariant 1 (strengthened):
+//   "Aries owns tenant boundaries, canonical state, approvals, audit, and
+//    workflow policy."
+//
+// Structural enforcement: every state-mutating route handler under app/api/
+// MUST reach one of the three recognized auth-gate functions either directly
+// in the route file or in any directly-imported (1-hop) local module.
+//
+// Motivation: PR #470 fixed an ungated route that PR #467's coverage check
+// missed because #467 only verified that getTenantContext *exists* and has
+// callers — not that every POST/PUT/DELETE/PATCH handler is actually gated.
+// This test provides that structural guarantee going forward.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { repoPath, walk } from './_helpers';
+
+// ── Auth-gate patterns ──────────────────────────────────────────────────────
+
+const AUTH_GATE_PATTERNS = [
+  /\bgetTenantContext\s*\(/,
+  /\bloadTenantContextOrResponse\s*\(/,
+  /\bverifyInternalCallbackRequest\s*\(/,
+];
+
+function hasAuthGate(source: string): boolean {
+  return AUTH_GATE_PATTERNS.some((p) => p.test(source));
+}
+
+// ── 1-hop import resolver ───────────────────────────────────────────────────
+
+const REPO_ROOT = repoPath();
+
+/**
+ * Resolve a TypeScript import specifier to an absolute file path.
+ * Handles @/ (repo root alias), ./ and ../ relative imports.
+ * Returns null for bare package imports or unresolvable paths.
+ */
+function resolveImport(specifier: string, fromFile: string): string | null {
+  let base: string;
+
+  if (specifier.startsWith('@/')) {
+    base = join(REPO_ROOT, specifier.slice(2));
+  } else if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    base = resolve(dirname(fromFile), specifier);
+  } else {
+    // bare package import — skip
+    return null;
+  }
+
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}/index.ts`,
+    `${base}/index.tsx`,
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+/**
+ * Parse all `from '...'` / `from "..."` import specifiers from a source file.
+ */
+function parseImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const importRe = /\bfrom\s+['"]([^'"]+)['"]/g;
+  let match: RegExpExecArray | null;
+  while ((match = importRe.exec(source)) !== null) {
+    specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+// ── State-mutating export detector ─────────────────────────────────────────
+
+const MUTATING_EXPORT_RE =
+  /export\s+(?:async\s+function|function|const)\s+(POST|PUT|DELETE|PATCH)\b/;
+
+function hasStateMutatingExport(source: string): boolean {
+  return MUTATING_EXPORT_RE.test(source);
+}
+
+// ── Allowlist ───────────────────────────────────────────────────────────────
+
+type AllowlistEntry = {
+  path: string; // relative to repo root, using forward slashes
+  rationale: string;
+};
+
+const ALLOWLIST: AllowlistEntry[] = [
+  {
+    path: 'app/api/auth/[...nextauth]/route.ts',
+    rationale: 'next-auth signin/signout/session must be pre-session',
+  },
+  {
+    path: 'app/api/auth/forgot-password/route.ts',
+    rationale: 'pre-session password reset — no session exists yet',
+  },
+  {
+    path: 'app/api/auth/reset-password/route.ts',
+    rationale: 'pre-session password reset — no session exists yet',
+  },
+  {
+    path: 'app/api/oauth/[provider]/callback/route.ts',
+    rationale: 'OAuth provider callback resolves tenant via state token, not session',
+  },
+  {
+    path: 'app/api/oauth/[provider]/start/route.ts',
+    rationale: 'pre-session operator OAuth dance start — delegates to handleIntegrationsConnect which gates on session',
+  },
+  {
+    path: 'app/api/oauth/meta/select-page/route.ts',
+    rationale:
+      '2-hop: delegates to handleMetaSelectPageHttp in backend/integrations/meta/select-page.ts which calls getTenantContext via a loader-pattern (options.tenantContextLoader ?? getTenantContext) — the call site is loader() not getTenantContext() so the 1-hop scanner cannot match it; candidate for tightening the scanner to also match loader-pattern aliases',
+  },
+  {
+    path: 'app/api/early-access/route.ts',
+    rationale: 'public early-access email signup — no tenant exists yet',
+  },
+  {
+    path: 'app/api/hackathon/register/route.ts',
+    rationale: 'public hackathon registration — intentionally pre-session per inline comment',
+  },
+  {
+    path: 'app/api/integrations/slack/events/route.ts',
+    rationale:
+      'Slack Events API webhook — authenticated via HMAC verifySlackSignature (not tenant-session); tenant resolution not applicable for inbound webhooks',
+  },
+  {
+    path: 'app/api/onboarding/draft/route.ts',
+    rationale: 'pre-session onboarding draft creation/update — tenant does not exist yet at this stage',
+  },
+  {
+    path: 'app/api/onboarding/start/route.ts',
+    rationale: 'pre-session tenant creation — this is the flow that creates the tenant',
+  },
+  {
+    path: 'app/api/internal/marketing/job-runtime/route.ts',
+    rationale: 'deprecated stub — returns HTTP 410 immediately with no state mutation',
+  },
+];
+
+const ALLOWLIST_SET = new Set(ALLOWLIST.map((e) => e.path));
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+test('every allowlist entry exists on disk (no stale paths)', () => {
+  const missing: string[] = [];
+  for (const entry of ALLOWLIST) {
+    const abs = join(REPO_ROOT, entry.path);
+    if (!existsSync(abs)) {
+      missing.push(entry.path);
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    `Stale allowlist entries — file no longer exists:\n  ${missing.join('\n  ')}`,
+  );
+});
+
+test('state-mutating routes scan finds >=30 routes (regression guard on scanner)', () => {
+  const routeFiles = walk(repoPath('app/api')).filter((f) => f.endsWith('/route.ts'));
+  const mutating = routeFiles.filter((f) => {
+    try {
+      return hasStateMutatingExport(readFileSync(f, 'utf8'));
+    } catch {
+      return false;
+    }
+  });
+  assert.ok(
+    mutating.length >= 30,
+    `Expected >=30 state-mutating routes; found ${mutating.length}. ` +
+      `The scanner regex may have regressed.`,
+  );
+});
+
+test('every state-mutating app/api route has an auth gate or is allowlisted', () => {
+  const routeFiles = walk(repoPath('app/api')).filter((f) => f.endsWith('/route.ts'));
+  const violations: string[] = [];
+
+  for (const abs of routeFiles) {
+    let source: string;
+    try {
+      source = readFileSync(abs, 'utf8');
+    } catch {
+      continue;
+    }
+
+    if (!hasStateMutatingExport(source)) continue;
+
+    // Compute the repo-relative path for allowlist lookup
+    const rel = abs.startsWith(REPO_ROOT + '/') ? abs.slice(REPO_ROOT.length + 1) : abs;
+
+    if (ALLOWLIST_SET.has(rel)) continue;
+
+    // Check direct (in-file) auth gate
+    if (hasAuthGate(source)) continue;
+
+    // Check 1-hop imports
+    const specifiers = parseImportSpecifiers(source);
+    let foundVia1Hop = false;
+    for (const spec of specifiers) {
+      const resolved = resolveImport(spec, abs);
+      if (!resolved) continue;
+      try {
+        const importedSource = readFileSync(resolved, 'utf8');
+        if (hasAuthGate(importedSource)) {
+          foundVia1Hop = true;
+          break;
+        }
+      } catch {
+        // unreadable import — skip
+      }
+    }
+
+    if (!foundVia1Hop) {
+      violations.push(rel);
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `State-mutating routes with no auth gate (direct or 1-hop) and not allowlisted:\n  ${violations.join('\n  ')}\n` +
+      `Each violation is a potential security gap. Fix the route or add to ALLOWLIST with rationale.`,
+  );
+});


### PR DESCRIPTION
## Why

PR #470 fixed an ungated route (/api/oauth/disconnect) that PR #467's invariant-1 test missed. #467 checked only that \`getTenantContext\` exists and has callers — not that *every* POST/PUT/DELETE/PATCH handler is gated. This PR closes that structural gap.

## What

Creates \`tests/prd-invariants/inv-01b-state-mutating-routes-auth-gate.test.ts\` and wires it into the PRD §20 invariant step of \`scripts/verify-regression-suite.mjs\`.

The test:
1. Walks \`app/api/\` for every \`route.ts\` with a state-mutating export (\`POST|PUT|DELETE|PATCH\`)
2. Requires one of three auth-gate patterns in the file or any 1-hop local import:
   - \`getTenantContext(\`
   - \`loadTenantContextOrResponse(\`
   - \`verifyInternalCallbackRequest(\`
3. Maintains an allowlist of legitimate exceptions (pre-session, public, or custom-auth)
4. Asserts the allowlist entries all exist on disk (stale-path guard)
5. Belt-and-braces: asserts ≥30 mutating routes found (scanner regression guard)

## Allowlist rationale

| Route | Rationale |
|---|---|
| \`app/api/auth/[...nextauth]/route.ts\` | next-auth signin/signout/session — must be pre-session |
| \`app/api/auth/forgot-password/route.ts\` | pre-session password reset |
| \`app/api/auth/reset-password/route.ts\` | pre-session password reset |
| \`app/api/oauth/[provider]/callback/route.ts\` | OAuth provider callback resolves tenant via state token |
| \`app/api/oauth/[provider]/start/route.ts\` | pre-session OAuth dance start |
| \`app/api/early-access/route.ts\` | public early-access email signup |
| \`app/api/hackathon/register/route.ts\` | public hackathon registration (intentionally pre-session per inline comment) |
| \`app/api/integrations/slack/events/route.ts\` | Slack Events API webhook — authenticated via HMAC \`verifySlackSignature\`; tenant-session N/A for inbound webhooks |
| \`app/api/onboarding/draft/route.ts\` | pre-session draft creation — tenant does not exist yet |
| \`app/api/onboarding/start/route.ts\` | pre-session tenant creation — this flow creates the tenant |
| \`app/api/internal/marketing/job-runtime/route.ts\` | deprecated stub — returns HTTP 410 immediately, no state mutation |

## Surfaced findings

**(c) \`app/api/oauth/meta/select-page/route.ts\`** — Auth gate is 2-hop via loader-pattern alias:

```ts
// backend/integrations/meta/select-page.ts
const loader = options.tenantContextLoader ?? getTenantContext;
tenantContext = await loader();
```

The 1-hop scanner matches `getTenantContext(` as a direct call site but not when aliased through a loader variable. The route is correctly protected at runtime — this is a scanner precision gap, not a real auth gap. Added to allowlist with rationale. **Candidate for tightening the scanner** to also match `getTenantContext` imported as a default-loader alias (follow-up PR scope).

## Test plan

- `npm run typecheck` — clean
- `npm run verify` — all 8 steps pass including the new invariant
- No routes outside the allowlist surfaced as ungated violations

## PRD reference

Closes §20 invariant 1 structural gap (follow-on to PR #470).