### PR TITLE
fix(publishing): Meta failure taxonomy + reconnect signal + creative_asset_ids backfill

### DIFF
--- a/app/api/internal/publishing/scheduled-dispatch/route.ts
+++ b/app/api/internal/publishing/scheduled-dispatch/route.ts
@@ -1,5 +1,11 @@
 import { verifyInternalCallbackRequest } from '@/lib/internal-callback-auth';
-import { publishToMetaGraph, isMetaProvider, MetaPublishError } from '@/backend/integrations/meta-publishing';
+import {
+  publishToMetaGraph,
+  isMetaProvider,
+  MetaPublishError,
+  classifyMetaPublishFailureKind,
+  type MetaPublishFailureKind,
+} from '@/backend/integrations/meta-publishing';
 import { toSignedPublicUrl } from '@/app/api/publish/dispatch/handler';
 import { resolveSignableBasename } from '@/backend/marketing/signable-basename';
 import pool from '@/lib/db';
@@ -40,12 +46,17 @@ async function readBody(req: Request): Promise<ScheduledDispatchBody> {
 // The join matches either form so the populated path is correct regardless of
 // which id producers write.
 //
-// Fallback: when `creative_asset_ids` is empty (no Aries code populates it
-// yet — every prod `posts` row has `creative_asset_ids = '{}'`), fall back to
-// the job-scoped join on `posts.job_id = creative_assets.source_job_id`. That
-// fallback is non-regressive for today's data (each job currently produces a
-// single shared image) and becomes per-post-exact the moment a producer starts
-// writing `creative_asset_ids`. See the F1 note returned to the team lead.
+// `posts.creative_asset_ids` is populated by the publish/synthesize writers
+// (synthesize-publish-posts.ts, publish-verification.ts, the fb/ig publish
+// handlers) and backfilled for pre-existing rows by
+// scripts/backfill-creative-asset-ids.mjs. The populated per-post join is the
+// primary path.
+//
+// Fallback (D2): when `creative_asset_ids` is empty — a legacy row predating
+// those writers, or a multi-asset legacy row the backfill left untouched — fall
+// back to the job-scoped join on `posts.job_id = creative_assets.source_job_id`.
+// Kept as a safety net for genuinely-empty rows; it fires only when no per-post
+// ids are recorded.
 //
 // storage_kind values come from the creative_assets CHECK constraint:
 //   - 'runtime_asset'  — Aries-generated (ingest-production-assets.ts).
@@ -210,6 +221,10 @@ export async function POST(req: Request): Promise<Response> {
     ok: boolean;
     error?: string;
     retryable?: boolean;
+    // Informational failure taxonomy so the worker can surface *why* a terminal
+    // row failed (e.g. an expired token → reconnect). Does NOT change the retry
+    // policy — `retryable` alone drives pending-vs-failed.
+    kind?: MetaPublishFailureKind;
   }> = [];
 
   // Tracks the platform_post_id of the first platform that went live, so the
@@ -220,7 +235,7 @@ export async function POST(req: Request): Promise<Response> {
   for (const platform of platforms) {
     if (!isMetaProvider(platform)) {
       // Unsupported provider can never succeed — terminal, not retryable.
-      results.push({ provider: platform, ok: false, error: 'unsupported_provider', retryable: false });
+      results.push({ provider: platform, ok: false, error: 'unsupported_provider', retryable: false, kind: 'permanent' });
       continue;
     }
     try {
@@ -241,7 +256,11 @@ export async function POST(req: Request): Promise<Response> {
       // A non-Meta error (e.g. a transient network throw) is treated as
       // retryable; a MetaPublishError carries its own retryable flag.
       const retryable = error instanceof MetaPublishError ? error.retryable : true;
-      results.push({ provider: platform, ok: false, error: errMsg, retryable });
+      // Derive the failure taxonomy for surfacing only. A raw non-Meta throw is
+      // 'permanent' per the classifier, but the route still treats it as
+      // retryable above (network blips re-claim) — the two are independent.
+      const kind = classifyMetaPublishFailureKind(error);
+      results.push({ provider: platform, ok: false, error: errMsg, retryable, kind });
       // Do NOT abort the loop: a later platform may still succeed, and the
       // worker needs every platform's outcome to write per-platform state.
       // Do NOT write posts.published_status here — a per-platform write would

--- a/app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts
@@ -13,6 +13,7 @@ import {
 import { loadSocialCopyArtifact } from '@/backend/social-content/social-copy-store';
 import {
   classifyMetaPublishFailure,
+  classifyMetaPublishFailureKind,
   isMetaProvider,
   MetaPublishError,
   normalizeMetaPlacement,
@@ -325,6 +326,28 @@ export async function handleFacebookPublish(req: Request, jobId: string) {
           retryable: false,
         }),
         { status: 502, headers: { 'content-type': 'application/json' } },
+      );
+    }
+
+    if (error instanceof MetaPublishError && classifyMetaPublishFailureKind(error) === 'auth') {
+      // The tenant's Meta connection is missing/expired. Terminal like any other
+      // retryable:false failure, but operator-actionable: surface a distinct
+      // reconnect signal instead of an opaque publish_failed.
+      console.warn('[publish-facebook] publish failed — Meta account needs reconnect', {
+        approvalId,
+        platform: PLATFORM_KEY,
+        jobId,
+        code: error.code,
+      });
+      return new Response(
+        JSON.stringify({
+          status: 'error',
+          reason: 'needs_reconnect',
+          code: error.code,
+          message: `${error.message} Reconnect your Facebook/Meta account to resume publishing.`,
+          retryable: false,
+        }),
+        { status: error.status, headers: { 'content-type': 'application/json' } },
       );
     }
 

--- a/app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts
@@ -13,6 +13,7 @@ import {
 import { loadSocialCopyArtifact } from '@/backend/social-content/social-copy-store';
 import {
   classifyMetaPublishFailure,
+  classifyMetaPublishFailureKind,
   isMetaProvider,
   MetaPublishError,
   normalizeMetaPlacement,
@@ -332,6 +333,29 @@ export async function handleInstagramPublish(req: Request, jobId: string) {
           retryAfterSeconds: null,
         }),
         { status: 502, headers: { 'content-type': 'application/json' } },
+      );
+    }
+
+    if (error instanceof MetaPublishError && classifyMetaPublishFailureKind(error) === 'auth') {
+      // The tenant's Meta connection is missing/expired. Terminal like any other
+      // retryable:false failure, but operator-actionable: surface a distinct
+      // reconnect signal instead of an opaque publish_failed.
+      console.warn('[publish-instagram] publish failed — Meta account needs reconnect', {
+        approvalId,
+        platform: PLATFORM_KEY,
+        jobId,
+        code: error.code,
+      });
+      return new Response(
+        JSON.stringify({
+          status: 'error',
+          reason: 'needs_reconnect',
+          code: error.code,
+          message: `${error.message} Reconnect your Instagram/Meta account to resume publishing.`,
+          retryable: false,
+          retryAfterSeconds: null,
+        }),
+        { status: error.status, headers: { 'content-type': 'application/json' } },
       );
     }
 

--- a/backend/integrations/meta-publishing.ts
+++ b/backend/integrations/meta-publishing.ts
@@ -103,6 +103,59 @@ export function classifyMetaPublishFailure(error: unknown): MetaPublishFailureCl
   return 'definitely_never_posted';
 }
 
+/**
+ * The Meta publish codes that mean "the tenant's Meta connection is broken and
+ * must be reconnected" — distinct from a malformed request (permanent) or a
+ * transient gateway hiccup (transient). Surfaced to operators as a
+ * reconnect-your-account signal rather than an opaque "publish failed".
+ */
+const META_AUTH_FAILURE_CODES: ReadonlySet<string> = new Set([
+  'oauth_token_missing',
+  'external_account_missing',
+]);
+
+/**
+ * The full failure taxonomy, derived (not stored) from a MetaPublishError's
+ * existing fields. Distinct from the 2-class `MetaPublishFailureClass` above,
+ * which only encodes the publish-acceptance axis:
+ *
+ *   'outcome_unknown' — the publish call was accepted (2xx) but no post id was
+ *   confirmed. NEVER auto-retry (a retry of a publish that secretly succeeded is
+ *   a duplicate). Wins over every other kind. Mirrors `outcomeUnknown`.
+ *
+ *   'auth' — the tenant's Meta connection is missing/expired. Terminal like any
+ *   other `retryable:false` failure, but operator-actionable: reconnect the
+ *   account. Does NOT change the retry policy beyond what `retryable:false`
+ *   already does.
+ *
+ *   'transient' — a network/5xx/rate-limit/container-timeout failure flagged
+ *   `retryable`. Safe for the worker to re-claim on a later pass.
+ *
+ *   'permanent' — a malformed request, unsupported operation, or any other
+ *   non-retryable failure (including non-MetaPublishError throws). Terminal.
+ */
+export type MetaPublishFailureKind = 'transient' | 'permanent' | 'auth' | 'outcome_unknown';
+
+/**
+ * Classify a thrown publish error into the 4-class taxonomy. Precedence:
+ * outcome-unknown (never retry) → auth (reconnect) → transient (retryable) →
+ * permanent (terminal). A non-MetaPublishError throw is treated as permanent
+ * here; the dispatch route independently treats raw non-Meta throws as
+ * retryable at the call site — that route behavior is unchanged by this fn.
+ */
+export function classifyMetaPublishFailureKind(error: unknown): MetaPublishFailureKind {
+  if (error instanceof MetaPublishError && error.outcomeUnknown) {
+    return 'outcome_unknown';
+  }
+  if (error instanceof MetaPublishError && META_AUTH_FAILURE_CODES.has(error.code)) {
+    return 'auth';
+  }
+  if (error instanceof MetaPublishError && error.retryable) {
+    return 'transient';
+  }
+  return 'permanent';
+}
+
 type MetaGraphResponse = Record<string, unknown>;
 
 type MetaPublishTarget = {

--- a/scripts/automations/scheduled-posts-worker.mjs
+++ b/scripts/automations/scheduled-posts-worker.mjs
@@ -232,7 +232,14 @@ export function planPlatformOutcomes(platforms, results, transportError) {
       return { platform, status: 'dispatched', error: null, retryable: false };
     }
     const retryable = result ? result.retryable !== false : true;
-    const error = result?.error ?? 'no_result_for_platform';
+    let error = result?.error ?? 'no_result_for_platform';
+    // Surface the failure taxonomy in the persisted error_message so an operator
+    // inspecting a stuck terminal row sees *why* (e.g. an expired token →
+    // reconnect required) instead of an opaque code. Surface-only — the retry
+    // policy is still driven entirely by `retryable` above.
+    if (result?.kind === 'auth') {
+      error = `auth: Meta account disconnected — reconnect required. ${error}`;
+    }
     return { platform, status: retryable ? 'pending' : 'failed', error, retryable };
   });
 }

--- a/scripts/backfill-creative-asset-ids.mjs
+++ b/scripts/backfill-creative-asset-ids.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/*
+ * Backfill: populate `posts.creative_asset_ids` for legacy rows.
+ *
+ * `posts.creative_asset_ids` (TEXT[]) is the per-post media link that lets the
+ * scheduled-dispatch resolver pick the *exact* image for a post instead of
+ * falling back to a job-scoped join that returns every image the weekly job
+ * produced. The publish/synthesize writers now populate it on every new row,
+ * but rows written before those writers landed are still '{}' and rely on the
+ * fallback — a multi-image job can publish the wrong creative.
+ *
+ * This one-shot pass fills `creative_asset_ids` for every post that has an empty
+ * array AND a `job_id`, using the job's generated `creative_assets`:
+ *
+ *   - exactly one asset for the job  -> set ARRAY[<that asset's source_asset_id>]
+ *     (non-regressive vs the current fallback, and now exact).
+ *   - more than one asset for the job -> AMBIGUOUS (legacy rows carry no
+ *     post_number, so the post->asset mapping is unknowable). Do NOT guess:
+ *     log + count, leave the row on the fallback.
+ *
+ * Idempotent: only touches rows where `array_length(creative_asset_ids, 1) IS
+ * NULL`, so re-running is a no-op. Never deletes ids.
+ *
+ * Tenant-scoped + sequential per tenant (guardrail #1: no Promise.all fan-out
+ * over the pool). Dry-run by default.
+ *
+ * NOT wired into init-db.js (D5: schema migrations only). Run manually:
+ *   node scripts/backfill-creative-asset-ids.mjs              # dry-run (default)
+ *   node scripts/backfill-creative-asset-ids.mjs --write      # persist changes
+ *   node scripts/backfill-creative-asset-ids.mjs --tenant t1  # limit to one tenant
+ */
+
+import process from 'node:process';
+
+/**
+ * Core backfill, decoupled from the pg pool so it is unit-testable with a mock
+ * queryable. `db` only needs a `.query(sql, params)` returning `{ rows }`.
+ *
+ * Returns aggregate counts: { tenants, total, populated, empty, ambiguousMulti }.
+ *   total           — empty-array rows with a job_id considered (the candidates)
+ *   populated       — single-asset rows set (or that would be set in dry-run)
+ *   empty           — candidate rows whose job produced zero usable assets
+ *   ambiguousMulti  — multi-asset rows left on the fallback (untouched)
+ */
+export async function backfillCreativeAssetIds(db, { write = false, tenantFilter = null, log = console.log } = {}) {
+  const counts = { tenants: 0, total: 0, populated: 0, empty: 0, ambiguousMulti: 0 };
+
+  const tenantRows = tenantFilter
+    ? [{ tenant_id: tenantFilter }]
+    : (
+        await db.query(
+          `SELECT DISTINCT tenant_id
+             FROM posts
+            WHERE array_length(creative_asset_ids, 1) IS NULL
+              AND job_id IS NOT NULL
+            ORDER BY tenant_id`,
+        )
+      ).rows;
+
+  for (const { tenant_id: tenantId } of tenantRows) {
+    counts.tenants += 1;
+
+    // Candidate posts: empty creative_asset_ids + a job_id, scoped to tenant.
+    const posts = (
+      await db.query(
+        `SELECT id, job_id
+           FROM posts
+          WHERE tenant_id = $1
+            AND array_length(creative_asset_ids, 1) IS NULL
+            AND job_id IS NOT NULL
+          ORDER BY id`,
+        [tenantId],
+      )
+    ).rows;
+
+    for (const post of posts) {
+      counts.total += 1;
+
+      // The job's generated assets, ordered by source_asset_id (img_1, img_2, ..).
+      const assets = (
+        await db.query(
+          `SELECT source_asset_id
+             FROM creative_assets
+            WHERE tenant_id = $1
+              AND source_job_id = $2
+              AND source_type = 'generated_by_aries'
+              AND source_asset_id IS NOT NULL
+            ORDER BY source_asset_id`,
+          [tenantId, post.job_id],
+        )
+      ).rows;
+
+      if (assets.length === 0) {
+        counts.empty += 1;
+        log(`[backfill] tenant=${tenantId} post=${post.id} job=${post.job_id}: 0 assets — left on fallback`);
+        continue;
+      }
+
+      if (assets.length > 1) {
+        counts.ambiguousMulti += 1;
+        log(
+          `[backfill] tenant=${tenantId} post=${post.id} job=${post.job_id}: ${assets.length} assets — AMBIGUOUS (no post_number), left on fallback`,
+        );
+        continue;
+      }
+
+      const assetId = assets[0].source_asset_id;
+      counts.populated += 1;
+      if (write) {
+        await db.query(
+          `UPDATE posts
+              SET creative_asset_ids = ARRAY[$3]::text[]
+            WHERE id = $1
+              AND tenant_id = $2
+              AND array_length(creative_asset_ids, 1) IS NULL`,
+          [post.id, tenantId, assetId],
+        );
+        log(`[backfill] tenant=${tenantId} post=${post.id} job=${post.job_id}: set creative_asset_ids = {${assetId}}`);
+      } else {
+        log(`[backfill] tenant=${tenantId} post=${post.id} job=${post.job_id}: would set creative_asset_ids = {${assetId}}`);
+      }
+    }
+  }
+
+  return counts;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const write = args.includes('--write');
+  const tenantIdx = args.indexOf('--tenant');
+  const tenantFilter = tenantIdx >= 0 ? args[tenantIdx + 1] : null;
+
+  console.log(`[backfill] mode = ${write ? 'WRITE' : 'dry-run'}`);
+  if (tenantFilter) console.log(`[backfill] tenant filter = ${tenantFilter}`);
+
+  const { default: pg } = await import('pg');
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST,
+    port: Number.parseInt(process.env.DB_PORT || '5432', 10),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  });
+
+  try {
+    const counts = await backfillCreativeAssetIds(pool, { write, tenantFilter });
+    console.log('[backfill] ---- report ----');
+    console.log(`[backfill]   tenants scanned    : ${counts.tenants}`);
+    console.log(`[backfill]   candidate rows      : ${counts.total}`);
+    console.log(`[backfill]   populated (1 asset) : ${counts.populated}${write ? '' : ' (dry-run)'}`);
+    console.log(`[backfill]   empty (0 assets)    : ${counts.empty}`);
+    console.log(`[backfill]   ambiguous (N>1)     : ${counts.ambiguousMulti} (left on fallback)`);
+    if (!write && counts.populated > 0) {
+      console.log('[backfill] rerun with --write to persist changes.');
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+// Only run when invoked directly (not when imported by a test).
+const invokedDirectly =
+  process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('[backfill] fatal:', err);
+    process.exit(1);
+  });
+}

--- a/tests/backfill-creative-asset-ids.test.ts
+++ b/tests/backfill-creative-asset-ids.test.ts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// @ts-expect-error — .mjs script imported for its exported pure function.
+import { backfillCreativeAssetIds } from '../scripts/backfill-creative-asset-ids.mjs';
+
+type PostRow = { id: string; tenant_id: string; job_id: string | null; creative_asset_ids: string[] | null };
+type AssetRow = { tenant_id: string; source_job_id: string; source_type: string; source_asset_id: string | null };
+
+// In-memory fake reproducing the SQL semantics the backfill relies on:
+//   - DISTINCT tenant_id for empty-array + job_id rows
+//   - candidate posts per tenant (empty-array + job_id)
+//   - job's generated_by_aries assets ordered by source_asset_id
+//   - UPDATE only when array_length(creative_asset_ids,1) IS NULL (idempotent)
+function buildFakeDb(posts: PostRow[], assets: AssetRow[]) {
+  const isEmpty = (ids: string[] | null) => !Array.isArray(ids) || ids.length === 0;
+  return {
+    updates: [] as Array<{ id: string; tenantId: string; value: string[] }>,
+    async query(sql: string, params: unknown[] = []) {
+      const norm = sql.replace(/\s+/g, ' ').trim();
+
+      if (norm.startsWith('SELECT DISTINCT tenant_id')) {
+        const seen = new Set<string>();
+        for (const p of posts) {
+          if (isEmpty(p.creative_asset_ids) && p.job_id) seen.add(p.tenant_id);
+        }
+        return { rows: [...seen].sort().map((tenant_id) => ({ tenant_id })) };
+      }
+
+      if (norm.startsWith('SELECT id, job_id')) {
+        const [tenantId] = params as [string];
+        const rows = posts
+          .filter((p) => p.tenant_id === tenantId && isEmpty(p.creative_asset_ids) && p.job_id)
+          .map((p) => ({ id: p.id, job_id: p.job_id }));
+        return { rows };
+      }
+
+      if (norm.startsWith('SELECT source_asset_id')) {
+        const [tenantId, jobId] = params as [string, string];
+        const rows = assets
+          .filter(
+            (a) =>
+              a.tenant_id === tenantId &&
+              a.source_job_id === jobId &&
+              a.source_type === 'generated_by_aries' &&
+              a.source_asset_id !== null,
+          )
+          .sort((l, r) => (l.source_asset_id! < r.source_asset_id! ? -1 : 1))
+          .map((a) => ({ source_asset_id: a.source_asset_id }));
+        return { rows };
+      }
+
+      if (norm.startsWith('UPDATE posts')) {
+        const [id, tenantId, assetId] = params as [string, string, string];
+        const post = posts.find((p) => p.id === id && p.tenant_id === tenantId);
+        // Idempotency guard: only writes when array_length IS NULL (empty).
+        if (post && isEmpty(post.creative_asset_ids)) {
+          post.creative_asset_ids = [assetId];
+          this.updates.push({ id, tenantId, value: [assetId] });
+        }
+        return { rows: [] };
+      }
+
+      throw new Error(`unexpected query: ${norm}`);
+    },
+  };
+}
+
+const silent = () => {};
+
+test('backfill: single-asset legacy row is populated with the job asset', async () => {
+  const posts: PostRow[] = [{ id: 'p1', tenant_id: 't1', job_id: 'job-a', creative_asset_ids: [] }];
+  const assets: AssetRow[] = [
+    { tenant_id: 't1', source_job_id: 'job-a', source_type: 'generated_by_aries', source_asset_id: 'img_1' },
+  ];
+  const db = buildFakeDb(posts, assets);
+  const counts = await backfillCreativeAssetIds(db, { write: true, log: silent });
+
+  assert.equal(counts.populated, 1);
+  assert.equal(counts.ambiguousMulti, 0);
+  assert.equal(counts.empty, 0);
+  assert.deepEqual(posts[0].creative_asset_ids, ['img_1']);
+  assert.equal(db.updates.length, 1);
+});
+
+test('backfill: multi-asset legacy row is AMBIGUOUS — counted and untouched', async () => {
+  const posts: PostRow[] = [{ id: 'p1', tenant_id: 't1', job_id: 'job-multi', creative_asset_ids: [] }];
+  const assets: AssetRow[] = [
+    { tenant_id: 't1', source_job_id: 'job-multi', source_type: 'generated_by_aries', source_asset_id: 'img_1' },
+    { tenant_id: 't1', source_job_id: 'job-multi', source_type: 'generated_by_aries', source_asset_id: 'img_2' },
+  ];
+  const db = buildFakeDb(posts, assets);
+  const counts = await backfillCreativeAssetIds(db, { write: true, log: silent });
+
+  assert.equal(counts.ambiguousMulti, 1);
+  assert.equal(counts.populated, 0);
+  assert.deepEqual(posts[0].creative_asset_ids, [], 'ambiguous row is left on the fallback');
+  assert.equal(db.updates.length, 0);
+});
+
+test('backfill: job with zero assets is counted empty and left untouched', async () => {
+  const posts: PostRow[] = [{ id: 'p1', tenant_id: 't1', job_id: 'job-empty', creative_asset_ids: [] }];
+  const db = buildFakeDb(posts, []);
+  const counts = await backfillCreativeAssetIds(db, { write: true, log: silent });
+
+  assert.equal(counts.empty, 1);
+  assert.equal(counts.populated, 0);
+  assert.deepEqual(posts[0].creative_asset_ids, []);
+});
+
+test('backfill: dry-run computes counts without writing', async () => {
+  const posts: PostRow[] = [{ id: 'p1', tenant_id: 't1', job_id: 'job-a', creative_asset_ids: [] }];
+  const assets: AssetRow[] = [
+    { tenant_id: 't1', source_job_id: 'job-a', source_type: 'generated_by_aries', source_asset_id: 'img_1' },
+  ];
+  const db = buildFakeDb(posts, assets);
+  const counts = await backfillCreativeAssetIds(db, { write: false, log: silent });
+
+  assert.equal(counts.populated, 1, 'dry-run still reports what it would populate');
+  assert.deepEqual(posts[0].creative_asset_ids, [], 'dry-run does not mutate the row');
+  assert.equal(db.updates.length, 0);
+});
+
+test('backfill: re-running after a write is a no-op (idempotent)', async () => {
+  const posts: PostRow[] = [{ id: 'p1', tenant_id: 't1', job_id: 'job-a', creative_asset_ids: [] }];
+  const assets: AssetRow[] = [
+    { tenant_id: 't1', source_job_id: 'job-a', source_type: 'generated_by_aries', source_asset_id: 'img_1' },
+  ];
+  const db = buildFakeDb(posts, assets);
+
+  await backfillCreativeAssetIds(db, { write: true, log: silent });
+  const second = await backfillCreativeAssetIds(db, { write: true, log: silent });
+
+  assert.equal(second.total, 0, 'no candidate rows remain — already populated');
+  assert.equal(second.populated, 0);
+  assert.equal(db.updates.length, 1, 'no second write');
+});
+
+test('backfill: queries are tenant-scoped — a tenant filter only touches its own rows', async () => {
+  const posts: PostRow[] = [
+    { id: 'p1', tenant_id: 't1', job_id: 'job-a', creative_asset_ids: [] },
+    { id: 'p2', tenant_id: 't2', job_id: 'job-b', creative_asset_ids: [] },
+  ];
+  const assets: AssetRow[] = [
+    { tenant_id: 't1', source_job_id: 'job-a', source_type: 'generated_by_aries', source_asset_id: 'img_1' },
+    { tenant_id: 't2', source_job_id: 'job-b', source_type: 'generated_by_aries', source_asset_id: 'img_9' },
+  ];
+  const db = buildFakeDb(posts, assets);
+  const counts = await backfillCreativeAssetIds(db, { write: true, tenantFilter: 't1', log: silent });
+
+  assert.equal(counts.tenants, 1);
+  assert.equal(counts.populated, 1);
+  assert.deepEqual(posts[0].creative_asset_ids, ['img_1']);
+  assert.deepEqual(posts[1].creative_asset_ids, [], 't2 untouched under a t1 filter');
+});

--- a/tests/meta-publishing.test.ts
+++ b/tests/meta-publishing.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import pool from '../lib/db';
 import {
   classifyMetaPublishFailure,
+  classifyMetaPublishFailureKind,
   publishToMetaGraph,
   MetaPublishError,
   waitForInstagramContainerReady,
@@ -780,4 +781,80 @@ test('publishToMetaGraph rejects a natively-scheduled story before any Graph cal
   } finally {
     restoreQuery();
   }
+});
+
+
+// ---- classifyMetaPublishFailureKind: the 4-class taxonomy ----
+//
+// Every known MetaPublishError code must map to exactly one kind from the
+// Current State table. The handlers + dispatch route + worker branch on this:
+// 'auth' -> needs_reconnect; 'transient' -> retryable; 'permanent' -> terminal;
+// 'outcome_unknown' -> never retry (claim left in place). outcome_unknown wins
+// over every other axis when outcomeUnknown is set.
+
+type KindCase = {
+  code: string;
+  status: number;
+  retryable?: boolean;
+  outcomeUnknown?: boolean;
+  expected: 'transient' | 'permanent' | 'auth' | 'outcome_unknown';
+};
+
+const KIND_CASES: KindCase[] = [
+  { code: 'unsupported_provider', status: 400, expected: 'permanent' },
+  { code: 'invalid_scheduled_for', status: 400, expected: 'permanent' },
+  { code: 'missing_content', status: 400, expected: 'permanent' },
+  { code: 'instagram_media_required', status: 400, expected: 'permanent' },
+  { code: 'story_single_media_required', status: 400, expected: 'permanent' },
+  { code: 'oauth_token_missing', status: 409, expected: 'auth' },
+  { code: 'external_account_missing', status: 409, expected: 'auth' },
+  { code: 'facebook_scheduled_publish_not_supported', status: 409, expected: 'permanent' },
+  { code: 'story_scheduled_publish_not_supported', status: 409, expected: 'permanent' },
+  { code: 'graph_network_error', status: 502, retryable: true, expected: 'transient' },
+  { code: 'graph_rate_limited', status: 429, retryable: true, expected: 'transient' },
+  { code: 'graph_api_error', status: 503, retryable: true, expected: 'transient' },
+  { code: 'graph_api_error', status: 400, retryable: false, expected: 'permanent' },
+  { code: 'instagram_container_timeout', status: 504, retryable: true, expected: 'transient' },
+  { code: 'instagram_container_failed', status: 422, retryable: false, expected: 'permanent' },
+  { code: 'facebook_publish_missing_id', status: 502, outcomeUnknown: true, expected: 'outcome_unknown' },
+  { code: 'instagram_publish_missing_id', status: 502, outcomeUnknown: true, expected: 'outcome_unknown' },
+];
+
+for (const c of KIND_CASES) {
+  test(`classifyMetaPublishFailureKind: ${c.code} (status ${c.status}) -> ${c.expected}`, () => {
+    const err = new MetaPublishError(c.code, `${c.code} message`, {
+      status: c.status,
+      retryable: c.retryable,
+      outcomeUnknown: c.outcomeUnknown,
+    });
+    assert.equal(classifyMetaPublishFailureKind(err), c.expected);
+  });
+}
+
+test('classifyMetaPublishFailureKind: outcome_unknown wins over transient (retryable + outcomeUnknown)', () => {
+  // A pathological error flagged BOTH retryable and outcomeUnknown must classify
+  // as outcome_unknown — never transient. Retrying a publish that secretly
+  // succeeded is a duplicate post.
+  const err = new MetaPublishError('weird_both', 'both flags set', {
+    status: 502,
+    retryable: true,
+    outcomeUnknown: true,
+  });
+  assert.equal(classifyMetaPublishFailureKind(err), 'outcome_unknown');
+});
+
+test('classifyMetaPublishFailureKind: a non-MetaPublishError throw is permanent', () => {
+  assert.equal(classifyMetaPublishFailureKind(new Error('boom')), 'permanent');
+  assert.equal(classifyMetaPublishFailureKind('a bare string'), 'permanent');
+  assert.equal(classifyMetaPublishFailureKind(undefined), 'permanent');
+});
+
+test('classifyMetaPublishFailureKind: auth wins over the retryable axis', () => {
+  // An auth code flagged retryable (defensive — should never happen) still
+  // classifies as auth so the operator sees the reconnect signal.
+  const err = new MetaPublishError('oauth_token_missing', 'expired', {
+    status: 409,
+    retryable: true,
+  });
+  assert.equal(classifyMetaPublishFailureKind(err), 'auth');
 });

--- a/tests/scheduled-dispatch-media-resolution.test.ts
+++ b/tests/scheduled-dispatch-media-resolution.test.ts
@@ -125,8 +125,9 @@ test('resolveMediaUrls matches creative_asset_ids against the uuid id too', asyn
 });
 
 test('resolveMediaUrls falls back to job-scope when creative_asset_ids is empty', async () => {
-  // No Aries code populates creative_asset_ids yet (every prod posts row has
-  // '{}'). The job-scoped fallback keeps media resolution working today.
+  // The publish/synthesize writers populate creative_asset_ids on new rows; a
+  // legacy/empty row falls back to the job-scoped join (D2 safety net). This
+  // pins that the fallback still fires only for genuinely-empty rows.
   const tenantId = '7';
   const posts: PostRow[] = [
     { id: '100', tenant_id: tenantId, job_id: 'job-A', creative_asset_ids: [] },
@@ -198,4 +199,36 @@ test('resolveMediaUrls skips runtime_asset rows with no served_asset_ref', async
   ];
   const urls = await resolveMediaUrls('100', tenantId, buildFakeDb(posts, assets));
   assert.deepEqual(urls, [], 'a row with no servable ref is skipped, never served from a host path');
+});
+
+
+test('resolveMediaUrls: populated path is primary, empty row falls back to the whole job (same multi-asset job)', async () => {
+  // P2 regression: in one multi-image weekly job, a post with populated
+  // creative_asset_ids must resolve to ONLY its own asset (populated path
+  // primary), while a sibling post still on the empty default falls back to the
+  // job-scoped join and sees the whole job set. The two paths must be distinct.
+  const tenantId = '9';
+  process.env.APP_BASE_URL = 'https://aries.example.test';
+  const posts: PostRow[] = [
+    { id: 'populated', tenant_id: tenantId, job_id: 'job-multi', creative_asset_ids: ['img_2'] },
+    { id: 'legacy-empty', tenant_id: tenantId, job_id: 'job-multi', creative_asset_ids: [] },
+  ];
+  const assets: AssetRow[] = [
+    runtimeAsset('a1', tenantId, 'job-multi', 'one.png', 'img_1'),
+    runtimeAsset('a2', tenantId, 'job-multi', 'two.png', 'img_2'),
+    runtimeAsset('a3', tenantId, 'job-multi', 'three.png', 'img_3'),
+  ];
+  const db = buildFakeDb(posts, assets);
+
+  const populated = await resolveMediaUrls('populated', tenantId, db);
+  assert.deepEqual(
+    populated,
+    ['https://aries.example.test/api/internal/hermes/media/two.png'],
+    'populated path is primary: exactly the per-post asset, not the whole job',
+  );
+
+  const legacy = await resolveMediaUrls('legacy-empty', tenantId, db);
+  assert.equal(legacy.length, 3, 'empty row falls back to the whole job set');
+  assert.ok(legacy.some((u) => u.includes('one')) && legacy.some((u) => u.includes('three')),
+    'fallback returns every asset of the job, confirming the two paths differ');
 });

--- a/tests/scheduled-post-partial-dispatch.test.ts
+++ b/tests/scheduled-post-partial-dispatch.test.ts
@@ -19,7 +19,7 @@ type WorkerModule = {
   rollupParentStatus: (statuses: string[]) => string;
   planPlatformOutcomes: (
     platforms: string[],
-    results: Array<{ provider: string; ok: boolean; error?: string; retryable?: boolean }>,
+    results: Array<{ provider: string; ok: boolean; error?: string; retryable?: boolean; kind?: string }>,
     transportError: string | null,
   ) => PlatformOutcome[];
 };
@@ -106,4 +106,39 @@ test('worker schema: scheduled_post_dispatches child table exists in init-db.js'
     /status IN \('pending','in_flight','dispatched','failed'\)/,
     'child status must allow the four-state lifecycle',
   );
+});
+
+
+test('planPlatformOutcomes: an auth kind prefixes the error_message with a reconnect signal', async () => {
+  const { planPlatformOutcomes } = await loadWorker();
+  const outcomes = planPlatformOutcomes(
+    ['facebook'],
+    [{ provider: 'facebook', ok: false, error: 'oauth_token_missing: token expired', retryable: false, kind: 'auth' }],
+    null,
+  );
+  const fb = outcomes.find((o) => o.platform === 'facebook')!;
+  // Retry policy unchanged: auth is terminal (retryable:false -> failed).
+  assert.equal(fb.status, 'failed');
+  assert.equal(fb.retryable, false);
+  // Surface-only: the operator can now see WHY a terminal row failed.
+  assert.match(fb.error ?? '', /reconnect required/i, 'auth reason surfaced in error_message');
+  assert.match(fb.error ?? '', /oauth_token_missing/, 'original code preserved');
+});
+
+test('planPlatformOutcomes: a non-auth kind leaves the error_message untouched', async () => {
+  const { planPlatformOutcomes } = await loadWorker();
+  const outcomes = planPlatformOutcomes(
+    ['facebook', 'instagram'],
+    [
+      { provider: 'facebook', ok: false, error: 'graph_api_error: 400', retryable: false, kind: 'permanent' },
+      { provider: 'instagram', ok: false, error: 'rate_limited', retryable: true, kind: 'transient' },
+    ],
+    null,
+  );
+  const fb = outcomes.find((o) => o.platform === 'facebook')!;
+  const ig = outcomes.find((o) => o.platform === 'instagram')!;
+  assert.equal(fb.error, 'graph_api_error: 400', 'permanent kind: error_message verbatim');
+  assert.equal(fb.status, 'failed');
+  assert.equal(ig.error, 'rate_limited', 'transient kind: error_message verbatim');
+  assert.equal(ig.status, 'pending', 'transient still retries — policy unchanged');
 });

--- a/tests/smoke-meta-publish.test.ts
+++ b/tests/smoke-meta-publish.test.ts
@@ -6,6 +6,11 @@ import {
   buildSignedPublicUrl,
   pickBestCaption,
 } from '../scripts/smoke-meta-publish';
+import {
+  MetaPublishError,
+  classifyMetaPublishFailure,
+  classifyMetaPublishFailureKind,
+} from '../backend/integrations/meta-publishing';
 
 test('buildPublishRouteUrl builds instagram URL correctly', () => {
   const url = buildPublishRouteUrl('https://aries.sugarandleather.com', 'mkt_abc123', 'instagram');
@@ -88,4 +93,60 @@ test('pickBestCaption omits hashtag block when hashtags array is empty', () => {
     posts: [{ channel: 'instagram_feed', caption: 'Clean caption', hashtags: [] }],
   };
   assert.equal(pickBestCaption(socialCopy, 'instagram'), 'Clean caption');
+});
+
+
+// ---------------------------------------------------------------------------
+// Publish-handler error-branch decision (P4)
+// ---------------------------------------------------------------------------
+//
+// The fb/ig publish handlers require DB/auth/session to drive end-to-end, so —
+// per the repo convention (publish-handler-caption-fallback.test.ts) — we pin
+// the error-branch DECISION in isolation. This mirrors the branch order in
+// publish-facebook/handler.ts and publish-instagram/handler.ts:
+//   outcome_unknown -> needs_manual_reconciliation (502, unchanged)
+//   auth            -> needs_reconnect (409)  [NEW]
+//   other Meta err  -> generic { reason: error.code } at error.status
+type HandlerBranch =
+  | { kind: 'needs_manual_reconciliation'; status: number }
+  | { kind: 'needs_reconnect'; reason: string; status: number }
+  | { kind: 'generic'; reason: string; status: number };
+
+function decidePublishHandlerBranch(error: unknown): HandlerBranch {
+  if (classifyMetaPublishFailure(error) === 'outcome_unknown') {
+    return { kind: 'needs_manual_reconciliation', status: 502 };
+  }
+  if (error instanceof MetaPublishError && classifyMetaPublishFailureKind(error) === 'auth') {
+    return { kind: 'needs_reconnect', reason: 'needs_reconnect', status: error.status };
+  }
+  if (error instanceof MetaPublishError) {
+    return { kind: 'generic', reason: error.code, status: error.status };
+  }
+  return { kind: 'generic', reason: 'publish_failed', status: 500 };
+}
+
+test('publish handler: oauth_token_missing -> needs_reconnect at 409', () => {
+  const err = new MetaPublishError('oauth_token_missing', 'token expired', { status: 409 });
+  const branch = decidePublishHandlerBranch(err);
+  assert.deepEqual(branch, { kind: 'needs_reconnect', reason: 'needs_reconnect', status: 409 });
+});
+
+test('publish handler: external_account_missing -> needs_reconnect at 409', () => {
+  const err = new MetaPublishError('external_account_missing', 'no page', { status: 409 });
+  const branch = decidePublishHandlerBranch(err);
+  assert.equal(branch.kind, 'needs_reconnect');
+  assert.equal(branch.status, 409);
+});
+
+test('publish handler: a transient graph error stays the generic retryable branch (not auth)', () => {
+  const err = new MetaPublishError('graph_network_error', 'ETIMEDOUT', { status: 502, retryable: true });
+  const branch = decidePublishHandlerBranch(err);
+  assert.equal(branch.kind, 'generic');
+  assert.equal(branch.reason, 'graph_network_error');
+});
+
+test('publish handler: outcome-unknown still wins (needs_manual_reconciliation, 502) — unchanged', () => {
+  const err = new MetaPublishError('instagram_publish_missing_id', 'no id', { status: 502, outcomeUnknown: true });
+  const branch = decidePublishHandlerBranch(err);
+  assert.deepEqual(branch, { kind: 'needs_manual_reconciliation', status: 502 });
 });


### PR DESCRIPTION
## Summary

Wave 2 of the backlog (`docs/plans/2026-05-30-publishing-reliability.md`). Hardens the Meta publish path: a structured failure taxonomy, a reconnect signal when a token expires, and a one-shot backfill for legacy `creative_asset_ids`.

**Item 1 — `creative_asset_ids` backfill (P1/P2)**
- `scripts/backfill-creative-asset-ids.mjs` (new) — one-shot, **dry-run default**, tenant-scoped + sequential per tenant (guardrail #1, no pool fan-out). Single-asset legacy jobs → populated from the job's `generated_by_aries` asset; multi-asset/ambiguous rows left on the fallback and counted; idempotent (`array_length IS NULL` only). Exports a pure `backfillCreativeAssetIds(db, opts)` for testing. Not wired into `init-db.js`.
- `scheduled-dispatch/route.ts` — replaced the stale "no Aries code populates it yet" comment with an accurate note (populated path primary, job-scope join is the legacy fallback). No SQL change.

**Item 2 — Meta failure taxonomy (P3/P4)**
- `backend/integrations/meta-publishing.ts` — new `MetaPublishFailureKind` + `classifyMetaPublishFailureKind` (precedence `outcome_unknown` > `auth` > `transient` > `permanent`). Additive; existing `classifyMetaPublishFailure` untouched.
- `publish-facebook` / `publish-instagram` handlers — new `auth` branch returns `reason:'needs_reconnect'` at 409; outcome-unknown path unchanged.
- `scheduled-dispatch/route.ts` — informational `kind` per platform result; retry policy unchanged.
- `scripts/automations/scheduled-posts-worker.mjs` — prefixes persisted `error_message` with a reconnect signal when `kind==='auth'`.

## Test Coverage
New backfill test; classifier parametrized over every code + outcome_unknown/auth precedence; populated-vs-fallback resolver test; handler `needs_reconnect`/409 test; worker `kind`-threading test. `npm run verify` green (re-run after rebase onto current master with id-based-media landed — no conflicts; my meta-publishing.ts change is a pure insertion above `publishToMetaGraph`).

## ⚠️ Manual prod step (data-only)
The backfill script must be **run manually against prod**: dry-run first (captures `total/populated/empty/ambiguous_multi`), then `--write`. No prod secret needed beyond the usual DB env; it's outside CI scope.

## Notes
No version bump (consistent with this session's serial backlog PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
