### PR TITLE
docs(plans): 8 non-analytics backlog epic plans

### DIFF
--- a/docs/plans/2026-05-30-ci-codeql-stabilization.md
+++ b/docs/plans/2026-05-30-ci-codeql-stabilization.md
@@ -1,0 +1,255 @@
+# CI / CodeQL stabilization
+
+**Status:** Open — P3 hygiene. Proportionate cleanup, not a rewrite.
+**Author:** Staff eng plan, 2026-05-30.
+**Related:**
+- ci-watcher issues: #279, #280, #330, #336, #421
+- `TODOS.md:180-195` ("CI infra — Autofix workflow HTTP 401 + checkout 'terminal prompts disabled' flake")
+- `.github/workflows/pr-agent-autofix-automerge.yml`
+- `.github/workflows/tests.yml`
+- `.github/workflows/issue-agent-fix.yml`
+
+---
+
+## Context
+
+Over the last three weeks the ci-watcher bot filed five issues against the CI surface. They cluster into two families:
+
+1. **CodeQL infra flakes** (#279, #280, #330, #336, #421) — the GitHub *default-setup* CodeQL check intermittently aborts in 0-6s (`Prepare` hard-fail), stalls in `queued` for 4h+ post-merge, or the top-level `CodeQL` rollup reports `failure` in ~2s while every sub-job is green. One (#421) is a 42s `Analyze (python)` failure that may be a real finding or a Python-runner regression.
+2. **Autofix/automerge auth flakes** (#280 and `TODOS.md:180`) — `pr-agent-autofix-automerge.yml` once failed with `HTTP 401: Bad credentials` on the labels API, and CodeQL's checkout once failed with `fatal: could not read Username for github.com: terminal prompts disabled`. Both self-resolved on re-trigger.
+
+The single most important fact, **verified this session**, reframes the whole epic: branch protection on `master` requires only the `full-suite` check, **not** the `CodeQL` rollup.
+
+```
+$ gh api repos/:owner/:repo/branches/master/protection \
+    --jq '.required_status_checks.contexts'
+["full-suite"]
+```
+
+So the CodeQL rollup races (#330, #336) and the `Prepare` aborts (#279) **do not block merges today** — they are noise on the PR checks tab, not a gate. That bounds the work: this is hygiene to stop ci-watcher churn and keep the autofix/automerge robot from tripping, not an emergency to unblock shipping.
+
+## Who cares
+
+- **Brendan** — sees red CodeQL X's on every PR and gets ci-watcher issues filed; wants the noise gone without weakening real security scanning.
+- **The autonomous PR-maintenance robot** (`pr-agent-autofix-automerge.yml`) — a transient 401 on label creation aborts the entire maintenance run and can leave a PR un-merged with no `agent:needs-attention` signal.
+- **Future agents** triaging CI — every recurring flake costs minutes of "is this real or infra" triage during ship cascades.
+
+## Decisions (locked, do not re-litigate)
+
+1. **CodeQL stays GitHub default setup.** There is no `.github/workflows/codeql.yml` (verified — `.github/workflows/` holds only `deploy.yml`, `issue-agent-fix.yml`, `pr-agent-autofix-automerge.yml`, `tests.yml`). We do NOT convert to advanced/committed-workflow CodeQL just to gain `continue-on-error` knobs. Default setup is configured in repo Security settings, which is out of band from this repo's YAML.
+2. **`full-suite` remains the sole hard merge gate.** We do not add `CodeQL` as a required check. The whole point of #505/#507 was to make the real test suite the gate; CodeQL is advisory.
+3. **Do not disable CodeQL.** It is cheap and occasionally useful. We harden around its flakiness, we do not remove security scanning.
+4. **Label creation is best-effort.** Labels are created with `--force` (idempotent) and exist already in the repo. A failure to (re)create them must never abort the maintenance run.
+5. **Scope is the four in-repo workflow files + ci-watcher issue triage.** GitHub-side settings changes (Security tab toggles, runner pool) are *recommendations* in this plan, executed by Brendan, not code we can land.
+
+## Current State (VERIFIED — file:line)
+
+**Branch protection** — `full-suite` only (see Context query above). CodeQL is not a required context.
+
+**Autofix/automerge label creation is unguarded** — `.github/workflows/pr-agent-autofix-automerge.yml:57-61`:
+```bash
+run: |
+  set -euo pipefail
+  gh label create agent:auto-merge --color 0E8A16 --description "..." --force
+  gh label create agent:needs-attention --color D93F0B --description "..." --force
+```
+This step runs under `set -euo pipefail` (line 58). A transient `HTTP 401` from the labels API (the exact failure in `TODOS.md:183`) makes `gh label create` exit non-zero, which aborts the entire `Resolve PR and guardrails` step and the whole job — before any PR resolution happens. The same unguarded pattern is duplicated in `issue-agent-fix.yml:67-72` and `issue-agent-fix.yml:127-128`.
+
+**Checkout uses default credential persistence** — `pr-agent-autofix-automerge.yml:46-49`:
+```yaml
+- name: Checkout repository
+  uses: actions/checkout@v6.0.2
+  with:
+    fetch-depth: 0
+```
+No explicit `persist-credentials`. The `terminal prompts disabled` flake (`TODOS.md:184`) hit CodeQL's *own* checkout (default setup, not this file), so there is nothing in-repo to fix there — it is documented as a re-trigger, not a code change.
+
+**The autofix job has no `gh` retry/backoff anywhere** — every `gh` call (lines 60-61, 77, 124-127, 236, 251-262, 269) is a bare invocation. A single transient 5xx/401 on any of them aborts under `pipefail`.
+
+**`tests.yml` (the real gate) is healthy** — `tests.yml:32-63`: checkout v6.0.2, Node 24 with npm cache, `npm ci`, `npm run lint`, full suite at `--test-concurrency=1` with a per-run `DATA_ROOT="${RUNNER_TEMP}/aries-data"`. No flakes reported against it. We leave it alone.
+
+**ci-watcher issues are stale** — #279, #280 reference PR #278 (merged 2026-05-07); #330 PR #326; #336 PR #332 (all merged). #421's PR #404 is merged to master. None point at an open blocking PR. They are post-merge retrospective noise.
+
+**#421 specifics** — the report itself flags two candidates (real Python finding vs. Python-runner env regression) and explicitly says log inspection is required. PRs after #404 (#417/#418/#420) had no `Analyze (python)` job at all, meaning CodeQL only language-detects Python when Python files in #404's tree change. This is a *log-read + classify* task, not a code-change task until we know which it is.
+
+## Architecture (data flow)
+
+```
+                         PR opened / synchronize / labeled
+                                      |
+        +-----------------------------+------------------------------+
+        |                             |                              |
+        v                             v                              v
+  tests.yml                  CodeQL (default setup,         pr-agent-autofix-
+  (full-suite)               GitHub-managed, NOT in repo)   automerge.yml
+        |                             |                              |
+   REQUIRED gate              Prepare -> Analyze(js/py/actions)  Resolve PR + guardrails
+   (branch protection)         -> Upload -> rollup "CodeQL"        |  (gh label create  <-- 401 abort point)
+        |                             |                            checkout (persist-credentials default)
+        v                       ADVISORY only                       |  Claude autofix -> validate -> settle
+   blocks merge                (NOT a required check)               |  gh pr merge --squash --auto
+                                      |                              v
+                              ci-watcher files issue            Deploy dispatch
+                              on red rollup / stuck queue
+                                      |
+                              #279 #280 #330 #336 #421  <-- noise we want to quiet
+```
+
+The fix surface is the right column (autofix robot hardening) plus an issue-triage sweep. The CodeQL column is GitHub-managed; we can only recommend Security-tab changes.
+
+## Child issues / phases
+
+| # | Phase | Priority | Effort (human / CC) | Dependencies |
+|---|-------|----------|---------------------|--------------|
+| 1 | Guard label-creation + add `gh` retry helper in autofix/issue workflows | P2 | 30m / 10m | none |
+| 2 | Triage + close stale ci-watcher CodeQL issues (#279, #280, #330, #336) | P3 | 20m / 5m | none |
+| 3 | Resolve #421 (read the Python job log, classify finding vs. infra) | P3 | 30m / 15m | log access |
+| 4 | Document CodeQL-flake re-trigger runbook + recommend Security-tab settings | P3 | 20m / 10m | none |
+
+Phases are independent and can land in any order. Phase 1 is the only code change with regression value; ship it first.
+
+---
+
+### Phase 1 — Harden the autofix/automerge robot against transient `gh` auth flakes
+
+**Implementation**
+
+In `pr-agent-autofix-automerge.yml`, make label creation best-effort and isolate it from the guardrail logic. Replace lines 60-61:
+```bash
+gh label create agent:auto-merge ... --force
+gh label create agent:needs-attention ... --force
+```
+with a non-fatal, retried form (decision #4 — labels are idempotent and already exist):
+```bash
+ensure_label() {  # best-effort; never abort the run on a transient labels-API flake
+  local name="$1" color="$2" desc="$3" attempt
+  for attempt in 1 2 3; do
+    if gh label create "$name" --color "$color" --description "$desc" --force; then return 0; fi
+    echo "::warning::gh label create $name failed (attempt $attempt/3); retrying"
+    sleep $((attempt * 3))
+  done
+  echo "::warning::gh label create $name failed after 3 attempts; continuing (labels are idempotent)"
+  return 0
+}
+ensure_label agent:auto-merge 0E8A16 "Agent-created PR is eligible for autonomous fixes and merge"
+ensure_label agent:needs-attention D93F0B "Agent automation needs human attention before merge"
+```
+The `return 0` keeps `set -euo pipefail` (line 58) from killing the step. Apply the identical helper to the two `gh label create` sites in `issue-agent-fix.yml:69-71` and `:128`.
+
+Keep the *merge-decision* `gh` calls (lines 236, 251-262) strict — a 401 there should still fail loud and tag `agent:needs-attention`, which is already the behavior. Only the non-load-bearing label/setup calls become best-effort.
+
+**Acceptance**
+- A simulated `gh label create` non-zero exit (e.g. temporarily point it at a bogus label color in a scratch branch run) no longer aborts the job; the step logs a `::warning::` and continues to "Resolve PR".
+- `actionlint .github/workflows/pr-agent-autofix-automerge.yml .github/workflows/issue-agent-fix.yml` is clean.
+- The happy path is unchanged: on a normal run all labels still get created and the PR still merges.
+
+---
+
+### Phase 2 — Close the stale CodeQL ci-watcher issues
+
+**Implementation**
+
+#279, #280, #330, #336 all reference PRs that are long merged, and all describe the CodeQL rollup / `Prepare` / autofix race. Given decision #2 (CodeQL is not a required check), none of these ever blocked a merge. Close each with a comment that:
+- States branch protection requires only `full-suite` (cite the API output), so a red `CodeQL` rollup is advisory and does not block.
+- Links Phase 1 for the autofix-side 401 in #280.
+- Links the Phase 4 runbook for the re-trigger procedure.
+
+```bash
+for n in 279 280 330 336; do
+  gh issue close "$n" --comment "Closing as stale CI infra noise. Verified $(date +%Y-%m-%d): branch protection requires only the \`full-suite\` check, not the \`CodeQL\` rollup, so these CodeQL default-setup races/aborts are advisory and never blocked a merge. The autofix-side 401 (#280) is hardened in <PR link from Phase 1>. Re-trigger runbook: docs/plans/2026-05-30-ci-codeql-stabilization.md (Phase 4)."
+done
+```
+
+**Acceptance**
+- #279, #280, #330, #336 are closed with the explanatory comment.
+- No new ci-watcher issue is filed for the same rollup race within one week (observational).
+
+---
+
+### Phase 3 — Resolve #421 (Python analyze failure: finding vs. infra)
+
+**Implementation**
+
+This is a *classify-first* task; the issue body says log access is required. Do NOT guess.
+1. Read the failing job log:
+   ```bash
+   gh run view 26241194782 --log-failed | sed -n '1,200p'
+   # or: gh api repos/:owner/:repo/actions/jobs/77227690777/logs
+   ```
+2. Branch on the tail:
+   - **SARIF / `N alerts found` / CWE reference** -> real Python finding. Locate the flagged file (likely a `scripts/*.py` or a doc-embedded snippet introduced by PR #404's OpenClaw removal), and either fix it or, if a confirmed false positive, dismiss the alert in the Security tab with justification. Open a one-line PR if code changes.
+   - **pip / environment / signal abort** -> infra. Confirm whether #404 changed anything Python-runner-relevant (it was a Lobster/OpenClaw removal — likely deleted the only `.py` files, leaving CodeQL with a phantom Python target). If no first-party Python remains, the right fix is GitHub-side: drop Python from CodeQL default-setup languages (Security tab) so the phantom `Analyze (python)` job stops being scheduled.
+3. Comment the classification on #421 and close.
+
+**Acceptance**
+- #421 has a comment stating finding-vs-infra with the log line that decided it.
+- If a finding: alert is fixed or dismissed-with-justification. If infra/phantom: Python either re-confirmed as a real target or recommended for removal from default-setup languages.
+- #421 closed.
+
+---
+
+### Phase 4 — Re-trigger runbook + Security-tab recommendations
+
+**Implementation**
+
+Add a short "CodeQL flake runbook" subsection to `TODOS.md` (replacing the open item at `TODOS.md:180-195` with a resolved pointer) capturing:
+- **Rollup says `failure` in <5s but all sub-jobs green** (#330 pattern): re-run failed checks from the Actions UI, or push an empty commit. It is a GitHub status-aggregation race; nothing to fix in-repo. Not a merge blocker (only `full-suite` gates).
+- **`Prepare` stuck `queued` post-merge** (#336): orphaned check run; ignore (PR already merged) or cancel the run for tidiness.
+- **`terminal prompts disabled` on CodeQL checkout** (`TODOS.md:184`): `actions/checkout` lost its token context; re-trigger with a push. In-repo `pr-agent`/`issue-agent` checkouts are unaffected (they pass `GH_TOKEN` explicitly).
+
+Recommendations for Brendan to action in **repo Settings -> Code security** (out of band, not code):
+- If #421 resolves to a phantom Python target, remove Python from default-setup languages.
+- Confirm Copilot Autofix for CodeQL is intentionally on/off; the `Prepare`/`Agent` jobs only appear when it is enabled (root cause hypothesis in #279).
+
+**Acceptance**
+- `TODOS.md:180-195` item is replaced by a resolved entry linking this plan.
+- Runbook subsection exists and covers the three flake signatures.
+
+---
+
+## Testing Plan
+
+Fixture-primary: this epic touches workflow YAML and issue triage, so "tests" are lint + simulated-failure runs, not the TS suite.
+
+| What | How | Type |
+|------|-----|------|
+| Workflow YAML validity | `actionlint .github/workflows/*.yml` | fixture (static) |
+| Label-flake non-fatal | Scratch branch: force `gh label create` to exit non-zero; assert step continues to "Resolve PR" and logs `::warning::` | fixture (simulated) |
+| Happy-path unchanged | `workflow_dispatch` on a throwaway PR with `skip_wait=true`; assert labels created + merge path reached | integration (manual dispatch) |
+| Merge-decision still strict | Confirm a forced 401 on `gh pr merge` (line 251) still tags `agent:needs-attention` and exits 1 | inspection |
+| No TS-suite regression | `npm run verify` (no app code changed; smoke only) | regression |
+| ci-watcher silence | Observe no new dup CodeQL issue for 1 week | observational |
+
+No new TS test files; no DB/Hermes/tenant surface is touched, so guardrail #1 (DB fan-out) and resumability do not apply. Turbopack is irrelevant (no app build change).
+
+## Rollback
+
+All changes are confined to workflow YAML and issue state.
+- **Phase 1:** `git revert` the workflow commit. The `ensure_label` helper is additive; reverting restores the prior unguarded `gh label create` lines. Zero data/runtime impact — these workflows do not touch prod containers, the DB, or Hermes.
+- **Phase 2:** reopen issues with `gh issue reopen <n>` if a close was premature.
+- **Phase 3:** if a "fix" for #421 regresses, `git revert` the one-line PR; a dismissed-alert can be un-dismissed in the Security tab.
+- **Phase 4:** doc-only; revert the `TODOS.md` edit.
+No deploy, no migration, no env-var change.
+
+## Out of Scope
+
+- Converting CodeQL from default setup to a committed `codeql.yml` advanced workflow.
+- Adding `CodeQL` as a required status check (explicitly rejected — decision #2).
+- Disabling or removing CodeQL scanning (decision #3).
+- Self-hosted vs. GitHub-hosted runner migration for CodeQL (#336's long-term suggestion) — that is a runner-infra decision, not P3 hygiene.
+- Any change to `tests.yml` / the `full-suite` gate (healthy, leave alone).
+- Any change to `deploy.yml`.
+- GitHub Security-tab toggles themselves — recommended in Phase 4 but executed by Brendan, not landable code.
+
+## Files Reference
+
+| Path | Role | Touched by |
+|------|------|-----------|
+| `.github/workflows/pr-agent-autofix-automerge.yml` | Autonomous PR maintenance + automerge; unguarded `gh label create` at :60-61 (401 abort) | Phase 1 |
+| `.github/workflows/issue-agent-fix.yml` | Issue->PR agent; same unguarded label pattern at :69-71, :128 | Phase 1 |
+| `.github/workflows/tests.yml` | The real `full-suite` required gate; healthy | none (reference) |
+| `.github/workflows/deploy.yml` | Deploy; unrelated | none (reference) |
+| `TODOS.md:180-195` | Logged 401 + terminal-prompts flake (P3 defer) | Phase 4 |
+| ci-watcher issues #279/#280/#330/#336 | Stale CodeQL infra noise | Phase 2 |
+| ci-watcher issue #421 | Python analyze failure, unclassified | Phase 3 |
+| (no `.github/workflows/codeql.yml`) | CodeQL is GitHub default setup, managed in Security tab | out of repo |

--- a/docs/plans/2026-05-30-honcho-performance-insights.md
+++ b/docs/plans/2026-05-30-honcho-performance-insights.md
@@ -1,0 +1,227 @@
+# Honcho performance-insights integration — feed real Meta post metrics into brand memory
+
+**Status:** Ready to build (supersedes the 2026-05-24 draft, which has stale call-site/type references).
+**Author:** Staff eng, 2026-05-30, master @ v0.1.13.15.
+**Supersedes:** `docs/plans/2026-05-24-honcho-performance-insights-integration.md` (kept for history; corrections noted in Current State).
+
+---
+
+## Context
+
+Aries already writes to Honcho on the publish-stage Hermes callback (`scheduleHermesPublishPerformanceHonchoWrite`), but the payload is **whatever Hermes happened to return in its publish-stage output** — there is no back-fetch of *actual* Meta performance after a post has been live. Honcho learns "we published X", never "X got 300 likes vs Y got 50." The brand-memory loop is open: the marketing pipeline can't learn from real-world performance because real-world performance never reaches Honcho.
+
+This epic closes that loop: 24–72h (and 7d / 30d terminal) after publish, fetch the post's real Meta `/insights` metrics, scrub platform IDs, and write a `research_conclusion` to the `peer-market-signal-<topicPseudonym>` Honcho peer via the **already-shipped** `recordPerformanceEvent` path.
+
+**This is NOT the analytics dashboard.** Issue #513 builds the operator-facing dashboard (Meta posts/account/story insights, `insights_*` tables, `MetaInsightsAdapter`). The two epics both want Meta `/insights` data and would double-build the fetch+store layer if not bounded. **This plan does not fetch Meta directly** — it consumes #513's stored snapshots and owns only the Honcho-write leg. The boundary is specified in Decisions and the dedicated **#513 boundary** section.
+
+## Who cares
+
+- **The marketing pipeline / strategist profile** — the consumer of `peer-market-signal-*` claims; today it strategizes blind to real outcomes.
+- **Brendan (operator)** — wants the next campaign to lean into what actually performed, not the model's guess.
+- **Eng** — the current publish-stage Honcho write fires with low-signal Hermes output and a UTC-now date; it looks wired but carries no real metrics. This replaces guesswork with measured data behind the same gate.
+
+## Decisions (locked — do not re-litigate)
+
+1. **#513 owns Meta fetch + storage. This epic owns only the Honcho write.** This plan does NOT call `graph.facebook.com/.../insights`. It reads from #513's `insights_post_metrics_daily` (and the post→job linkage) and calls `recordPerformanceEvent`. Reason: a second Meta fetch path duplicates token resolution, rate-limit handling, scope dependence, and pool pressure that #513 already builds (issue #513 children D/E). One fetcher, two consumers (dashboard reads tables directly; Honcho reads tables → writes memory). See the **#513 boundary** section.
+2. **Hard dependency on #513 child E (Meta adapter) landing.** Until `insights_post_metrics_daily` is populated for FB+IG, this epic has no data source. It does not ship before #513-E. This epic is sequenced *after* #513-E, *parallel-safe* with #513-F/G.
+3. **Reuse the shipped write contract verbatim.** `scheduleHermesPublishPerformanceHonchoWrite` / `recordPerformanceEvent` / `scrubPlatformIdsFromPerformancePayload` / `topicPseudonymHexForPerformanceMemory` in `backend/memory/write-events.ts` are correct and stay. No new Honcho write function. The new code is a **worker that calls the existing function with real metrics**.
+4. **Same gate, no new env var.** `HONCHO_WRITE_PUBLISH_ENABLED` already governs the write; `recordPerformanceEvent` self-gates and no-ops when off. The metrics snapshot (in #513's tables) is unaffected by the gate — only the Honcho leg is.
+5. **The job document is `SocialContentJobRuntimeDocument`, read via `loadSocialContentJobRuntime(jobId)`** (`backend/marketing/runtime-state.ts:521`). The 2026-05-24 draft's `MarketingJobRuntimeDocument` / `readMarketingJobRuntimeDocument(jobId)` do not exist — do not use them.
+6. **Idempotency is the existing key `sha256(jobId|publish|platform|YYYYMMDD)`** (`recordPerformanceEvent`, write-events.ts:679). Re-polling the same post on the same UTC day dedupes for free. We must pass the **post's real publish day**, not UTC-now, so the dedupe window is the publish day, and 24h/72h/7d/30d polls of the *same* metric-day collapse correctly. (The current callback passes UTC-now — see Current State note.)
+
+## Current State (VERIFIED — master @ v0.1.13.15)
+
+**Honcho write surface (shipped, correct):**
+- `backend/memory/write-events.ts:708` — `scheduleHermesPublishPerformanceHonchoWrite({ doc, payloadRecord })`: `setImmediate`-wrapped, self-gates on `isHonchoEnabled() && isHonchoWritePublishEnabled()`, resolves tenant slug + `topicPseudonymHexForPerformanceMemory`, computes `ymd` as **UTC-now** (`new Date().toISOString().slice(0,10)...`, line 722), then calls `recordPerformanceEvent`.
+- `backend/memory/write-events.ts:652` — `recordPerformanceEvent`: validates `publishedAtYmd` (`^\d{8}$`), validates `topicPseudonymHex`, scrubs via `scrubPlatformIdsFromPerformancePayload`, requires an https `source_url` (`extractPerformanceMetricsSourceUrl`), claims idempotency key (`idempotencyKey([jobId,'publish',platform,ymd])`, line 679), curates, persists queued finding to `peer-market-signal`.
+- `backend/memory/write-events.ts:413` — `scrubPlatformIdsFromPerformancePayload`: strips `platform_post_id`/`post_id`/`fb_post_id`/`instagram_media_id`/`*_post_id`, redacts bare 10–20 digit numeric strings.
+- `backend/memory/write-events.ts:447` — `extractPerformanceMetricsSourceUrl`: pulls first https `source_url|permalink|insights_url|metrics_url|canonical_url`, recurses into `.metrics`. **The payload MUST carry an https source url** or the write is skipped with a warning.
+- `backend/memory/write-events.ts:388` — `topicPseudonymHexForPerformanceMemory(jobId, competitorUrl)`: stable 32-hex.
+
+**Existing (low-signal) call sites — to be left in place and complemented, not removed:**
+- `backend/marketing/hermes-callbacks.ts:1879` and `:1900` — fire `scheduleHermesPublishPerformanceHonchoWrite` on publish-stage completion with `multiStage.get('publish')?.primaryOutput ?? firstOutputRecord(payload)`. (The 2026-05-24 draft cited `:1558,1579` — stale.) These fire **at publish time**, before any real metrics exist; they typically no-op the write (no https `source_url` / no metrics) or write near-empty signal. This epic adds the *delayed, metric-bearing* write; the at-publish call stays as a harmless no-op until we decide to remove it (Out of Scope / P4).
+
+**Publish records (the post→platform linkage we depend on):**
+- `posts.platform_post_id TEXT` (`scripts/init-db.js:405`), `posts.published_at TIMESTAMPTZ` (`:408`), `posts.job_id`, `posts.platform`, `posts.published_status`. `meta-publishing.ts:592` INSERTs the post row with `platform_post_id`. **`scheduled_posts` has NO `published_at`, no platform-post-id, no `insights_fetched_at`** (verified `scripts/init-db.js:455-514`) — the 2026-05-24 draft's "query `scheduled_posts` for `published_at`/`insights_fetched_at`" is wrong; published-post state lives on `posts`.
+- Token/account resolution for Meta: `resolveMetaPublishTarget` → `getDecryptedAccessTokenContextForTenantProvider(tenantId, provider)` (`meta-publishing.ts:166`) yields `{ accessToken, connectionId, externalAccountId }`. (Relevant only to #513-E, which does the fetching; listed for boundary clarity.)
+
+**#513 scaffold is NOT on master.** Verified: `backend/insights/` does not exist; `grep -c insights_ scripts/init-db.js` = 0. The `insights_*` tables and `MetaInsightsAdapter` live on the unmerged `hammad/analytics-backend` branch (#513). **This epic cannot start until #513-A (schema) + #513-E (Meta adapter populating `insights_post_metrics_daily`) have merged.**
+
+**Worker pattern to mirror:** `scripts/automations/scheduled-posts-worker.mjs` — `buildPool()` with `max: 3` (`:32`), `tickSafe(pool)` with `try/finally` resetting the `running` guard (`:430`), self-schedules via `setInterval(... INTERVAL_MS)` (`:462`). docker-compose runs it as a single-replica `restart: unless-stopped` sidecar pointed at in-network `http://aries-app:3000`.
+
+## Architecture (target)
+
+```
+#513 (UPSTREAM — owns fetch+store; this epic does NOT duplicate):
+  insights-sync-worker ─> MetaInsightsAdapter ─> graph.facebook.com/v21.0/.../insights
+    ─> UPSERT insights_post_metrics_daily (tenant-scoped: reach, impressions,
+       likes, comments, shares, saved, video_views, day)  + insights_posts
+       (external_post_id, permalink, posted_at, links to posts/job)
+
+THIS EPIC (owns the Honcho write leg only):
+  honcho-performance-worker (NEW sidecar, ~30-min tick, try/finally guarded)
+    │  per tenant, batched:
+    ├─ SELECT due posts: posts.published_at between 24h..30d ago,
+    │    published_status='published', job_id NOT NULL, AND a fresh-enough
+    │    insights_post_metrics_daily row exists, AND not already honcho-written
+    │    for (job_id, platform, metric_day)  [tracked in honcho_perf_writes]
+    ├─ for each due post:
+    │     doc = loadSocialContentJobRuntime(job_id)              (runtime-state.ts:521)
+    │     metrics = latest insights_post_metrics_daily row for the post
+    │     payloadRecord = {
+    │        platform, published_at_ymd: <post publish day>,
+    │        metrics: { reach, impressions, likes, comments, shares, saves,
+    │                   video_views, source_url: <https insights permalink> },
+    │        metrics_fetched_at, metrics_source_url: <https graph url> }
+    │     payloadRecord = scrubPlatformIdsFromPerformancePayload(payloadRecord)  (belt+braces; fn also runs inside recordPerformanceEvent)
+    │     recordPerformanceEvent({ tenantCtx, jobId, topicPseudonymHex,
+    │        publishedAtYmd: <post day>, platform, payloadRecord })   (awaited; worker is not request-path)
+    └─ mark honcho_perf_writes(job_id, platform, metric_day) on success
+                          │
+                          ▼ (existing, unchanged)
+            curateFinding ─> peer-market-signal-<topicPseudonym>  (Honcho)
+                          ▲
+   gate: HONCHO_WRITE_PUBLISH_ENABLED (recordPerformanceEvent self-gates → no-op when off)
+```
+
+Two independent loops, one fetcher: #513's worker writes `insights_*`; this worker reads `insights_*` + writes Honcho. No shared mutable state beyond #513's read-only-to-us tables.
+
+## #513 boundary (the anti-duplication contract — READ THIS)
+
+| Concern | #513 (dashboard analytics) | This epic (Honcho perf) |
+|---|---|---|
+| Fetch Meta `/insights` | **OWNS** (`MetaInsightsAdapter`, #513-E) | NEVER calls Meta |
+| Meta token/scope/re-consent | **OWNS** (#513-B/C) | depends on, doesn't manage |
+| Store raw metrics | **OWNS** (`insights_post_metrics_daily`, `insights_posts`) | read-only consumer |
+| Rate-limit / 429 backoff | **OWNS** (in adapter) | N/A (no Meta calls) |
+| Operator dashboard UI | **OWNS** | none |
+| Write metrics to Honcho memory | none | **OWNS** (`recordPerformanceEvent`) |
+| Scrub platform IDs before memory | none | **OWNS** (`scrubPlatformIdsFromPerformancePayload`) |
+| `peer-market-signal-*` peer | none | **OWNS** |
+| Dedupe Honcho writes | none | **OWNS** (`honcho_perf_writes` + existing idempotency key) |
+
+**Failure mode if the boundary is ignored:** if this epic adds its own Meta fetch (as the 2026-05-24 draft suggested), we get two token resolvers, two 429 backoff implementations, two `instagram_business_account` resolutions, and `ARIES_WEB_CONCURRENCY * DB_POOL_MAX` pool pressure doubles for the same data (CLAUDE.md guardrail #1). The contract: **#513-E's `insights_post_metrics_daily` is the single source; this worker is a pure reader-of-tables / writer-of-memory.**
+
+**Interface this epic needs from #513-E (assert in a contract test, fixture-backed):** for a published post we can resolve `(tenant_id, job_id, platform, external_post_id, posted_at)` and read `{ reach, impressions, likes, comments, shares, saved, video_views, day, source_url-or-permalink }`. If #513-E's `insights_posts` does not carry `job_id`, this epic's join is `insights_posts.external_post_id = posts.platform_post_id AND insights_posts.tenant_id = posts.tenant_id`, then `posts.job_id` → `loadSocialContentJobRuntime`. Confirm the join key with #513-E before building Phase P1/P0's query.
+
+## Child issues / phases
+
+| # | Title | Priority | Effort (human / CC) | Dependencies |
+|---|-------|----------|---------------------|--------------|
+| P0 | `honcho_perf_writes` ledger table + due-posts query (read model) | High | 2h / 25m | #513-A, #513-E merged |
+| P1 | `recordPerformanceEvent` payload builder from insights rows (pure fn) | High | 3h / 35m | P0, #513-E table shape frozen |
+| P2 | `honcho-performance-worker` sidecar (tick/finally, batched, tenant-scoped) | High | 4h / 45m | P1 |
+| P3 | docker-compose sidecar + ops gate verification | Medium | 1.5h / 20m | P2 |
+| P4 | Remove/quiet the at-publish low-signal write (optional cleanup) | Low | 1h / 15m | P2 shipped + observed |
+
+```
+#513-A ─┐
+#513-E ─┴─> P0 ──> P1 ──> P2 ──> P3
+                                  └─> P4 (optional, after observation)
+```
+
+**Sequencing rationale:** P0/P1 are pure data-shape work testable with fixtures the moment #513-E's table columns are frozen — no live Meta. P2 wires the loop. P3 deploys. P4 is deferred cleanup so we can observe both writes side-by-side first.
+
+---
+
+## P0 — Ledger table + due-posts query
+
+**Implementation:**
+1. Add to `scripts/init-db.js` (additive, idempotent, follow the house pattern):
+   ```sql
+   CREATE TABLE IF NOT EXISTS honcho_perf_writes (
+     tenant_id  INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+     job_id     TEXT    NOT NULL,
+     platform   TEXT    NOT NULL,
+     metric_day DATE    NOT NULL,
+     written_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+     PRIMARY KEY (tenant_id, job_id, platform, metric_day)
+   );
+   ```
+   This is a *worker-side* ledger distinct from the Honcho-side `honcho_write_idempotency_keys` (write-events.ts) — it lets the due-posts query cheaply skip already-written posts without re-driving `recordPerformanceEvent`'s idempotency claim every tick. `tenant_id INTEGER` matches `organizations.id int4` (do not repeat #513's BIGINT convention violation).
+2. New `backend/memory/perf-insights-read.ts`: `selectDuePerformancePosts(tenantId, client)` → joins `posts` (published_at in 24h..30d, `published_status='published'`, `job_id NOT NULL`) to #513's `insights_post_metrics_daily` (latest row per post), LEFT JOIN `honcho_perf_writes` to exclude already-written `(job_id, platform, metric_day)`. Tenant-scoped, parameterized, `LIMIT` capped (e.g. 200/tick). **No `pool.connect()` held across anything** — single `pool.query`.
+
+**Acceptance:** table created idempotently with INTEGER tenant FK + CASCADE; query returns due rows for one tenant only (cross-tenant isolation asserted); already-written `(job_id,platform,metric_day)` excluded; `LIMIT` capped.
+
+## P1 — Payload builder (pure function)
+
+**Implementation:** `backend/memory/perf-insights-payload.ts`:
+- `buildPerformancePayloadRecord({ platform, publishDayYmd, metricsRow, sourceUrl, fetchedAt })` → returns the `payloadRecord` shape `recordPerformanceEvent` consumes: `{ platform, published_at_ymd, metrics: { reach, impressions, likes, comments, shares, saves, video_views, source_url }, metrics_fetched_at, metrics_source_url }`.
+- `sourceUrl` MUST be https (the post permalink or the graph insights URL); if missing/non-https, return `null` and the worker skips (mirrors `recordPerformanceEvent`'s own guard — fail-soft, logged).
+- Map #513 column names → payload metric keys explicitly (e.g. `saved` → `saves`). Run `scrubPlatformIdsFromPerformancePayload` here as belt-and-braces (idempotent with the scrub inside `recordPerformanceEvent`).
+
+**Acceptance:** pure unit test — given a fixture `insights_post_metrics_daily` row + permalink, emits a payload with no raw `platform_post_id`/`ig_media_id`/numeric-id strings, a valid https `source_url`, and `published_at_ymd` = the **post's** publish day (not UTC-now). Missing https source → returns null.
+
+## P2 — `honcho-performance-worker` sidecar
+
+**Implementation:** new `scripts/automations/honcho-performance-worker.mjs` (mirror `scheduled-posts-worker.mjs`):
+- `buildPool()` with `max: 3`; dedicated small pool, NOT the app pool (guardrail #1 — keep worker DB pressure off the request path).
+- `tickSafe(pool)` with `try { ... } finally { running = false }`; `setInterval(() => void tickSafe(pool), INTERVAL_MS)` at 30 min. Mirror the `running` re-entrancy guard so a slow tick never overlaps.
+- Each tick, per connected tenant: `selectDuePerformancePosts` → for each, `loadSocialContentJobRuntime(job_id)`; if doc missing, skip + log (don't throw). Build payload (P1); if null, mark nothing and continue. `topicPseudonymHex = topicPseudonymHexForPerformanceMemory(job_id, doc.inputs?.competitor_url ?? null)`. Build `tenantCtx` (same shape as write-events.ts:729). `await recordPerformanceEvent({ tenantCtx, jobId, topicPseudonymHex, publishedAtYmd, platform, payloadRecord })`.
+- On success, UPSERT `honcho_perf_writes(tenant_id, job_id, platform, metric_day)` `ON CONFLICT DO NOTHING`.
+- **Per-post try/catch** so one bad post doesn't abort the tenant batch (resumability — partial progress preserved; CLAUDE.md). **Per-tenant try/catch** so one tenant doesn't abort the tick.
+- `recordPerformanceEvent` self-gates on `HONCHO_WRITE_PUBLISH_ENABLED`; when off, it no-ops and we do NOT write the ledger (so flipping the gate on later re-drives the writes). Verify: do not mark `honcho_perf_writes` unless `isHonchoWritePublishEnabled()` is true — read the gate in the worker to decide whether to ledger.
+
+**Acceptance:** with a seeded published post (publish_at 36h ago) + a seeded `insights_post_metrics_daily` row, one tick calls `recordPerformanceEvent` once with the scrubbed payload and writes one `honcho_perf_writes` row; a second tick 10 min later is a no-op (ledger hit); a thrown error on one post leaves the other posts' writes intact and `running` reset to false; with gate OFF, no Honcho write and no ledger row.
+
+## P3 — docker-compose sidecar + ops
+
+**Implementation:** add `aries-honcho-performance-worker` to `docker-compose.yml`, mirroring `aries-scheduled-posts-worker`: single replica, `restart: unless-stopped`, in-network `APP_BASE_URL=http://aries-app:3000`, `APP_INSTANCE_ID=honcho-performance-worker`, same DB env, `command` runs the new script. Inherits `HONCHO_WRITE_PUBLISH_ENABLED` (ON in prod). Does NOT need Meta env (no Meta calls).
+
+**Acceptance:** sidecar boots, logs a tick, no Meta env required; stopping the service halts Honcho perf writes without touching the app or #513's sync worker.
+
+## P4 — Quiet the at-publish low-signal write (optional, deferred)
+
+After P2 has run in prod and we've confirmed the delayed worker writes real-metric findings, remove or guard the two at-publish `scheduleHermesPublishPerformanceHonchoWrite` calls (`hermes-callbacks.ts:1879,1900`) so Honcho isn't fed the empty at-publish payload. Defer until observation confirms the worker covers the same `(job, platform, day)` keys.
+
+**Acceptance:** publish callback no longer fires the perf write (or fires it only when the payload already carries metrics); no change to the worker's writes; idempotency keys unaffected.
+
+---
+
+## Testing Plan (fixture-primary)
+
+| Layer | What | Fixture / live | Count |
+|-------|------|----------------|-------|
+| Unit | `buildPerformancePayloadRecord`: column→metric mapping, https-source guard, publish-day (not UTC-now), no raw IDs leak | fixture `insights_post_metrics_daily` row | +5 |
+| Unit | `selectDuePerformancePosts` SQL shape: 24h..30d window, status filter, ledger-exclude, LIMIT cap | in-memory/SQL string assert | +3 |
+| Integration | one tick → `recordPerformanceEvent` called once with scrubbed payload; ledger row written; gate-OFF → no write, no ledger | mock `recordPerformanceEvent` + seeded posts | +4 |
+| Integration | re-tick dedupe (ledger hit); per-post throw isolation; per-tenant isolation (no cross-tenant due rows) | seeded multi-tenant | +3 |
+| Live-DB | with a real published post + seeded insights row in the live DB, worker writes a `peer-market-signal` queued finding and a `honcho_perf_writes` row; no raw `platform_post_id`/`ig_media_id` in the Honcho payload | live DB (precedent: `tests/marketing/ingest-production-assets-live-db.test.ts`) | +2 |
+| Contract | #513 interface: assert the `(tenant_id, job_id, platform, external_post_id, posted_at)` + metric columns are resolvable from a fixture mirroring #513-E's `insights_posts`/`insights_post_metrics_daily` | fixture | +1 |
+
+Run via `tsx --test` with `APP_BASE_URL=https://aries.example.com`; gate the suite under `npm run verify` additions. No test calls Meta.
+
+## Rollback
+
+- **Kill switch:** `HONCHO_WRITE_PUBLISH_ENABLED=false` — `recordPerformanceEvent` no-ops; the worker stops writing memory and stops ledgering (#513's `insights_*` tables keep filling, dashboard unaffected). No data migration.
+- **Stop the sidecar:** `docker compose stop aries-honcho-performance-worker` — halts the Honcho leg entirely; app + #513 sync worker untouched.
+- **Schema:** `honcho_perf_writes` is additive/idempotent; dropping it only forces re-evaluation of dedupe via the existing Honcho-side idempotency key (no data loss, possible duplicate-write attempts that the Honcho key still catches).
+
+## Out of Scope
+
+- **Fetching Meta `/insights` directly** — owned by #513-E. This epic is a pure consumer.
+- **The analytics dashboard UI** — #513-G.
+- **Stories perf into Honcho** — #513-F builds story ingestion; feeding story metrics to Honcho is a fast-follow once #513-F lands (same pattern, `insights_story_snapshots` source).
+- **Removing the at-publish write** — tracked as deferred P4, not blocking.
+- **Backfilling Honcho for posts published before this worker** — one-off script if desired later.
+- **Non-Meta platforms (TikTok/YouTube)** — gated on #513 adding those adapters first.
+- **Aggregating `peer-market-signal-*` into strategy hints for the next run** — the marketing pipeline's job once signal accumulates.
+
+## Files Reference
+
+| File | Change | Phase |
+|------|--------|-------|
+| `scripts/init-db.js` | add `honcho_perf_writes` table (INTEGER tenant FK + CASCADE) | P0 |
+| `backend/memory/perf-insights-read.ts` (NEW) | `selectDuePerformancePosts` — joins `posts` + #513 `insights_post_metrics_daily`, ledger-excludes | P0 |
+| `backend/memory/perf-insights-payload.ts` (NEW) | `buildPerformancePayloadRecord` — insights row → `recordPerformanceEvent` payload | P1 |
+| `scripts/automations/honcho-performance-worker.mjs` (NEW) | tick/finally sidecar, batched, tenant-scoped, calls `recordPerformanceEvent` | P2 |
+| `docker-compose.yml` | `aries-honcho-performance-worker` sidecar (mirror scheduled-posts-worker) | P3 |
+| `backend/memory/write-events.ts` | UNCHANGED — reused as-is (`recordPerformanceEvent:652`, `scrub:413`, `topicPseudonym:388`) | — |
+| `backend/marketing/runtime-state.ts` | UNCHANGED — `loadSocialContentJobRuntime:521` reused | — |
+| `backend/marketing/hermes-callbacks.ts:1879,1900` | optionally quiet the at-publish write | P4 |
+
+## Related
+
+- Issue #513 — Meta insights dashboard epic; **hard upstream dependency** (children A + E). Boundary defined above.
+- `docs/plans/2026-05-24-honcho-performance-insights-integration.md` — prior draft; corrected here (stale `:1558,1579` call sites → `:1879,1900`; `MarketingJobRuntimeDocument` → `SocialContentJobRuntimeDocument`; `scheduled_posts.published_at`/`insights_fetched_at` do not exist — published state is on `posts`; "build your own Meta fetcher" → reuse #513-E).
+- `docs/plans/2026-05-11-aries-honcho-continuous-profile-writes.md` — the Phase 2 spec that shipped the write functions.

--- a/docs/plans/2026-05-30-honcho-writes-rollout.md
+++ b/docs/plans/2026-05-30-honcho-writes-rollout.md
@@ -1,0 +1,256 @@
+# Honcho continuous-profile-writes — LAND + flip + verify in prod
+
+**Status:** Open. Rollout/verify plan, not greenfield.
+**Author:** Auto-generated 2026-05-30 from the Honcho rollout backlog session.
+**Source spec:** `docs/plans/2026-05-11-aries-honcho-continuous-profile-writes.md` (Phases 1–3 + assertions V0–V14).
+**Related landed work:**
+- PR #441 `v0.1.8.7 feat(memory): flip Honcho Phases 1+2+3 on in production`
+- PR #443 `v0.1.8.8 fix(memory): make Honcho writes actually reach Honcho v3`
+- `docs/plans/2026-05-24-honcho-performance-insights-integration.md` (downstream perf-poller)
+
+---
+
+## Context
+
+The v2 continuous-profile-writes spec (`2026-05-11`) defined four write surfaces and three phases, each behind its own env gate under the outer `HONCHO_ENABLED` guard. The backlog (`TODOS.md`) still frames this as "Phase 1 gated on a user decision; Phases 2+3 on branches that need landing." **That framing is stale.** Ground-truth inspection shows all three phases' code is already on `master`, all call-sites are wired, and the `docker-compose.yml` env defaults are already flipped to `true`.
+
+What is actually still open is narrower and entirely operational:
+
+1. **Prod `.env` is missing two Honcho JWTs.** `HONCHO_CONTROL_PLANE_JWT` and `HONCHO_DATA_PLANE_JWT` are absent from the production `.env` (verified). Without them, `HonchoHttpTransport` sends unauthenticated requests; against a JWT-gated Honcho that is a 401/403 that surfaces as `honcho_unauthorized` and the write silently no-ops.
+2. **`HONCHO_BASE_URL` points at a local host.** Prod `.env` has `HONCHO_BASE_URL=http://host.docker.internal:8000`, i.e. a dev-loopback target, not the production Honcho data plane.
+3. **There is no V0–V14 prod verification harness.** The spec enumerates 15 assertions; unit/fixture coverage exists (`tests/memory-write-events.test.ts` etc.), but nothing exercises the live prod Honcho workspace end-to-end after the secrets land.
+4. **One stale branch to reconcile.** `feat/honcho-approval-writes-phase1` (3 commits) is unmerged but its content already landed via the squashed PRs above — it needs confirming-then-closing, not landing.
+
+This plan sequences those four items: confirm-and-close the stale branch, complete the prod secrets, then run a fixture-primary verification harness mapping every assertion to a check.
+
+## Who cares
+
+- **Brendan (operator/tenant):** wants the marketing pipeline to actually accumulate brand/policy/preference memory so future research and creative reflect his approvals and rejections. Today writes are silently no-oping in prod because the transport can't authenticate.
+- **Marketing pipeline (read side):** `HermesMarketingPort.loadMemoryContext` already queries `peer-brand`/`peer-policy`; it gets nothing new until writes land for real.
+- **On-call / future eng:** needs a documented per-phase kill switch and a verification harness to prove writes land without a full E2E pipeline run.
+
+## Decisions (locked, do not re-litigate)
+
+- **D1. No code changes to the write path.** All five `schedule*HonchoWrite` entry points and `curateFinding` extensions are landed and correct. This plan ships secrets + a verification harness only. (If V-assertions fail, that is a bug ticket, not a re-design.)
+- **D2. Silent degradation stays.** Missing/invalid Honcho config must never break approval/publish/schedule/preference flows. This is already the implemented behavior (`isHonchoEnabled()` short-circuit + `setImmediate` off-response-path + swallowed errors). Do not add fail-loud config validation to the request path. `validateHonchoConfig` stays startup-only.
+- **D3. Per-phase env gates are the rollback primitive.** `HONCHO_WRITE_APPROVALS_ENABLED`, `HONCHO_WRITE_PUBLISH_ENABLED`, `HONCHO_WRITE_PREFERENCES_ENABLED` each kill one surface without redeploy. No code rollback path needed.
+- **D4. Flip order is approvals → publish → preferences.** Even though compose defaults are all `true`, the verification harness validates one gate at a time so a misbehaving surface is isolated. Start with the lowest-volume, explicit-intent surface (approvals).
+- **D5. Reuse `ARIES_TENANT_PSEUDONYM_SALT` with `aries-user:` domain separator** for `pseudonymForUser` (already implemented, `backend/memory/pseudonym.ts:38`). No new salt env var.
+- **D6. No new peer types, no schema migration.** Idempotency table and findings table already exist in `scripts/init-db.js`.
+
+## Current State (VERIFIED)
+
+| Component | State | Evidence |
+|---|---|---|
+| Phase 1 writers (`recordApprovalEvent`, `recordDenialEvent`) | landed | `backend/memory/write-events.ts:176,243` |
+| Phase 2 writers (`recordPublishEvent`, `recordScheduleEvent`, `recordPerformanceEvent`) | landed | `backend/memory/write-events.ts:482,565,652` |
+| Phase 3 writer (`recordCreativeVoicePreferenceEvent`) | landed | `backend/memory/write-events.ts:899` |
+| Approval call-site wired | yes | `backend/marketing/orchestrator.ts:2232` (`scheduleMarketingApprovalHonchoWrites`) |
+| Publish-verify call-site wired | yes | `app/api/publish/dispatch/handler.ts:79` |
+| Schedule call-site wired | yes | `app/api/social-content/jobs/[jobId]/posts/[postId]/schedule/route.ts:219` |
+| Perf-callback call-site wired | yes | `backend/marketing/hermes-callbacks.ts:1879,1900` |
+| Preference call-site wired | yes | `app/api/social-content/jobs/[jobId]/creative-voice-preference/handler.ts:127` |
+| Curator `rejected_angle`/`preference` conditional auto-approve | landed | `backend/memory/curator.ts:71-82,183-208` |
+| `pseudonymForUser` domain separator | `aries-user:` | `backend/memory/pseudonym.ts:38` |
+| Idempotency table DDL | exists | `scripts/init-db.js:526` (`honcho_write_idempotency_keys`) |
+| Preferences table DDL | exists | `scripts/init-db.js:517` (`marketing_operator_creative_preferences`) |
+| Findings/queue table | exists | `backend/memory/research-jobs.ts:57` (`aries_research_findings`) |
+| compose `HONCHO_*` gate defaults | all `true` | `docker-compose.yml:101-104` |
+| Prod `.env` `HONCHO_ENABLED` / approvals / publish | `true` | `.env` |
+| Prod `.env` `HONCHO_BASE_URL` | `http://host.docker.internal:8000` (dev loopback) | `.env` — **needs prod data-plane URL** |
+| Prod `.env` `HONCHO_CONTROL_PLANE_JWT` | **ABSENT** | `.env` — **gap** |
+| Prod `.env` `HONCHO_DATA_PLANE_JWT` | **ABSENT** | `.env` — **gap** |
+| Prod `.env` `ARIES_TENANT_PSEUDONYM_SALT` | SET | `.env` |
+| Transport bearer selection | control-plane for workspace create/delete, data-plane otherwise; each falls back to the other | `backend/memory/honcho-http-transport.ts:35-40` |
+| Stale branch `feat/honcho-approval-writes-phase1` | 3 commits, unmerged, content already on master via #441/#443 | `git log origin/master..origin/feat/honcho-approval-writes-phase1` |
+| V0–V14 prod verification harness | **does not exist** | no `scripts/verify-honcho*.mjs` |
+
+**Net:** code is done; the rollout is blocked on (a) two missing JWTs + a prod base URL, (b) a stale branch to close, (c) a verification harness to prove the writes land.
+
+## Architecture (data flow once secrets land)
+
+```
+ Operator action (approve / deny / schedule / publish-verify / save-preference)
+   │
+   ▼
+ Route handler / orchestrator  ── responds 200/202 immediately ──▶ Browser
+   │   (off the response path)
+   ▼ setImmediate(void async)
+ schedule*HonchoWrite()  ──▶  record*Event()
+   │                              │
+   │   isHonchoEnabled() &&       │ claimIdempotencyKey(sha256(...))  ─┐
+   │   isHonchoWrite<Gate>()      │   INSERT … ON CONFLICT DO NOTHING  │ Postgres
+   │   else: no-op                │   (dedupe; loser short-circuits) ◀─┘ honcho_write_idempotency_keys
+   ▼                              ▼
+ curateFinding()  ──┬── auto_approve ──▶ TenantMemoryClient.appendApprovedMessage
+                    │                         │  HonchoHttpTransport (Bearer JWT)
+                    │                         ▼
+                    │                   ┌──────────────────────────────┐
+                    │                   │  Honcho prod data plane      │
+                    │                   │  workspace = tenant pseudonym│
+                    │                   │  peer-brand / peer-policy /  │
+                    │                   │  peer-approver-* / peer-user-*/
+                    │                   │  peer-market-signal-*        │
+                    │                   └──────────────────────────────┘
+                    └── queue_for_review ─▶ aries_research_findings (Postgres, review queue)
+                                              └─▶ GET /api/tenant/research/review-queue
+```
+
+Failure isolation: a 401/503 from Honcho throws `MemoryError` inside the `setImmediate` callback, is caught + logged, never reaches the caller. The idempotency key is claimed *before* the Honcho call, so a failed write burns its key — see Rollback / known trade-off.
+
+## Phases
+
+| # | Phase | Priority | Effort (human / CC) | Dependencies |
+|---|---|---|---|---|
+| 0 | Confirm + close stale `feat/honcho-approval-writes-phase1` branch | P1 | 15m / 5m | — |
+| 1 | Complete prod Honcho secrets (2 JWTs + prod base URL) | P0 | 30m / n/a (human-only, prod creds) | Honcho prod tenant provisioned |
+| 2 | Approvals verification (gate `HONCHO_WRITE_APPROVALS_ENABLED`, V0–V6) | P0 | 1h / 30m | Phase 1 |
+| 3 | Publish verification (gate `HONCHO_WRITE_PUBLISH_ENABLED`, V7–V11) | P1 | 1h / 30m | Phase 2 |
+| 4 | Preferences verification (gate `HONCHO_WRITE_PREFERENCES_ENABLED`, V12–V14) | P2 | 30m / 20m | Phase 2 |
+| 5 | Idempotency-key burn monitor + lost-write log alert | P2 | 45m / 30m | Phase 2 |
+
+---
+
+### Phase 0 — Confirm + close the stale branch
+
+**Implementation**
+- `git log origin/master..origin/feat/honcho-approval-writes-phase1 --oneline` shows 3 commits (`c4da722`, `4ab6b11`, `4a432a5`). Diff each file region against `master`: the Phase 1 writers + curator extensions on master already include the Copilot-review fixes (`backend/memory/write-events.ts:81` atomic `claimIdempotencyKey`, `backend/memory/curator.ts:71-78` explicit-denial gate). Confirm no unique hunk remains.
+- If `git diff origin/master origin/feat/honcho-approval-writes-phase1 -- backend/ tests/` is empty (modulo already-landed content), delete the remote branch via `gh`/`git push origin --delete`. Do **not** open a PR.
+
+**Acceptance**
+- `git diff origin/master origin/feat/honcho-approval-writes-phase1` shows no behavioral delta on the write path.
+- Branch deleted (or a one-line note in `TODOS.md` recording it was content-confirmed-merged and closed).
+
+---
+
+### Phase 1 — Complete prod Honcho secrets (human-only)
+
+**Implementation** (operator, on the prod host — never commit secrets):
+- Obtain from the Honcho prod tenant: data-plane JWT, control-plane JWT, and the prod data-plane base URL.
+- Set in production `.env` (alongside the already-present `ARIES_TENANT_PSEUDONYM_SALT`):
+  - `HONCHO_DATA_PLANE_JWT=<data-plane JWT>`
+  - `HONCHO_CONTROL_PLANE_JWT=<control-plane JWT>` (used only for workspace create/delete; data-plane is the fallback per `honcho-http-transport.ts:36-39`)
+  - `HONCHO_BASE_URL=<prod data-plane URL>` (replace `http://host.docker.internal:8000`)
+- `validateHonchoConfig` (startup) already asserts `HONCHO_BASE_URL` present and salt ≥16 chars when `HONCHO_ENABLED=true`; it does **not** assert the JWTs (silent-degradation by design, D2). So a missing JWT will not fail startup — Phase 2's V-checks are what catch it.
+- Restart the `aries-app` container so the new env is read.
+
+**Acceptance**
+- Startup log shows no `[honcho]` config throw.
+- A manual one-shot write smoke (Phase 2 V1) lands a message in the prod Honcho workspace — this is the real proof the JWT + URL are correct, since the config validator stays silent on JWTs.
+
+---
+
+### Phase 2 — Approvals verification (V0–V6)
+
+**Implementation**
+- Build `scripts/verify-honcho-writes.mjs` as a tenant-scoped harness with two backends: a **fixture mode** (in-process, injects a fake `HonchoTransport` capturing appended messages — no live Honcho) and a **prod mode** (`--prod`, reads back from the live workspace via a data-plane GET). Fixture mode is the primary, runs in CI; prod mode is the post-flip gate Brendan runs once.
+- Approvals checks call `recordApprovalEvent` / `recordDenialEvent` directly with a captured transport and assert against the resulting `appendApprovedMessage` calls and the `aries_research_findings` queue rows (using a test DB pool, or a disposable tenant in prod mode).
+
+**Acceptance — each maps to a spec assertion:**
+- **V0** double-approve same job/stage → exactly one `honcho_write_idempotency_keys` row for the derived key; second call no-ops.
+- **V1** strategy approve → `session-strategy-<jobId>` + `peer-brand`, one `kind=fact`, `approved_by=<userPseudonym>`; assert no raw tenant/user id in any field (regex the appended message JSON for the raw `userId`).
+- **V2** deny `production` w/ `denial_reason_code=wrong-colors` → `peer-policy` `kind=rejected_angle` claim contains the code + stage + job, no free text; second `peer-approver-*` `kind=fact` audit; finding auto-approved.
+- **V3** deny w/o reason code → `rejected_angle` lands in `aries_research_findings` `queue_for_review`; audit `kind=fact` still written.
+- **V4** gate off (`HONCHO_WRITE_APPROVALS_ENABLED=false`) → approve+deny produce zero appended messages; approval-store record still written.
+- **V5** Honcho 503 (fixture transport throws `MemoryError`) → caller path returns normally, error logged, no throw.
+- **V6** Honcho 3s latency (fixture transport delays) → the `schedule*` caller returns synchronously (write is on `setImmediate`); assert the schedule call itself does not await.
+
+---
+
+### Phase 3 — Publish verification (V7–V11)
+
+**Implementation** — same harness, `--surface=publish`. Exercises `recordPublishEvent`, `recordScheduleEvent`, `recordPerformanceEvent` with captured transport + test pool.
+
+**Acceptance:**
+- **V7** publish-verify `verified` → `peer-policy` `kind=constraint`, `queue_for_review` (third-party source). Verify it lands in `aries_research_findings`, not Honcho-appended.
+- **V8** schedule post → `peer-policy` `kind=constraint`, auto-approved, `approved_by=system` (first-party).
+- **V9** Hermes publish-stage callback with `https` `source_url` → `peer-market-signal-<topicHex>` `kind=research_conclusion`, queued. Assert payload ran through `scrubPlatformIdsFromPerformancePayload` (inject `platform_post_id` + a 15-digit numeric string → both stripped/redacted).
+- **V10** duplicate publish for same job+platform+date → one idempotency row, second is no-op.
+- **V11** volume bound: simulate 50 jobs × 5 platforms × daily callbacks for a month, count `claimIdempotencyKey` wins → assert < 1,500 writes/tenant/month. If exceeded, file Phase 2.5 pruning ticket (does not block flip).
+
+---
+
+### Phase 4 — Preferences verification (V12–V14)
+
+**Implementation** — `--surface=preferences`, exercises `recordCreativeVoicePreferenceEvent`.
+
+**Acceptance:**
+- **V12** explicit toggle save → `peer-user-<userPseudonym>` `kind=preference`, auto-approved, `metadata.explicit_user_intent=true`.
+- **V13** `explicitUserIntent=false` → zero appended messages (writer short-circuits at `write-events.ts:905`).
+- **V14** label with a `<First Last>` name → `scrubPreferenceLabelForHoncho` redacts before claim. Run with `ARIES_MEMORY_LABEL_REDACTION_V2=1` (prod default per `docker-compose.yml:78`) and assert "Bold Minimalist" survives while "John Smith" → `[redacted_name]`; also assert email → `[redacted_email]`.
+
+---
+
+### Phase 5 — Idempotency-key burn monitor (operational hardening)
+
+**Implementation**
+- The known trade-off: `claimIdempotencyKey` inserts the key *before* the Honcho append, so a Honcho failure burns the key and the write is never retried (acceptable per spec §Write durability). Add a lightweight check: a periodic query (or a one-shot script) comparing distinct `honcho_write_idempotency_keys` rows against successful appends inferred from the memory-error log rate. If >5% of attempts log a `MemoryError`, that is the Phase 4 outbox contingency trigger from the source plan's NOT-in-scope list.
+
+**Acceptance**
+- A grep-able log line `[honcho-write-events] … failed` count is surfaced (existing `console.error` lines suffice); document the threshold (5% lost-write rate → escalate to outbox) in `TODOS.md`. No new infra.
+
+---
+
+## Testing Plan
+
+Fixture-primary: every V-assertion has an in-process fixture check (injected `HonchoTransport`, test DB pool) that runs in CI. Prod-mode (`--prod`) re-runs the read-back assertions against the live workspace once per flip, run by the operator.
+
+| Assertion | Surface | Fixture check | Prod read-back | Existing coverage |
+|---|---|---|---|---|
+| V0 idempotency (approve) | approvals | yes | row count | `tests/memory-write-events.test.ts` |
+| V1 strategy approve | approvals | yes | GET session/peer | `tests/memory-write-events.test.ts` |
+| V2 explicit deny | approvals | yes | GET both peers | `tests/memory-write-events.test.ts` |
+| V3 deny no-reason → queue | approvals | yes | `review-queue` row | `tests/memory-write-events.test.ts` |
+| V4 gate off | approvals | yes | n/a | `tests/memory-honcho-env.test.ts` |
+| V5 Honcho 503 | approvals | yes (throwing transport) | n/a | — (add) |
+| V6 latency non-blocking | approvals | yes (delayed transport) | n/a | — (add) |
+| V7 publish constraint | publish | yes | `review-queue` row | `tests/publish-verification.test.ts` |
+| V8 schedule constraint | publish | yes | GET peer-policy | `tests/memory-write-events.test.ts` |
+| V9 perf scrub + queue | publish | yes (inject platform_post_id) | `review-queue` row | `tests/memory-write-events.test.ts` |
+| V10 idempotency (publish) | publish | yes | row count | `tests/memory-write-events.test.ts` |
+| V11 volume bound | publish | yes (simulated month) | n/a | — (add to harness) |
+| V12 explicit pref | preferences | yes | GET peer-user | `tests/memory-write-events.test.ts` |
+| V13 inferred rejected | preferences | yes | n/a | `tests/memory-write-events.test.ts` |
+| V14 label scrub | preferences | yes | GET peer-user claim | `tests/memory-label-redaction.test.ts` |
+
+Run gate before flip: `npm run verify` then `APP_BASE_URL=https://aries.example.com tsx --test tests/memory-write-events.test.ts tests/memory-label-redaction.test.ts tests/publish-verification.test.ts tests/memory-honcho-*.test.ts`.
+
+## Rollback
+
+- **Per-surface:** set the offending gate to `false` (`HONCHO_WRITE_APPROVALS_ENABLED` / `_PUBLISH_` / `_PREFERENCES_`) and restart `aries-app`. No data migration; existing Honcho records are append-only and inert.
+- **Whole feature:** `HONCHO_ENABLED=false`. All `schedule*` calls short-circuit.
+- **Secrets backout:** blank `HONCHO_DATA_PLANE_JWT` / `HONCHO_CONTROL_PLANE_JWT` — writes fail-closed silently (D2), caller flows unaffected.
+- **Known trade-off (do not "fix" without the outbox decision):** a write that fails after the idempotency key is claimed is lost and not retried. Acceptable per source-plan §Write durability; escalation threshold is Phase 5's >5% lost-write rate.
+
+## Out of Scope
+
+- Any change to the write-path code, curator rules, or schema (D1, D6).
+- The Meta `/insights` performance poller that *feeds* `recordPerformanceEvent` — that is `docs/plans/2026-05-24-honcho-performance-insights-integration.md`, a separate workstream. This plan only verifies the write function, not the data source.
+- A Postgres outbox for lost writes (source-plan Phase 4 contingency).
+- Pruning superseded messages (source-plan Phase 2.5 contingency, triggered by V11).
+- New peer types or session patterns.
+- Server-side JWT minting (cross-repo, Honcho-side).
+
+## Files Reference
+
+| File | Role |
+|---|---|
+| `backend/memory/write-events.ts` | All five writers + `schedule*` wrappers + scrubbers (landed) |
+| `backend/memory/curator.ts` | `curateFinding` + `rejected_angle`/`preference` conditional auto-approve |
+| `backend/memory/honcho-env.ts` | `isHonchoEnabled` + three write-gate readers + `validateHonchoConfig` |
+| `backend/memory/honcho-http-transport.ts` | JWT bearer selection (control vs data plane) |
+| `backend/memory/pseudonym.ts` | `pseudonymForUser` (`aries-user:` domain separator, L38) |
+| `backend/memory/research-jobs.ts` | `aries_research_findings` queue (L57) + `ensureMarketingMemoryQueueJob` |
+| `backend/marketing/orchestrator.ts` | approval mirror call-site (L2232) |
+| `app/api/publish/dispatch/handler.ts` | publish-verify call-site (L79) |
+| `app/api/social-content/jobs/[jobId]/posts/[postId]/schedule/route.ts` | schedule call-site (L219) |
+| `backend/marketing/hermes-callbacks.ts` | perf-callback call-sites (L1879, L1900) |
+| `app/api/social-content/jobs/[jobId]/creative-voice-preference/handler.ts` | preference call-site (L127) |
+| `app/api/tenant/research/review-queue/route.ts` | review-queue read endpoint (queued findings) |
+| `scripts/init-db.js` | idempotency table (L526) + preferences table (L517) |
+| `docker-compose.yml` | `HONCHO_*` env gates (L101-104), all defaulting `true` |
+| `tests/memory-write-events.test.ts` | primary fixture coverage for all surfaces |
+| `tests/memory-label-redaction.test.ts` | V14 scrub coverage |
+| `tests/publish-verification.test.ts` | V7 publish coverage |
+| `scripts/verify-honcho-writes.mjs` | **new** — V0–V14 harness (fixture + `--prod`) |
+| `docs/plans/2026-05-11-aries-honcho-continuous-profile-writes.md` | source spec (V0–V14 definitions) |

--- a/docs/plans/2026-05-30-id-based-hermes-media.md
+++ b/docs/plans/2026-05-30-id-based-hermes-media.md
@@ -1,0 +1,193 @@
+# ID-based Hermes media addressing (creative_assets.id)
+
+Epic: GitHub issue #508. Risk **L**, investigation confidence **0.62**, load-bearing break on live publishing.
+
+## Context
+
+Generated creative images live in a **flat, non-tenant-namespaced** Hermes image cache, bind-mounted read-only into the Aries container at `HERMES_IMAGE_CACHE_MOUNT` (default `/hermes-media`). The browser-facing media route addresses these images by **basename only** and resolves bytes as `<mount>/<basename>` (`app/api/internal/hermes/media/[...path]/route.ts:64,77`). Basenames are not globally unique: two `creative_assets` rows from different tenants or jobs can share a filename (e.g. `image.png`), and Hermes is not guaranteed to emit collision-free names.
+
+The ownership check, `tenantOwnsHermesMediaBasename` (`backend/marketing/runtime-state.ts:677`), gate-keeps the route with a **basename match** against `served_asset_ref`/`storage_key` (`SELECT 1 ... WHERE tenant_id=$1 AND $2 IN (regexp_replace(served_asset_ref,'^.*/',''), regexp_replace(storage_key,'^.*/',''))`, lines ~698-708). So if tenant A and tenant B both have a row whose ref ends in `image.png`, the check passes for **both**, and the route serves whichever file physically sits at `<mount>/image.png`. That is a cross-tenant content-serve bug, not just a theoretical collision.
+
+Goal: address generated media by its primary key (`creative_assets.id`, a UUID), enforce ownership with the authoritative `WHERE id=$1 AND tenant_id=$2`, and resolve bytes from that row's `storage_key`.
+
+## Who cares
+
+- **Brendan / live tenants** — this is prod (live publishing tenants). A cross-tenant image serve is a data-leak class bug and the dashboard preview path runs through the same route.
+- **Publishing pipeline** — FB/IG publishes sign internal media URLs to public proxy URLs; the cutover must not break live Meta fetches (see the load-bearing break below).
+- **Security review** — basename-keyed ownership on a shared cache is exactly the kind of finding `/cso` flags.
+
+## Decisions (locked, do not re-litigate)
+
+1. **Address by `creative_assets.id` (UUID PK), not by basename.** Confirmed schema: `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`, `UNIQUE (tenant_id, id)` (`scripts/init-db.js:178,195`).
+2. **Ownership is enforced in SQL with `WHERE id=$1 AND tenant_id=$2`.** No more basename `regexp_replace` matching for id-addressed reads.
+3. **Use `pool.query` directly, single query per request — no `Promise.all` fan-out** (guardrail #1). The id route is one indexed PK lookup; do not parallelize it with anything.
+4. **404, never 403**, on missing row / wrong tenant / unresolvable bytes — preserve the existing no-existence-leak posture (route returns 404 throughout today).
+5. **Keep the existing path-traversal guards** (`isWithinRoot` + double `realpath`) when resolving `storage_key` bytes. They stay verbatim.
+6. **Tenant-scoping is non-negotiable** — every read resolves tenant context server-side via `loadTenantContextOrResponse()` (already the pattern at route.ts:41).
+
+## Current State (VERIFIED)
+
+- **Internal media route** `app/api/internal/hermes/media/[...path]/route.ts`
+  - Session-auth via `loadTenantContextOrResponse()` (`:41`).
+  - Accepts exactly one segment, treats it as a basename (`:56-64`), rejects separators/`..` (`:67`).
+  - Resolves `path.resolve(mountRoot, basename)` (`:77`), double-realpath guard (`:88-112`).
+  - Ownership: `tenantOwnsHermesMediaBasename(tenantId, basename)` (`:124`); 404 if not owned.
+  - Streams bytes from the mount (`:134,151`).
+- **Ownership fn** `backend/marketing/runtime-state.ts:677` — DB basename match first (`:698-708`), then sequential filesystem scan of tenant runtime JSON (`:716+`). Vulnerable to cross-tenant basename collision.
+- **Ingest writer** `backend/marketing/ingest-production-assets.ts`
+  - Writes `served_asset_ref = '/api/internal/hermes/media/<basename>'` (`:149`), `storage_kind='runtime_asset'`, `storage_key=readPath` (the in-container mount path) (`:80-93,154-161`).
+  - `INSERT ... ON CONFLICT (tenant_id, checksum) WHERE checksum IS NOT NULL DO NOTHING` — does **not** currently `RETURNING id`.
+- **Public proxy** `app/api/public/media/[token]/[basename]/route.ts` — unauthenticated, gated by HMAC token; resolves bytes by **basename** against the mount (`:67-90`). Serves only `runtime_asset` mount files; cannot serve `ingested_asset` DATA_ROOT files.
+- **Signing** `app/api/publish/dispatch/handler.ts:219 toSignedPublicUrl(internalUrl, tenantId, basename)` — token signs `{tenantId, basename, expiresAt}` (`lib/signed-media-token.ts:42`), URL is `/api/public/media/<token>/<basename>`. Callers compute `basename = path.basename(url)` then sign: dispatch handler `:306-308`, `publish-instagram/handler.ts:137`, `publish-facebook/handler.ts:132`, `scheduled-dispatch/route.ts:176`.
+- **Workspace views** `backend/marketing/workspace-views.ts:1356` selects `served_asset_ref` and sets `previewUrl/fullPreviewUrl = row.served_asset_ref` (`:1543-1544`).
+- **Upload-replace** `backend/marketing/upload-replace.ts:185` — manual uploads INSERT `storage_kind='ingested_asset'`, `storage_key=<DATA_ROOT path>`, and **no `served_asset_ref`** (column omitted → NULL). These uploads are **not servable** via the basename route today (latent bug).
+- **Dashboard projection** `backend/social-content/dashboard-projection.ts` — preview URLs come from runtime-doc `artifact_url` / data-URIs (`:741,760`), not from `served_asset_ref`. Lowest blast radius.
+- **Existing tests:** `tests/hermes-media-tenant-scope.test.ts`, `tests/marketing/ingest-production-assets.test.ts`, `tests/publish-creative-asset-ids.test.ts` (all present; live-db precedent exists).
+
+## The load-bearing break (publishing)
+
+If the internal URL becomes `/api/internal/hermes/media/<id>`, then `path.basename(url)` at the publish call sites yields the **UUID**. `toSignedPublicUrl` signs `{basename: <uuid>}`, and `/api/public/media/[token]/[basename]` resolves `<mount>/<uuid>` — which does not exist. **Live FB/IG publishes 404 at Meta-fetch time, silently.** This is why this issue is staged and not auto-shipped. Any cutover that changes `served_asset_ref` to id-based MUST fix the signing path in the same change, or publishing breaks.
+
+## Architecture
+
+```
+                         BROWSER (operator session)
+                              |
+                              v
+   GET /api/internal/hermes/media/<UUID>         <-- NEW: id branch
+   GET /api/internal/hermes/media/<basename>     <-- KEPT: back-compat fallback
+        |  session tenant ctx (loadTenantContextOrResponse)
+        |
+        +-- UUID?  SELECT storage_kind, storage_key, served_asset_ref, media_type
+        |          FROM creative_assets WHERE id=$1 AND tenant_id=$2   (pool.query, 1 query)
+        |              | no row -> 404
+        |              v
+        |          resolve bytes from storage_key (isWithinRoot + realpath) -> stream
+        |
+        +-- basename? tenantOwnsHermesMediaBasename(tenant, basename) -> <mount>/<basename>
+
+                         META (Graph API fetch, no session)
+                              ^
+                              |
+   GET /api/public/media/<token>/<basename-or-id>   <-- per Decision #1 (option A vs B)
+        ^
+        | toSignedPublicUrl(internalUrl, tenantId, ref)   publish handlers
+        |     dispatch :306 / IG :137 / FB :132 / scheduled :176
+
+  WRITERS:  ingest-production-assets.ts  -> served_asset_ref = /media/<id>  (RETURNING id)
+            upload-replace.ts            -> served_asset_ref = /media/<id>  (optional, Decision #4)
+```
+
+## Open design decisions — recommendations
+
+### Decision 1 — Signing fix: Option A or B? (gates the rollout)
+
+- **Option A (recommended for v1):** Publish handlers resolve `id -> on-disk basename` (look up `creative_assets.storage_key`, take `path.basename`) **before** signing, so the signed public URL and `/api/public/media` stay basename-based and unchanged. Smaller diff, isolates the public proxy from this epic.
+- **Option B:** Make `/api/public/media` id-aware (token carries id; route looks up `creative_assets` by id+tenant; can also serve `ingested_asset` DATA_ROOT files). Larger, but removes the public route's basename collision too and unblocks serving manual uploads to Meta.
+
+**Recommendation: A for this epic, file B as a fast-follow.** Rationale: the internal-route fix already closes the cross-tenant *browser* serve (the security bug). The public proxy is token-gated (HMAC, 1h TTL, single approved image) so its basename collision window is far narrower, and it never serves cross-tenant by accident because the token binds `tenantId`. Doing A keeps the publish blast radius to "resolve id->basename before signing" — one helper, four call sites — and ships the security fix without touching the live Meta-fetch contract. Token shape (`signed-media-token.ts`) stays `{tenantId, basename, expiresAt}`, so existing in-flight tokens remain valid.
+
+### Decision 2 — Cutover vs coexistence
+
+**Recommendation: coexistence + keep the basename fallback route.** New ingest/upload rows get id-based `served_asset_ref`; old rows keep their basename refs and continue to resolve through `tenantOwnsHermesMediaBasename`. No backfill migration of historical `served_asset_ref` in v1. Rationale: a backfill is a write against a live prod table for marginal benefit (old rows already passed ownership), and the fallback route is cheap to keep. Revisit a backfill only if/when we delete the basename route.
+
+### Decision 3 — Route shape: separate `[id]` vs fold into `[...path]`
+
+**Recommendation: fold into the existing `[...path]` catch-all, branch on a strict UUID regex.** Next.js 16 route precedence between a single-segment `[id]` and `[...path]` for a UUID-shaped segment is unverified and fragile; one file with an explicit `UUID_RE.test(segments[0])` branch removes the ambiguity and keeps both code paths visible side by side. Single segment, UUID -> id path; single segment, not UUID -> basename path; anything else -> 404.
+
+### Decision 4 — Also make `ingested_asset` (manual uploads) servable?
+
+**Recommendation: yes, in this epic, via the internal id route only.** `upload-replace.ts` already has the row id at INSERT (`RETURNING id`, `:194`); add `served_asset_ref = '/api/internal/hermes/media/<id>'` and let the id route resolve `storage_kind='ingested_asset'` bytes from the DATA_ROOT `storage_key` (with the same realpath guard, rooted at the ingested-assets root, not the Hermes mount). This is a small, contained latent-bug fix. Do **not** expand the public proxy to ingested assets in v1 (that is Option B / fast-follow). Keep dashboard projection (`dashboard-projection.ts`) on its current runtime-doc/data-URI path — out of scope, lowest risk.
+
+## Phases
+
+| # | Phase | Priority | Effort (human / CC) | Dependencies |
+|---|-------|----------|---------------------|--------------|
+| 1 | Id-aware internal media route (branch in `[...path]`) | P0 | 0.5d / 1 session | none |
+| 2 | Ingest writer emits id-based `served_asset_ref` | P0 | 0.5d / 1 session | none (parallel w/ P1) |
+| 3 | Publish signing: resolve id->basename before signing (Option A) | P0 | 0.5d / 1 session | P2 |
+| 4 | Workspace-views previewUrl uses id-based ref (automatic) + verify | P1 | 0.25d / 1 session | P1, P2 |
+| 5 | Manual-upload servability (`ingested_asset` via id route) | P2 | 0.5d / 1 session | P1 |
+
+### Phase 1 — Id-aware internal media route
+
+**Implementation** (`app/api/internal/hermes/media/[...path]/route.ts`):
+- Add `const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;`.
+- After tenant ctx + single-segment validation (`:41-72`), branch: if `UUID_RE.test(segments[0])` run the id path; else fall through to the existing basename path unchanged.
+- Id path: `const { rows } = await pool.query('SELECT storage_kind, storage_key, served_asset_ref, media_type FROM creative_assets WHERE id=$1 AND tenant_id=$2 LIMIT 1', [segments[0], Number(tenantId)]);` — one query, no fan-out (guardrail #1). No row -> 404.
+- Resolve bytes from `storage_key`: choose the allowed root by `storage_kind` (`runtime_asset` -> Hermes mount root; `ingested_asset` -> ingested-assets DATA_ROOT root). Reuse `isWithinRoot` + double-`realpath`. `external_url`/`none` or null `storage_key` -> 404.
+- Stream with `new Uint8Array(buffer)` and content-type from the resolved path (reuse `contentTypeForPath`).
+
+**Acceptance:**
+- GET `/media/<idA>` as tenant A serves A's bytes; same path as tenant B -> 404 (no cross-serve, no existence leak).
+- Non-UUID single segment still resolves through `tenantOwnsHermesMediaBasename` (back-compat green).
+- Null/`external_url`/`none` `storage_key` -> 404. Path traversal in resolved `storage_key` blocked.
+
+### Phase 2 — Ingest writer emits id-based ref
+
+**Implementation** (`backend/marketing/ingest-production-assets.ts`):
+- `INSERT_PRODUCTION_ASSET_SQL`: append `RETURNING id`. `served_asset_ref` can no longer be computed pre-insert from the id; either (a) INSERT with `served_asset_ref=NULL`, read `RETURNING id`, then `UPDATE ... SET served_asset_ref='/api/internal/hermes/media/'||id WHERE id=$1 AND tenant_id=$2` (two statements, still sequential — no fan-out), or (b) use a CTE: `WITH ins AS (INSERT ... RETURNING id) UPDATE creative_assets SET served_asset_ref='/api/internal/hermes/media/'||id FROM ins WHERE creative_assets.id=ins.id`. Prefer (b) — single round-trip, atomic.
+- Keep `storage_key=readPath` (mount path) and the `ON CONFLICT (tenant_id, checksum) WHERE checksum IS NOT NULL` predicate exactly (guards the partial index, per the file's own warning `:74-79`). On conflict (0 rows), no ref rewrite — existing row keeps its ref.
+
+**Acceptance:** new ingest rows have `served_asset_ref='/api/internal/hermes/media/<that row's id>'`; `storage_key` unchanged; replayed callback still idempotent (0 inserted on duplicate checksum).
+
+### Phase 3 — Publish signing (Option A)
+
+**Implementation:** at each sign site, before `toSignedPublicUrl`, if the internal URL's last segment is a UUID, look up the row's on-disk basename (`SELECT storage_key FROM creative_assets WHERE id=$1 AND tenant_id=$2`, `path.basename(storage_key)`) and sign with that basename + an internal URL the public route can resolve. Add one shared helper `resolveSignableBasename(internalUrl, tenantId)` to avoid duplicating the lookup across dispatch handler `:306`, IG `:137`, FB `:132`, scheduled `:176`. Non-UUID URLs keep today's `path.basename(url)` behavior. Single query per URL (guardrail #1) — do not `Promise.all` the lookups across media_urls; map sequentially.
+
+**Acceptance:** a job whose `served_asset_ref` is id-based produces a signed public URL whose `/api/public/media/<token>/<basename>` resolves real bytes (parity test). Legacy basename refs still sign and resolve unchanged.
+
+### Phase 4 — Workspace-views verify
+
+**Implementation:** none required — `workspace-views.ts:1543` already passes `served_asset_ref` straight through to `previewUrl/fullPreviewUrl`, so id-based refs flow automatically. Add a test asserting the `<img src>` is the id URL and that the route serves it under session.
+
+**Acceptance:** operator dashboard preview renders an id-addressed image end-to-end (route serves bytes for the session tenant).
+
+### Phase 5 — Manual-upload servability
+
+**Implementation** (`backend/marketing/upload-replace.ts`): add `served_asset_ref` to `INSERT_REPLACEMENT_SQL` (`:185`) via the same CTE pattern as Phase 2, set to `/api/internal/hermes/media/<id>`. Phase-1 id route resolves `ingested_asset` bytes from the DATA_ROOT `storage_key`.
+
+**Acceptance:** a manual replacement upload becomes servable through the internal id route for the owning tenant; cross-tenant -> 404.
+
+## Testing Plan (fixture-primary)
+
+| Test file | Type | Asserts |
+|-----------|------|---------|
+| `tests/hermes-media-id-addressing.test.ts` (new) | live-db | two rows, different tenants, same on-disk basename; GET `/media/<idA>` as A -> A's bytes; as B -> 404; `ingested_asset` id serves 200; non-UUID/missing/null `storage_key`/`external_url` -> 404; path traversal blocked |
+| `tests/marketing/ingest-production-assets.test.ts` (update) | fixture | `served_asset_ref` is `/media/<id>`; idempotent replay; `storage_key` unchanged |
+| `tests/publish-creative-asset-ids.test.ts` (update) | fixture | id->basename resolution before signing; legacy basename path unchanged |
+| publishing parity (new or extend dispatch test) | fixture | id-based ref -> signed public URL -> `/api/public/media` resolves real bytes |
+| `tests/hermes-media-tenant-scope.test.ts` (keep green) | live-db | basename fallback path still enforces ownership |
+
+Run `npm run verify` (bakes env overrides) then the focused `validate:social-content` / publish tests with `APP_BASE_URL=https://aries.example.com`. Validate against the live DB per project memory (mock-pass does not count as done).
+
+## Rollback
+
+- All changes are additive/back-compat: the basename route + `tenantOwnsHermesMediaBasename` stay. Reverting Phases 1-3 restores basename-only addressing; existing rows (basename refs) keep working because no historical refs are rewritten (Decision 2).
+- No schema migration (id, `served_asset_ref`, `storage_key` all already exist). Nothing to down-migrate.
+- If publishing regresses post-deploy, revert Phase 2 (stop writing id refs); Phase 3's id-branch becomes inert because no new id refs are produced.
+
+## Out of Scope
+
+- Backfilling historical `served_asset_ref` to id-based (Decision 2).
+- Option B (id-aware public proxy + serving `ingested_asset` to Meta) — fast-follow.
+- Dashboard projection (`dashboard-projection.ts`) preview source change — stays on runtime-doc/data-URI.
+- Tenant-namespacing the physical Hermes cache directory (Hermes-side concern; out of Aries scope).
+- Deleting the basename route or `tenantOwnsHermesMediaBasename`.
+
+## Files Reference
+
+| File | Role | Change |
+|------|------|--------|
+| `app/api/internal/hermes/media/[...path]/route.ts` | internal media GET | P1: UUID branch + id->storage_key resolve |
+| `backend/marketing/ingest-production-assets.ts` | ingest writer | P2: `RETURNING id`, id-based `served_asset_ref` (CTE) |
+| `app/api/publish/dispatch/handler.ts` | `toSignedPublicUrl` + dispatch | P3: `resolveSignableBasename` helper, id->basename before sign (`:306`) |
+| `app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts` | IG publish | P3: use shared resolver (`:137`) |
+| `app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts` | FB publish | P3: use shared resolver (`:132`) |
+| `app/api/internal/publishing/scheduled-dispatch/route.ts` | scheduled publish | P3: use shared resolver (`:176`) |
+| `app/api/public/media/[token]/[basename]/route.ts` | public proxy | unchanged in v1 (Option A); Option B fast-follow |
+| `backend/marketing/runtime-state.ts` | `tenantOwnsHermesMediaBasename` | unchanged (back-compat fallback, `:677`) |
+| `backend/marketing/workspace-views.ts` | preview URLs | P4: no code change; verify id refs flow (`:1543`) |
+| `backend/marketing/upload-replace.ts` | manual upload INSERT | P5: add id-based `served_asset_ref` (`:185`) |
+| `lib/signed-media-token.ts` | token shape | unchanged (Option A keeps basename claim) |
+| `scripts/init-db.js` | schema | unchanged (id/refs already present, `:178`) |

--- a/docs/plans/2026-05-30-publishing-reliability.md
+++ b/docs/plans/2026-05-30-publishing-reliability.md
@@ -1,0 +1,232 @@
+# Publishing reliability — creative_asset_ids population + Meta failure taxonomy
+
+**Status:** Open. Two bundled publishing-reliability items from `TODOS.md`.
+**Author:** Staff eng plan, 2026-05-30.
+**Related:**
+- `app/api/internal/publishing/scheduled-dispatch/route.ts` (per-post media resolver + stale comment)
+- `backend/integrations/meta-publishing.ts` (Meta Graph publish + `MetaPublishError`)
+- `backend/marketing/synthesize-publish-posts.ts`, `backend/integrations/publish-verification.ts` (existing `creative_asset_ids` writers)
+- Prior art: PR `d7fda3a` (populate `creative_asset_ids` in publish stage), `e7b0956` (merge into Phase 2 scheduling)
+
+---
+
+## Context
+
+Two adjacent reliability gaps in the Meta publishing path, bundled because they touch the same files and the same operator failure mode (the wrong image goes out, or a post silently dies with no actionable signal).
+
+1. **`posts.creative_asset_ids` is the per-post media link** that lets `resolveMediaUrls` pick the *exact* image for a scheduled post instead of falling back to a job-scoped join that returns *every* image the weekly job produced. The write paths now exist in code (shipped via `d7fda3a` / `e7b0956`), but the resolver still carries a stale comment asserting "no Aries code populates it yet — every prod `posts` row has `creative_asset_ids = '{}'`" (`scheduled-dispatch/route.ts:43-48`), and **existing prod rows written before those PRs are still `'{}'`**. Until the data is backfilled and the manual schedule path is verified to carry ids forward, a multi-image weekly job can still publish the wrong creative.
+
+2. **Meta publish failures already carry a 2-axis model** (`retryable` + `outcomeUnknown`) but there is **no explicit auth class**. `oauth_token_missing` / `external_account_missing` are surfaced as generic `retryable:false` errors — indistinguishable from a malformed-request 400 — so an operator whose token expired gets "publish failed" with no "reconnect your account" signal, and the worker treats it as terminal-but-opaque. We want a single, named transient / permanent / auth taxonomy with distinct retry + surface behavior.
+
+## Who cares
+
+- **Brendan (single-tenant prod operator):** publishing the wrong image to a live Meta account is a brand-visible mistake; a silent "publish failed" with no reconnect prompt is a dead end.
+- **The scheduled-posts worker** (`scripts/automations/scheduled-posts-worker.mjs`): needs a clean retryable/terminal signal so it neither hammers a permanently-broken post nor abandons a transient one.
+- **Future analytics / Honcho performance loop:** depends on `creative_asset_ids` to attribute performance back to a specific creative.
+
+## Decisions (locked — do not re-litigate)
+
+- **D1.** `creative_asset_ids` is `TEXT[]`, entries match **either** `creative_assets.id` (uuid text) **or** `creative_assets.source_asset_id` (`img_1`, …). The resolver already joins on both forms (`scheduled-dispatch/route.ts:85-86`); do not change the column type or the dual-form contract.
+- **D2.** The job-scope fallback in `resolveMediaUrls` (`route.ts:89-93`) **stays** as a safety net for legacy rows. We do not remove it; we make the populated path primary and verify the fallback only fires for genuinely-empty rows.
+- **D3.** The Meta failure taxonomy is **derived**, not stored: it is computed from the existing `MetaPublishError` fields. We do **not** add a new DB column for it. `outcomeUnknown` already encodes the never-auto-retry class and must keep its exact current semantics (a 2xx-accepted publish with no confirmed id is NOT safe to retry).
+- **D4.** The Graph publish calls (`/feed`, `/media_publish`, `/photo_stories`) have **no idempotency primitive** — closing the double-publish window is explicitly out of scope (documented at `scheduled-dispatch/route.ts:185-201`). The taxonomy must never auto-retry an `outcome_unknown` failure.
+- **D5.** Backfill is a **one-shot script run against prod**, idempotent and tenant-scoped, gated behind a dry-run default. It does not run in `init-db.js` (schema migrations only).
+- **D6.** No new env flag for the taxonomy. The `auth` class changes the *response shape* (a `needs_reconnect` reason) but not the retry policy beyond what `retryable:false` already does — it is additive and safe to ship un-gated.
+
+## Current State (VERIFIED)
+
+### Item 1 — creative_asset_ids
+
+- **Schema:** `posts.creative_asset_ids TEXT[] NOT NULL DEFAULT '{}'` — `scripts/init-db.js:432`.
+- **Writers that already populate it (on master):**
+  - `backend/marketing/synthesize-publish-posts.ts:350,362` — autonomous-mode synthesized posts set `creativeAssetIds = assetId ? [assetId] : []` from the ingested `creative_assets` (post_number → Nth asset by `source_asset_id`).
+  - `backend/integrations/publish-verification.ts:159-182` — `persistPublishedPost` normalizes and inserts `creative_asset_ids` (drops blanks/dupes; empty array keeps the column default).
+  - `app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts:108` and `.../publish-facebook/handler.ts:104` — capture `publishedAssetId` from the approved creative and thread it into the persisted post.
+- **Reader:** `resolveMediaUrls` (`scheduled-dispatch/route.ts:63-118`) joins `posts → creative_assets` on the per-post ids (`route.ts:82-87`) with a job-scope fallback when the array is empty (`route.ts:89-93`).
+- **The gap (VERIFIED):**
+  - The resolver comment at `scheduled-dispatch/route.ts:43-48` still asserts "no Aries code populates it yet — every prod `posts` row has `creative_asset_ids = '{}'`." **Stale** — contradicted by the writers above (PR `d7fda3a` is an ancestor of `master`).
+  - **Rows written before `d7fda3a` are still `'{}'`** and rely on the fallback; a backfill has never run. (Could not query prod from this worktree — `psql` not installed; treat backfill as required, verify counts at run time.)
+  - The **manual social-content schedule path** (`app/api/social-content/jobs/[jobId]/posts/[postId]/schedule/route.ts:211` → `upsertScheduledPost`) reads an existing `posts` row and creates a `scheduled_posts` row; it does **not** write `creative_asset_ids` itself — it inherits whatever the `posts` row already had. So any post created by a path that did not set the column publishes via the fallback.
+
+### Item 2 — Meta failure taxonomy
+
+- **Error type:** `MetaPublishError` (`meta-publishing.ts:50-76`) carries `code`, `status`, `retryable` (default false), `outcomeUnknown` (default false).
+- **Existing classifier:** `classifyMetaPublishFailure` (`meta-publishing.ts:99-104`) returns `'definitely_never_posted' | 'outcome_unknown'` — only the publish-acceptance axis.
+- **All thrown codes (VERIFIED, `meta-publishing.ts`):**
+  | Code | status | retryable | outcomeUnknown | True nature |
+  |---|---|---|---|---|
+  | `unsupported_provider` | 400 | – | – | permanent |
+  | `invalid_scheduled_for` | 400 | – | – | permanent |
+  | `missing_content` | 400 | – | – | permanent |
+  | `instagram_media_required` | 400 | – | – | permanent |
+  | `story_single_media_required` | 400 | – | – | permanent |
+  | `oauth_token_missing` | 409 | – | – | **auth** (no class today) |
+  | `external_account_missing` | 409 | – | – | **auth** (no class today) |
+  | `*_scheduled_publish_not_supported` | 409 | – | – | permanent |
+  | `graph_network_error` | 502 | true | – | transient |
+  | `graph_rate_limited` | 429 | true | – | transient (after MAX_429_RETRIES) |
+  | `graph_api_error` (5xx) | 5xx | true | – | transient |
+  | `graph_api_error` (4xx) | 4xx | false | – | permanent |
+  | `instagram_container_timeout` | 504 | true | – | transient |
+  | `instagram_container_failed` | 422 | false | – | permanent |
+  | `*_publish_missing_id` | 502 | false | **true** | outcome-unknown |
+- **Consumers:**
+  - `publish-facebook/handler.ts:289-344` and `publish-instagram/handler.ts:294-344` — branch on `classifyMetaPublishFailure` for the `needs_manual_reconciliation` (outcome-unknown) case, then fall through to a generic `{status:'error', reason: error.code}` for everything else. **No auth-specific branch.**
+  - `scheduled-dispatch/route.ts:231-244` — maps `MetaPublishError.retryable` straight onto the per-platform result; auth failures (`retryable:false`) become opaque terminal failures.
+  - `scheduled-posts-worker.mjs:234` — `retryable = result ? result.retryable !== false : true`; drives `pending` (retry) vs `failed` (terminal). It never learns a failure was auth-related, so a tenant whose token expired gets N posts silently marked `failed` with no reconnect signal.
+
+## Architecture
+
+```
+                         ┌─────────────────── Item 1: per-post media link ───────────────────┐
+ publish handlers ──┐    │                                                                    │
+ (fb / ig)          │    │   posts.creative_asset_ids  (TEXT[]: uuid OR source_asset_id)      │
+ synthesize-posts ──┼──► │        ▲ writers (live on master)        │                          │
+ publish-verif.  ───┘    │        │                                 ▼                          │
+                         │   [BACKFILL one-shot]            resolveMediaUrls(postId,tenant)    │
+ manual schedule ───────►│   inherits row's ids       ┌── per-post join (ids present) ◄── primary
+   (upsertScheduledPost) │                            └── job-scope join (ids empty)  ◄── fallback (D2)
+                         └────────────────────────────────────────────┬───────────────────────┘
+                                                                       │ signed media_urls
+                                                                       ▼
+ scheduled-posts-worker ──POST──► /api/internal/publishing/scheduled-dispatch ──► publishToMetaGraph
+        ▲   retry/terminal                                  │                          │
+        │                                                   │              throws MetaPublishError
+        │   ┌──────────── Item 2: failure taxonomy ─────────┘                          │
+        └───┤ classifyMetaPublishFailureKind(error) ──► 'transient' | 'permanent' |    │
+            │   'auth' | 'outcome_unknown'                                              │
+            │     transient  → retryable, worker re-claims                              │
+            │     permanent  → terminal 'failed'                                        ◄┘
+            │     auth       → terminal 'failed' + reason:'needs_reconnect' surfaced
+            │     outcome_unknown → claim left, never retried (D4)
+            └────────────────────────────────────────────────────────────────────────
+```
+
+## Child issues / phases
+
+| # | Phase | Priority | Effort (human / CC) | Dependencies |
+|---|---|---|---|---|
+| P1 | Backfill `creative_asset_ids` on prod + verify manual schedule path | P1 | M / S | none |
+| P2 | Make populated path primary: remove stale comment, populated-first test | P1 | S / S | P1 |
+| P3 | Meta failure taxonomy: add `auth` + named transient/permanent classifier | P2 | S / S | none (parallel to P1/P2) |
+| P4 | Wire taxonomy into handlers + worker surface (`needs_reconnect`) | P2 | S / S | P3 |
+
+---
+
+### P1 — Backfill + verify the manual schedule path
+
+**Implementation**
+
+1. Write `scripts/backfill-creative-asset-ids.mjs` (one-shot, dry-run default, **not** wired into `init-db.js` per D5). For each `posts` row where `array_length(creative_asset_ids,1) IS NULL` AND `job_id IS NOT NULL`, resolve the job's `creative_assets` (`source_job_id = posts.job_id`, `source_type='generated_by_aries'`, ordered by `source_asset_id`) and:
+   - If the job produced exactly one asset, set `creative_asset_ids = ARRAY[<that asset's source_asset_id>]` — non-regressive vs the current fallback, and now exact.
+   - If the job produced multiple assets, the post→asset mapping is ambiguous for legacy rows (no `post_number` recorded on the row). **Do not guess.** Log these rows and leave them on the fallback. Report the count.
+   - Tenant-scope every query (`WHERE tenant_id = $1`); iterate tenants. Respect guardrail #1 — sequential per-tenant, no `Promise.all` fan-out over the pool.
+2. Run `--dry-run` first, capture before/after counts (`total`, `populated`, `empty`, `ambiguous_multi`). Then run for real.
+3. Verify the manual schedule path: confirm `upsertScheduledPost` (`backend/social-content/scheduled-posts.ts`) and the schedule route (`schedule/route.ts:211`) read a `posts` row that already has `creative_asset_ids` set (it does for posts created by the synthesize / publish-verification writers). Add an assertion-style check; if a post-creation path is found that does NOT set the column, file it as a P1 follow-up (do not expand scope here).
+
+**Acceptance**
+
+- Dry-run report prints `total / populated / empty / ambiguous_multi` counts for prod.
+- After the real run, every single-asset legacy row has a non-empty `creative_asset_ids`; multi-asset ambiguous rows are logged and untouched.
+- Re-running the script is a no-op (idempotent: it only touches `array_length IS NULL` rows).
+- A scheduled post for a multi-image job, when dispatched, resolves to its own image (verified via `resolveMediaUrls` returning the per-post asset, not the whole job set).
+
+### P2 — Make the populated path primary
+
+**Implementation**
+
+1. Delete the stale "no Aries code populates it yet — every prod `posts` row has `creative_asset_ids = '{}'`" comment block (`scheduled-dispatch/route.ts:43-48`); replace with a 2-line note that the column is populated by the publish/synthesize writers and the job-scope join is a legacy/empty-row fallback (D2).
+2. No SQL change to `resolveMediaUrls` — the join already prefers populated ids. Keep the fallback (D2).
+3. Add a regression test asserting the **populated path is taken** (per-post asset returned) and the fallback only fires when the array is empty. Extend `tests/scheduled-dispatch-media-resolution.test.ts` / `tests/publish-creative-asset-ids.test.ts` (both already exercise this seam via the injectable `DispatchQueryable`).
+
+**Acceptance**
+
+- `npm run validate:banned-patterns` passes (confirm the deleted comment is not itself a banned literal first).
+- New test proves: row with ids → per-post join used; row with `'{}'` → job-scope fallback used. Both assert exact returned URLs.
+
+### P3 — Failure taxonomy classifier
+
+**Implementation**
+
+1. In `meta-publishing.ts`, add `export type MetaPublishFailureKind = 'transient' | 'permanent' | 'auth' | 'outcome_unknown';`
+2. Add `export function classifyMetaPublishFailureKind(error: unknown): MetaPublishFailureKind`:
+   - `outcome_unknown` first if `error instanceof MetaPublishError && error.outcomeUnknown` (preserve D3 / D4 semantics).
+   - `auth` if `error.code === 'oauth_token_missing' || error.code === 'external_account_missing'`.
+   - `transient` if `error.retryable === true`.
+   - `permanent` otherwise (including non-`MetaPublishError` throws). Note: a bare network throw is already wrapped as `graph_network_error` (retryable) before it reaches a caller, and the dispatch route independently treats raw non-Meta throws as retryable at `route.ts:237` — keep that route behavior; this classifier is for `MetaPublishError`s.
+3. Keep the existing `classifyMetaPublishFailure` (2-class) for the outcome-unknown branch consumers — do **not** rename it (avoids touching the handler reconciliation branches). The new function is additive.
+4. Unit-test every code in the table above maps to the expected kind.
+
+**Acceptance**
+
+- `tests/meta-publishing.test.ts` extended: a parametrized test over each known code asserts `classifyMetaPublishFailureKind` returns the kind from the Current State table.
+- `outcome_unknown` still wins over `transient`/`permanent` when `outcomeUnknown` is set (a `*_publish_missing_id` at status 502 is `outcome_unknown`, never `transient`).
+- `oauth_token_missing` and `external_account_missing` return `auth`.
+
+### P4 — Wire taxonomy into handlers + worker
+
+**Implementation**
+
+1. In `publish-facebook/handler.ts` and `publish-instagram/handler.ts`, after the existing `outcome_unknown` branch (lines ~289/294), add an `auth` branch using `classifyMetaPublishFailureKind`: return `{status:'error', reason:'needs_reconnect', code: error.code, message: <reconnect-your-Meta-account copy>}` with the existing `error.status` (409). This is a distinct, operator-actionable signal — not a generic `publish_failed`.
+2. In `scheduled-dispatch/route.ts`, when building each per-platform result (lines ~231-244), include the failure kind: `{provider, ok:false, error, retryable, kind}`. Keep `retryable` exactly as today (auth stays `retryable:false` → terminal). The `kind` is informational so the worker can surface it.
+3. In `scheduled-posts-worker.mjs`, thread `kind` from the dispatch result through `normalizeResults` (line ~228-236) onto the per-platform `scheduled_post_dispatches.error_message` (e.g. prefix `auth: token expired — reconnect required`) so an operator inspecting a stuck `failed` row sees *why*. No retry-policy change — auth is already terminal; this is a surface-only improvement.
+
+**Acceptance**
+
+- Auth failure (mock `oauth_token_missing`) through a publish handler returns `reason:'needs_reconnect'` at status 409 — verified in `tests/smoke-meta-publish.test.ts` or a new handler test.
+- Dispatch route includes `kind` on each per-platform result; transient still maps to `pending`/retry, auth + permanent to terminal `failed`.
+- Worker writes the auth reason into `scheduled_post_dispatches.error_message`; a terminal `failed` row for an expired token is distinguishable from a malformed-request `failed` row.
+- `outcome_unknown` path is byte-for-byte unchanged (claim left in place, no retry) — regression-asserted.
+
+## Testing Plan
+
+Fixture-primary; the publish seam is fully injectable (`DispatchQueryable`, `fetchImpl`, mock pools) so no live Meta calls.
+
+| Layer | Test | Type | Asserts |
+|---|---|---|---|
+| Backfill | `tests/backfill-creative-asset-ids.test.ts` (new) | fixture (mock pool) | single-asset row populated; multi-asset row untouched + counted; re-run no-op |
+| Resolver | `tests/scheduled-dispatch-media-resolution.test.ts` (extend) | fixture | populated ids → per-post join; `'{}'` → job-scope fallback; exact URLs |
+| Resolver | `tests/publish-creative-asset-ids.test.ts` (existing, keep green) | fixture | writers populate the column; resolver scopes per-post |
+| Classifier | `tests/meta-publishing.test.ts` (extend) | unit | every code → expected kind; `outcome_unknown` precedence; auth codes |
+| Handlers | `tests/smoke-meta-publish.test.ts` (extend) | fixture (fetch mock) | `auth` → `needs_reconnect`/409; transient → retryable; outcome-unknown → `needs_manual_reconciliation` unchanged |
+| Worker | worker normalize test (extend existing) | unit | `kind` threaded; retry policy unchanged; auth reason in `error_message` |
+| Live-DB | `tests/marketing/synthesize-publish-posts-live-db.test.ts` (keep green) | live PG | synthesized posts carry `creative_asset_ids` |
+| Gate | `npm run verify` + `npm run validate:banned-patterns` | suite | no banned literals reintroduced; fast regression green |
+
+**Run before pushing:** `npm run verify` (CLAUDE.md pre-push gate). The backfill script is run manually against prod, not in CI — verify dry-run counts first (treat-as-production guardrail).
+
+## Rollback
+
+- **P1 (backfill):** data-only. Rollback = nothing to revert in code; the script never deletes ids, only fills `NULL`-length rows. If a populated id is wrong, the resolver's job-scope fallback (D2) does not re-engage for a populated row — to revert a specific tenant, `UPDATE posts SET creative_asset_ids = '{}' WHERE tenant_id = $1 AND <condition>` re-enables the fallback. Capture the dry-run report so the affected row set is known.
+- **P2:** comment + test only; `git revert` is clean, no behavior change to the SQL.
+- **P3:** additive function; unused if P4 not shipped. Revert is isolated.
+- **P4:** the `needs_reconnect` branch and `kind` field are additive. Reverting restores the generic `{reason: error.code}` response. Retry policy never changed, so the worker behaves identically on revert. The `outcome_unknown` path is untouched by design and is the highest-risk-if-broken surface — guarded by an unchanged regression test.
+
+## Out of Scope
+
+- Closing the double-publish window (no Meta-side idempotency primitive; documented at `scheduled-dispatch/route.ts:185-201`) — D4.
+- Auto-refreshing expired Meta tokens / triggering re-consent flow — `auth` class only *surfaces* the need to reconnect; the OAuth reconnect UI is a separate workstream.
+- Video / Reels / Stories publishing surface changes (see MEMORY: Meta publish surface).
+- Performance-metrics fetch loop (covered by `docs/plans/2026-05-24-honcho-performance-insights-integration.md`).
+- Multi-asset legacy-row disambiguation (no `post_number` on legacy rows) — backfill leaves these on the fallback rather than guessing.
+- Changing the `creative_asset_ids` column type or the dual-id-form join (D1).
+
+## Files Reference
+
+| File | Role | Touched by |
+|---|---|---|
+| `scripts/init-db.js:432` | `posts.creative_asset_ids` schema | read only |
+| `scripts/backfill-creative-asset-ids.mjs` | one-shot backfill (new) | P1 |
+| `app/api/internal/publishing/scheduled-dispatch/route.ts:43-48,63-118,231-244` | resolver + stale comment + per-platform result | P2, P4 |
+| `backend/marketing/synthesize-publish-posts.ts:350,362` | autonomous writer (verify) | P1 (read) |
+| `backend/integrations/publish-verification.ts:159-182` | publish-verification writer (verify) | P1 (read) |
+| `app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts:104,289-344` | writer + error branches | P4 |
+| `app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts:108,294-344` | writer + error branches | P4 |
+| `app/api/social-content/jobs/[jobId]/posts/[postId]/schedule/route.ts:211` | manual schedule path (verify inherits ids) | P1 (verify) |
+| `backend/integrations/meta-publishing.ts:50-104` | `MetaPublishError` + classifiers | P3 |
+| `scripts/automations/scheduled-posts-worker.mjs:228-236` | retry/terminal + surface | P4 |
+| `tests/publish-creative-asset-ids.test.ts` | resolver + writer regression | P2 |
+| `tests/scheduled-dispatch-media-resolution.test.ts` | resolver regression | P2 |
+| `tests/meta-publishing.test.ts` | classifier unit | P3 |
+| `tests/smoke-meta-publish.test.ts` | handler surface | P4 |
+| `tests/marketing/synthesize-publish-posts-live-db.test.ts` | live-PG writer | P1 (keep green) |

--- a/docs/plans/2026-05-30-social-content-list-perf-phase3.md
+++ b/docs/plans/2026-05-30-social-content-list-perf-phase3.md
@@ -1,0 +1,292 @@
+# Social-content list endpoint perf — Phase 3 (list-projection + client-refetch)
+
+## Context
+
+`GET /api/social-content/posts` is the campaign-list / results / dashboard-home hot
+path. Phases 1–2 (shipped v0.1.13.5/.6) removed double-hydration and made the
+shell non-blocking, but the endpoint still **fully hydrates every job's workspace
+view** to build the list. With N jobs it fans out N full `buildSocialContentWorkspaceView`
+calls at concurrency 4 — each of which does a `creative_assets` Postgres query, a
+dashboard-content build, a stage-payload-bundle load, and (when review state drifts)
+a `saveSocialContentWorkspaceRecord` DB write. The list-screen comment itself
+records the symptom: "this can take 10-40s" (`frontend/aries-v1/post-list.tsx:28`).
+
+Phase 3 is the structural fix the prior phases deferred: return a **lightweight
+projection** (the ~13 scalars + `counts` + first-3 previews the list cards actually
+render) without building the full per-job workspace view, and have the detail
+screen **refetch full detail client-side** when a card is opened.
+
+## Who cares
+
+- **Brendan / operators** — the social-content list and `/dashboard/results` are
+  the daily landing screens; a 10-40s load on every visit is the single worst
+  perceived-latency surface in the app.
+- **Eng** — the full fan-out is the largest single contributor to the
+  `ARIES_WEB_CONCURRENCY * DB_POOL_MAX` connection budget (guardrail #1); one list
+  request can occupy 4 pool slots for the entire hydration window per container.
+
+## Decisions (locked — do not re-litigate)
+
+1. **Projection is server-side, not a client trim.** The endpoint must stop
+   *computing* the full workspace view per job, not just stop serializing it.
+   Trimming the JSON without removing the compute leaves the latency untouched.
+2. **`pendingApprovals` accuracy is non-negotiable and stays full-fidelity.** The
+   v0.1.13.7 attempt to skip the DB `creative_assets` merge under-counted approvals
+   when an operator rejected a DB-only asset (see the reverted-attempt note in
+   `tests/runtime-views-list-projection.test.ts`). The projection must derive
+   `pendingApprovals` from a path that still honors persisted reject decisions —
+   the golden oracle test (`assertListMatchesOracle`) stays green.
+3. **Card fields are frozen by the current UI.** The projection returns exactly
+   what `post-list.tsx` + the three view-models read (enumerated in Current State).
+   The full `dashboard.{posts,assets,publishItems,calendarEvents,statuses}` arrays
+   are dropped from the list payload; the detail screen fetches them on open.
+4. **Detail fetch reuses the existing per-job endpoint.** Client-refetch points at
+   the already-shipped `GET /api/social-content/jobs/[jobId]` (full status) —
+   no new detail endpoint.
+5. **Tenant-scoping and dedup semantics are preserved byte-for-byte.** Same
+   first-wins dedup key (`externalPostId || name || job::<id>`), same updatedAt sort.
+6. **Resumability / no fan-out regression.** Keep `processConcurrent(…, 4)`; do not
+   raise concurrency (guardrail #1). The win comes from *less work per slot*, not
+   more slots.
+
+## Current State (VERIFIED — master @ v0.1.13.15)
+
+- **Route** `app/api/social-content/posts/route.ts:17-21` — `Promise.all` of
+  `listSocialContentJobsForTenant`, `listDeletedSocialContentJobsForTenant`,
+  `loadTenantBrandKit`; returns `{ posts, hasMore, deletedPosts, currentBrandKitExtractedAt }`.
+- **List builder** `backend/marketing/runtime-views.ts:1594-1692`
+  (`listSocialContentJobsForTenant`). Default page limit 20
+  (`CAMPAIGN_LIST_DEFAULT_LIMIT`, line 1592). Two-phase fan-out:
+  - Phase 1 (`:1632-1644`) per job: `loadSocialContentJobRuntime` →
+    `getMarketingJobStatus({runtimeDoc})` → **`buildSocialContentWorkspaceView({runtimeDoc})`**.
+  - Phase 2 (`:1664-1676`) per job: `buildReviewItemsFromContext(...).filter(!approved).length`
+    for `pendingApprovals`.
+  - Then `buildCampaignListItem` (`:1682`) + updatedAt sort (`:1685-1689`).
+- **The expensive call** `buildSocialContentWorkspaceView`
+  (`backend/marketing/workspace-views.ts:1406-...`) per job does:
+  `ensureSocialContentWorkspaceRecord`, `buildSocialContentDashboardProjection`,
+  `getMarketingDashboardSocialContentJobContent` (`dashboard-content.ts:2902`),
+  `loadStagePayloadBundle` (`:446`), a **`creative_assets` Postgres query**
+  (`workspace-views.ts:1357` SQL / `:1378` `pool.query`), `buildBrandReview` /
+  `buildStrategyReview` / `buildCreativeReview`, and a conditional
+  `saveSocialContentWorkspaceRecord` **DB write** (`:1484`).
+- **Card item shape** `RuntimePostListItem`
+  (`backend/marketing/runtime-views.ts:75-114` server / `lib/api/aries-v1.ts:36-87`
+  client) embeds the full `dashboard` object (`runtime-views.ts:490-496`) plus
+  `previewPosts`/`previewAssets` = `dashboard.{posts,assets}.slice(0,3)` (`:488-489`)
+  and `counts` (`:474-487`).
+- **Who actually reads which fields:**
+  - `frontend/aries-v1/view-models/post-list.ts:86-100` — scalars only
+    (`id,name,summary,status,trustNote,objective,dateRange,nextScheduled,pendingApprovals,stageLabel,updatedAt`).
+  - `frontend/aries-v1/view-models/results.ts:143-154` — same scalars + `status`.
+  - `frontend/aries-v1/post-list.tsx:163-186` (rendered card) — reads
+    **`counts.*`**, **`previewPosts`**, **`previewAssets`**, **`dashboard.assets`**
+    (only for asset-by-id preview matching), `funnelStage`, `dashboardStatus`,
+    `brandKitExtractedAt`, `softCancelRequestedAt`, `deletedAt`.
+  - `frontend/aries-v1/generate-this-week.ts:80-95` — `executionState`,
+    `approvalRequired`, `status`, `dashboardStatus`.
+  - **Nothing reads** `dashboard.{posts,publishItems,calendarEvents,statuses}`
+    on the list path (calendar view-model reads scheduled-posts, not these).
+- **Client hook** `hooks/use-runtime-social-content.ts` — module-scoped in-flight
+  dedupe (Phase-1 win) over `api.getSocialContentList()`
+  (`lib/api/aries-v1.ts:427-428`). Detail today comes bundled in the list item's
+  `dashboard`; there is no per-card detail fetch yet.
+- **Detail endpoint already exists** `app/api/social-content/jobs/[jobId]/route.ts`
+  → `handleGetMarketingJobStatus(jobId, …, {responseDialect:'social-content'})`.
+- **Existing guards** `tests/runtime-views-list-projection.test.ts` (golden oracle
+  + byte-identity) and `tests/social-content-list-refetch.test.ts` (hook dedupe).
+
+## Architecture
+
+```
+Phase 3 list path (target):
+
+Browser  /dashboard/social-content
+  GET /api/social-content/posts
+    -> listSocialContentJobsForTenant(tenantId)        [runtime-views.ts]
+         phase1 (concurrency 4, per job):
+           loadSocialContentJobRuntime(jobId)          <- 1 disk read
+           getMarketingJobStatus({runtimeDoc})         <- cheap, doc-threaded
+           buildListProjection({runtimeDoc, status})   <- NEW: counts + 3 previews
+                + creative_assets count query          <- KEEP (approval fidelity)
+         phase2 (concurrency 4): pendingApprovals from same context
+    -> { posts: ListProjection[], hasMore, deletedPosts, brandKit }
+                                       |
+                                       v
+  list cards render from projection only (no full dashboard arrays)
+
+Browser opens a card -> /dashboard/social-content/[jobId]
+  GET /api/social-content/jobs/[jobId]   (EXISTING full-status endpoint)
+    -> handleGetMarketingJobStatus -> full workspace view for ONE job
+                                       |
+                                       v
+  detail screen hydrates posts/assets/publishItems/calendar/statuses
+```
+
+The shift: full `buildSocialContentWorkspaceView` moves **off the N-job list path**
+and onto the **1-job detail path** the user actually opened.
+
+## Child issues / phases table
+
+| # | Phase | Priority | Effort (human / CC) | Dependencies |
+|---|-------|----------|---------------------|--------------|
+| 1 | Server: `buildListProjection` (counts + previews + approvals, no full view) | P0 | 1.5d / 0.5d | none |
+| 2 | API/types: split `SocialContentListItem` (projection) from `RuntimePostListItem` (detail) | P0 | 0.5d / 0.25d | 1 |
+| 3 | Client: detail refetch on card open via existing `[jobId]` endpoint | P1 | 1d / 0.5d | 2 |
+| 4 | Apply same projection to `listDeletedSocialContentJobsForTenant` | P1 | 0.5d / 0.25d | 1 |
+| 5 | Benchmark + telemetry (full-endpoint timing, pool slots) | P1 | 0.5d / 0.25d | 1,2 |
+
+### Phase 1 — Server list projection
+
+**Implementation**
+- Add `buildListProjection(status, runtimeDoc)` in `backend/marketing/runtime-views.ts`
+  that produces the card fields **without** calling `buildSocialContentWorkspaceView`:
+  - `counts` and `previewPosts`/`previewAssets` come from
+    `buildSocialContentDashboardProjection(runtimeDoc, dashboardContent, …)` — the
+    *projection* step only — skipping `loadStagePayloadBundle`, the
+    `buildBrand/Strategy/CreativeReview` builders, and `saveSocialContentWorkspaceRecord`.
+  - Keep the `creative_assets` count query (Decision 2). Extract a narrow
+    `countPendingCreativeReviewsForJob(tenantId, jobId, runtimeDoc)` from the
+    existing merge logic so `pendingApprovals` stays oracle-equal without building
+    the full creative review payload. Prefer `SELECT count`-shaped SQL over
+    selecting+mapping every asset row.
+  - Drop the full `dashboard.{posts,publishItems,calendarEvents,statuses}` arrays
+    from the item; keep `dashboard.assets` **only if** Phase 3 client work still
+    needs it for preview matching — otherwise fold preview-asset resolution into
+    `previewAssets` and drop `dashboard` entirely from the list item.
+- Rewrite phase-1 of `listSocialContentJobsForTenant` (`:1632-1644`) to call
+  `buildListProjection` instead of `buildSocialContentWorkspaceView`. Keep dedup
+  key derivation working — derive the key from `status` + the projection's
+  `post.externalPostId/name` (the dashboard projection still exposes the campaign
+  identity) so first-wins ordering is unchanged.
+- **Do not** raise `processConcurrent` concurrency past 4 (guardrail #1).
+- Preserve the resumability contract: projection is read-only; never write runtime
+  docs from the list path (the old `saveSocialContentWorkspaceRecord` side-effect is
+  removed from this path, which is strictly safer).
+
+**Acceptance**
+- `tests/runtime-views-list-projection.test.ts` golden oracle stays green:
+  list `pendingApprovals` == re-hydrating review-items count for every fixture,
+  including the rejected-DB-only-asset case.
+- A fixture-backed micro-bench (Phase 5) shows the per-job DB query count drops to
+  ≤1 (the creative-assets count) and zero DB writes on the list path.
+- No call to `buildSocialContentWorkspaceView`, `loadStagePayloadBundle`, or
+  `saveSocialContentWorkspaceRecord` remains reachable from
+  `listSocialContentJobsForTenant` (grep + test).
+
+### Phase 2 — API / type split
+
+**Implementation**
+- In `lib/api/aries-v1.ts`, introduce `SocialContentListItem` = the projection
+  (scalars + `counts` + `previewPosts` + `previewAssets` + the recycle-bin fields),
+  and keep `RuntimePostListItem` as the detail-bearing type (or alias it to the
+  full per-job status type). `SocialContentListResponse.posts/deletedPosts` become
+  `SocialContentListItem[]`.
+- Mirror the server type in `backend/marketing/runtime-views.ts`
+  (`RuntimePostListItem` → emit the slimmer item). Per the
+  widening-union memory: grep every `=== '<field>'` / `!== '<field>'` and field
+  access site-wide when removing `dashboard.*` from the type — TS will catch
+  property removal, but verify the three view-models + `post-list.tsx` +
+  `generate-this-week.ts` compile and that nothing else dereferences the dropped
+  arrays.
+
+**Acceptance**
+- `npm run typecheck` clean; the three view-models and `post-list.tsx` consume only
+  projection fields.
+- `SocialContentListResponse` no longer carries `dashboard.{posts,publishItems,calendarEvents,statuses}`.
+
+### Phase 3 — Client detail refetch
+
+**Implementation**
+- Add `getSocialContentJob(jobId)` to the `lib/api/aries-v1.ts` client (GET
+  `/api/social-content/jobs/${jobId}`) if not already present.
+- On card open (the `Link` to `/dashboard/social-content/[jobId]`), the detail
+  screen fetches full status from the per-job endpoint instead of relying on the
+  list item's embedded `dashboard`. Reuse the existing in-flight dedupe pattern
+  from `use-runtime-social-content.ts` for the detail fetch (module-scoped map keyed
+  by jobId) so React 19 strict-mode double-invoke collapses to one request.
+- The list cards' previews keep working from `previewPosts`/`previewAssets` — no
+  detail fetch needed for the list itself.
+
+**Acceptance**
+- `tests/social-content-list-refetch.test.ts` extended: opening a card issues
+  exactly one `/api/social-content/jobs/[jobId]` GET; rapid double-open dedupes.
+- List render no longer depends on `dashboard.posts/publishItems/...` (visual QA in
+  Brendan's dashboard — only rendered UI counts as done, per memory).
+
+### Phase 4 — Deleted-list projection
+
+**Implementation**
+- Apply the same `buildListProjection` swap to
+  `listDeletedSocialContentJobsForTenant` (`runtime-views.ts:1699-...`), preserving
+  the `deletedAt/deletedBy/softCancelRequestedAt` enrichment (`:1756-1758`) and the
+  cross-tenant ownership guard (`doc.tenant_id !== tenantId`, `:1714`).
+
+**Acceptance**
+- Recycle Bin renders identically; ownership guard test stays green
+  (`tests/runtime-views-auth-hardening.test.ts`).
+
+### Phase 5 — Benchmark + telemetry
+
+**Implementation**
+- Fixture-primary bench: seed K jobs under a temp `DATA_ROOT` and time
+  `listSocialContentJobsForTenant` before/after, asserting reduced wall time and
+  DB-query count via a query-counting `pool` stub.
+- Add a single structured log line on the route with total elapsed + job count
+  (mirroring the existing `[jobs-cache]` / `[marketing-hydration]` lines) so prod
+  latency is observable post-deploy.
+
+**Acceptance**
+- Bench fixture demonstrates ≥ (N-1)/N reduction in per-job heavy work on the list
+  path; full-endpoint timing recorded (guardrail #1 — bench the endpoint, not the
+  helper).
+
+## Testing Plan
+
+| Test | Type | Fixture | Asserts |
+|------|------|---------|---------|
+| `runtime-views-list-projection.test.ts` (extend) | unit, fixture | temp DATA_ROOT jobs incl. rejected DB-only asset | projection `pendingApprovals` == oracle; counts/previews match prior output |
+| `runtime-views-list-projection.test.ts` (new case) | unit | seeded jobs | no `buildSocialContentWorkspaceView` / no DB write reachable on list path |
+| `social-content-list-refetch.test.ts` (extend) | unit, fetch-stub | counting fetch | card open → one `[jobId]` GET; double-open dedupes |
+| `runtime-views-auth-hardening.test.ts` | unit | cross-tenant doc | deleted-list ownership guard intact |
+| List-projection bench (new) | perf, fixture | K jobs + query-counting pool stub | per-job DB queries ≤1, zero writes, reduced wall time |
+| Live dashboard visual QA | manual (`/pair-agent` read+write) | prod tenant | cards + Recycle Bin + detail open render correctly (only rendered UI = done) |
+| `npm run verify` | gate | built-in env | regression suite green pre-push |
+
+## Rollback
+
+- Pure code change, no schema/migration. Revert the Phase 1 commit to restore full
+  per-job hydration on the list path; the API type split (Phase 2) is the only
+  shared-contract change — if reverting after Phase 3 ships, the detail screen must
+  fall back to the list item's `dashboard` (keep that fallback branch until Phase 3
+  has soaked one deploy). Gate the projection swap behind a process-wide flag
+  (`ARIES_SOCIAL_LIST_PROJECTION=1`, default OFF until verified, then default ON in
+  `docker-compose.yml`) so rollback is an env flip, not a redeploy.
+
+## Out of Scope
+
+- Pagination UI / infinite scroll (the `hasMore` plumbing already exists; wiring a
+  "load more" control is separate).
+- Caching the projection (the `[jobs-cache]` layer is a different lever; do not add
+  a new cache here).
+- Touching `getMarketingDashboardContentForTenant` / the tenant-wide dashboard
+  aggregate path.
+- Raising `processConcurrent` concurrency or `DB_POOL_MAX` (guardrail #1).
+- Any change to the per-job detail endpoint's payload shape.
+
+## Files Reference
+
+| File | Role | Change |
+|------|------|--------|
+| `backend/marketing/runtime-views.ts` | list builders + item shape | add `buildListProjection`; swap phase-1; slim `RuntimePostListItem` |
+| `backend/marketing/workspace-views.ts` | full view (heavy) | extract `countPendingCreativeReviewsForJob` from the creative_assets merge |
+| `backend/marketing/dashboard-content.ts` | `getMarketingDashboardSocialContentJobContent` | reused by projection (projection-only step) |
+| `app/api/social-content/posts/route.ts` | list route | add timing log; behind projection flag |
+| `app/api/social-content/jobs/[jobId]/route.ts` | detail route | reused by client refetch (no change) |
+| `lib/api/aries-v1.ts` | client types + `getSocialContentList` | add `SocialContentListItem`, `getSocialContentJob` |
+| `hooks/use-runtime-social-content.ts` | list hook + dedupe | add detail-fetch dedupe pattern |
+| `frontend/aries-v1/post-list.tsx` | rendered cards | consume projection; drop `dashboard.*` derefs |
+| `frontend/aries-v1/view-models/{post-list,results,dashboard-home}.ts` | list view-models | verify projection-only field usage |
+| `frontend/aries-v1/generate-this-week.ts` | gate logic | uses `executionState`/`approvalRequired` (keep) |
+| `tests/runtime-views-list-projection.test.ts` | golden oracle | extend for projection |
+| `tests/social-content-list-refetch.test.ts` | hook dedupe | extend for detail fetch |

--- a/docs/plans/2026-05-30-story-reel-video-publishing.md
+++ b/docs/plans/2026-05-30-story-reel-video-publishing.md
@@ -1,0 +1,277 @@
+# Story / Reel / Video PUBLISHING to Facebook + Instagram
+
+> Status: draft plan (2026-05-30). Epic. This is **WRITING** video/ephemeral content to Meta — distinct from issue #513, which **READS** story insights. Do not conflate the two; this plan never touches `backend/insights/*`.
+
+## Context
+
+Aries' weekly social pipeline today publishes exactly two shapes: a single-image (or multi-image carousel) **feed** post on Instagram, and an image/carousel/text **feed** post on Facebook. The Meta publish module already grew an image **Story** branch (`MetaPlacement = 'feed' | 'story'`), but that branch is image-only, is not wired through the scheduling worker, and there is no video path at all. So every motion-first surface — IG Reels, IG video Stories, FB video, FB video Stories — is dark.
+
+This epic adds **video as a first-class media type** and lights up the motion surfaces: IG Reels (`media_type=REELS`), IG video Stories, FB video posts, and FB video Stories. It threads a new `surface` axis (`feed`/`story`/`reel`) and the existing `media_type` (`image`/`video`) end-to-end: Hermes publish-stage payload → callback ingestion → `posts`/`scheduled_posts` → the scheduled-posts worker → the dispatch route → `publishToMetaGraph`. It also adds the video-specific Graph upload dance (async container poll for IG, resumable/chunked upload for FB video) and the media validation (codec/aspect/duration/size) Meta enforces per surface.
+
+This is an **L feature, not a flag.** It adds a Graph upload protocol that does not exist in the codebase (FB resumable video upload, IG video-container status polling that is materially slower than image containers), a new media-validation layer, a `media_type=video` Hermes contract dependency, and three new publish branches. A boolean env flag gates *rollout*, but the work is multi-PR and cannot be a one-line toggle.
+
+## Who cares
+
+- **Operators / the @sugarandleather tenant** — Reels and Stories are where Meta's organic reach now lives; feed-only means the highest-distribution surfaces are unused.
+- **Product** — "weekly social content OS" that cannot post a Reel or a video Story is missing the table-stakes 2026 formats.
+- **Eng** — the existing image-Story branch in `meta-publishing.ts:297-335,403-413` is half-wired (no worker plumbing); shipping video without finishing that plumbing leaves two dead code paths.
+
+## Decisions (locked — do not re-litigate)
+
+1. **Both repos in scope.** Brendan owns Aries + Hermes. Hermes must emit `media_type: "video"` + `placement` + a video `asset_url`; Aries persists/validates/publishes. Ship as one coherent unit to avoid the Aries-ahead / Hermes-behind failure mode.
+2. **Surface axis = `feed | story | reel`**, orthogonal to `media_type = image | video`. `posts.media_type` already exists (`scripts/init-db.js:429`); add a new `surface` column rather than overloading `media_type`. Stories can be image **or** video; Reels are always video; feed can be image or video.
+3. **Reuse the existing Facebook-Login + Graph v21.0 token path** (`backend/integrations/meta/discover.ts`, `getDecryptedAccessTokenContextForTenantProvider`). No new OAuth scope is required for *publishing* video/Reels/Stories — `pages_manage_posts` + `instagram_content_publish` (already requested) cover it. (Insights scopes are #513's problem, not this plan's.)
+4. **No Meta-side scheduling for video Stories or Reels.** The `scheduled_posts` worker is the only "post tomorrow 09:00" mechanism; it fires live at the scheduled instant. FB *feed* video may keep `scheduled_publish_time`; IG and all Stories/Reels publish live.
+5. **FB video Stories use `/video_stories` (resumable upload + finish), not `/photo_stories`.** Image Stories keep the existing `/photo_stories` branch unchanged.
+6. **Resumability is mandatory (CLAUDE.md).** Video upload is multi-step and slow; a transient failure mid-upload must preserve the uploaded container/video id and resume, never re-upload from scratch and never re-publish a confirmed post.
+7. **Rollout flag `ARIES_VIDEO_PUBLISH_ENABLED`** (default OFF) gates whether `surface in (reel)` / `media_type='video'` entries are persisted+dispatched. It is a rollout switch over a large feature, **not** the feature itself.
+
+## Current State (VERIFIED — master @ v0.1.13.15)
+
+**Publish module — `backend/integrations/meta-publishing.ts`:**
+- `MetaPlacement = 'feed' | 'story'` (line 19); `MetaPublishRequest` has `placement?` but **no `mediaType`** (lines 25-35).
+- IG feed: two-step `POST /{ig}/media` → poll → `POST /{ig}/media_publish` (`createInstagramContainer:395`, `waitForInstagramContainerReady:454`, `publishInstagram:489`). All container creation uses **`image_url`** only (lines 410, 419, 433) — no `video_url`, no `media_type=REELS`, no `media_type=VIDEO`.
+- IG Story branch exists but is **image-only**: `media_type: 'STORIES'` + `image_url` (line 410). The module header comment (lines 11-18) explicitly says "Image stories only — video stories need video upload, which this path does not implement."
+- FB feed: `/{page}/photos` (unpublished) → `/{page}/feed` with `attached_media` (`publishFacebook:337`). FB Story: `/{page}/photos` → `/{page}/photo_stories` (`publishFacebookPhotoStory:297`). **No `/videos` or `/video_stories` path.**
+- Container poll budget: `CONTAINER_POLL_MAX_ATTEMPTS=15`, ~60s total (lines 451-452). Video containers routinely take longer than 60s to transcode — this budget is too small for video.
+- Single-media + scheduling guards fail closed for Story (lines 548-566): exactly-one-media, no `scheduledFor`. `publishInstagram` rejects any `scheduledFor` (line 501).
+- The `outcomeUnknown` / `MetaPublishFailureClass` machinery (lines 50-104) is the resumability contract: a 2xx with no post id must NOT be auto-retried. Video publish must honor the same classification.
+
+**Hermes callback ingestion — `backend/marketing/hermes-callbacks.ts`:**
+- `WeeklyScheduleEntry` (line 1428) has `post_number?`, `recommended_day?`, `platforms?: string[]`, `platform_targets?: Array<{ platform?: string }>`. **No `placement`, no `media_type`.**
+- `readWeeklySchedule()` (line 1435) reads `stages.publish.primary_output.schedule` (fallback `weekly_schedule`).
+- The schedule loop (lines 1371-1387) reads only `platforms` / `platform_targets[].platform` + `recommended_day` — it discards any placement/media_type the strategist emits.
+- (The `placement` fields at lines 60/84/215/336/390 are the **creative-asset** placement string, a different concept — do not confuse with schedule-entry placement.)
+
+**Post synthesis — `backend/marketing/synthesize-publish-posts.ts`:**
+- `INSERT_SYNTHESIZED_POST_SQL` (line 101) inserts `media_type` (already a column) but hardcodes it; no `surface`. Idempotency key is `${jobId}:${postNumber}:${platform}` (line 353) — **collides** if the same post number yields both a feed and a reel on one platform.
+- `ON CONFLICT (tenant_id, platform, idempotency_key)` (line 109).
+
+**Auto-schedule — `backend/marketing/auto-schedule.ts`:**
+- `PLATFORM_POSTING_DEFAULTS` (line 91): `instagram {hour:11,minute:0,staggerMinutes:0}`, `facebook {hour:13,minute:0,staggerMinutes:5}`. Flat per-platform — **no surface dimension.**
+
+**Worker — `scripts/automations/scheduled-posts-worker.mjs`:**
+- `CLAIM_ROW_SQL` (line 57) selects `sp.id, sp.post_id, sp.tenant_id, sp.target_platforms, p.caption, p.platform_post_id` — **no `surface`, no `media_type`.**
+- Dispatch body (line 253) sends only `{ tenant_id, post_id, platforms, content }` — surface/media_type are NOT forwarded.
+- Claim → release connection → network publish → fresh connection for post-publish write (lines 358-402): the pool-safe pattern (no DB client held across the Graph call). Video upload latency must stay inside this connection-free window.
+
+**Dispatch route — `app/api/internal/publishing/scheduled-dispatch/route.ts`:**
+- Parses `tenant_id, platforms, content, post_id, media_urls` from body (lines 151-165). **No `placement`/`surface`/`media_type`.**
+- Calls `publishToMetaGraph({ tenantId, provider, content, mediaUrls })` (line 221) — never passes `placement`, so every dispatch is feed.
+
+**Schema — `scripts/init-db.js`:**
+- `posts.media_type TEXT NOT NULL DEFAULT 'image'` (line 429); `creative_assets.media_type` CHECK already allows `'video'` (line 182).
+- No `surface` column on `posts` or `scheduled_posts`.
+- Migrations dir tail: `20260515120000_posts_idempotency_key.sql` (latest).
+
+**Prior thinking:** `~/.gstack/projects/DeliciousHouse-aries-app/draft-spec-stories.md` (image-Stories MVP, parked at Phase 4) explicitly **defers video Stories to "v0.1.13.x"** — this plan is that deferred work plus Reels and FB video. The insights spec (`specs/20260530-...-insights-meta-fb-ig-stories.md` = #513) is READ-side and out of scope here.
+
+## Architecture (target data flow)
+
+```
+Hermes strategist + content-generator
+  schedule[].platform_targets[]: { platform, placement: feed|story|reel, media_type: image|video, asset_url }
+        │  (video asset_url points to a 9:16 / 16:9 MP4 in the Hermes media cache)
+        ▼
+backend/marketing/hermes-callbacks.ts
+  WeeklyScheduleEntry gains { placement, media_type }  ──>  readWeeklySchedule() preserves them
+        │
+        ▼
+backend/marketing/synthesize-publish-posts.ts
+  INSERT posts (… media_type, surface …)   idempotency_key = jobId:postNo:platform:surface
+        │
+        ▼
+backend/marketing/auto-schedule.ts
+  PLATFORM_POSTING_DEFAULTS[platform][surface]  ──>  scheduled_posts (… surface, media_type mirrored …)
+        │
+        ▼  (every 60s)
+scripts/automations/scheduled-posts-worker.mjs
+  CLAIM_ROW_SQL selects sp.surface, p.media_type  ──>  dispatch body { …, surface, media_type }
+        │
+        ▼
+app/api/internal/publishing/scheduled-dispatch/route.ts
+  publishToMetaGraph({ …, placement: surface, mediaType })
+        │
+        ▼
+backend/integrations/meta-publishing.ts  (NEW video branches)
+   ├─ validateMediaForSurface(mediaUrls, surface, mediaType)   ← NEW (codec/aspect/duration/size)
+   ├─ IG video feed  : POST /media media_type=VIDEO video_url  → poll(extended) → media_publish
+   ├─ IG Reel        : POST /media media_type=REELS video_url  → poll(extended) → media_publish
+   ├─ IG video Story : POST /media media_type=STORIES video_url→ poll(extended) → media_publish
+   ├─ FB video feed  : POST /{page}/videos (resumable) → finish[+scheduled_publish_time]
+   └─ FB video Story : POST /{page}/video_stories start→transfer→finish
+        │
+        ▼
+graph.facebook.com/v21.0  (Page token + ig_business_account from meta/discover.ts)
+```
+
+## Child issues / phases
+
+| # | Phase | Priority | Effort (human / CC) | Dependencies |
+|---|-------|----------|---------------------|--------------|
+| A | Schema + contract: `surface` columns, idempotency key, `WeeklyScheduleEntry` + ingestion | Critical | 2h / 30m | none |
+| B | Media validation layer (`validateMediaForSurface`) | High | 3h / 1h | A |
+| C | IG video publish — feed VIDEO + Reel + video Story (extended container poll) | High | 8h / 3h | A, B |
+| D | FB video publish — `/videos` resumable + `/video_stories` | High | 10h / 4h | A, B |
+| E | Worker + dispatch-route plumbing (surface/media_type end-to-end) + auto-schedule surface dimension | High | 4h / 1.5h | A |
+| F | Hermes side: strategist emits reel/video entries; content-generator renders 9:16/16:9 MP4 | High | 6h / — (separate repo) | A (contract) |
+| G | Rollout flag, docs, live E2E on tenant 15, ship | Medium | 4h / 1.5h | C, D, E, F |
+
+**Sequencing:** A first (everything depends on the surface axis + contract). B before C/D (publish branches call the validator). C and D parallel (independent Graph paths). E parallel with C/D (pure plumbing). F parallel from day 1 (Hermes lead time; gated on A's contract shape). G last (needs real Hermes video output to verify live).
+
+```
+A ─┬─> B ─┬─> C ──┐
+   │      └─> D ──┼─> G
+   ├─> E ─────────┘
+   └─> F (Hermes, parallel) ──> G
+```
+
+---
+
+### A — Schema + contract (Critical, 2h)
+
+**Implementation:**
+1. New migration `migrations/20260531120000_posts_surface.sql`:
+   ```sql
+   ALTER TABLE posts ADD COLUMN IF NOT EXISTS surface text NOT NULL DEFAULT 'feed'
+     CHECK (surface IN ('feed','story','reel'));
+   ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS surface text NOT NULL DEFAULT 'feed'
+     CHECK (surface IN ('feed','story','reel'));
+   ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS media_type text NOT NULL DEFAULT 'image'
+     CHECK (media_type IN ('image','video'));
+   ```
+   `scheduled_posts.surface` + `media_type` are denormalized so worker dispatch does not JOIN `posts` at claim time (it already LEFT JOINs for caption, but mirroring keeps the dispatch shape stable and lets a partial index target pending rows by surface). Mirror the columns in `scripts/init-db.js` for fresh installs.
+2. `backend/marketing/hermes-callbacks.ts`: extend `WeeklyScheduleEntry` (line 1428) with `placement?: 'feed' | 'story' | 'reel'` and `media_type?: 'image' | 'video'`, and add the same to `platform_targets[]`. Update the loop (lines 1371-1387) to carry `placement` (default `'feed'`) and `media_type` (default `'image'`) per platform into the ordinal map, alongside `recommended_day`.
+3. Backward compat: absent `placement` ⇒ `'feed'`; absent `media_type` ⇒ `'image'`. A reel entry with `media_type` missing is a contract violation — log + skip (do not silently post an image reel).
+
+**Acceptance:** `\d posts` shows `surface` with CHECK; all pre-existing rows `surface='feed'`. A fixture callback carrying `placement:'reel', media_type:'video'` round-trips into `readWeeklySchedule()` output with both fields preserved; a legacy callback with neither yields `feed`/`image`.
+
+### B — Media validation layer (High, 3h)
+
+**Implementation:** New `validateMediaForSurface(mediaUrls, surface, mediaType)` in `meta-publishing.ts` (or a sibling `meta-media-validation.ts`). Fail-closed before any Graph call, mirroring the existing Story guards (lines 548-566). Enforce Meta's per-surface constraints:
+- **IG Reel / IG video Story:** exactly 1 video; aspect 9:16 (Reels accept 0.01–10 but 9:16 is required for full-screen); duration 3s–90s (Reels) / ≤60s (Story); MP4/MOV, H.264, AAC; ≤ ~1GB.
+- **IG video feed:** 1 video, 4:5–16:9, 3s–60s.
+- **FB video feed:** 1 video; ≤ ~10GB / 240min (we cap far lower, e.g. ≤4min); MP4 preferred.
+- **FB video Story:** 1 video, 9:16, ≤60s.
+- **Story (any):** still exactly 1 media, no `scheduledFor` (extend the existing guard to cover video).
+- Aspect/duration are validated from Hermes-provided metadata (Hermes emits `width`/`height`/`duration_seconds` alongside `asset_url`) — Aries does not download+probe the file. Missing metadata ⇒ reject (fail closed), do not assume.
+
+**Acceptance:** unit table: a 9:16 30s MP4 passes for Reel; a 1:1 image fails for Reel (`media_type_mismatch`); a 120s video fails for Story (`duration_exceeds_story_limit`); a 2-video array fails for any Story/Reel (`single_media_required`). All throw `MetaPublishError` with `status:400`, `retryable:false`.
+
+### C — IG video publish (High, 8h)
+
+**Implementation:**
+1. Add `mediaType?: 'image' | 'video'` to `MetaPublishRequest` (line 25) and thread through `publishToMetaGraph` (line 540) → `publishInstagram` (line 489) → `createInstagramContainer` (line 395).
+2. Widen `MetaPlacement` to `'feed' | 'story' | 'reel'`; update `normalizeMetaPlacement` (line 21) to accept `'reel'`. **Per CLAUDE.md memory "Widening union → grep inequalities": grep every `=== 'story'` / `=== 'feed'` / `!== 'feed'` in the module and call sites after widening — literal-inequality checks won't be caught by TS.**
+3. `createInstagramContainer`: when `mediaType==='video'`, send `video_url` (not `image_url`) plus `media_type=VIDEO` (feed), `media_type=REELS` (reel), or `media_type=STORIES` (video story). Call `validateMediaForSurface` first.
+4. Extend the container poll for video: video containers transcode slowly. Add a separate `VIDEO_CONTAINER_POLL_MAX_ATTEMPTS` / longer cap (target ~5min, e.g. up to 60 attempts with 5s backoff) — keep image at the existing 60s budget. Reuse `waitForInstagramContainerReady`'s `FINISHED`/`ERROR`/`EXPIRED` handling.
+5. Final `media_publish` is the one-shot, never-auto-retried call — preserve `outcomeUnknown:true` on the missing-id path (line 534). Container creation + poll are the safe-to-retry pre-publish steps (wrap in `withSafePrePublishRetry` like the image path).
+
+**Resumability:** if the process dies after container creation but before `media_publish`, the container id is the resumable handle. Persist the `creation_id` on the `scheduled_post_dispatches` row (or a new nullable `posts.last_media_container_id`) so a resume polls the existing container instead of re-uploading the video. Do not re-create a container on retry of a confirmed-published post.
+
+**Acceptance:** against tenant 15, an IG Reel publishes from a real 9:16 MP4 and appears in the Reels tab; an IG video Story appears in the 24h tray; a forced kill between container-ready and `media_publish` resumes without re-uploading; a 2xx-no-id leaves the claim in `needs_manual_reconciliation`, not retried.
+
+### D — FB video publish (High, 10h)
+
+**Implementation:** FB video does NOT reuse `/photos`. Two new paths:
+1. **FB video feed → `/{page}/videos`** with resumable upload: `start` (file size) → `transfer` chunks → `finish`. For MVP, if Hermes provides a public `asset_url`, use the simpler **`file_url` non-resumable** form (`POST /{page}/videos?file_url=...&description=...`) and reserve chunked resumable for the size-cap fallback. `scheduled_publish_time` may be set on feed (FB allows scheduled video).
+2. **FB video Story → `/{page}/video_stories`**: `start` (returns `video_id` + `upload_url`) → upload the bytes → `finish` (`upload_phase=finish`, `video_id`). One-shot finish = the never-auto-retry boundary (`outcomeUnknown`).
+3. Route `publishFacebook` (line 337) on `(placement, mediaType)`: image feed/story unchanged; `mediaType==='video'` + `feed` → `/videos`; `+ story` → `/video_stories`.
+
+**Resumability:** the FB `video_id` from `start` is the resumable handle — persist it, and on resume re-issue `finish` (idempotent on a video already finished) rather than re-uploading. Honor `outcomeUnknown` on a `finish` that returns 2xx with no usable post id.
+
+**Pool guardrail (CLAUDE.md #1):** the FB resumable transfer is multi-request and slow; it MUST run in the worker's connection-free window (between claim-release and post-publish write, `scheduled-posts-worker.mjs:381`). Do not hold a `pool.connect()` client across the upload.
+
+**Acceptance:** a FB video feed post publishes from a real MP4 and is visible on the Page; a FB video Story appears; a kill mid-transfer resumes via the persisted `video_id`; scheduled FB video honors `scheduled_publish_time`.
+
+### E — Worker + dispatch plumbing + auto-schedule surface dimension (High, 4h)
+
+**Implementation:**
+1. `scheduled-posts-worker.mjs` `CLAIM_ROW_SQL` (line 57): add `sp.surface, sp.media_type` (and/or `p.media_type`) to the SELECT.
+2. Dispatch body (line 253): add `surface` and `media_type`.
+3. Route (`scheduled-dispatch/route.ts`): parse `surface`/`media_type` from body (after line 165), pass `placement: surface, mediaType` into `publishToMetaGraph` (line 221).
+4. `synthesize-publish-posts.ts`: add `surface` to `INSERT_SYNTHESIZED_POST_SQL` (line 101) and write the Hermes-provided `media_type`; change idempotency key (line 353) to `${jobId}:${postNumber}:${platform}:${surface}` so a feed + reel on the same post number/platform don't collide (the `ON CONFLICT` index already keys on `idempotency_key`). **Per CLAUDE.md memory: grep for any literal parse of the old `jobId:postNo:platform` key shape** (`parsePostNumberFromIdempotencyKey`, hermes-callbacks.ts:1393) and update it to tolerate the 4th segment.
+5. `auto-schedule.ts` `PLATFORM_POSTING_DEFAULTS` (line 91): nest by surface, e.g. `instagram: { feed:{...}, story:{...}, reel:{...} }`, and have `computeAutoScheduleSlots` pick by `(platform, surface)`. Mirror `surface`/`media_type` into the `scheduled_posts` insert it drives.
+
+**Acceptance:** a callback with 7 feed + 1 reel + 1 story produces 9 `posts` + 9 `scheduled_posts` rows with correct `surface`/`media_type`; the worker forwards both fields; the route passes them through; idempotency replay of the mixed callback is a no-op (no duplicate rows).
+
+### F — Hermes side (High, separate repo)
+
+**Implementation (tracked here for coherence):**
+1. **Strategist** (`aries-strategist`): emit reel/video-story schedule entries with `platform_targets[].placement` + `media_type:"video"` + a `recommended_day`.
+2. **Content-generator** (`aries-content-generator`): when `media_type:"video"`, render a 9:16 (Reel/Story) or 16:9/4:5 (feed) MP4 via the video-gen path; emit `asset_url` + `width`/`height`/`duration_seconds` metadata (B depends on these).
+3. Persist video assets into the Hermes media cache so `backend/marketing/ingest-production-assets.ts` resolves them via `HERMES_IMAGE_CACHE_MOUNT` (same mechanism as images; confirm video MIME passes the media route `app/api/internal/hermes/media/[...path]/route.ts`).
+
+**Acceptance:** a fresh one_off on tenant 15 produces ≥1 video schedule entry per platform with valid metadata; the asset resolves through the media mount and streams to the browser preview.
+
+### G — Rollout flag + docs + live E2E + ship (Medium, 4h)
+
+**Implementation:**
+1. `ARIES_VIDEO_PUBLISH_ENABLED` (default OFF): when OFF, `readWeeklySchedule()` strips `placement:'reel'` and `media_type:'video'` entries before persist (campaign still succeeds on image/feed). Document in `CLAUDE.md` "Environment Variables" and `.env.example` + `docker-compose.yml`.
+2. Live E2E on tenant 15: one real IG Reel, one IG video Story, one FB video post, one FB video Story.
+3. `/ship-triage-deploy`; bump `VERSION` (minor — new column + contract field + Graph paths) + `CHANGELOG.md`.
+
+**Acceptance:** flag OFF ⇒ zero video rows persisted, feed unaffected; flag ON ⇒ all four live posts verified rendered (per memory: only rendered-on-platform counts as done); `full-suite` gate green.
+
+## Testing Plan (fixture-primary)
+
+| Layer | What | Count |
+|-------|------|-------|
+| Unit | `WeeklyScheduleEntry` parse: placement+media_type present / absent / reel-missing-media_type | +4 |
+| Unit | `normalizeMetaPlacement('reel')` + grep-verified union widening (no stale `=== 'story'`) | +2 |
+| Unit | `validateMediaForSurface`: reel ok / image-for-reel fail / 120s-story fail / 2-media-story fail / missing-metadata fail | +5 |
+| Unit | idempotency key now `jobId:postNo:platform:surface`; `parsePostNumberFromIdempotencyKey` tolerates 4th segment | +3 |
+| Unit | `PLATFORM_POSTING_DEFAULTS` slot pick by `(platform, surface)` | +3 |
+| Integration (fake fetch) | IG Reel: container `media_type=REELS video_url` → extended poll → `media_publish` | +2 |
+| Integration (fake fetch) | IG video Story container; 2xx-no-id ⇒ `outcomeUnknown` (not retried) | +2 |
+| Integration (fake fetch) | FB `/videos` file_url path; FB `/video_stories` start→finish; resume re-issues finish via persisted video_id | +3 |
+| Integration | worker `CLAIM_ROW_SQL` selects surface/media_type; dispatch body forwards them; route passes `placement`+`mediaType` | +3 |
+| Integration | mixed callback (7 feed + 1 reel + 1 story) → 9 posts/scheduled_posts correctly typed; replay no-op | +2 |
+| Live-DB | tenant-scoped synth insert + auto-schedule against real DB (precedent: `tests/marketing/ingest-production-assets-live-db.test.ts`) | +1 |
+| E2E (live, manual) | IG Reel, IG video Story, FB video, FB video Story all render on @sugarandleather | manual |
+
+**~30 automated + 4 manual.** New test files allowlisted in `scripts/verify-regression-suite.mjs`. All tests set `APP_BASE_URL=https://aries.example.com`; run `npm run verify` then `npm run test:concurrent` before ship (touches routes + worker + backend).
+
+## Rollback
+
+- **Schema:** additive + idempotent (`ADD COLUMN IF NOT EXISTS ... DEFAULT 'feed'`). Reverse: `ALTER TABLE posts DROP COLUMN surface;` (+ `scheduled_posts` surface/media_type). No data loss.
+- **Flag:** `ARIES_VIDEO_PUBLISH_ENABLED=0` strips video entries at ingestion — instant kill switch, feed path untouched.
+- **Hermes:** stop emitting `media_type:"video"` — independent, no Aries deploy.
+- **Stuck dispatch row:** existing cancel UX + `UPDATE scheduled_posts SET dispatch_status='failed' WHERE id=X`. A video container that timed out is terminal-skippable; never re-`media_publish` an `outcomeUnknown` row.
+
+## Out of Scope
+
+- **Story/Reel INSIGHTS / analytics** — that is issue #513 (READ side); this plan is publish-only.
+- **TikTok / YouTube Shorts** video (separate OAuth + content shape; `backend/integrations/adapters/tiktok.ts` is unrelated scaffold).
+- **Multi-clip / edited / music-overlay / sticker / interactive Stories** (poll, link, mention).
+- **Per-tenant cadence config, multiple reels/day, Story Highlights, carousel video.**
+- **Operator manual video upload** (pipeline-generated only).
+- **Probing video bytes server-side** — validation is metadata-driven from Hermes.
+
+## Files Reference
+
+| File | Change | Phase |
+|------|--------|-------|
+| `migrations/20260531120000_posts_surface.sql` | NEW: `surface` on posts+scheduled_posts, `media_type` on scheduled_posts | A |
+| `scripts/init-db.js` (≈line 429) | mirror `surface`/`media_type` for fresh installs | A |
+| `backend/marketing/hermes-callbacks.ts:1371-1387,1428` | `WeeklyScheduleEntry` + loop carry placement/media_type | A |
+| `backend/integrations/meta-publishing.ts:19,21,25,395-449,489-538` | widen `MetaPlacement`, add `mediaType`, IG VIDEO/REELS/STORIES branches, extended video poll | C |
+| `backend/integrations/meta-publishing.ts:297-393` | FB `/videos` + `/video_stories` branches | D |
+| `backend/integrations/meta-media-validation.ts` | NEW: `validateMediaForSurface` | B |
+| `backend/marketing/synthesize-publish-posts.ts:101,353` | add `surface`, 4-segment idempotency key | E |
+| `backend/marketing/auto-schedule.ts:91` | nest `PLATFORM_POSTING_DEFAULTS` by surface | E |
+| `scripts/automations/scheduled-posts-worker.mjs:57,253` | claim + forward surface/media_type | E |
+| `app/api/internal/publishing/scheduled-dispatch/route.ts:151-165,221` | parse + pass placement/mediaType | E |
+| `backend/marketing/ingest-production-assets.ts:46` | accept video assets via media mount | F |
+| `docker-compose.yml`, `.env.example`, `CLAUDE.md` | document `ARIES_VIDEO_PUBLISH_ENABLED` | G |
+| `tests/meta-publishing-video.test.ts` | NEW (IG/FB video branches + outcomeUnknown) | C,D |
+| `tests/meta-media-validation.test.ts` | NEW | B |
+| `tests/hermes-callback-video-surface.test.ts` | NEW | A,E |
+| `tests/marketing-auto-schedule.test.ts` | +surface slot tests | E |
+| `scripts/verify-regression-suite.mjs`, `VERSION`, `CHANGELOG.md` | allowlist + bump | G |
+
+## Related
+
+- Draft `~/.gstack/projects/DeliciousHouse-aries-app/draft-spec-stories.md` — image-Stories MVP; explicitly defers video Stories to here.
+- Issue #513 — story/post/account **insights** (READ). Disjoint from this publish epic.
+- CLAUDE.md guardrails honored: pool fan-out #1 (no DB client across video upload), resumability (container/video_id persisted, `outcomeUnknown` never re-published), Turbopack (no build changes), tenant-scoping (token via `getDecryptedAccessTokenContextForTenantProvider`).

--- a/docs/plans/2026-05-30-test-suite-repair.md
+++ b/docs/plans/2026-05-30-test-suite-repair.md
@@ -1,0 +1,194 @@
+# Test-suite repair — turn the REQUIRED full-suite gate green
+
+**Status:** Open for a builder to pick up.
+**Author:** Staff eng, 2026-05-30.
+**Epic:** Repair the remaining red tests so the REQUIRED `full-suite` gate on `master` is green.
+**Related:**
+- `TODOS.md` → top "Ship" section (the four P0 triage items; this plan covers three of them).
+- `#513` child A owns `tests/auth/integrations-tenant-context.test.ts` — **explicitly out of scope here.**
+- `.github/workflows/tests.yml:50-63` — the `full-suite` job that must go green.
+
+---
+
+## Context
+
+`full-suite` is now a REQUIRED status check on `master` (memory: *test-suite rot + gate gap*, shipped #505/#507). CI runs every `tests/**/*.test.ts` at `--test-concurrency=1` against a per-runner `DATA_ROOT` (`.github/workflows/tests.yml:60-63`). Until that job is reliably green, every PR is noisy and real regressions hide behind unrelated red.
+
+The TODOS.md triage was written **2026-04-23** and last retriaged **2026-05-23**. Since then, repair PRs landed: `#432` (OAuth/integrations aligned to Postgres handlers), `#433` (brand-profile contract ported off deleted python), `#434` (frontend-api-layer unstuck), and `#502` ("repair 63 rotted tests + 2 product edge cases (full suite green)"). **The working tree already reflects those rewrites.** This plan's primary job is therefore *verification* — confirm the five EPIC-named files actually pass on a clean runner — plus closing a small set of residual-risk seams that the triage text predates and that a clean-room CI run could still surface.
+
+This is deliberately scoped. We are not re-architecting the test harness; we are driving one specific gate from "assumed green" to "verified green," and fixing whatever the verification turns up.
+
+## Who cares
+
+- **Every engineer** opening a PR — a red base gate trains people to ignore CI, which is how the rot started (memory: *test-suite rot + gate gap*).
+- **Marketing pipeline owners** — `frontend-api-layer.test.ts` is the contract test for the customer-facing campaign workspace hydration (brand/strategy/creative/publish review). It is the single largest signal we have that the dashboard renders truthful data.
+- **Auth/integrations owners** — `oauth-connect.test.ts` guards the Meta OAuth connect/disconnect/reconnect/callback flows.
+
+## Decisions (locked, do not re-litigate)
+
+1. **`tests/auth/integrations-tenant-context.test.ts` is OUT.** It is owned by `#513` child A. Do not touch it, do not assert on it, do not duplicate its fixes here. If it is red, that is #513's problem.
+2. **The test rewrites are the source of truth, not TODOS.md.** Where the triage text and the current test file disagree (and they do — see Current State), the file wins. Do not "re-fix" a file that already uses the new seam.
+3. **No production behavior changes to make a test pass.** If a test asserts the wrong thing, fix the test. If a test catches a real product bug, that is a *separate* finding to be raised, not silently patched into green. (#502 already did this dance for "2 product edge cases" — do not regress those.)
+4. **Verify on a clean runner profile.** Local "passes for me" is not acceptance. Acceptance is the exact CI invocation: `find tests -name '*.test.ts' | sort` piped to `tsx --test --test-concurrency=1`, with `APP_BASE_URL` and a per-run `DATA_ROOT` set. Test-ordering pollution is a known failure mode in this repo (the 2026-05-23 retriage found `auth-tenant-membership` / `oauth-callback-runtime` only failed *in suite*), so isolated passes do not count.
+5. **No new node_modules-coupled or Postgres-coupled tests.** The harness must stay self-contained: mock `pool.query`, set required env via the file's `with*Env` helper, write fixtures under a per-test `mkdtemp` `DATA_ROOT`.
+
+## Current State (VERIFIED — file:line)
+
+All five EPIC-named files were read at `HEAD` (`b08a80a`). Working tree is clean.
+
+**The marketing XL item — already migrated:**
+- `tests/marketing-validated-runtime.test.ts:158` and `tests/marketing-brand-identity-parity.test.ts:194` import `tenantBrandProfilePath` / `tenantBusinessProfilePath` from `backend/marketing/validated-profile-store` and write fixtures directly. Both files still *define* a `runScript()` helper (`marketing-validated-runtime.test.ts:54`, `marketing-brand-identity-parity.test.ts:71`) that shells `python3 lobster/bin/<script>` — but **it is never called** (verified: zero `runScript(` invocations). It is dead code left over from the port.
+- The store functions all exist: `validated-profile-store.ts:97` (`tenantBrandProfilePath`), `:105` (`tenantBusinessProfilePath`), `:186` (`loadValidatedMarketingProfileDocs`), `:247` (`loadValidatedMarketingProfileSnapshot`). `backend/tenant/business-profile.ts:716` (`getBusinessProfile`) exists.
+- `tests/frontend-api-layer.test.ts:9` imports `__setMarketingExecutionPortForTests` (exists at `orchestrator.ts:1407`); the legacy `__ARIES_EXECUTION_TEST_INVOKER__` seam is gone. `setExecutionTestInvoker` (`:14-106`) is an adapter that wraps a `MarketingExecutionPort` mock and translates the old `{ args: { action } }` shape, so per-test bodies did not need rewriting.
+
+**Residual risk inside `frontend-api-layer.test.ts` (the part to actually verify/fix):** the artifact-path layout is **inconsistent across fixtures**. Production reads default to tenant-scoped `<cacheRoot>/<tenantId>/<runId>/<step>.json` (`backend/marketing/artifact-store.ts:41-63`, `stageCacheRootForTenant`) and only fall back to the legacy `<cacheRoot>/<runId>/` layout when `ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1` (`artifact-store.ts:73-75`). That env flag is **never set** in the test file. Yet some fixtures write tenant-scoped (`:2137-2140`, `:2517`, `:2874-2876` use `.../<tenantId>/<stage2RunId>/...`) while others write *flat* (`:815-816` test "blocks downstream approval metadata", `:1681-1682` test "prefers richer compiled Stage 4 bundles", `:1873-1874` test "keeps fresher runtime review fields", `:2333-2335` test "does not leak stale strategy review"). The flat ones only pass if that specific hydration path tolerates the legacy layout; this is the seam most likely to be red on a clean runner and is the verification's first suspect.
+
+**Source-fingerprint gating (verified mechanic):** `loadValidatedMarketingProfileDocs` nulls out any doc whose source URL does not match `options.currentSourceUrl` (`validated-profile-store.ts:198-201`, `recordMatchesCurrentSource`). The fixtures set the runtime doc's `inputs.brand_url` to `https://<tenantId>.example.com` (`frontend-api-layer.test.ts:451`, `:775`) and the brand-kit `source_url`/`canonical_url` to the same host. A fixture whose brand-profile `website_url` drifts from the runtime `brand_url` will silently hydrate `null` and fail the review assertions.
+
+**The auth item — already migrated:**
+- `tests/auth/oauth-connect.test.ts:14` declares `META_ENV_KEYS = ['META_APP_ID','META_APP_SECRET','OAUTH_TOKEN_ENCRYPTION_KEY']` and sets all three in `withMetaEnv` (`:21-23`). Tenant IDs are numeric strings (`'1'`/`'2'`, e.g. `:291`, `:337`, `:397`). A full SQL mock (`makeQueryMock`, `:85-178`) serves `dbGetConnection` (`WHERE tenant_id = $1 AND provider = $2`), `dbGetConnectionById` (`WHERE id = $1`), upsert/insert/pending-state/audit, and throws on unhandled SQL.
+- `seedConnectedProvider` (`:44-61`) still seeds the in-memory `oauthStore()`, and the disconnect/reconnect assertions read back from `oauthStore().connectionsById` (`:413`, `:506`). So the tests are a **hybrid**: `pool.query` is mocked for the read/lookup path, while the in-memory store is used for the post-mutation assertion. The note that worked-row uses `connection_status` (`:56`) but the SQL-mock synthetic row uses `status` (`:122-123`) is the kind of column-name drift that can make tests 5/7/8 (disconnect/reconnect) flaky — verify these specifically.
+
+**The infra item — already migrated:**
+- `tests/onboarding-draft-route.test.ts:246` is the rewritten test 3 exactly as triage prescribed: it re-sets `DB_HOST/USER/PASSWORD/NAME` inside `withDraftEnv` (`:256-259`, because the helper deletes them at `:148-151`), injects a non-network `28P01` error via `installDbMock` (`:261-264`), and asserts `503` + `error: 'onboarding_draft_unavailable'` + redaction of `password authentication failed|aries_user|28P01` (`:270-272`). `tests/onboarding-draft-store.test.ts` and `tests/password-reset.test.ts` already pass per the 2026-05-23 retriage.
+
+**The gate itself:** `.github/workflows/tests.yml:60` exports `DATA_ROOT="${RUNNER_TEMP}/aries-data"`, `:61` globs all `tests/**/*.test.ts`, `:63` runs `tsx --test --test-concurrency=1`. `scripts/verify-regression-suite.mjs:150-161` already lists `onboarding-draft-route`, `oauth-connect`, and `marketing-validated-runtime` in the fast suite, and flags `frontend-api-layer.test.ts` as `~70s; needs split`.
+
+## Architecture (data flow under test)
+
+```
+  full-suite CI job (tests.yml:60-63)
+    DATA_ROOT=$RUNNER_TEMP/aries-data   APP_BASE_URL=https://aries.example.com
+    tsx --test --test-concurrency=1  tests/**/*.test.ts
+        |
+        +-- frontend-api-layer.test.ts ----------------------------+
+        |     setExecutionTestInvoker -> __setMarketingExecutionPortForTests
+        |        (MarketingExecutionPort mock; orchestrator.ts:1407)
+        |     fixtures: <DATA_ROOT>/generated/{draft,validated}/<tenantId>/...
+        |               ARTIFACT_STAGEn_CACHE_DIR/<tenantId>/<runId>/<step>.json   <-- tenant-scoped
+        |        v                                                  |
+        |   route handlers -> backend/marketing/jobs-status, artifact-store,
+        |        validated-profile-store (source-fingerprint gate :198-201)
+        |
+        +-- oauth-connect.test.ts ---------------------------------+
+        |     withMetaEnv (META_APP_ID/SECRET, OAUTH_TOKEN_ENCRYPTION_KEY)
+        |     t.mock.method(pool,'query', makeQueryMock(rows))  +  oauthStore() seed
+        |        v
+        |   app/api/internal/integrations/* handlers -> oauthDb (dbGetConnection/...)
+        |
+        +-- onboarding-draft-route.test.ts ------------------------+
+        |     withDraftEnv (DB_* set) + installDbMock(throw 28P01)
+        |        v
+        |   app/api/onboarding/draft/route -> backend/onboarding/draft-store
+        |        (network errs -> DATA_ROOT fallback; non-network -> 503 redacted)
+        |
+        +-- marketing-validated-runtime.test.ts ------------------+
+        +-- marketing-brand-identity-parity.test.ts --------------+
+              fixtures written directly to validated-profile-store paths;
+              assertions via loadValidatedMarketingProfileSnapshot + getBusinessProfile
+              (NO python subprocess; runScript() helper is dead code)
+```
+
+## Child issues / phases
+
+| # | Phase | Priority | Effort (human / CC) | Depends on |
+|---|---|---|---|---|
+| A | Establish the clean-room baseline: run the exact CI invocation, capture the real red set | P0 | 0.5d / 20m | none |
+| B | Marketing hydration: fix tenant-scoped artifact-path + source-fingerprint fixture drift in `frontend-api-layer.test.ts` | P0 | 1.5d / 1.5h | A |
+| C | Marketing contract: confirm validated-runtime + brand-identity-parity green; delete dead `runScript()` helper | P0 | 0.5d / 30m | A |
+| D | Auth: confirm oauth-connect green; fix `status`/`connection_status` column drift + any 503/404/ECONNREFUSED residue (tests 5/7/8/10) | P0 | 1d / 1h | A |
+| E | Infra: confirm onboarding-draft-route test 3 green on clean `DATA_ROOT` | P0 | 0.25d / 15m | A |
+| F | Lock it in: full clean-room re-run, confirm `full-suite` green, no `integrations-tenant-context` regressions attributed here | P0 | 0.5d / 30m | B,C,D,E |
+
+### Phase A — Clean-room baseline (do this first, do not skip)
+
+**Implementation.** Reproduce CI exactly. From repo root:
+```bash
+NODE_ENV=development npm ci                       # worktree has NO node_modules — required
+export DATA_ROOT="$(mktemp -d)/aries-data"
+export APP_BASE_URL=https://aries.example.com
+mapfile -t TEST_FILES < <(find tests -name '*.test.ts' | sort)
+npx --no-install tsx --test --test-concurrency=1 "${TEST_FILES[@]}" 2>&1 | tee /tmp/full-suite.log
+```
+Then extract the actual failing files and test names (`grep -E '^(not ok|# fail)' /tmp/full-suite.log`). **This is the real worklist.** Triage each failure into: (1) one of the four in-scope files, (2) `integrations-tenant-context` (hand to #513, do not touch), (3) a new/unexpected red (escalate before fixing). Run each in-scope failing file *also* in isolation to detect ordering pollution vs. a real defect.
+
+**Acceptance.** A written red-set: file → test name → category (B/C/D/E / out / new). If the in-scope files already pass clean, Phases B–E collapse to "confirmed green, no change" and you proceed straight to F. The plan must survive both outcomes.
+
+### Phase B — Marketing hydration artifact-path + fingerprint drift
+
+**Implementation.** For each `frontend-api-layer.test.ts` failure from Phase A in the hydration group, the fix is fixture-side, not product-side:
+- **Tenant-scope the flat fixtures.** Rewrite the flat artifact writes (`:815-816`, `:1681-1682`, `:1873-1874`, `:2333-2335`) to insert the `tenantId` segment: `path.join(process.env.ARTIFACT_STAGE2_CACHE_DIR!, tenantId, stage2RunId, 'campaign_planner.json')`, matching the tenant-scoped fixtures at `:2137-2140`. Mirror the surrounding `mkdir(path.dirname(...), { recursive: true })`. Do **not** instead set `ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1` — the legacy layout is a deprecated read path (`artifact-store.ts:65-75`, scheduled for removal), and tests should assert the layout production writes today.
+- **Align brand_url fingerprints.** Where a review hydrates `null` unexpectedly, confirm the fixture brand-profile / website-analysis `website_url` matches the runtime doc `inputs.brand_url` (`:451`, `:775`) so `recordMatchesCurrentSource` (`validated-profile-store.ts:198-201`) does not null the doc. Fix the fixture, not the gate.
+- **Copy/window/voice drift (triage's tests 6/9/29).** If any assertion fails on a literal string (eyebrow/heading/voice label), check whether shipped copy moved (precedent: `campaign-workspace.tsx` `eyebrow` `Checkpoint`→`Review`). If the copy is correct and the test is stale, update the assertion; if the copy regressed, raise it as a product finding per Decision 3.
+
+**Acceptance.** Every `frontend-api-layer.test.ts` test passes in isolation **and** in the full sorted suite. No `ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK` was introduced. Diff is fixtures/assertions only — zero edits under `backend/` or `app/`.
+
+### Phase C — Marketing contract files
+
+**Implementation.** These already import the TS store directly and reference only existing exports, so the expectation is "already green." Confirm via Phase A. Then remove the dead `runScript()` helper in both files (`marketing-validated-runtime.test.ts:54-80`, `marketing-brand-identity-parity.test.ts:71-...`) and its now-unused imports (`spawnSync` from `node:child_process`) — leaving a python-subprocess helper in a file that no longer calls python is a rot trap and a misleading signal to the next reader. If Phase A shows a real failure (e.g. a snapshot field the store does not populate), fix the fixture to match the verified store output shape (`ValidatedMarketingProfileSnapshot`, `validated-profile-store.ts:216-239`).
+
+**Acceptance.** Both files green in suite. `grep -rn 'lobster/bin\|spawnSync.*python' tests/marketing-*.test.ts` returns nothing. No new python dependency.
+
+### Phase D — Auth oauth-connect
+
+**Implementation.** Confirm via Phase A. For any residual red:
+- **Column drift (tests 5/7/8 — disconnect/reconnect).** The worked seed row uses `connection_status` (`:56`) and the post-mutation assertion reads `oauthStore().connectionsById.get(...).connection_status` (`:413`, `:506`), but `makeQueryMock`'s synthetic upsert row returns `status` (`:122-123`). Make the mock's row shape match the column the handler + store actually use (check `backend/integrations/oauth-db.ts` / the connect handler for whether the live column is `connection_status` or `status`, then make the mock consistent). Fix the mock, not the schema.
+- **Callback ECONNREFUSED (test 10).** Ensure the callback-flow test mocks both `pool.query` (for `dbGetPendingState`) and `globalThis.fetch` (token exchange, `:609`) so no real socket is opened. The pending-state lookup currently returns empty (`:160-164`); a callback test that needs a hit must seed it through the mock, not the DB.
+- **503/404 (tests 5/7/8).** These resolve once the mock serves the right rows for the disconnect/reconnect lookups (`dbGetConnectionById`, `:99-104`) with numeric tenant IDs.
+
+**Acceptance.** All 10 tests in `oauth-connect.test.ts` pass in suite. No real Postgres socket or outbound HTTP is opened (verify the unhandled-SQL `throw` at `:177` is never hit and no `ECONNREFUSED` appears in the log). `integrations-tenant-context.test.ts` is untouched.
+
+### Phase E — Infra onboarding-draft-route test 3
+
+**Implementation.** Confirm via Phase A. The test (`:246-273`) is already shaped correctly. The only clean-runner risk is the `DATA_ROOT` fallback: when CI sets `DATA_ROOT=$RUNNER_TEMP/aries-data`, the draft store's network-error fallback path writes there — but test 3 injects a **non-network** `28P01` error, which must bypass the fallback and surface 503 (`backend/onboarding/draft-store.ts` `shouldUseFallbackDraftStore`). Verify `shouldUseFallbackDraftStore` treats `28P01` as non-recoverable (does not match `ECONNREFUSED`/`ENOTFOUND`). If it falls through to the fallback and returns 200, that is a real product bug in the error classifier — raise it (Decision 3) rather than weakening the test.
+
+**Acceptance.** `onboarding-draft-route.test.ts` all tests pass in suite with `DATA_ROOT` set to a writable temp dir (mirroring CI). No `ECONNREFUSED` in the log for this file.
+
+### Phase F — Lock it in
+
+**Implementation.** Re-run the exact Phase A invocation on a clean `DATA_ROOT`. Confirm zero failures attributable to B/C/D/E. Run `npm run verify` (the fast gate the pre-push hook expects) and `npm run lint`. Open the PR; the `full-suite` required check is the real acceptance.
+
+**Acceptance.** `full-suite` green on the PR. If `integrations-tenant-context` is still red, the PR body states it explicitly and attributes it to #513 (it must not be made worse by this work).
+
+## Testing Plan (fixture-primary)
+
+| Layer | What | How | Gate |
+|---|---|---|---|
+| Marketing hydration | brand/strategy/creative/publish review hydration from tenant-scoped artifacts | `frontend-api-layer.test.ts` fixtures under per-test `mkdtemp` DATA_ROOT + `__setMarketingExecutionPortForTests` mock | full-suite |
+| Marketing contract | validated-store path layout + snapshot precedence + business-profile sync | `marketing-validated-runtime.test.ts`, `marketing-brand-identity-parity.test.ts` direct-store fixtures (no subprocess) | full-suite |
+| Auth | OAuth connect/disconnect/reconnect/callback with Postgres-backed handlers | `oauth-connect.test.ts` `t.mock.method(pool,'query', makeQueryMock)` + `withMetaEnv` + numeric tenant IDs | full-suite |
+| Infra | draft route 503 redaction on non-network DB error | `onboarding-draft-route.test.ts` `installDbMock` throwing `28P01`, DB env kept set | full-suite, fast verify |
+| Ordering | no cross-file pollution | each in-scope file run isolated AND in the full sorted glob | Phase A + F |
+| Boundary | no python subprocess, no real socket, no real HTTP | grep for `lobster/bin`/`spawnSync python`; assert unhandled-SQL throw never fires | Phase C/D |
+
+Fixtures are primary: every assertion is driven by JSON written to a per-test `mkdtemp` DATA_ROOT or by an in-memory mock; nothing touches a live Postgres or the network. This matches CLAUDE.md guardrail #1 (no DB fan-out) trivially — the suite makes zero real DB calls — and the resumability rule is not in play (no stage execution is run for real).
+
+## Rollback
+
+Pure test-and-fixture changes plus (Phase C) dead-helper deletion. Revert the PR to restore the prior state; no migration, no runtime behavior, no env-var, no schema change ships. If a fixture fix accidentally masks a real regression, the offending test reverts independently. There is no production blast radius.
+
+## Out of Scope
+
+- `tests/auth/integrations-tenant-context.test.ts` — **owned by #513 child A.** Not touched here.
+- Splitting the ~70s `frontend-api-layer.test.ts` for speed (`verify-regression-suite.mjs:150` "needs split") — separate perf task, not a correctness fix.
+- Any production code change to make a test pass (Decision 3). Real product bugs surfaced during verification are raised as separate findings, not patched into green.
+- Re-architecting the test harness, adding Jest/Vitest, or introducing a Postgres test container.
+- The Honcho write-path test files and the four P0→P3 Honcho backlog items in TODOS.md — unrelated workstream.
+- CI matrix / node-version changes (#507 already moved CI to node 24).
+
+## Files Reference
+
+| File | Role |
+|---|---|
+| `.github/workflows/tests.yml:50-63` | The `full-suite` REQUIRED gate; canonical invocation to reproduce |
+| `tests/frontend-api-layer.test.ts` | XL hydration contract; flat-vs-tenant-scoped fixture drift at `:815`,`:1681`,`:1873`,`:2333` (Phase B) |
+| `tests/marketing-validated-runtime.test.ts` | Direct-store contract; dead `runScript()` at `:54` (Phase C) |
+| `tests/marketing-brand-identity-parity.test.ts` | Direct-store parity; dead `runScript()` at `:71` (Phase C) |
+| `tests/auth/oauth-connect.test.ts` | OAuth flows; `makeQueryMock` `:85`, column drift `:56`/`:122` (Phase D) |
+| `tests/onboarding-draft-route.test.ts` | Draft 503 redaction test 3 at `:246` (Phase E) |
+| `backend/marketing/validated-profile-store.ts` | `tenantBrandProfilePath:97`, snapshot `:247`, fingerprint gate `:198-201` |
+| `backend/marketing/artifact-store.ts` | `stageCacheRootForTenant:52`, legacy-read gate `:73` |
+| `backend/marketing/orchestrator.ts` | `__setMarketingExecutionPortForTests:1407` (test seam) |
+| `backend/tenant/business-profile.ts` | `getBusinessProfile:716` |
+| `backend/onboarding/draft-store.ts` | `shouldUseFallbackDraftStore` (network-vs-non-network classifier; Phase E) |
+| `scripts/verify-regression-suite.mjs:150-161` | Fast suite membership for these files |


### PR DESCRIPTION
Adds grounded implementation plans for every non-analytics backlog epic, so the queue behind #513 (analytics) is ready to pick up. Each plan was authored by a dedicated Opus agent that verified its claims against real code (open issues, `TODOS.md`, existing `docs/plans/`), not from memory.

## Plans (docs/plans/2026-05-30-*.md)

| Plan | Gist |
|------|------|
| `test-suite-repair` | Turn the REQUIRED `full-suite` gate green. Verification-first: the 5 EPIC test files are already migrated in-tree (#432/#433/#434/#502), so Phase A reproduces the real CI red set, B–E close residual seams. **Excludes** integrations-tenant-context (owned by #513-A). |
| `story-reel-video-publishing` | L-feature: add video media-type + Reel/Story-video publish branches (IG REELS/VIDEO/STORIES + FB `/videos`, `/video_stories`) end-to-end. Distinct from #513's insights READ work. |
| `id-based-hermes-media` (#508) | Address media by `creative_assets.id` with SQL-enforced tenant ownership, replacing the cross-tenant-leaky basename resolution; basename route kept as back-compat. |
| `social-content-list-perf-phase3` | Stop full per-job hydration on `GET /api/social-content/posts`; lightweight server projection + client-side detail refetch. |
| `ci-codeql-stabilization` | P3 hygiene: harden the autofix robot against transient `gh` 401s, close stale CodeQL ci-watcher issues, flake runbook. |
| `honcho-writes-rollout` | All 3 write phases are already on master + compose gates true; real gaps are 2 missing prod JWTs, a stale branch, and the missing V0–V14 verification harness. |
| `honcho-performance-insights` | Feed real Meta post metrics into brand memory by consuming #513's `insights_*` tables (with an explicit anti-duplication boundary vs #513). |
| `publishing-reliability` | Backfill `posts.creative_asset_ids` (writers already shipped via d7fda3a; gap is legacy data) + add an auth class to the Meta failure taxonomy with a `needs_reconnect` surface. |

## Notes
- Docs-only change. No code touched.
- Several plans surfaced that the backlog is further along than the issues implied — captured in each plan's verified "Current State".
- Companion artifact: the #513 eng-review lives under `~/.gstack` (not committed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)