### PR TITLE
ci: harden autofix/issue-agent workflows against transient gh label flakes

### DIFF
--- a/.github/workflows/issue-agent-fix.yml
+++ b/.github/workflows/issue-agent-fix.yml
@@ -66,9 +66,19 @@ jobs:
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          gh label create agent:fix --color 5319E7 --description "Agent should investigate and propose a code fix" --force
-          gh label create agent:in-progress --color FBCA04 --description "Agent is currently working on this issue" --force
-          gh label create agent:auto-merge --color 0E8A16 --description "Agent-created PR is eligible for autonomous fixes and merge" --force
+          ensure_label() {  # best-effort; never abort the run on a transient labels-API flake
+            local name="$1" color="$2" desc="$3" attempt
+            for attempt in 1 2 3; do
+              if gh label create "$name" --color "$color" --description "$desc" --force; then return 0; fi
+              echo "::warning::gh label create $name failed (attempt $attempt/3); retrying"
+              sleep $((attempt * 3))
+            done
+            echo "::warning::gh label create $name failed after 3 attempts; continuing (labels are idempotent)"
+            return 0
+          }
+          ensure_label agent:fix 5319E7 "Agent should investigate and propose a code fix"
+          ensure_label agent:in-progress FBCA04 "Agent is currently working on this issue"
+          ensure_label agent:auto-merge 0E8A16 "Agent-created PR is eligible for autonomous fixes and merge"
           gh issue edit "$ISSUE_NUMBER" --add-label agent:in-progress
 
       - name: Claude issue fixer
@@ -125,7 +135,17 @@ jobs:
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          gh label create agent:auto-merge --color 0E8A16 --description "Agent-created PR is eligible for autonomous fixes and merge" --force
+          ensure_label() {  # best-effort; never abort the run on a transient labels-API flake
+            local name="$1" color="$2" desc="$3" attempt
+            for attempt in 1 2 3; do
+              if gh label create "$name" --color "$color" --description "$desc" --force; then return 0; fi
+              echo "::warning::gh label create $name failed (attempt $attempt/3); retrying"
+              sleep $((attempt * 3))
+            done
+            echo "::warning::gh label create $name failed after 3 attempts; continuing (labels are idempotent)"
+            return 0
+          }
+          ensure_label agent:auto-merge 0E8A16 "Agent-created PR is eligible for autonomous fixes and merge"
 
           gh pr list --state open --limit 100 --json number,url,body,headRefName,createdAt,isDraft > /tmp/open-prs.json
           pr_json="$(jq --arg issue "$ISSUE_NUMBER" -c '

--- a/.github/workflows/pr-agent-autofix-automerge.yml
+++ b/.github/workflows/pr-agent-autofix-automerge.yml
@@ -57,8 +57,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh label create agent:auto-merge --color 0E8A16 --description "Agent-created PR is eligible for autonomous fixes and merge" --force
-          gh label create agent:needs-attention --color D93F0B --description "Agent automation needs human attention before merge" --force
+          ensure_label() {  # best-effort; never abort the run on a transient labels-API flake
+            local name="$1" color="$2" desc="$3" attempt
+            for attempt in 1 2 3; do
+              if gh label create "$name" --color "$color" --description "$desc" --force; then return 0; fi
+              echo "::warning::gh label create $name failed (attempt $attempt/3); retrying"
+              sleep $((attempt * 3))
+            done
+            echo "::warning::gh label create $name failed after 3 attempts; continuing (labels are idempotent)"
+            return 0
+          }
+          ensure_label agent:auto-merge 0E8A16 "Agent-created PR is eligible for autonomous fixes and merge"
+          ensure_label agent:needs-attention D93F0B "Agent automation needs human attention before merge"
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             pr_number="${INPUT_PR_NUMBER:-}"

--- a/TODOS.md
+++ b/TODOS.md
@@ -177,21 +177,37 @@ auto-retries. The final publish calls remain one-shot.
 - [ ] Refactor Hermes media addressing to be ID-based. `/api/internal/hermes/media/[...path]` currently identifies assets by basename (last URL path segment) and proves ownership by string-matching `regexp_replace` over `served_asset_ref` / `storage_key`. v0.1.5.6 patched the ownership symptom but the design is still basename-coupled. Proper fix: make the route URL `/api/internal/hermes/media/<creative_assets.id>`, turn ownership into a primary-key + `tenant_id` lookup, and serve the file from `storage_key`. Update the `served_asset_ref` written at ingest (`backend/marketing/ingest-production-assets.ts`) and every consumer — calendar backlog thumbnails, creative-review previews, `scheduled-dispatch` media resolution. Removes basename coupling, the dual-column regex match, and basename-collision risk. (Logged 2026-05-21 after v0.1.5.6.)
 
 
-### CI infra — Autofix workflow HTTP 401 + checkout 'terminal prompts disabled' flake
+### CI infra — Autofix 401 + CodeQL flake runbook (RESOLVED)
 
-**What:** Two related transient infra failures observed during the v0.1.7.4→v0.1.8.4 ship run (2026-05-23):
-- `pr-agent-autofix-automerge.yml` failed once on PR #431 with `HTTP 401: Bad credentials` calling the GitHub labels API. Self-resolved on subsequent PRs.
-- `Analyze (javascript-typescript)` (CodeQL) failed once on PR #438 at the checkout step: `fatal: could not read Username for github.com: terminal prompts disabled`. Self-resolved after a re-trigger push.
+**Resolved** by `docs/plans/2026-05-30-ci-codeql-stabilization.md` (Phase 1 + Phase 4). The autofix-side
+`HTTP 401: Bad credentials` on `gh label create` is now hardened: both `pr-agent-autofix-automerge.yml`
+and `issue-agent-fix.yml` wrap label creation in a best-effort `ensure_label` helper (3 retries with
+backoff, then `::warning::` and `return 0`) so a transient labels-API flake can no longer abort the
+maintenance/fix run. Label creation is idempotent (`--force`) and the labels already exist in the repo.
 
-**Why:** Both are GitHub Actions token auth flakes, not code bugs, but they block the merge gate when they hit. Each cost a few minutes of triage during the ship cascade.
+**Branch protection reminder:** `master` requires only the `full-suite` check, **not** the `CodeQL`
+rollup (`gh api repos/:owner/:repo/branches/master/protection --jq '.required_status_checks.contexts'`
+=> `["full-suite"]`). CodeQL is advisory, so the flake signatures below never block a merge.
 
-**Fix candidates:**
-- Add `continue-on-error: true` to the labels-creation step in `pr-agent-autofix-automerge.yml` (labels are idempotent via `--force`; failure to create them is non-critical).
-- Add a single retry-on-401 wrapper around `gh label create` calls.
-- For the CodeQL checkout flake: nothing local to fix — it's `actions/checkout` losing the GITHUB_TOKEN context. Document the re-trigger workflow.
+**CodeQL flake runbook (re-trigger, do not panic):**
+- **Rollup says `failure` in <5s but every sub-job is green** (#330 pattern): GitHub status-aggregation
+  race. Re-run failed checks from the Actions UI, or push an empty commit. Nothing to fix in-repo. Not a
+  merge blocker.
+- **`Prepare` stuck `queued` post-merge** (#336 pattern): orphaned check run. Ignore (the PR already
+  merged) or cancel the run for tidiness.
+- **`terminal prompts disabled` on CodeQL checkout** (PR #438 pattern): `actions/checkout` lost its
+  token context on CodeQL's *own* default-setup checkout. Re-trigger with a push. The in-repo
+  `pr-agent`/`issue-agent` checkouts are unaffected — they pass `GH_TOKEN` explicitly.
 
-**Priority:** P3 (defer until it recurs more often than transient)
-**Source:** Investigated 2026-05-23, agent recommended defer; logged here for next-time reference.
+**Security-tab recommendations for Brendan (out of band, not landable code):**
+- If #421's `Analyze (python)` resolves to a phantom Python target (PR #404 removed the only `.py`
+  files), remove Python from CodeQL default-setup languages so the phantom job stops being scheduled.
+- Confirm Copilot Autofix for CodeQL is intentionally on/off; the `Prepare`/`Agent` jobs only appear
+  when it is enabled.
+
+**Priority:** P3 hygiene — code portion done; remaining items (#279/#280/#330/#336/#421 issue triage,
+Security-tab toggles) are GitHub-side actions tracked in the plan, executed by Brendan.
+**Source:** Investigated 2026-05-23 (deferred); hardened 2026-05-30 via the CI/CodeQL stabilization plan.
 
 ### Honcho continuous-profile-writes — flip HONCHO_ENABLED and Phase 1 flag in prod
 


### PR DESCRIPTION
## Summary

Wave 1 of the backlog (`docs/plans/2026-05-30-ci-codeql-stabilization.md`). P3 CI hygiene to stop ci-watcher churn and harden the autofix/automerge robots against transient `gh` label-API flakes. **No app code** — workflow YAML + a TODOS runbook.

**Key framing (verified):** branch protection on `master` requires only the `full-suite` check, NOT the CodeQL rollup — so the CodeQL races (#330/#336) and `Prepare` aborts (#279) are PR-tab noise, not a merge gate. This is hygiene, not an emergency.

**Changes:**
- `.github/workflows/pr-agent-autofix-automerge.yml` — replaced the two unguarded `gh label create ... --force` calls (the HTTP 401 abort point) with a best-effort `ensure_label` helper: 3 retries + backoff, then `::warning::` + `return 0` so a transient labels-API 401 can't abort the step under `set -euo pipefail`.
- `.github/workflows/issue-agent-fix.yml` — same `ensure_label` helper at both label-creation sites. Load-bearing `gh issue edit --add-label` and all merge-decision `gh` calls stay strict.
- `TODOS.md` — replaced the stale "CI 401 + terminal-prompts" item with a RESOLVED entry: the CodeQL-flake re-trigger runbook, the `full-suite`-only branch-protection reminder, and the Security-tab recommendations.

## Pre-Landing Review
Workflow-YAML + docs only. `ensure_label` bash passes `bash -n`; both workflows parse cleanly. No app-code risk.

## Test Coverage
No application code paths changed. `npm run verify` 38/38 green (re-run after rebase onto current master).

## Plan Completion
- Phase 1 (autofix/automerge auth hardening) + Phase 4 (TODOS runbook): done.
- Phases 2-3 — closing GitHub issues #279/#280/#330/#336/#421 + Security-tab toggles — are GitHub-side actions the plan assigns to Brendan, not landable code. Left for the human.

## Notes
No version bump (CI-infra + docs, zero runtime change — same as #514/#515).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
