### PR TITLE
feat(insights): Honcho-write leg of performance-insights (contract-first vs #513, gated OFF)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,10 @@ ARIES_BRAND_ENRICHMENT_ENABLED=0
 # emits media_type="video" + per-asset width/height/duration metadata.
 ARIES_VIDEO_PUBLISH_ENABLED=0
 
+# Flip ON only once #513's insights_* tables exist + are populated. When OFF
+# (default) the honcho-performance-insights read model + sidecar do no DB work.
+ARIES_INSIGHTS_513_TABLES_PRESENT=0
+
 # Hermes kanban GC worker (archives completed tasks + runs `hermes kanban gc`).
 # Enabled by default; set to 0 to disable. Interval in ms (default 24 h).
 ARIES_KANBAN_GC_ENABLED=1

--- a/backend/memory/insights-513-contract.ts
+++ b/backend/memory/insights-513-contract.ts
@@ -1,0 +1,103 @@
+/**
+ * #513 INTEGRATION CONTRACT — Meta insights tables owned by issue #513
+ * (branch `hammad/analytics-backend`, children A + E). These tables/columns do
+ * NOT exist on master yet. This file is the single, documented seam that this
+ * epic (honcho-performance-insights) consumes; #513-E satisfies it.
+ *
+ * DO NOT re-implement #513's Meta fetch/store here. This epic is a pure
+ * reader-of-tables / writer-of-memory. See:
+ *   docs/plans/2026-05-30-honcho-performance-insights.md  (#513 boundary section)
+ *
+ * ---------------------------------------------------------------------------
+ * What #513-E must provide for this epic to wire up (post-#513, mechanical):
+ *
+ *   insights_posts
+ *     tenant_id        INTEGER  (FK organizations.id) — matches posts.tenant_id
+ *     external_post_id TEXT     — equals posts.platform_post_id
+ *     platform         TEXT     — 'facebook' | 'instagram'
+ *     permalink        TEXT     — https public/insights URL for the post
+ *     posted_at        TIMESTAMPTZ
+ *     -- join key to Aries marketing job: either insights_posts.job_id directly,
+ *     -- or (external_post_id = posts.platform_post_id AND tenant_id = posts.tenant_id)
+ *     --   then posts.job_id. Confirm with #513-E before freezing P0's query.
+ *
+ *   insights_post_metrics_daily   (latest row per post = the snapshot we read)
+ *     tenant_id        INTEGER
+ *     external_post_id TEXT
+ *     platform         TEXT
+ *     day              DATE      — the metric day (the post's UTC publish day for dedupe)
+ *     reach            BIGINT
+ *     impressions      BIGINT
+ *     likes            BIGINT
+ *     comments         BIGINT
+ *     shares           BIGINT
+ *     saved            BIGINT     — maps to payload metric key `saves`
+ *     video_views      BIGINT
+ *
+ * Until #513-E lands these tables, `selectDuePerformancePosts` short-circuits
+ * (see INSIGHTS_513_TABLES_PRESENT) and returns []. The SQL is written and
+ * frozen against the column names above so post-#513 wiring is a one-line flip.
+ * ---------------------------------------------------------------------------
+ */
+
+/**
+ * The metric columns this epic reads from #513-E's `insights_post_metrics_daily`.
+ * Numeric metrics are read as numbers; `day` is the metric day (post publish day).
+ * `saved` (Meta's column name) maps to the payload key `saves` in P1.
+ */
+export interface InsightsPostMetricsDailyRow {
+  reach: number | null;
+  impressions: number | null;
+  likes: number | null;
+  comments: number | null;
+  shares: number | null;
+  /** Meta column name; mapped to payload `saves`. */
+  saved: number | null;
+  video_views: number | null;
+  /** The metric day (YYYY-MM-DD). The post's UTC publish day drives Honcho dedupe. */
+  day: string;
+}
+
+/**
+ * One due published post joined to its latest #513 metrics row. The resolved
+ * shape `selectDuePerformancePosts` returns and the worker consumes.
+ */
+export interface DuePerformancePost {
+  /** organizations.id — INTEGER, matches posts.tenant_id. */
+  tenantId: number;
+  /** Aries marketing job id (posts.job_id) → loadSocialContentJobRuntime. */
+  jobId: string;
+  /** 'facebook' | 'instagram' (lower-cased). */
+  platform: string;
+  /** The post's real UTC publish day, YYYY-MM-DD (NOT UTC-now). */
+  publishDay: string;
+  /**
+   * https permalink / insights URL for the post (#513 insights_posts.permalink).
+   * Required by recordPerformanceEvent's https source_url guard. If #513 cannot
+   * supply an https permalink, the worker fail-soft-skips this post.
+   */
+  permalink: string | null;
+  /** Latest #513 metrics snapshot for this post. */
+  metrics: InsightsPostMetricsDailyRow;
+}
+
+/**
+ * #513 GATE. Returns `true` once #513-A schema + #513-E adapter have merged to
+ * master and `insights_post_metrics_daily` is populated. While `false`,
+ * `selectDuePerformancePosts` returns [] without touching the DB, so this epic
+ * compiles, tests (fixture-backed), and ships dormant on master ahead of #513.
+ *
+ * Read at CALL TIME (a function, not a load-time const) so the docker sidecar's
+ * process env applies and tests / dynamic toggling work. The env override
+ * (`ARIES_INSIGHTS_513_TABLES_PRESENT=1`) lets the post-#513 contract/live-DB
+ * tests exercise the real query without a code change.
+ *
+ * POST-#513 WIRING (mechanical): default this to `true` (or delete the gate)
+ * and confirm DUE_PERFORMANCE_POSTS_SQL's join key against #513-E's actual
+ * insights_posts shape.
+ */
+export function insights513TablesPresent(
+  env: Partial<Record<string, string | undefined>> = process.env,
+): boolean {
+  return env.ARIES_INSIGHTS_513_TABLES_PRESENT === '1';
+}

--- a/backend/memory/perf-insights-payload.ts
+++ b/backend/memory/perf-insights-payload.ts
@@ -1,0 +1,116 @@
+/**
+ * P1 — Pure payload builder for the honcho-performance-worker.
+ *
+ * Maps a #513-E `insights_post_metrics_daily` row + post permalink into the
+ * `payloadRecord` shape `recordPerformanceEvent` (backend/memory/write-events.ts)
+ * consumes. NO DB, NO Meta, NO side effects — fully unit-testable on master
+ * ahead of #513 (the input row shape is the frozen contract in
+ * insights-513-contract.ts).
+ *
+ * Boundary: this epic owns the Honcho write leg only. See
+ *   docs/plans/2026-05-30-honcho-performance-insights.md
+ */
+
+import type { InsightsPostMetricsDailyRow } from './insights-513-contract';
+import { scrubPlatformIdsFromPerformancePayload } from './write-events';
+
+export interface BuildPerformancePayloadInput {
+  /** 'facebook' | 'instagram' (lower-cased by the builder). */
+  platform: string;
+  /**
+   * The post's real UTC publish day. Accepts YYYY-MM-DD or YYYYMMDD; normalized
+   * to YYYY-MM-DD in `published_at_ymd`. This is NOT UTC-now — it drives Honcho's
+   * idempotency window so 24h/72h/7d/30d re-polls of the same metric-day collapse.
+   */
+  publishDayYmd: string;
+  /** Latest #513 metrics snapshot row for the post. */
+  metricsRow: InsightsPostMetricsDailyRow;
+  /**
+   * https permalink / insights URL for the post. MUST be https — mirrors
+   * recordPerformanceEvent's own source_url guard. Non-https / missing → null
+   * return (worker fail-soft skips).
+   */
+  sourceUrl: string | null;
+  /** ISO timestamp the metrics snapshot was fetched (provenance only). */
+  fetchedAt: string;
+}
+
+/** The shape `recordPerformanceEvent` consumes as `payloadRecord`. */
+export interface PerformancePayloadRecord {
+  platform: string;
+  published_at_ymd: string;
+  metrics: {
+    reach: number | null;
+    impressions: number | null;
+    likes: number | null;
+    comments: number | null;
+    shares: number | null;
+    /** #513 column `saved` → payload key `saves`. */
+    saves: number | null;
+    video_views: number | null;
+    source_url: string;
+  };
+  metrics_fetched_at: string;
+  metrics_source_url: string;
+}
+
+const YMD_DASHED = /^\d{4}-\d{2}-\d{2}$/;
+const YMD_COMPACT = /^\d{8}$/;
+
+/** Normalize YYYYMMDD or YYYY-MM-DD → YYYY-MM-DD; null if neither. */
+function normalizePublishDay(input: string): string | null {
+  const v = input?.trim();
+  if (!v) return null;
+  if (YMD_DASHED.test(v)) return v;
+  if (YMD_COMPACT.test(v)) return `${v.slice(0, 4)}-${v.slice(4, 6)}-${v.slice(6, 8)}`;
+  return null;
+}
+
+function isHttpsUrl(value: string | null | undefined): value is string {
+  return typeof value === 'string' && /^https:\/\//i.test(value.trim());
+}
+
+/**
+ * Build the scrubbed payloadRecord. Returns null (worker skips, fail-soft) when:
+ *  - sourceUrl is missing/non-https (recordPerformanceEvent would skip anyway), or
+ *  - publishDayYmd is unparseable.
+ *
+ * The returned record is run through `scrubPlatformIdsFromPerformancePayload`
+ * here as belt-and-braces (idempotent with the scrub inside recordPerformanceEvent),
+ * so no raw platform_post_id / ig_media_id / bare numeric-id string can leak even
+ * if a future caller threads one through.
+ */
+export function buildPerformancePayloadRecord(
+  input: BuildPerformancePayloadInput,
+): PerformancePayloadRecord | null {
+  if (!isHttpsUrl(input.sourceUrl)) return null;
+  const publishedAtYmd = normalizePublishDay(input.publishDayYmd);
+  if (!publishedAtYmd) return null;
+
+  const m = input.metricsRow;
+  const sourceUrl = input.sourceUrl.trim();
+
+  const record: PerformancePayloadRecord = {
+    platform: String(input.platform || 'unknown').toLowerCase(),
+    published_at_ymd: publishedAtYmd,
+    metrics: {
+      reach: m.reach ?? null,
+      impressions: m.impressions ?? null,
+      likes: m.likes ?? null,
+      comments: m.comments ?? null,
+      shares: m.shares ?? null,
+      saves: m.saved ?? null,
+      video_views: m.video_views ?? null,
+      source_url: sourceUrl,
+    },
+    metrics_fetched_at: input.fetchedAt,
+    metrics_source_url: sourceUrl,
+  };
+
+  // Belt-and-braces scrub. The cast is safe: the scrub only ever removes keys /
+  // redacts numeric-id strings; none of this record's keys or values match the
+  // strip predicate, so the shape is preserved.
+  return scrubPlatformIdsFromPerformancePayload(
+    record as unknown as Record<string, unknown>,
+  ) as unknown as PerformancePayloadRecord;
+}

--- a/backend/memory/perf-insights-read.ts
+++ b/backend/memory/perf-insights-read.ts
@@ -1,0 +1,198 @@
+/**
+ * P0 — Read model for the honcho-performance-worker.
+ *
+ * Selects published posts that are due for a delayed real-metrics Honcho write
+ * and resolves them against #513-E's `insights_post_metrics_daily` snapshot.
+ *
+ * This epic is a PURE READER of #513's tables — it never fetches Meta. The
+ * `insights_*` tables are owned by #513 (see insights-513-contract.ts). Until
+ * #513-A/E land on master those tables do not exist, so `selectDuePerformancePosts`
+ * short-circuits to [] behind INSIGHTS_513_TABLES_PRESENT. The SQL below is
+ * written and frozen against #513-E's documented column names so post-#513
+ * wiring is a one-line gate flip (confirm the join key first).
+ *
+ * Boundary / contract: docs/plans/2026-05-30-honcho-performance-insights.md
+ */
+
+import {
+  insights513TablesPresent,
+  type DuePerformancePost,
+  type InsightsPostMetricsDailyRow,
+} from './insights-513-contract';
+
+/** Minimal query surface — satisfied by both `pg.Pool` and `pg.PoolClient`. */
+export interface Queryable {
+  query<R extends Record<string, unknown> = Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ): Promise<{ rows: R[] }>;
+}
+
+/** Max due posts resolved per tick — caps worker DB pressure (guardrail #1). */
+export const DUE_POSTS_LIMIT = 200;
+
+/**
+ * Due-posts query (#513-GATED). Joins `posts` (the published-state source of
+ * truth — NOT scheduled_posts) to #513-E's `insights_post_metrics_daily` and
+ * LEFT JOINs the worker-side `honcho_perf_writes` ledger to exclude already-
+ * written `(job_id, platform, metric_day)`.
+ *
+ * Window: published 24h..30d ago, status='published', job_id NOT NULL.
+ * Latest metrics row per post via DISTINCT ON (external_post_id) ORDER BY day DESC.
+ *
+ * #513 JOIN KEY: this uses the fallback join documented in the plan's #513
+ * boundary —  insights_posts.external_post_id = posts.platform_post_id
+ * AND insights_posts.tenant_id = posts.tenant_id. If #513-E's insights_posts
+ * carries job_id directly, swap to that (mechanical). Confirm with #513-E
+ * before un-gating.
+ *
+ * Exported so a post-#513 contract / live-DB test can run it against the real
+ * planner without booting the worker.
+ *
+ * $1 tenant_id (INTEGER), $2 LIMIT.
+ */
+export const DUE_PERFORMANCE_POSTS_SQL = `
+  SELECT
+    p.tenant_id            AS tenant_id,
+    p.job_id               AS job_id,
+    LOWER(ip.platform)     AS platform,
+    to_char(p.published_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS publish_day,
+    ip.permalink           AS permalink,
+    m.reach                AS reach,
+    m.impressions          AS impressions,
+    m.likes                AS likes,
+    m.comments             AS comments,
+    m.shares               AS shares,
+    m.saved                AS saved,
+    m.video_views          AS video_views,
+    to_char(m.day, 'YYYY-MM-DD') AS metric_day
+  FROM posts p
+  JOIN insights_posts ip
+    ON ip.external_post_id = p.platform_post_id
+   AND ip.tenant_id = p.tenant_id
+  JOIN LATERAL (
+    SELECT d.reach, d.impressions, d.likes, d.comments, d.shares,
+           d.saved, d.video_views, d.day
+    FROM insights_post_metrics_daily d
+    WHERE d.external_post_id = ip.external_post_id
+      AND d.tenant_id = ip.tenant_id
+    ORDER BY d.day DESC
+    LIMIT 1
+  ) m ON true
+  LEFT JOIN honcho_perf_writes w
+    ON w.tenant_id = p.tenant_id
+   AND w.job_id = p.job_id
+   AND w.platform = LOWER(ip.platform)
+   AND w.metric_day = m.day
+  WHERE p.tenant_id = $1
+    AND p.published_status = 'published'
+    AND p.job_id IS NOT NULL
+    AND p.platform_post_id IS NOT NULL
+    AND p.published_at IS NOT NULL
+    AND p.published_at <= NOW() - INTERVAL '24 hours'
+    AND p.published_at >= NOW() - INTERVAL '30 days'
+    AND w.job_id IS NULL
+  ORDER BY p.published_at DESC
+  LIMIT $2
+`;
+
+interface DuePerformanceRow extends Record<string, unknown> {
+  tenant_id: number;
+  job_id: string;
+  platform: string;
+  publish_day: string;
+  permalink: string | null;
+  reach: number | null;
+  impressions: number | null;
+  likes: number | null;
+  comments: number | null;
+  shares: number | null;
+  saved: number | null;
+  video_views: number | null;
+  metric_day: string;
+}
+
+function toNum(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve due performance posts for ONE tenant. Tenant-scoped + parameterized
+ * (cross-tenant isolation by construction), LIMIT-capped, single `client.query`
+ * (no pool.connect held across work).
+ *
+ * #513-GATED: returns [] without touching the DB while #513-E's tables are not
+ * present (INSIGHTS_513_TABLES_PRESENT === false). Post-#513: flip the gate.
+ */
+export async function selectDuePerformancePosts(
+  tenantId: number,
+  client: Queryable,
+  limit: number = DUE_POSTS_LIMIT,
+): Promise<DuePerformancePost[]> {
+  if (!insights513TablesPresent()) {
+    // #513 (insights_post_metrics_daily / insights_posts) not on master yet.
+    // No data source → no due posts. See insights-513-contract.ts.
+    return [];
+  }
+  const cap = Number.isFinite(limit) && limit > 0 ? Math.min(limit, DUE_POSTS_LIMIT) : DUE_POSTS_LIMIT;
+  const { rows } = await client.query<DuePerformanceRow>(DUE_PERFORMANCE_POSTS_SQL, [tenantId, cap]);
+  return rows.map((r): DuePerformancePost => {
+    const metrics: InsightsPostMetricsDailyRow = {
+      reach: toNum(r.reach),
+      impressions: toNum(r.impressions),
+      likes: toNum(r.likes),
+      comments: toNum(r.comments),
+      shares: toNum(r.shares),
+      saved: toNum(r.saved),
+      video_views: toNum(r.video_views),
+      day: r.metric_day,
+    };
+    return {
+      tenantId: r.tenant_id,
+      jobId: r.job_id,
+      platform: String(r.platform || 'unknown').toLowerCase(),
+      publishDay: r.publish_day,
+      permalink: r.permalink ?? null,
+      metrics,
+    };
+  });
+}
+
+/**
+ * Mark a successful Honcho perf write in the worker-side ledger so subsequent
+ * ticks cheaply skip it. ON CONFLICT DO NOTHING — idempotent. `metricDay` is the
+ * #513 metric day (the post's publish day), matching the due-query exclusion.
+ *
+ * The worker MUST only call this when the Honcho write was actually attempted
+ * (gate ON); see P2 worker for the gate read.
+ */
+export async function markHonchoPerfWritten(
+  tenantId: number,
+  jobId: string,
+  platform: string,
+  metricDay: string,
+  client: Queryable,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO honcho_perf_writes (tenant_id, job_id, platform, metric_day)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (tenant_id, job_id, platform, metric_day) DO NOTHING`,
+    [tenantId, jobId, platform.toLowerCase(), metricDay],
+  );
+}
+
+/** Distinct tenant ids that have any candidate published post in the window. */
+export async function selectTenantsWithDuePosts(client: Queryable): Promise<number[]> {
+  const { rows } = await client.query<{ tenant_id: number }>(
+    `SELECT DISTINCT tenant_id FROM posts
+     WHERE published_status = 'published'
+       AND job_id IS NOT NULL
+       AND platform_post_id IS NOT NULL
+       AND published_at IS NOT NULL
+       AND published_at <= NOW() - INTERVAL '24 hours'
+       AND published_at >= NOW() - INTERVAL '30 days'`,
+  );
+  return rows.map((r) => Number(r.tenant_id)).filter((n) => Number.isFinite(n));
+}

--- a/backend/memory/perf-insights-read.ts
+++ b/backend/memory/perf-insights-read.ts
@@ -185,6 +185,11 @@ export async function markHonchoPerfWritten(
 
 /** Distinct tenant ids that have any candidate published post in the window. */
 export async function selectTenantsWithDuePosts(client: Queryable): Promise<number[]> {
+  if (!insights513TablesPresent()) {
+    // No DB touch while the #513 insights tables are absent (matches
+    // selectDuePerformancePosts) — the sidecar must not scan posts every tick.
+    return [];
+  }
   const { rows } = await client.query<{ tenant_id: number }>(
     `SELECT DISTINCT tenant_id FROM posts
      WHERE published_status = 'published'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,6 +214,48 @@ services:
     restart: unless-stopped
     networks:
       - docker_stack
+
+  # Delayed real-Meta performance -> Honcho memory. Reads #513's stored
+  # insights_post_metrics_daily snapshots (NEVER fetches Meta) and writes a
+  # research_conclusion to peer-market-signal-* via recordPerformanceEvent.
+  # Gated by HONCHO_WRITE_PUBLISH_ENABLED (recordPerformanceEvent self-gates).
+  # No Meta env required. Until #513-A/E land, the due-posts query returns []
+  # so this sidecar ticks as a harmless no-op.
+  aries-honcho-performance-worker:
+    image: ${ARIES_APP_IMAGE:-aries-app:local}
+    command: ["npx", "tsx", "scripts/automations/honcho-performance-worker.ts"]
+    depends_on:
+      aries-app:
+        condition: service_healthy
+    environment:
+      HOME: /home/node
+      NODE_ENV: production
+      CODE_ROOT: /app
+      DATA_ROOT: /data
+      APP_INSTANCE_ID: honcho-performance-worker
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_POOL_MAX: 3
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      APP_BASE_URL: http://aries-app:${PORT:-3000}
+      NEXTAUTH_URL: http://aries-app:${PORT:-3000}
+      INTERNAL_API_SECRET: ${INTERNAL_API_SECRET}
+      # Honcho write surface (same vars as the app service). Defaults match the
+      # app service so the worker writes through the same gate; recordPerformanceEvent
+      # no-ops when HONCHO_WRITE_PUBLISH_ENABLED is off.
+      HONCHO_ENABLED: ${HONCHO_ENABLED:-true}
+      HONCHO_WRITE_PUBLISH_ENABLED: ${HONCHO_WRITE_PUBLISH_ENABLED:-true}
+      HONCHO_BASE_URL: ${HONCHO_BASE_URL:-}
+      HONCHO_CONTROL_PLANE_JWT: ${HONCHO_CONTROL_PLANE_JWT:-}
+      HONCHO_DATA_PLANE_JWT: ${HONCHO_DATA_PLANE_JWT:-}
+      ARIES_TENANT_PSEUDONYM_SALT: ${ARIES_TENANT_PSEUDONYM_SALT:-}
+      # #513 gate: flip to 1 once insights_post_metrics_daily is populated.
+      ARIES_INSIGHTS_513_TABLES_PRESENT: ${ARIES_INSIGHTS_513_TABLES_PRESENT:-}
+    restart: unless-stopped
+    networks:
+      - docker_stack
 networks:
   docker_stack:
     external: true

--- a/scripts/automations/honcho-performance-worker.ts
+++ b/scripts/automations/honcho-performance-worker.ts
@@ -1,0 +1,252 @@
+/**
+ * P2 — honcho-performance-worker
+ *
+ * Delayed, metric-bearing Honcho write leg for published Meta posts. 24h..30d
+ * after publish, reads #513-E's stored `insights_post_metrics_daily` snapshot
+ * (NEVER fetches Meta — see the #513 boundary in
+ * docs/plans/2026-05-30-honcho-performance-insights.md), scrubs platform IDs,
+ * and calls the already-shipped `recordPerformanceEvent` to write a
+ * `research_conclusion` to `peer-market-signal-<topicPseudonym>`.
+ *
+ * Run as a sidecar via `tsx scripts/automations/honcho-performance-worker.ts`
+ * (mirrors scheduled-posts-worker.mjs's tick/finally + setInterval pattern, but
+ * is TS so it can import the TS write surface directly). `runTick` is exported
+ * for the integration tests; `main()` self-schedules at 30-min intervals.
+ *
+ * Gate: HONCHO_WRITE_PUBLISH_ENABLED. `recordPerformanceEvent` self-gates and
+ * no-ops when off; the worker also reads the gate to decide whether to ledger,
+ * so flipping the gate ON later re-drives the writes.
+ *
+ * #513-GATED: until #513-A/E land, `selectDuePerformancePosts` returns [] (see
+ * insights-513-contract.ts) so the worker boots and ticks as a harmless no-op.
+ */
+
+import 'dotenv/config';
+
+import { pathToFileURL } from 'node:url';
+
+import { Pool } from 'pg';
+
+import {
+  selectDuePerformancePosts,
+  selectTenantsWithDuePosts,
+  markHonchoPerfWritten,
+  type Queryable,
+} from '@/backend/memory/perf-insights-read';
+import { buildPerformancePayloadRecord } from '@/backend/memory/perf-insights-payload';
+import {
+  recordPerformanceEvent,
+  topicPseudonymHexForPerformanceMemory,
+} from '@/backend/memory/write-events';
+import { loadSocialContentJobRuntime } from '@/backend/marketing/runtime-state';
+import { isHonchoEnabled, isHonchoWritePublishEnabled } from '@/backend/memory/honcho-env';
+import type { TenantRole } from '@/lib/tenant-context';
+
+const INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+
+let running = false;
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+function buildPool(): Pool {
+  return new Pool({
+    host: process.env.DB_HOST || 'localhost',
+    port: Number(process.env.DB_PORT) || 5432,
+    user: process.env.DB_USER || 'aries_user',
+    password: process.env.DB_PASSWORD || 'aries_pass',
+    database: process.env.DB_NAME || 'aries_dev',
+    // Dedicated small pool, NOT the app pool (guardrail #1 — keep worker DB
+    // pressure off the request path).
+    max: 3,
+  });
+}
+
+export interface TickReport {
+  tenantsScanned: number;
+  due: number;
+  written: number;
+  skippedNoDoc: number;
+  skippedNoPayload: number;
+  failed: number;
+}
+
+/**
+ * One tick. Per tenant, per due post: load runtime doc, build payload, write to
+ * Honcho via recordPerformanceEvent, ledger on success. Per-post and per-tenant
+ * try/catch so one bad row/tenant never aborts the batch (resumability — partial
+ * progress preserved; CLAUDE.md). Exported for integration tests.
+ *
+ * `deps` lets tests inject mocks; defaults are the real functions.
+ */
+export async function runTick(
+  client: Queryable,
+  deps: {
+    loadDoc?: typeof loadSocialContentJobRuntime;
+    record?: typeof recordPerformanceEvent;
+    markWritten?: typeof markHonchoPerfWritten;
+    gateEnabled?: () => boolean;
+  } = {},
+): Promise<TickReport> {
+  const loadDoc = deps.loadDoc ?? loadSocialContentJobRuntime;
+  const record = deps.record ?? recordPerformanceEvent;
+  const markWritten = deps.markWritten ?? markHonchoPerfWritten;
+  // Gate read: only ledger when the Honcho write would actually fire. When the
+  // gate is OFF, recordPerformanceEvent no-ops AND we skip the ledger, so
+  // flipping the gate ON later re-drives every due write.
+  const gateEnabled = deps.gateEnabled ?? (() => isHonchoEnabled() && isHonchoWritePublishEnabled());
+
+  const report: TickReport = {
+    tenantsScanned: 0,
+    due: 0,
+    written: 0,
+    skippedNoDoc: 0,
+    skippedNoPayload: 0,
+    failed: 0,
+  };
+
+  const gateOn = gateEnabled();
+
+  let tenants: number[] = [];
+  try {
+    tenants = await selectTenantsWithDuePosts(client);
+  } catch (err) {
+    console.error('[honcho-performance-worker] tenant scan failed', err);
+    return report;
+  }
+
+  for (const tenantId of tenants) {
+    report.tenantsScanned += 1;
+    try {
+      const due = await selectDuePerformancePosts(tenantId, client);
+      report.due += due.length;
+
+      for (const post of due) {
+        try {
+          const doc = await loadDoc(post.jobId);
+          if (!doc) {
+            report.skippedNoDoc += 1;
+            console.warn(
+              `[honcho-performance-worker] no runtime doc for job=${post.jobId} tenant=${tenantId}; skipping`,
+            );
+            continue;
+          }
+
+          const payloadRecord = buildPerformancePayloadRecord({
+            platform: post.platform,
+            publishDayYmd: post.publishDay,
+            metricsRow: post.metrics,
+            sourceUrl: post.permalink,
+            fetchedAt: new Date().toISOString(),
+          });
+          if (!payloadRecord) {
+            // No https source / unparseable publish day — fail-soft, no ledger
+            // (mirrors recordPerformanceEvent's own guard).
+            report.skippedNoPayload += 1;
+            continue;
+          }
+
+          const topicPseudonymHex = topicPseudonymHexForPerformanceMemory(
+            post.jobId,
+            doc.inputs?.competitor_url ?? null,
+          );
+          const tenantIdStr = String(doc.tenant_id);
+          const tenantCtx = {
+            tenantId: tenantIdStr,
+            tenantSlug: doc.tenant_id ? `tenant-${tenantIdStr}` : 'tenant-unknown',
+            userId: tenantIdStr,
+            role: 'tenant_admin' as TenantRole,
+          };
+          // published_at_ymd is YYYY-MM-DD from the builder; recordPerformanceEvent
+          // wants compact YYYYMMDD for its idempotency key.
+          const publishedAtYmd = payloadRecord.published_at_ymd.replace(/-/g, '');
+
+          await record(
+            {
+              tenantCtx,
+              jobId: post.jobId,
+              topicPseudonymHex,
+              publishedAtYmd,
+              platform: post.platform,
+              payloadRecord: payloadRecord as unknown as Record<string, unknown>,
+            },
+          );
+
+          // Ledger only when the gate is ON (so a gate-OFF run leaves nothing to
+          // re-drive once it flips ON). metric_day = the post's publish day.
+          if (gateOn) {
+            await markWritten(tenantId, post.jobId, post.platform, post.metrics.day, client);
+            report.written += 1;
+          }
+        } catch (postErr) {
+          report.failed += 1;
+          console.error(
+            `[honcho-performance-worker] post error job=${post.jobId} tenant=${tenantId}`,
+            postErr,
+          );
+        }
+      }
+    } catch (tenantErr) {
+      report.failed += 1;
+      console.error(`[honcho-performance-worker] tenant error tenant=${tenantId}`, tenantErr);
+    }
+  }
+
+  return report;
+}
+
+async function tickSafe(pool: Pool): Promise<void> {
+  if (running) {
+    console.warn('[honcho-performance-worker] previous tick still running; skipping');
+    return;
+  }
+  running = true;
+  try {
+    const report = await runTick(pool as unknown as Queryable);
+    if (report.due > 0 || report.failed > 0) {
+      console.log(`[honcho-performance-worker] summary ${JSON.stringify(report)}`);
+    }
+  } catch (error) {
+    console.error('[honcho-performance-worker] tick error', error);
+  } finally {
+    running = false;
+  }
+}
+
+async function main(): Promise<void> {
+  const pool = buildPool();
+  console.log(`[honcho-performance-worker] starting; interval=${INTERVAL_MS}ms`);
+
+  await tickSafe(pool);
+
+  if (process.env.ARIES_HONCHO_PERF_RUN_ONCE?.trim() === '1') {
+    await pool.end();
+    process.exit(0);
+  }
+
+  intervalHandle = setInterval(() => void tickSafe(pool), INTERVAL_MS);
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.once(signal, async () => {
+      if (intervalHandle) clearInterval(intervalHandle);
+      await pool.end().catch(() => {});
+      process.exit(0);
+    });
+  }
+}
+
+// Only self-start when run directly as the sidecar entrypoint, not when
+// imported by a test. Compare the resolved entrypoint to this module's own URL
+// (a substring check on the filename would also match the *.test.ts importer,
+// which booted main() against a real DB during the unit test).
+const isDirectRun = (() => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === pathToFileURL(entry).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  void main();
+}

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -543,6 +543,23 @@ async function initDb() {
         written_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
 
+      -- Worker-side ledger for the honcho-performance-worker (delayed real-Meta
+      -- performance -> Honcho memory). Distinct from honcho_write_idempotency_keys
+      -- (the Honcho-side claim inside recordPerformanceEvent): this lets the
+      -- due-posts query cheaply skip already-written (job_id, platform, metric_day)
+      -- without re-driving the Honcho idempotency claim every 30-min tick.
+      -- tenant_id INTEGER matches organizations.id (int4) -- do not use BIGINT.
+      -- metric_day is the post's UTC publish day (the #513 metric day), so
+      -- 24h/72h/7d/30d re-polls of the same metric-day collapse to one ledger row.
+      CREATE TABLE IF NOT EXISTS honcho_perf_writes (
+        tenant_id  INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+        job_id     TEXT    NOT NULL,
+        platform   TEXT    NOT NULL,
+        metric_day DATE    NOT NULL,
+        written_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        PRIMARY KEY (tenant_id, job_id, platform, metric_day)
+      );
+
       -- Hackathon landing page registrations. Standalone table -- not tied to
       -- organizations or users because the /hackathon landing page is public
       -- and most registrants will not have Aries accounts. Email is unique

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -171,6 +171,19 @@ const steps = [
       'tests/public-generated-routes.test.ts',
     ],
   },
+  {
+    // honcho-performance-insights (delayed real-Meta perf -> Honcho memory).
+    // Fixture-primary: payload builder + due-posts SQL shape + worker tick
+    // (mocked recordPerformanceEvent). The #513 (insights_*) live-DB legs are
+    // separate (tests/memory/perf-insights-live-db.test.ts) and #513-gated.
+    name: 'honcho performance-insights unit tests',
+    args: [
+      '--test',
+      'tests/memory/perf-insights-payload.test.ts',
+      'tests/memory/perf-insights-read.test.ts',
+      'tests/memory/honcho-performance-worker.test.ts',
+    ],
+  },
 ];
 
 for (const [index, step] of steps.entries()) {

--- a/tests/memory/honcho-performance-worker.test.ts
+++ b/tests/memory/honcho-performance-worker.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runTick } from '../../scripts/automations/honcho-performance-worker';
+import type { Queryable } from '../../backend/memory/perf-insights-read';
+import type { SocialContentJobRuntimeDocument } from '../../backend/marketing/runtime-state';
+
+// P2 — worker tick. recordPerformanceEvent / loadDoc / markWritten are injected
+// mocks; selectDuePerformancePosts reads the gated #513 query, so we run with
+// ARIES_INSIGHTS_513_TABLES_PRESENT=1 and a stub client returning seeded rows.
+
+const TENANT_ID = 7;
+
+function makeDoc(jobId: string): SocialContentJobRuntimeDocument {
+  return {
+    job_id: jobId,
+    tenant_id: String(TENANT_ID),
+    inputs: { request: {}, brand_url: 'https://brand.example.com', competitor_url: 'https://comp.example.com' },
+  } as unknown as SocialContentJobRuntimeDocument;
+}
+
+/**
+ * Client whose first SELECT (tenant scan) returns the tenant, the second SELECT
+ * (due posts) returns the seeded due rows, and any INSERT (ledger) is recorded.
+ */
+function makeClient(dueRows: Record<string, unknown>[]): {
+  client: Queryable;
+  ledgerInserts: unknown[][];
+} {
+  const ledgerInserts: unknown[][] = [];
+  const client: Queryable = {
+    async query(text: string, values?: unknown[]) {
+      const t = text.trim();
+      if (t.startsWith('SELECT DISTINCT tenant_id')) {
+        return { rows: [{ tenant_id: TENANT_ID }] as never[] };
+      }
+      if (t.startsWith('INSERT INTO honcho_perf_writes')) {
+        ledgerInserts.push(values ?? []);
+        return { rows: [] as never[] };
+      }
+      // due-posts query
+      return { rows: dueRows as never[] };
+    },
+  };
+  return { client, ledgerInserts };
+}
+
+const DUE_ROW = {
+  tenant_id: TENANT_ID,
+  job_id: 'job-1',
+  platform: 'instagram',
+  publish_day: '2026-05-25',
+  permalink: 'https://www.instagram.com/p/ABC/',
+  reach: '1200',
+  impressions: '1500',
+  likes: '300',
+  comments: '12',
+  shares: '5',
+  saved: '9',
+  video_views: '0',
+  metric_day: '2026-05-25',
+};
+
+test('one tick calls recordPerformanceEvent once with scrubbed payload + writes ledger (gate ON)', async () => {
+  process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
+  try {
+    const { client, ledgerInserts } = makeClient([DUE_ROW]);
+    const recorded: unknown[] = [];
+    const report = await runTick(client, {
+      loadDoc: async () => makeDoc('job-1'),
+      record: async (input) => {
+        recorded.push(input);
+      },
+      gateEnabled: () => true,
+    });
+
+    assert.equal(recorded.length, 1);
+    const input = recorded[0] as { jobId: string; publishedAtYmd: string; payloadRecord: Record<string, unknown> };
+    assert.equal(input.jobId, 'job-1');
+    assert.equal(input.publishedAtYmd, '20260525'); // compact for idempotency key
+    const json = JSON.stringify(input.payloadRecord);
+    assert.ok(!json.includes('platform_post_id'));
+    assert.ok(!json.includes('instagram_media_id'));
+    assert.match(json, /https:\/\/www\.instagram\.com\/p\/ABC\//);
+
+    assert.equal(report.written, 1);
+    assert.equal(ledgerInserts.length, 1);
+    assert.deepEqual(ledgerInserts[0], [TENANT_ID, 'job-1', 'instagram', '2026-05-25']);
+  } finally {
+    delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  }
+});
+
+test('gate OFF: no recordPerformanceEvent call and no ledger write', async () => {
+  process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
+  try {
+    const { client, ledgerInserts } = makeClient([DUE_ROW]);
+    let recordCalls = 0;
+    const report = await runTick(client, {
+      loadDoc: async () => makeDoc('job-1'),
+      record: async () => {
+        recordCalls += 1;
+      },
+      gateEnabled: () => false,
+    });
+    // record() is still invoked (it self-gates internally in prod), but our mock
+    // counts it; the contract that matters is NO ledger row when gate is off.
+    assert.equal(report.written, 0);
+    assert.equal(ledgerInserts.length, 0, 'no ledger row when gate off → re-drives later');
+    // The worker passes payload through regardless; the no-op is recordPerformanceEvent's.
+    assert.ok(recordCalls >= 0);
+  } finally {
+    delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  }
+});
+
+test('missing runtime doc skips the post, no ledger, no throw', async () => {
+  process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
+  try {
+    const { client, ledgerInserts } = makeClient([DUE_ROW]);
+    let recordCalls = 0;
+    const report = await runTick(client, {
+      loadDoc: async () => null,
+      record: async () => {
+        recordCalls += 1;
+      },
+      gateEnabled: () => true,
+    });
+    assert.equal(recordCalls, 0);
+    assert.equal(report.skippedNoDoc, 1);
+    assert.equal(ledgerInserts.length, 0);
+  } finally {
+    delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  }
+});
+
+test('per-post throw isolation: one bad post does not abort the batch', async () => {
+  process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
+  try {
+    const rows = [
+      { ...DUE_ROW, job_id: 'job-bad' },
+      { ...DUE_ROW, job_id: 'job-good' },
+    ];
+    const { client, ledgerInserts } = makeClient(rows);
+    const writtenJobs: string[] = [];
+    const report = await runTick(client, {
+      loadDoc: async (jobId: string) => makeDoc(jobId),
+      record: async (input) => {
+        if ((input as { jobId: string }).jobId === 'job-bad') {
+          throw new Error('boom');
+        }
+        writtenJobs.push((input as { jobId: string }).jobId);
+      },
+      gateEnabled: () => true,
+    });
+    assert.deepEqual(writtenJobs, ['job-good']);
+    assert.equal(report.failed, 1);
+    assert.equal(report.written, 1);
+    assert.equal(ledgerInserts.length, 1);
+    assert.deepEqual(ledgerInserts[0], [TENANT_ID, 'job-good', 'instagram', '2026-05-25']);
+  } finally {
+    delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  }
+});
+
+test('null payload (no https permalink) is skipped, no ledger', async () => {
+  process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
+  try {
+    const { client, ledgerInserts } = makeClient([{ ...DUE_ROW, permalink: null }]);
+    let recordCalls = 0;
+    const report = await runTick(client, {
+      loadDoc: async () => makeDoc('job-1'),
+      record: async () => {
+        recordCalls += 1;
+      },
+      gateEnabled: () => true,
+    });
+    assert.equal(recordCalls, 0);
+    assert.equal(report.skippedNoPayload, 1);
+    assert.equal(ledgerInserts.length, 0);
+  } finally {
+    delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  }
+});

--- a/tests/memory/honcho-performance-worker.test.ts
+++ b/tests/memory/honcho-performance-worker.test.ts
@@ -91,7 +91,7 @@ test('one tick calls recordPerformanceEvent once with scrubbed payload + writes 
   }
 });
 
-test('gate OFF: no recordPerformanceEvent call and no ledger write', async () => {
+test('gate OFF (publish gate): no ledger write so posts re-drive when it flips on; record() self-gates in prod', async () => {
   process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
   try {
     const { client, ledgerInserts } = makeClient([DUE_ROW]);

--- a/tests/memory/perf-insights-payload.test.ts
+++ b/tests/memory/perf-insights-payload.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildPerformancePayloadRecord,
+} from '../../backend/memory/perf-insights-payload';
+import type { InsightsPostMetricsDailyRow } from '../../backend/memory/insights-513-contract';
+
+// P1 — pure payload builder. No DB, no #513 tables needed: the input row is the
+// frozen contract shape. These tests run on master ahead of #513.
+
+const METRICS: InsightsPostMetricsDailyRow = {
+  reach: 1200,
+  impressions: 1500,
+  likes: 300,
+  comments: 12,
+  shares: 5,
+  saved: 9, // Meta column name -> payload `saves`
+  video_views: 0,
+  day: '2026-05-25',
+};
+
+test('maps #513 columns to payload metric keys (saved -> saves)', () => {
+  const out = buildPerformancePayloadRecord({
+    platform: 'Instagram',
+    publishDayYmd: '2026-05-25',
+    metricsRow: METRICS,
+    sourceUrl: 'https://www.instagram.com/p/ABC123/',
+    fetchedAt: '2026-05-27T00:00:00.000Z',
+  });
+  assert.ok(out);
+  assert.equal(out.platform, 'instagram'); // lower-cased
+  assert.equal(out.published_at_ymd, '2026-05-25');
+  assert.equal(out.metrics.reach, 1200);
+  assert.equal(out.metrics.saves, 9);
+  assert.equal(out.metrics.video_views, 0);
+  assert.equal(out.metrics.source_url, 'https://www.instagram.com/p/ABC123/');
+  assert.equal(out.metrics_source_url, 'https://www.instagram.com/p/ABC123/');
+  // No `saved` key leaks through.
+  assert.equal((out.metrics as Record<string, unknown>).saved, undefined);
+});
+
+test('published_at_ymd is the POST publish day, not UTC-now', () => {
+  const out = buildPerformancePayloadRecord({
+    platform: 'facebook',
+    publishDayYmd: '2026-05-25',
+    metricsRow: METRICS,
+    sourceUrl: 'https://www.facebook.com/12/posts/34',
+    fetchedAt: '2026-05-29T10:00:00.000Z',
+  });
+  assert.ok(out);
+  // Even though fetchedAt is the 29th, the publish day is the 25th.
+  assert.equal(out.published_at_ymd, '2026-05-25');
+});
+
+test('accepts compact YYYYMMDD publish day and normalizes to dashed', () => {
+  const out = buildPerformancePayloadRecord({
+    platform: 'facebook',
+    publishDayYmd: '20260525',
+    metricsRow: METRICS,
+    sourceUrl: 'https://www.facebook.com/12/posts/34',
+    fetchedAt: '2026-05-29T10:00:00.000Z',
+  });
+  assert.ok(out);
+  assert.equal(out.published_at_ymd, '2026-05-25');
+});
+
+test('returns null when source url is missing or non-https', () => {
+  assert.equal(
+    buildPerformancePayloadRecord({
+      platform: 'facebook',
+      publishDayYmd: '2026-05-25',
+      metricsRow: METRICS,
+      sourceUrl: null,
+      fetchedAt: '2026-05-29T10:00:00.000Z',
+    }),
+    null,
+  );
+  assert.equal(
+    buildPerformancePayloadRecord({
+      platform: 'facebook',
+      publishDayYmd: '2026-05-25',
+      metricsRow: METRICS,
+      sourceUrl: 'http://insecure.example.com/p/1',
+      fetchedAt: '2026-05-29T10:00:00.000Z',
+    }),
+    null,
+  );
+});
+
+test('returns null when publish day is unparseable', () => {
+  assert.equal(
+    buildPerformancePayloadRecord({
+      platform: 'facebook',
+      publishDayYmd: 'not-a-date',
+      metricsRow: METRICS,
+      sourceUrl: 'https://www.facebook.com/12/posts/34',
+      fetchedAt: '2026-05-29T10:00:00.000Z',
+    }),
+    null,
+  );
+});
+
+test('belt-and-braces scrub: no raw platform_post_id / numeric-id strings leak', () => {
+  // Even if a future caller threads a stray id through the metrics row, the
+  // builder runs scrubPlatformIdsFromPerformancePayload and it must be gone.
+  const dirty = {
+    ...METRICS,
+    instagram_media_id: '17900000000000000',
+  } as unknown as InsightsPostMetricsDailyRow;
+  const out = buildPerformancePayloadRecord({
+    platform: 'instagram',
+    publishDayYmd: '2026-05-25',
+    metricsRow: dirty,
+    sourceUrl: 'https://www.instagram.com/p/ABC123/',
+    fetchedAt: '2026-05-27T00:00:00.000Z',
+  });
+  assert.ok(out);
+  const json = JSON.stringify(out);
+  assert.ok(!json.includes('instagram_media_id'), 'platform id key must be stripped');
+  assert.ok(!json.includes('17900000000000000'), 'bare numeric id must be redacted');
+});

--- a/tests/memory/perf-insights-read.test.ts
+++ b/tests/memory/perf-insights-read.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DUE_PERFORMANCE_POSTS_SQL,
+  DUE_POSTS_LIMIT,
+  selectDuePerformancePosts,
+  markHonchoPerfWritten,
+  type Queryable,
+} from '../../backend/memory/perf-insights-read';
+
+// P0 — read-model SQL shape + gate behavior. Pure fixture/mock assertions; the
+// real-planner live-DB legs are #513-gated (tests/memory/perf-insights-live-db.test.ts).
+
+function recordingClient(rows: Record<string, unknown>[] = []): {
+  client: Queryable;
+  calls: { text: string; values?: unknown[] }[];
+} {
+  const calls: { text: string; values?: unknown[] }[] = [];
+  const client: Queryable = {
+    async query(text: string, values?: unknown[]) {
+      calls.push({ text, values });
+      return { rows: rows as never[] };
+    },
+  };
+  return { client, calls };
+}
+
+test('due-posts SQL: 24h..30d window, status + job_id filter, ledger-exclude, LIMIT', () => {
+  const sql = DUE_PERFORMANCE_POSTS_SQL;
+  assert.match(sql, /published_at <= NOW\(\) - INTERVAL '24 hours'/);
+  assert.match(sql, /published_at >= NOW\(\) - INTERVAL '30 days'/);
+  assert.match(sql, /published_status = 'published'/);
+  assert.match(sql, /p\.job_id IS NOT NULL/);
+  // ledger exclude (LEFT JOIN honcho_perf_writes ... w.job_id IS NULL)
+  assert.match(sql, /LEFT JOIN honcho_perf_writes/);
+  assert.match(sql, /w\.job_id IS NULL/);
+  // reads from #513 tables, never Meta
+  assert.match(sql, /insights_post_metrics_daily/);
+  assert.match(sql, /insights_posts/);
+  // tenant-scoped + limited
+  assert.match(sql, /p\.tenant_id = \$1/);
+  assert.match(sql, /LIMIT \$2/);
+});
+
+test('selectDuePerformancePosts is tenant-scoped + LIMIT-capped (gate ON)', async () => {
+  process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
+  try {
+    const { client, calls } = recordingClient([]);
+    await selectDuePerformancePosts(7, client, 99999);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].values, [7, DUE_POSTS_LIMIT]); // capped to max
+  } finally {
+    delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  }
+});
+
+test('selectDuePerformancePosts maps rows into DuePerformancePost (gate ON)', async () => {
+  process.env.ARIES_INSIGHTS_513_TABLES_PRESENT = '1';
+  try {
+    const { client } = recordingClient([
+      {
+        tenant_id: 7,
+        job_id: 'job-abc',
+        platform: 'instagram',
+        publish_day: '2026-05-25',
+        permalink: 'https://www.instagram.com/p/ABC/',
+        reach: '1200',
+        impressions: '1500',
+        likes: '300',
+        comments: '12',
+        shares: '5',
+        saved: '9',
+        video_views: '0',
+        metric_day: '2026-05-25',
+      },
+    ]);
+    const out = await selectDuePerformancePosts(7, client);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].tenantId, 7);
+    assert.equal(out[0].jobId, 'job-abc');
+    assert.equal(out[0].platform, 'instagram');
+    assert.equal(out[0].publishDay, '2026-05-25');
+    assert.equal(out[0].permalink, 'https://www.instagram.com/p/ABC/');
+    assert.equal(out[0].metrics.reach, 1200); // numeric coercion
+    assert.equal(out[0].metrics.saved, 9);
+    assert.equal(out[0].metrics.day, '2026-05-25');
+  } finally {
+    delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  }
+});
+
+test('#513 GATE: returns [] without touching DB when tables absent (default)', async () => {
+  delete process.env.ARIES_INSIGHTS_513_TABLES_PRESENT;
+  const { client, calls } = recordingClient([{ tenant_id: 1 }]);
+  const out = await selectDuePerformancePosts(7, client);
+  assert.deepEqual(out, []);
+  assert.equal(calls.length, 0, 'must not query the DB while #513 tables are absent');
+});
+
+test('markHonchoPerfWritten upserts ON CONFLICT DO NOTHING with lower-cased platform', async () => {
+  const { client, calls } = recordingClient([]);
+  await markHonchoPerfWritten(7, 'job-abc', 'Instagram', '2026-05-25', client);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].text, /INSERT INTO honcho_perf_writes/);
+  assert.match(calls[0].text, /ON CONFLICT \(tenant_id, job_id, platform, metric_day\) DO NOTHING/);
+  assert.deepEqual(calls[0].values, [7, 'job-abc', 'instagram', '2026-05-25']);
+});


### PR DESCRIPTION
## Summary

Wave 2 of the backlog (`docs/plans/2026-05-30-honcho-performance-insights.md`). Builds the **Aries-side Honcho-write leg** of the performance-insights epic, **contract-first** against #513's unmerged `insights_*` backend, **gated OFF** (`ARIES_INSIGHTS_513_TABLES_PRESENT`, default off). Nothing depends on #513's tables at compile/test time — the gate short-circuits and fixtures stand in for #513's row shape.

**Changes:**
- `backend/memory/insights-513-contract.ts` (new) — the **#513 integration seam**: typed row contract (`InsightsPostMetricsDailyRow`, `DuePerformancePost`) documenting exactly what #513-E must provide, plus the call-time gate `insights513TablesPresent()`.
- `backend/memory/perf-insights-payload.ts` (new) — pure builder: #513 metrics row → `recordPerformanceEvent` payload (maps `saved`→`saves`, enforces https `source_url`, uses the post's publish day not UTC-now, scrub).
- `backend/memory/perf-insights-read.ts` (new) — due-posts read model (posts ⋈ #513 `insights_post_metrics_daily`, ledger-excluded, tenant-scoped, LIMIT-capped) + `markHonchoPerfWritten` ledger upsert. #513-gated → returns `[]` without touching the DB until #513 lands.
- `scripts/automations/honcho-performance-worker.ts` (new) — tick/finally sidecar mirroring `scheduled-posts-worker`; per-tenant + per-post try/catch, gate-aware ledgering, `runTick` exported for tests.
- `scripts/init-db.js` — `honcho_perf_writes` ledger table (additive, idempotent; rebased cleanly alongside story-video's surface/media_type columns).
- `docker-compose.yml` — `aries-honcho-performance-worker` sidecar (no Meta env; #513 gate var).

## Integration seam — what remains post-#513
The seam is `insights-513-contract.ts`. #513-E satisfies it by populating `insights_posts` + `insights_post_metrics_daily`. **Post-#513 wiring is two mechanical steps:** (1) flip `ARIES_INSIGHTS_513_TABLES_PRESENT=1`, and (2) confirm the `insights_posts` join key in `DUE_PERFORMANCE_POSTS_SQL` (currently the plan's documented `external_post_id = posts.platform_post_id` fallback). The query is frozen against #513-E's documented columns.

## Test Coverage
16 new fixture/mock tests (payload mapping, SQL shape, worker tick, gate-off no-ledger, dedupe, per-post throw isolation, null-payload skip), wired into `npm run verify`. typecheck + lint + verify green; **full CI-exact suite run locally after rebase: 2127 pass, 0 fail.** No #513-gated failures (contract-first short-circuits).

## Notes / blockers for you
- **Gate stays OFF** until #513 lands + populates `insights_*`. (Also depends on the Meta insights scopes from the #510/#513 memory note — read-side, separate.)
- No version bump (consistent with this session's serial backlog PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
