### PR TITLE
fix(marketing): refuse publish auto-approve when preflight fails or publish_ready=false (slice C)

### DIFF
--- a/backend/marketing/hermes-callbacks.ts
+++ b/backend/marketing/hermes-callbacks.ts
@@ -1038,6 +1038,48 @@ type AutoApproveFn = (
   doc: MarketingJobRuntimeDocument,
 ) => Promise<ApproveMarketingJobResponse>;
 
+type PublishGuardrailReason =
+  | { kind: 'preflight_failed'; status: string }
+  | { kind: 'publish_not_ready' };
+
+/**
+ * Inspect a publish-stage callback payload for signals that the run is NOT
+ * safe to auto-approve. Returns the first matching signal, or null if the
+ * payload looks safe.
+ *
+ * Recognized refusal signals (anywhere in the output records):
+ *   - `preflight_check.status === 'failed'` — preflight gate explicitly flagged
+ *     the run.
+ *   - `publish_ready === false` — pipeline explicitly says it isn't ready.
+ *
+ * Why: auto-approve bypasses human review by design; without this gate a
+ * "completed" pipeline with `publish_ready=false` would be promoted to the
+ * launch state with no content (see mkt_bb1c146c-* incident).
+ */
+function findPublishAutoApproveRefusalSignal(
+  payload: HermesRunCallbackPayload | undefined,
+): PublishGuardrailReason | null {
+  if (!payload) return null;
+  const records: Record<string, unknown>[] = Array.isArray(payload.output)
+    ? payload.output.filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object' && !Array.isArray(entry))
+    : payload.output && typeof payload.output === 'object' && !Array.isArray(payload.output)
+      ? [payload.output as Record<string, unknown>]
+      : [];
+  for (const record of records) {
+    if (record.publish_ready === false) {
+      return { kind: 'publish_not_ready' };
+    }
+    const preflight = record.preflight_check;
+    if (preflight && typeof preflight === 'object' && !Array.isArray(preflight)) {
+      const status = (preflight as Record<string, unknown>).status;
+      if (typeof status === 'string' && status.trim().toLowerCase() === 'failed') {
+        return { kind: 'preflight_failed', status: status.trim() };
+      }
+    }
+  }
+  return null;
+}
+
 /**
  * After a `requires_approval` callback writes an approval checkpoint to the doc,
  * call `approveMarketingJob` with `approvedBy: 'ai-orchestrator'` so the pipeline
@@ -1054,6 +1096,7 @@ export async function maybeAutoApproveMarketingCheckpoint(
   doc: MarketingJobRuntimeDocument,
   approve: AutoApproveFn = approveMarketingJob,
   env: NodeJS.ProcessEnv = process.env,
+  payload?: HermesRunCallbackPayload,
 ): Promise<void> {
   if (!autoApproveMarketingPipelineEnabled(env)) return;
 
@@ -1069,6 +1112,36 @@ export async function maybeAutoApproveMarketingCheckpoint(
   // a checkpoint here would be a misroute and should not be auto-approved.
   const stage = checkpoint.stage;
   if (stage !== 'strategy' && stage !== 'production' && stage !== 'publish') return;
+
+  // Publish-stage guardrail: refuse to auto-approve when the callback payload
+  // explicitly signals the run is not ready. Without this, a "completed"
+  // pipeline with preflight_check.status='failed' or publish_ready=false can be
+  // silently promoted with no content (see mkt_bb1c146c-* QA incident).
+  if (stage === 'publish') {
+    const refusal = findPublishAutoApproveRefusalSignal(payload);
+    if (refusal) {
+      const reason =
+        refusal.kind === 'preflight_failed'
+          ? `preflight_check.status=${refusal.status}`
+          : 'publish_ready=false';
+      appendHistory(
+        doc,
+        `auto-approve refused for publish: ${reason}; leaving checkpoint for human review`,
+        { stage },
+      );
+      recordStageFailure(doc, 'publish', {
+        code: 'publish_auto_approve_refused',
+        message: `Auto-approve refused: ${reason}. Run is not safe to promote without human review.`,
+        retryable: false,
+      });
+      saveMarketingJobRuntime(doc.job_id, doc);
+      console.error('[hermes-callbacks] publish_auto_approve_refused', {
+        job_id: doc.job_id,
+        reason: refusal,
+      });
+      return;
+    }
+  }
 
   appendHistory(doc, `auto-approving ${stage} checkpoint (ARIES_AUTO_APPROVE_MARKETING_PIPELINE=1)`, {
     stage,
@@ -1506,7 +1579,7 @@ export async function applyHermesMarketingCallback(
     }
     createApprovalCheckpoint(doc, run, payload, socialApprovalStep, completedSocialStage);
     saveMarketingJobRuntime(doc.job_id, doc);
-    await maybeAutoApproveMarketingCheckpoint(doc);
+    await maybeAutoApproveMarketingCheckpoint(doc, undefined, undefined, payload);
     return;
   }
 

--- a/tests/marketing/callback-auto-approve.test.ts
+++ b/tests/marketing/callback-auto-approve.test.ts
@@ -14,6 +14,50 @@ import type {
   MarketingStage,
 } from '../../backend/marketing/runtime-state';
 import { maybeAutoApproveMarketingCheckpoint } from '../../backend/marketing/hermes-callbacks';
+import type { HermesRunCallbackPayload } from '../../backend/execution/hermes-callbacks';
+
+function makePublishCheckpoint(): MarketingApprovalCheckpoint {
+  return makeCheckpoint({
+    stage: 'publish',
+    approval_id: 'mkta_pub_001',
+    workflow_step_id: 'approve_stage_4_publish',
+  });
+}
+
+function makePublishDoc(): MarketingJobRuntimeDocument {
+  const ts = new Date().toISOString();
+  return makeDoc({
+    current_stage: 'publish',
+    state: 'approval_required',
+    status: 'awaiting_approval',
+    stages: {
+      research: { stage: 'research', status: 'completed', started_at: null, completed_at: ts, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      strategy: { stage: 'strategy', status: 'completed', started_at: null, completed_at: ts, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      production: { stage: 'production', status: 'completed', started_at: null, completed_at: ts, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      publish: { stage: 'publish', status: 'awaiting_approval', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+    },
+    approvals: {
+      current: makePublishCheckpoint(),
+      history: [],
+    },
+  });
+}
+
+function makeCallbackPayload(output: Record<string, unknown> | Array<Record<string, unknown>>): HermesRunCallbackPayload {
+  return {
+    event_id: 'evt_test_001',
+    aries_run_id: 'arun_test_001',
+    status: 'requires_approval',
+    output,
+    approval: {
+      stage: 'publish',
+      approval_step: 'approve_publish',
+      workflow_step_id: 'approve_stage_4_publish',
+      prompt: 'Review before publishing',
+      resume_token: 'resume_token_test_001',
+    },
+  } as HermesRunCallbackPayload;
+}
 
 // ---------------------------------------------------------------------------
 // Test environment
@@ -371,6 +415,122 @@ test('flag ON + approve returns approval_resolution_in_progress → benign no-op
         doc.history.some((h) => /resolution in flight/.test(h.note ?? '')),
         'history must record in-flight resolution',
       );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice C: Publish auto-approve guardrail
+// ---------------------------------------------------------------------------
+
+test('publish guardrail: preflight_check.status="failed" → refuses auto-approve, marks publish failed', async () => {
+  await withDataRoot(async () => {
+    await withEnvOverride('ARIES_AUTO_APPROVE_MARKETING_PIPELINE', '1', async () => {
+      const doc = makePublishDoc();
+      const stub = makeApproveStub();
+      const payload = makeCallbackPayload({
+        type: 'launch_review_preview',
+        preflight_check: { status: 'failed', reason: 'no_creative_assets' },
+      });
+
+      await maybeAutoApproveMarketingCheckpoint(doc, stub.approve, undefined, payload);
+
+      assert.equal(stub.calls.length, 0, 'approve must NOT fire when preflight_check.status=failed');
+      assert.equal(doc.stages.publish.status, 'failed', 'publish stage must be marked failed');
+      assert.ok(
+        doc.history.some((h) => /auto-approve refused for publish/.test(h.note ?? '')),
+        'history must record the refusal',
+      );
+      assert.ok(
+        doc.history.some((h) => /preflight_check\.status=failed/.test(h.note ?? '')),
+        'history must include the preflight_check refusal reason',
+      );
+    });
+  });
+});
+
+test('publish guardrail: publish_ready=false → refuses auto-approve, marks publish failed', async () => {
+  await withDataRoot(async () => {
+    await withEnvOverride('ARIES_AUTO_APPROVE_MARKETING_PIPELINE', '1', async () => {
+      const doc = makePublishDoc();
+      const stub = makeApproveStub();
+      const payload = makeCallbackPayload({
+        type: 'launch_review_preview',
+        publish_ready: false,
+      });
+
+      await maybeAutoApproveMarketingCheckpoint(doc, stub.approve, undefined, payload);
+
+      assert.equal(stub.calls.length, 0, 'approve must NOT fire when publish_ready=false');
+      assert.equal(doc.stages.publish.status, 'failed', 'publish stage must be marked failed');
+      assert.ok(
+        doc.history.some((h) => /publish_ready=false/.test(h.note ?? '')),
+        'history must include the publish_ready refusal reason',
+      );
+    });
+  });
+});
+
+test('publish guardrail: signal in second output record (array) → refuses', async () => {
+  await withDataRoot(async () => {
+    await withEnvOverride('ARIES_AUTO_APPROVE_MARKETING_PIPELINE', '1', async () => {
+      const doc = makePublishDoc();
+      const stub = makeApproveStub();
+      const payload = makeCallbackPayload([
+        { type: 'unrelated' },
+        { type: 'launch_review_preview', preflight_check: { status: 'failed' } },
+      ]);
+
+      await maybeAutoApproveMarketingCheckpoint(doc, stub.approve, undefined, payload);
+
+      assert.equal(stub.calls.length, 0, 'approve must NOT fire when signal appears in any record');
+      assert.equal(doc.stages.publish.status, 'failed');
+    });
+  });
+});
+
+test('publish guardrail: payload safe (publish_ready=true, preflight passed) → proceeds with auto-approve', async () => {
+  await withDataRoot(async () => {
+    await withEnvOverride('ARIES_AUTO_APPROVE_MARKETING_PIPELINE', '1', async () => {
+      const doc = makePublishDoc();
+      const stub = makeApproveStub();
+      const payload = makeCallbackPayload({
+        type: 'launch_review_preview',
+        publish_ready: true,
+        preflight_check: { status: 'passed' },
+      });
+
+      await maybeAutoApproveMarketingCheckpoint(doc, stub.approve, undefined, payload);
+
+      assert.equal(stub.calls.length, 1, 'approve must fire when payload is safe');
+      assert.notEqual(doc.stages.publish.status, 'failed', 'publish must not be marked failed');
+    });
+  });
+});
+
+test('publish guardrail: signal only triggers for publish stage (strategy with publish_ready=false still approves)', async () => {
+  await withDataRoot(async () => {
+    await withEnvOverride('ARIES_AUTO_APPROVE_MARKETING_PIPELINE', '1', async () => {
+      const doc = makeDoc(); // strategy checkpoint
+      const stub = makeApproveStub();
+      const payload = makeCallbackPayload({ publish_ready: false });
+
+      await maybeAutoApproveMarketingCheckpoint(doc, stub.approve, undefined, payload);
+
+      assert.equal(stub.calls.length, 1, 'strategy auto-approve must proceed; guardrail is publish-only');
+    });
+  });
+});
+
+test('publish guardrail: no payload passed → preserves legacy behavior (proceeds)', async () => {
+  await withDataRoot(async () => {
+    await withEnvOverride('ARIES_AUTO_APPROVE_MARKETING_PIPELINE', '1', async () => {
+      const doc = makePublishDoc();
+      const stub = makeApproveStub();
+
+      await maybeAutoApproveMarketingCheckpoint(doc, stub.approve);
+
+      assert.equal(stub.calls.length, 1, 'approve must fire when no payload is provided (no signal to refuse on)');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a guardrail in `maybeAutoApproveMarketingCheckpoint` that refuses to auto-approve the publish stage when the Hermes callback payload's output records contain `preflight_check.status === 'failed'` or `publish_ready === false`.
- On refusal: marks publish stage failed with code `publish_auto_approve_refused`, records the reason in history + console.error, and leaves the checkpoint in place for human review.
- Closes the failure mode found in the mkt_bb1c146c-* QA: an autonomous run could be silently promoted to "completed" with zero content.

## Why

`ARIES_AUTO_APPROVE_MARKETING_PIPELINE=1` is the single-tenant prod default. Before this PR, an explicit Hermes "not safe to publish" signal was ignored because the auto-approve path didn't inspect the callback payload. This is slice C of the campaign-pipeline correctness backlog (slices B and D follow).

## Test plan

- [x] New tests in `tests/marketing/callback-auto-approve.test.ts` cover: preflight failed, publish_ready=false, signal in array element 2, safe payload proceeds, strategy stage unaffected, no-payload backward-compat
- [x] `tsx --test tests/marketing/callback-auto-approve.test.ts` — 15/15 pass
- [x] `npm run typecheck` — clean
- [x] `npm run verify` — 38/38 pass
- [x] `npm run guardrails:agent` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)