### PR TITLE
fix(invariants): inv-01b recognizes loader-alias auth gate (slice D)

### DIFF
--- a/tests/prd-invariants/inv-01b-state-mutating-routes-auth-gate.test.ts
+++ b/tests/prd-invariants/inv-01b-state-mutating-routes-auth-gate.test.ts
@@ -23,6 +23,12 @@ const AUTH_GATE_PATTERNS = [
   /\bgetTenantContext\s*\(/,
   /\bloadTenantContextOrResponse\s*\(/,
   /\bverifyInternalCallbackRequest\s*\(/,
+  // Loader-alias pattern: `const loader = options.tenantContextLoader ?? getTenantContext;`
+  // followed by `loader()` at the call site. The handler still gates on a
+  // tenant context — the alias just lets tests inject a stub. Match the
+  // `?? getTenantContext` fallback so the 1-hop scanner recognizes this
+  // form without needing to follow the loader through a second indirection.
+  /\?\?\s*getTenantContext\b/,
 ];
 
 function hasAuthGate(source: string): boolean {
@@ -114,11 +120,6 @@ const ALLOWLIST: AllowlistEntry[] = [
   {
     path: 'app/api/oauth/[provider]/start/route.ts',
     rationale: 'pre-session operator OAuth dance start — delegates to handleIntegrationsConnect which gates on session',
-  },
-  {
-    path: 'app/api/oauth/meta/select-page/route.ts',
-    rationale:
-      '2-hop: delegates to handleMetaSelectPageHttp in backend/integrations/meta/select-page.ts which calls getTenantContext via a loader-pattern (options.tenantContextLoader ?? getTenantContext) — the call site is loader() not getTenantContext() so the 1-hop scanner cannot match it; candidate for tightening the scanner to also match loader-pattern aliases',
   },
   {
     path: 'app/api/early-access/route.ts',


### PR DESCRIPTION
## Summary

- Adds a fourth AUTH_GATE pattern to inv-01b that matches the loader-alias idiom: `const loader = options.tenantContextLoader ?? getTenantContext;` then `loader()` at the call site.
- Removes the `app/api/oauth/meta/select-page/route.ts` allowlist entry. The route now passes inv-01b on its own merit because the 1-hop scanner can see the `?? getTenantContext` fallback in the imported backend module.

## Why

The previous allowlist masked a class of routes that would also be ungated if they ever lost the loader fallback. By teaching the scanner the alias form, future regressions in this pattern will fail inv-01b. This is slice D of the campaign-pipeline correctness backlog (C #474, B #475).

## Test plan

- [x] `tsx --test tests/prd-invariants/inv-01b-state-mutating-routes-auth-gate.test.ts` — 3/3 pass
- [x] `npm run typecheck` — clean
- [x] `npm run verify` — 38/38 pass
- [x] `npm run guardrails:agent` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)