### PR TITLE
feat(workspace): show "Completed (no content)" when pipeline finishes with no content (slice B)

### DIFF
--- a/backend/marketing/workspace-store.ts
+++ b/backend/marketing/workspace-store.ts
@@ -14,7 +14,11 @@ export type MarketingCampaignWorkflowState =
   | 'revisions_requested'
   | 'approved'
   | 'ready_to_publish'
-  | 'published';
+  | 'published'
+  // Pipeline reached runtime state=completed but no publish-ready or live
+  // content was produced. UI must show "Completed (no content)" instead of
+  // falling through to "Draft" — see mkt_bb1c146c-* QA incident.
+  | 'completed_no_content';
 
 export type MarketingReviewStageKey = 'brand' | 'strategy' | 'creative';
 
@@ -105,6 +109,12 @@ export type CampaignWorkflowSnapshot = {
   creativeAssetIds: string[];
   publishReadySignal: boolean;
   publishedSignal: boolean;
+  /**
+   * True when the marketing job's runtime state is `completed`. Used to
+   * surface "Completed (no content)" instead of "Draft" when a run finished
+   * but never produced publishable content (publishReadySignal=false).
+   */
+  completedSignal: boolean;
 };
 
 export type CampaignWorkflowResolution = {
@@ -578,6 +588,12 @@ export function resolveCampaignWorkflowState(
     (!snapshot.creativeReviewReady || creativeResolved)
   ) {
     workflowState = 'approved';
+  } else if (snapshot.completedSignal) {
+    // Runtime finished but produced no publishable or published content.
+    // Distinguish from `draft` so the operator can see the run is dead, not
+    // still in progress.
+    workflowState = 'completed_no_content';
+    publishBlockedReason = 'Pipeline completed but produced no publishable content. Start a new campaign or investigate the run.';
   }
 
   if (workflowState === 'approved' && !snapshot.publishReadySignal) {

--- a/backend/marketing/workspace-views.ts
+++ b/backend/marketing/workspace-views.ts
@@ -1367,6 +1367,7 @@ export async function buildCampaignWorkspaceView(jobId: string): Promise<Campaig
       rawDashboard.statuses.countsByStatus.published_to_meta_paused > 0 ||
       rawDashboard.statuses.countsByStatus.scheduled > 0 ||
       rawDashboard.statuses.countsByStatus.live > 0,
+    completedSignal: runtimeDoc.state === 'completed',
   });
 
   const dashboard = withGatedDashboardStatus(rawDashboard, workflowResolution.workflowState);

--- a/frontend/aries-v1/campaign-workspace.tsx
+++ b/frontend/aries-v1/campaign-workspace.tsx
@@ -53,7 +53,7 @@ function isActiveJobStatus(status: string): boolean {
   );
 }
 
-function workflowStateLabel(value: string): string {
+export function workflowStateLabel(value: string): string {
   if (value === 'brand_review_required') return 'Brand review ready';
   if (value === 'strategy_review_required') return 'Strategy review ready';
   if (value === 'creative_review_required') return 'Creative review ready';
@@ -61,6 +61,7 @@ function workflowStateLabel(value: string): string {
   if (value === 'published') return 'Published';
   if (value === 'approved') return 'Approved';
   if (value === 'revisions_requested') return 'Needs revisions';
+  if (value === 'completed_no_content') return 'Completed (no content)';
   return value
     .replace(/_/g, ' ')
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
@@ -96,11 +97,12 @@ function visibleActorLabel(value: string | null | undefined): string | null {
   return normalized;
 }
 
-function workflowStateTone(value: string): string {
+export function workflowStateTone(value: string): string {
   if (value === 'published') return 'border-emerald-400/25 bg-emerald-400/10 text-emerald-100';
   if (value === 'ready_to_publish') return 'border-violet-400/25 bg-violet-400/10 text-violet-100';
   if (value === 'approved') return 'border-sky-400/25 bg-sky-400/10 text-sky-100';
   if (value === 'revisions_requested') return 'border-rose-400/25 bg-rose-400/10 text-rose-100';
+  if (value === 'completed_no_content') return 'border-rose-400/25 bg-rose-400/10 text-rose-100';
   return 'border-amber-400/25 bg-amber-400/10 text-amber-100';
 }
 

--- a/lib/api/marketing.ts
+++ b/lib/api/marketing.ts
@@ -37,7 +37,8 @@ export type MarketingWorkflowState =
   | 'revisions_requested'
   | 'approved'
   | 'ready_to_publish'
-  | 'published';
+  | 'published'
+  | 'completed_no_content';
 export type MarketingReviewType = 'brand' | 'strategy' | 'creative' | 'workflow_approval';
 export type MarketingReviewDecisionStatus =
   | 'not_ready'

--- a/tests/workspace-completed-no-content.test.ts
+++ b/tests/workspace-completed-no-content.test.ts
@@ -1,0 +1,122 @@
+// Slice B: campaign workspace must surface "Completed (no content)" instead
+// of falling through to "Draft" when a marketing run reaches runtime
+// state=completed but produced no publish-ready or published content.
+//
+// Motivation: mkt_bb1c146c-* QA finding — the run had state=completed but
+// publish_ready=false, and the workspace header rendered "Draft" because the
+// state resolver had no case for "completed but empty" and the label fallback
+// title-cased the raw workflow state.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveCampaignWorkflowState } from '../backend/marketing/workspace-store';
+import type { CampaignWorkflowSnapshot, CampaignWorkspaceRecord } from '../backend/marketing/workspace-store';
+import { workflowStateLabel, workflowStateTone } from '../frontend/aries-v1/campaign-workspace';
+
+function makeRecord(): CampaignWorkspaceRecord {
+  const ts = '2026-05-26T00:00:00.000Z';
+  return {
+    schema_name: 'marketing_campaign_workspace',
+    schema_version: '1.0.0',
+    job_id: 'mkt_test_001',
+    tenant_id: '42',
+    workflow_state: 'draft',
+    brief: {
+      websiteUrl: 'https://aries.sugarandleather.com/',
+      businessName: '',
+      businessType: '',
+      approverName: '',
+      goal: '',
+      offer: '',
+      competitorUrl: '',
+      channels: [],
+      brandVoice: '',
+      styleVibe: '',
+      visualReferences: [],
+      mustUseCopy: '',
+      mustAvoidAesthetics: '',
+      notes: '',
+      brandAssets: [],
+    },
+    stage_reviews: {
+      brand: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+      strategy: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+      creative: { status: 'not_ready', latestNote: null, updatedAt: null, evidenceKind: null },
+    },
+    creative_asset_reviews: {},
+    status_history: [],
+    created_at: ts,
+    updated_at: ts,
+  };
+}
+
+function makeSnapshot(overrides: Partial<CampaignWorkflowSnapshot> = {}): CampaignWorkflowSnapshot {
+  return {
+    brandWorkflowReady: false,
+    strategyReviewReady: false,
+    creativeReviewReady: false,
+    creativeAssetIds: [],
+    publishReadySignal: false,
+    publishedSignal: false,
+    completedSignal: false,
+    ...overrides,
+  };
+}
+
+test('resolveCampaignWorkflowState: completedSignal + no publish content → completed_no_content', () => {
+  const record = makeRecord();
+  const snapshot = makeSnapshot({ completedSignal: true });
+  const resolution = resolveCampaignWorkflowState(record, snapshot);
+  assert.equal(resolution.workflowState, 'completed_no_content');
+  assert.match(
+    resolution.publishBlockedReason ?? '',
+    /completed.*no publishable content/i,
+    'publishBlockedReason explains why',
+  );
+});
+
+test('resolveCampaignWorkflowState: completedSignal=false + no publish content → draft (unchanged)', () => {
+  const record = makeRecord();
+  const snapshot = makeSnapshot({ completedSignal: false });
+  const resolution = resolveCampaignWorkflowState(record, snapshot);
+  assert.equal(resolution.workflowState, 'draft');
+});
+
+test('resolveCampaignWorkflowState: completedSignal=true but publishReadySignal=true → ready_to_publish wins', () => {
+  const record = makeRecord();
+  const snapshot = makeSnapshot({ completedSignal: true, publishReadySignal: true });
+  const resolution = resolveCampaignWorkflowState(record, snapshot);
+  assert.equal(resolution.workflowState, 'ready_to_publish');
+});
+
+test('resolveCampaignWorkflowState: completedSignal=true but publishedSignal=true → published wins', () => {
+  const record = makeRecord();
+  const snapshot = makeSnapshot({ completedSignal: true, publishedSignal: true });
+  const resolution = resolveCampaignWorkflowState(record, snapshot);
+  assert.equal(resolution.workflowState, 'published');
+});
+
+test('workflowStateLabel: completed_no_content renders as "Completed (no content)"', () => {
+  assert.equal(workflowStateLabel('completed_no_content'), 'Completed (no content)');
+});
+
+test('workflowStateLabel: completed_no_content does NOT title-case to "Completed No Content"', () => {
+  // Regression: the previous fallback title-cased unknown states. This test
+  // pins the explicit label so a future refactor does not regress.
+  assert.notEqual(workflowStateLabel('completed_no_content'), 'Completed No Content');
+});
+
+test('workflowStateLabel: completed_no_content header MUST NOT read "Draft"', () => {
+  // The mkt_bb1c146c-* incident: header rendered "Draft" because the state
+  // fell through to the default branch. After this fix the resolver yields
+  // 'completed_no_content', so the label must reflect that — never "Draft".
+  assert.notEqual(workflowStateLabel('completed_no_content'), 'Draft');
+});
+
+test('workflowStateTone: completed_no_content uses an attention tone (not default amber)', () => {
+  const tone = workflowStateTone('completed_no_content');
+  // Attention tone is rose-class to signal "Needs attention", distinct from
+  // the default amber used for in-progress / unknown states.
+  assert.match(tone, /rose/);
+});


### PR DESCRIPTION
## Summary

- Adds a new `completed_no_content` workflow state to the campaign workspace and threads a `completedSignal` (derived from `runtimeDoc.state === 'completed'`) through `CampaignWorkflowSnapshot`.
- When the run has reached runtime `state='completed'` but produced no publish-ready or published content, the resolver now yields `completed_no_content` instead of falling through to `draft`.
- Workspace header label renders "Completed (no content)" in a rose attention tone; other consumers (workflowCampaignStatus, workflowCompatibilityStatus, gatedItemStatus, runtimeStatusFromWorkflowState) already fall through to safe defaults.

## Why

mkt_bb1c146c-* QA finding: the workspace header read "Draft" when the underlying run was actually finished but empty, giving the operator no signal that the run was over. This is slice B of the campaign-pipeline correctness backlog (C shipped in #474; D follows).

## Test plan

- [x] New `tests/workspace-completed-no-content.test.ts` covers: completedSignal → completed_no_content, completedSignal=false → draft (unchanged), publish-ready beats completed, published beats completed, label = "Completed (no content)", label ≠ "Draft", tone is non-default attention
- [x] `tsx --test tests/workspace-completed-no-content.test.ts` — 8/8 pass
- [x] `npm run typecheck` — clean
- [x] `npm run verify` — 38/38 pass
- [x] `npm run guardrails:agent` — passed
- [ ] Post-deploy: visit a known dead campaign on production via /browse to confirm the header reads "Completed (no content)" instead of "Draft"

🤖 Generated with [Claude Code](https://claude.com/claude-code)