### PR TITLE
test(marketing): drop dead python-subprocess runScript helpers (test-suite-repair Phase C)

### DIFF
--- a/tests/marketing-brand-identity-parity.test.ts
+++ b/tests/marketing-brand-identity-parity.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -66,35 +65,6 @@ async function withRuntimeEnv<T>(run: (input: { dataRoot: string; workdir: strin
     await rm(dataRoot, { recursive: true, force: true });
     await rm(workdir, { recursive: true, force: true });
   }
-}
-
-function runScript(input: {
-  scriptName: string;
-  args?: string[];
-  stdinJson: Record<string, unknown>;
-  dataRoot: string;
-  workdir: string;
-}) {
-  return spawnSync(
-    'python3',
-    [path.join(PROJECT_ROOT, 'lobster', 'bin', input.scriptName), ...(input.args ?? [])],
-    {
-      cwd: input.workdir,
-      env: {
-        ...process.env,
-        CODE_ROOT: PROJECT_ROOT,
-        DATA_ROOT: input.dataRoot,
-        ARTIFACT_PIPELINE_CWD: path.join(PROJECT_ROOT, 'lobster'),
-        ALLOW_TMP_RUNTIME_PERSISTENCE: '1',
-        ARTIFACT_STAGE1_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage1-cache'),
-        ARTIFACT_STAGE2_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage2-cache'),
-        ARTIFACT_STAGE3_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage3-cache'),
-        ARTIFACT_STAGE4_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage4-cache'),
-      },
-      input: `${JSON.stringify(input.stdinJson)}\n`,
-      encoding: 'utf8',
-    },
-  );
 }
 
 function fakeTenantClient() {

--- a/tests/marketing-validated-runtime.test.ts
+++ b/tests/marketing-validated-runtime.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -49,34 +48,6 @@ async function withRuntimeEnv<T>(run: (input: { dataRoot: string; workdir: strin
     await rm(dataRoot, { recursive: true, force: true });
     await rm(workdir, { recursive: true, force: true });
   }
-}
-
-function runScript(input: {
-  scriptName: string;
-  args?: string[];
-  stdinJson: Record<string, unknown>;
-  dataRoot: string;
-  workdir: string;
-}) {
-  return spawnSync(
-    'python3',
-    [path.join(PROJECT_ROOT, 'lobster', 'bin', input.scriptName), ...(input.args ?? [])],
-    {
-      cwd: input.workdir,
-      env: {
-        ...process.env,
-        CODE_ROOT: PROJECT_ROOT,
-        DATA_ROOT: input.dataRoot,
-        ALLOW_TMP_RUNTIME_PERSISTENCE: '1',
-        ARTIFACT_STAGE1_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage1-cache'),
-        ARTIFACT_STAGE2_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage2-cache'),
-        ARTIFACT_STAGE3_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage3-cache'),
-        ARTIFACT_STAGE4_CACHE_DIR: path.join(input.dataRoot, 'lobster-stage4-cache'),
-      },
-      input: `${JSON.stringify(input.stdinJson)}\n`,
-      encoding: 'utf8',
-    },
-  );
 }
 
 test('brand-profile contract persists to validated runtime store and syncs present business-profile fields', async () => {


### PR DESCRIPTION
## Summary

Wave 0 of the 8-plan backlog (`docs/plans/2026-05-30-test-suite-repair.md`).

**Key finding:** the REQUIRED `full-suite` gate is *already green* on master.
Reproduced the exact CI invocation (`find tests -name '*.test.ts' | sort` →
`tsx --test --test-concurrency=1`, `APP_BASE_URL` + per-run `DATA_ROOT` set):
**2039 pass / 0 fail / 9 skipped**, zero `not ok` lines. The five EPIC-named
files (`frontend-api-layer`, `oauth-connect`, `onboarding-draft-route`,
`marketing-validated-runtime`, `marketing-brand-identity-parity`) and the
#513-owned `integrations-tenant-context` all pass. So Phases A–E of the plan
collapse to "confirmed green" and this PR is just the plan's Phase C cleanup.

**Phase C — dead-code removal:** both marketing test files were ported off the
deleted `lobster/bin` python subprocesses (#432/#433) but each still defined a
`runScript()` helper that shells `python3 lobster/bin/<script>` with **zero call
sites**. Dead code and a documented rot trap. Removed the helper + its unused
`spawnSync` import from both files (59 deletions, 0 insertions).

## Test Coverage
Test-only diff — no application code paths changed. The 2 edited files pass 5/5;
`npm run verify` passes 38/38.

## Pre-Landing Review
Pure deletion of verified-dead code (no call sites, no behavior change). No findings.

## Plan Completion
- Phases A–E: confirmed green on master, no change needed (verify-first outcome).
- Phase C: done — `grep runScript( tests/marketing-*.test.ts` returns no call sites; `spawnSync` import removed.
- Out of scope (untouched): `tests/auth/integrations-tenant-context.test.ts` (owned by #513).

## Notes
No version bump (test-only, zero runtime change — same as docs PR #514).
Flagged separately: master has a pre-existing `VERSION` (0.1.13.15) vs
`package.json` (0.1.13.1) drift, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
