### PR TITLE
chore(deps): bump resend from 6.12.3 to 6.12.4 (supersedes #536)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "recharts": "^3.8.0",
-        "resend": "^6.12.3",
+        "resend": "^6.12.4",
         "sharp": "^0.34.5",
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
@@ -3710,13 +3710,13 @@
       "license": "MIT"
     },
     "node_modules/resend": {
-      "version": "6.12.3",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
-      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
       "license": "MIT",
       "dependencies": {
         "postal-mime": "2.7.4",
-        "svix": "1.92.2"
+        "standardwebhooks": "1.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -3866,15 +3866,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/svix": {
-      "version": "1.92.2",
-      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
-      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "recharts": "^3.8.0",
-    "resend": "^6.12.3",
+    "resend": "^6.12.4",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
Regenerated #536 against current master to clear its package-lock.json drift conflict (the only conflicting file; package.json auto-merged). Patch bump; the sole transitive change is resend swapping its internal webhook dependency svix 1.92.2 → standardwebhooks 1.0.0. resend is used only for transactional email — no API surface change for Aries.

Closes #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)