### PR TITLE
refactor(social-content): migrate internal wire keys with read-both compat (v0.1.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.1.13.1 — refactor(social-content): migrate internal wire keys with read-both/write-new compat
+
+Renames Aries-internal wire keys from "campaign" to "social content / post" terminology. All renames use a **read-both/write-new** pattern so in-flight jobs persisted with old field/step names are not orphaned at deploy time.
+
+### Changed
+- Step name `campaign_planner` → `social_content_planner` in `artifact-collector.ts`. Readers attempt both step names and both file-system paths; writers emit only the new name. In-flight runs without a `social_content_planner.json` will fall back to `campaign_planner.json` transparently.
+- Payload field `campaign_planner_path` → `social_content_planner_path` in `artifact-collector.ts` outputs. Writers emit both the new key and a legacy alias; all readers (`workspace-views.ts`, `asset-library.ts`) prefer the new key and fall back to the old one.
+- `job_type` enum literal `'one_off_campaign'` → `'one_off_post'` (phase 1 of 2): `MarketingJobType` union, `StartSocialContentJobRequest`, `StartSocialContentJobResponse`, and `SocialContentJobRuntimeDocument.job_type` now include both literals. New jobs write `'one_off_post'`; all comparisons accept both. Existing DB rows with `job_type = 'one_off_campaign'` continue to work.
+
+### Follow-up (separate PR)
+- Phase 2 DB migration: `UPDATE marketing_jobs SET job_type = 'one_off_post' WHERE job_type = 'one_off_campaign'`. Drop `'one_off_campaign'` from the union after confirming no in-flight rows carry the old value.
+
+### Wire-byte verification (pre-deploy check)
+- On-disk job files: `mkt_fa9f7000` (live tenant-15 one-off job) has `job_type: "one_off_campaign"` — handled by read-both compat.
+- Step payload cache dirs (`/data/lobster-stage2-cache/`) are empty — no `campaign_planner.json` files exist on disk for any tenant; only the step-facts path is exercised, not the file-system fallback.
+
 ## v0.1.13.0 — refactor(social-content): rename campaign → social content / post across Aries codebase
 
 Aligns the entire Aries TypeScript codebase with the PRD terminology: the weekly recurring multi-post job is now "social content job" and each item in it is a "post". The old "campaign" term is preserved only where it refers to the broader multi-week marketing strategy concept, DB column names (`campaign_id`, `campaign_name`), or Hermes wire literals.

--- a/app/api/marketing/jobs/handler.ts
+++ b/app/api/marketing/jobs/handler.ts
@@ -31,7 +31,7 @@ const MARKETING_ONBOARDING_REQUIRED = {
   message: 'Complete tenant onboarding before starting a marketing job.',
 } as const;
 
-type PublicJobType = 'weekly_social_content' | 'one_off_campaign';
+type PublicJobType = 'weekly_social_content' | 'one_off_post' | 'one_off_campaign';
 type ResponseDialect = 'marketing' | 'social-content';
 
 function coerceFieldValue(value: FormDataEntryValue | null): string {
@@ -476,7 +476,7 @@ export async function handlePostMarketingJobs(
   const requestBody = await parseCreateJobRequest(req);
   const requestedJobType = resolveRequestedJobType(requestBody.jobType, dialect);
 
-  if (requestedJobType !== 'weekly_social_content' && requestedJobType !== 'one_off_campaign') {
+  if (requestedJobType !== 'weekly_social_content' && requestedJobType !== 'one_off_post' && requestedJobType !== 'one_off_campaign') {
     return NextResponse.json({ error: `unsupported_job_type:${String(requestBody.jobType ?? '')}` }, { status: 400 });
   }
 
@@ -524,7 +524,7 @@ export async function handlePostMarketingJobs(
     // clause) reads only UTC -- the timezone reasoning happens here, once. A
     // 422 with structured field errors matches the form hook's
     // parseMarketingFieldErrors expectations.
-    if (requestedJobType === 'one_off_campaign') {
+    if (requestedJobType === 'one_off_post' || requestedJobType === 'one_off_campaign') {
       const result = validateAndConvertOneOffBrief(
         hydratedPayload.oneOff as Record<string, unknown> | null | undefined,
         resolvedTenantId,

--- a/app/api/social-content/jobs/[jobId]/posts/[postId]/schedule/route.ts
+++ b/app/api/social-content/jobs/[jobId]/posts/[postId]/schedule/route.ts
@@ -26,7 +26,7 @@ import { loadSocialContentJobRuntime, asRecord, asString } from '@/backend/marke
  */
 async function resolveCampaignEndDateForJob(jobId: string): Promise<Date | null> {
   const doc = await loadSocialContentJobRuntime(jobId);
-  if (!doc || doc.job_type !== 'one_off_campaign') {
+  if (!doc || (doc.job_type !== 'one_off_post' && doc.job_type !== 'one_off_campaign')) {
     return null;
   }
   const request = asRecord(doc.inputs.request);

--- a/backend/marketing/artifact-collector.ts
+++ b/backend/marketing/artifact-collector.ts
@@ -320,9 +320,10 @@ export async function collectStrategyReviewArtifacts(
   const validatedDocs = runtimeDoc ? await loadValidatedMarketingProfileDocs(runtimeDoc.tenant_id, {
     currentSourceUrl: sourceUrl,
   }) : null;
-  const [websiteStep, plannerStep, reviewStep] = await Promise.all([
+  const [websiteStep, plannerStep, plannerStepLegacy, reviewStep] = await Promise.all([
     facts.stagePayload('strategy', 'website_brand_analysis'),
-    facts.stagePayload('strategy', 'campaign_planner'),
+    facts.stagePayload('strategy', 'social_content_planner'),
+    facts.stagePayload('strategy', 'campaign_planner'), // legacy compat: read old step name for in-flight runs
     facts.stagePayload('strategy', 'strategy_review_preview'),
   ]);
   const runId = (await resolveRunId(primaryOutput, runtimeDoc, 2)) || facts.runId || null;
@@ -335,7 +336,8 @@ export async function collectStrategyReviewArtifacts(
     stringValue(asRecord(primaryOutput)?.validated_brand_profile_path) ||
     validatedDocs?.paths.brandProfile ||
     null;
-  const plannerPath = runId && tenantId ? stepPayloadPath(2, runId, 'campaign_planner', tenantId) : '';
+  const plannerPath = runId && tenantId ? stepPayloadPath(2, runId, 'social_content_planner', tenantId) : '';
+  const plannerPathLegacy = runId && tenantId ? stepPayloadPath(2, runId, 'campaign_planner', tenantId) : '';
   const reviewPath = runId && tenantId ? stepPayloadPath(2, runId, 'strategy_review_preview', tenantId) : '';
   const rawRunWebsite = websiteStep || (websitePath ? await facts.jsonAtPath(websitePath) : null);
   const runWebsite = sourceMatchedRecord(
@@ -347,7 +349,9 @@ export async function collectStrategyReviewArtifacts(
     validatedDocs?.brandProfile || (brandProfilePath ? await facts.jsonAtPath(brandProfilePath) : null),
     sourceUrl,
   );
-  const plannerCandidate = plannerStep || (plannerPath ? await facts.jsonAtPath(plannerPath) : null);
+  const plannerCandidate = plannerStep || plannerStepLegacy
+    || (plannerPath ? await facts.jsonAtPath(plannerPath) : null)
+    || (plannerPathLegacy ? await facts.jsonAtPath(plannerPathLegacy) : null); // legacy path fallback
   const reviewCandidate = reviewStep || (reviewPath ? await facts.jsonAtPath(reviewPath) : null);
   const planner = strategyPayloadMatchesCurrentSource(plannerCandidate, sourceUrl, runWebsite, !!rawRunWebsite) ? plannerCandidate : null;
   const review = strategyPayloadMatchesCurrentSource(reviewCandidate, sourceUrl, runWebsite, !!rawRunWebsite) ? reviewCandidate : null;
@@ -372,7 +376,8 @@ export async function collectStrategyReviewArtifacts(
       website_brand_analysis_path: websitePath || null,
       validated_website_analysis_path: websitePath || null,
       validated_brand_profile_path: brandProfilePath,
-      campaign_planner_path: plannerPath || null,
+      social_content_planner_path: plannerPath || null,
+      campaign_planner_path: plannerPath || null, // legacy alias: keep until all readers migrate
       strategy_review_path: reviewPath || null,
       website,
       brand_profile: brandProfile,

--- a/backend/marketing/asset-library.ts
+++ b/backend/marketing/asset-library.ts
@@ -293,8 +293,10 @@ export async function buildMarketingAssetLibrary(
     stringValue(strategyFallback.outputs.website_brand_analysis_path) ||
     null;
   const plannerPath =
-    stringValue(strategyOutputs?.campaign_planner_path) ||
-    stringValue(strategyFallback.outputs.campaign_planner_path) ||
+    stringValue(strategyOutputs?.social_content_planner_path) ||
+    stringValue(strategyOutputs?.campaign_planner_path) || // legacy compat
+    stringValue(strategyFallback.outputs.social_content_planner_path) ||
+    stringValue(strategyFallback.outputs.campaign_planner_path) || // legacy compat
     null;
   const strategyReviewPath =
     stringValue(strategyOutputs?.strategy_review_path) ||

--- a/backend/marketing/dashboard-content.ts
+++ b/backend/marketing/dashboard-content.ts
@@ -782,7 +782,8 @@ async function parseProposalPlan(runtimeDoc: SocialContentJobRuntimeDocument): P
     }
   }
 
-  const planner = await readStageStepPayload(runtimeDoc, 2, 'campaign_planner')
+  const planner = await readStageStepPayload(runtimeDoc, 2, 'social_content_planner')
+    ?? await readStageStepPayload(runtimeDoc, 2, 'campaign_planner') // legacy compat
   const plan = recordValue(planner?.campaign_plan) ?? {}
   const brandProfiles = recordValue(planner?.brand_profiles_record) ?? {}
   const validatedProfile = await loadValidatedMarketingProfileSnapshot(runtimeDoc.tenant_id, {

--- a/backend/marketing/jobs-status.ts
+++ b/backend/marketing/jobs-status.ts
@@ -311,7 +311,7 @@ export function getMarketingJobStatusCacheSizeForTests(): number {
 // one_off_campaign docs must return false so their authoritative campaignEndDate
 // is not overridden by the synthetic weekly window.
 export function isWeeklySnapshotPathForTests(doc: SocialContentJobRuntimeDocument): boolean {
-  return requestedJobTypeFromDoc(doc) === 'weekly_social_content' && doc.job_type !== 'one_off_campaign';
+  return requestedJobTypeFromDoc(doc) === 'weekly_social_content' && doc.job_type !== 'one_off_post' && doc.job_type !== 'one_off_campaign';
 }
 
 // Exposed for regression tests. Builds the campaign window shape for a
@@ -320,7 +320,7 @@ export function isWeeklySnapshotPathForTests(doc: SocialContentJobRuntimeDocumen
 export function buildOneOffWindowForTests(
   doc: SocialContentJobRuntimeDocument,
 ): { start: string | null; end: string } | null {
-  if (doc.job_type !== 'one_off_campaign') return null;
+  if (doc.job_type !== 'one_off_post' && doc.job_type !== 'one_off_campaign') return null;
   const request = recordValue(doc.inputs?.request);
   const oneOff = recordValue(request?.oneOff);
   const end = stringValue(oneOff?.campaignEndDate);
@@ -1490,7 +1490,7 @@ async function buildCampaignWindow(
   // value the worker filters on). Surface it on SocialContentWindow.end so
   // the dashboard renders "Stops publishing on <date>" via the existing
   // formatDateRange path -- no new dashboard UI needed.
-  if (runtimeDoc.job_type === 'one_off_campaign') {
+  if (runtimeDoc.job_type === 'one_off_post' || runtimeDoc.job_type === 'one_off_campaign') {
     const request = recordValue(runtimeDoc.inputs.request);
     const oneOff = recordValue(request?.oneOff);
     const oneOffEnd = stringValue(oneOff?.campaignEndDate);
@@ -1659,6 +1659,7 @@ async function buildMarketingJobStatus(jobId: string): Promise<SocialContentJobS
   // campaigns don't have their authoritative campaignEndDate overridden by a
   // synthetically derived today+6d weekly window.
   const isWeeklySocialContent = requestedJobTypeFromDoc(runtimeDoc) === 'weekly_social_content'
+    && runtimeDoc.job_type !== 'one_off_post'
     && runtimeDoc.job_type !== 'one_off_campaign';
   const weeklySnapshot = isWeeklySocialContent ? buildWeeklyCalendarSnapshot(runtimeDoc) : null;
   const postWindow = weeklySnapshot?.postWindow ?? (await buildCampaignWindow(runtimeDoc, facts));

--- a/backend/marketing/orchestrator.ts
+++ b/backend/marketing/orchestrator.ts
@@ -96,7 +96,7 @@ import {
 
 export type StartSocialContentJobRequest = {
   tenantId: string;
-  jobType: 'weekly_social_content' | 'one_off_campaign';
+  jobType: 'weekly_social_content' | 'one_off_post' | 'one_off_campaign';
   /** Optional. User id of the authenticated caller that initiated the
    * campaign. Persisted on the runtime document so the campaign delete
    * permission check can allow the creator to delete their own campaigns
@@ -118,7 +118,7 @@ export type StartSocialContentJobResponse = {
   status: 'accepted' | 'needs_connection';
   jobId: string;
   tenantId: string;
-  jobType: 'weekly_social_content' | 'one_off_campaign';
+  jobType: 'weekly_social_content' | 'one_off_post' | 'one_off_campaign';
   runtimeArtifactPath: string;
   approvalRequired: boolean;
   currentStage: MarketingStage;
@@ -331,7 +331,7 @@ type MarketingWorkflowRuntimeContext = {
 export function buildOneOffBriefForArgs(
   doc: SocialContentJobRuntimeDocument,
 ): Record<string, unknown> | null {
-  if (doc.job_type !== 'one_off_campaign') {
+  if (doc.job_type !== 'one_off_post' && doc.job_type !== 'one_off_campaign') {
     return null;
   }
   const request = asRecord(doc.inputs.request);
@@ -1682,11 +1682,11 @@ export async function startSocialContentJob(input: StartSocialContentJobRequest)
   if (!input?.tenantId || typeof input.tenantId !== 'string' || input.tenantId.trim().length === 0) {
     throw new Error('missing_required_fields:tenantId');
   }
-  // The type union was widened to include 'one_off_campaign' in v0.1.11.0 but
-  // this runtime check was missed, throwing for every one-off submission. The
-  // accept-list is enumerated explicitly here (rather than `!== weekly`) so a
-  // future union widening must reach this site too.
-  if (input.jobType !== 'weekly_social_content' && input.jobType !== 'one_off_campaign') {
+  // The type union was widened to include 'one_off_campaign' in v0.1.11.0 and
+  // 'one_off_post' in v0.1.13.1 (read-both/write-new compat). The accept-list
+  // is enumerated explicitly (rather than `!== weekly`) so a future union
+  // widening must reach this site too.
+  if (input.jobType !== 'weekly_social_content' && input.jobType !== 'one_off_post' && input.jobType !== 'one_off_campaign') {
     throw new Error(`unsupported_job_type:${input.jobType}`);
   }
   const brandCampaignInput = ensureSocialContentJobInput(input);
@@ -1724,9 +1724,9 @@ export async function startSocialContentJob(input: StartSocialContentJobRequest)
   // publishingRequested must be true from the start. Weekly campaigns derive this
   // flag from requestedPublishFlag(doc) (payload keys like publishRequested /
   // livePublishPlatforms), which the one_off payload never sets.
-  if (input.jobType === 'weekly_social_content' || input.jobType === 'one_off_campaign') {
+  if (input.jobType === 'weekly_social_content' || input.jobType === 'one_off_post' || input.jobType === 'one_off_campaign') {
     ensureSocialContentRuntimeState(doc, {
-      publishingRequested: input.jobType === 'one_off_campaign' ? true : undefined,
+      publishingRequested: (input.jobType === 'one_off_post' || input.jobType === 'one_off_campaign') ? true : undefined,
     });
   }
   saveSocialContentJobRuntime(jobId, doc);

--- a/backend/marketing/ports/hermes.ts
+++ b/backend/marketing/ports/hermes.ts
@@ -134,7 +134,7 @@ function usesPerStageProfilePipeline(doc?: SocialContentJobRuntimeDocument): boo
     return false;
   }
   const jobType = (request as Record<string, unknown>).jobType;
-  return jobType === 'weekly_social_content' || jobType === 'one_off_campaign';
+  return jobType === 'weekly_social_content' || jobType === 'one_off_post' || jobType === 'one_off_campaign';
 }
 
 function readEnvValue(env: HermesMarketingEnv, key: string): string {

--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -158,7 +158,7 @@ export type SocialContentJobRuntimeDocument = {
    * this label to assemble a one_off_brief Hermes payload and the schedule
    * path uses it to populate `scheduled_posts.campaign_end_date`.
    */
-  job_type: 'weekly_social_content' | 'one_off_campaign';
+  job_type: 'weekly_social_content' | 'one_off_post' | 'one_off_campaign';
   state: MarketingJobState;
   status: MarketingJobStatus;
   current_stage: MarketingStage;
@@ -324,8 +324,8 @@ export function createSocialContentJobRuntimeDocument(input: {
   // Unknown jobType values fall back to 'weekly_social_content' -- the legacy
   // behaviour for any tenant submitting without an explicit jobType.
   const resolvedJobType: SocialContentJobRuntimeDocument['job_type'] =
-    input.payload?.jobType === 'one_off_campaign'
-      ? 'one_off_campaign'
+    input.payload?.jobType === 'one_off_post' || input.payload?.jobType === 'one_off_campaign'
+      ? 'one_off_post'
       : 'weekly_social_content';
   return {
     schema_name: MARKETING_RUNTIME_SCHEMA_NAME,

--- a/backend/marketing/runtime-views.ts
+++ b/backend/marketing/runtime-views.ts
@@ -1097,7 +1097,7 @@ async function workflowApprovalItem(
   // A separate launch-review path would require a parallel one_off projection,
   // which is out of scope.
   const isWeeklySocialContent =
-    requestedJobType === 'weekly_social_content' || requestedJobType === 'one_off_campaign';
+    requestedJobType === 'weekly_social_content' || requestedJobType === 'one_off_post' || requestedJobType === 'one_off_campaign';
   const isLaunchReviewCheckpoint = workflowStepId === 'approve_stage_4' && !isWeeklySocialContent;
   const launchReviewSections = isLaunchReviewCheckpoint
     ? launchReviewApprovalSections(runtimeDoc)

--- a/backend/marketing/workspace-views.ts
+++ b/backend/marketing/workspace-views.ts
@@ -466,13 +466,15 @@ async function loadStagePayloadBundle(
   const runtimeBrandProfilePath =
     stringValue(strategyOutputs.validated_brand_profile_path) ||
     stringValue(strategyOutputs.brand_profile_path);
-  const runtimeCampaignPlannerPath = stringValue(strategyOutputs.campaign_planner_path);
+  const runtimeCampaignPlannerPath = stringValue(strategyOutputs.social_content_planner_path)
+    ?? stringValue(strategyOutputs.campaign_planner_path); // legacy compat
   const runtimeStrategyPreviewPath = stringValue(strategyOutputs.strategy_review_path);
   const runtimeProductionPreviewPath = stringValue(productionOutputs.production_review_path);
 
   const fallbackWebsiteAnalysisPath = stringValue(strategyFallback.outputs.website_brand_analysis_path);
   const fallbackBrandProfilePath = stringValue(strategyFallback.outputs.validated_brand_profile_path);
-  const fallbackCampaignPlannerPath = stringValue(strategyFallback.outputs.campaign_planner_path);
+  const fallbackCampaignPlannerPath = stringValue(strategyFallback.outputs.social_content_planner_path)
+    ?? stringValue(strategyFallback.outputs.campaign_planner_path); // legacy compat
   const fallbackStrategyPreviewPath = stringValue(strategyFallback.outputs.strategy_review_path);
   const fallbackProductionPreviewPath = stringValue(productionFallback.outputs.production_review_path);
   const runtimeWebsiteAnalysisFile = await readJsonIfExists(runtimeWebsiteAnalysisPath);

--- a/backend/social-content/dashboard-projection.ts
+++ b/backend/social-content/dashboard-projection.ts
@@ -1021,7 +1021,7 @@ export function buildSocialContentDashboardProjection(
   // gate accepted only weekly, which silently emptied the dashboard for any
   // one_off campaign and left aggregate routes stuck on "Loading…".
   const reqJobType = requestedJobTypeFromDoc(runtimeDoc);
-  if (reqJobType !== 'weekly_social_content' && reqJobType !== 'one_off_campaign') {
+  if (reqJobType !== 'weekly_social_content' && reqJobType !== 'one_off_post' && reqJobType !== 'one_off_campaign') {
     return dashboard;
   }
   const realPublishedPostCount =

--- a/lib/api/marketing.ts
+++ b/lib/api/marketing.ts
@@ -1,7 +1,7 @@
 import { requestJson, type ApiClientOptions } from './http';
 import type { ApprovalDenialReasonCode } from '@/lib/marketing/approval-denial-reason-codes';
 
-export type MarketingJobType = 'weekly_social_content' | 'one_off_campaign';
+export type MarketingJobType = 'weekly_social_content' | 'one_off_post' | 'one_off_campaign';
 
 /**
  * One-off campaign metadata. Present only when jobType === 'one_off_campaign'.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aries-platform-bootstrap-runtime",
-  "version": "0.1.13.0",
+  "version": "0.1.13.1",
   "description": "Next.js application for weekly social content automation: connect platforms, generate and review a week of content, and publish on a schedule.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Renames Aries-internal wire keys from \"campaign\" → \"social content / post\" terminology using **read-both/write-new** for every rename so in-flight jobs persisted with old field names are not orphaned at deploy time.

## Wire-byte verification

Before writing any code, I verified actual on-disk state:

- **`mkt_fa9f7000`** (live tenant-15 one-off): `job_type = \"one_off_campaign\"` in the JSON on disk → handled by read-both compat in all comparisons.
- **Stage payload cache** (`/data/lobster-stage2-cache/`): directory does not exist — no `campaign_planner.json` files on disk for any tenant. Only the step-facts read path is exercised; file-system fallback added as belt-and-suspenders.
- **`campaign_planner_path` / `campaign_window`**: zero hits in any on-disk marketing-job JSON file. No existing output payloads carry these keys.

## Read-both/write-new pattern applied

| Wire key | Old | New | Pattern |
|---|---|---|---|
| Step name | `campaign_planner` | `social_content_planner` | Read both step names + both file paths; write only new |
| Output field | `campaign_planner_path` | `social_content_planner_path` | Write both keys (legacy alias kept); readers prefer new, fall back to old |
| DB enum literal | `one_off_campaign` | `one_off_post` | New docs write `one_off_post`; all comparisons check both; DB rows unchanged |

## Files changed

- `artifact-collector.ts` — reads both step names/paths; emits `social_content_planner_path` + legacy alias
- `workspace-views.ts`, `asset-library.ts` — prefer new path key, fall back to old
- `dashboard-content.ts` — prefer new step name, fall back to legacy
- `runtime-state.ts` — adds `one_off_post` to `job_type` union; writes new value for new docs
- `orchestrator.ts`, `jobs-status.ts`, `runtime-views.ts`, `ports/hermes.ts` — all comparisons accept both literals
- `dashboard-projection.ts`, `handler.ts`, `schedule/route.ts`, `lib/api/marketing.ts` — union extended

## Follow-up PR (DB migration, phase 2)

```sql
UPDATE marketing_jobs SET job_type = 'one_off_post' WHERE job_type = 'one_off_campaign';
```

Ship after confirming no in-flight rows carry `one_off_campaign`. Then drop the literal from the union.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (banned patterns + repo boundary + protocol drift)
- [x] `npm run verify` — 38/38 pass
- [x] `npm run test:concurrent` — 1 pre-existing DB-credential failure unrelated to this change (same failure on master)
- [x] On-disk wire-byte check performed before any read-path changes
- [x] Backward compat: existing docs with `job_type = 'one_off_campaign'` recognized by all updated comparison sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)