### PR TITLE
refactor(execution): drop misleading ARIES_ prefix from workflow-keys const

### DIFF
--- a/backend/execution/index.ts
+++ b/backend/execution/index.ts
@@ -13,7 +13,7 @@ export {
 } from './errors';
 
 export {
-  ARIES_ATOMIC_MARKETING_WORKFLOW_KEYS,
+  ATOMIC_MARKETING_WORKFLOW_KEYS,
   ARIES_WORKFLOWS,
   getAriesWorkflow,
   type AriesWorkflowDef,

--- a/backend/execution/workflow-catalog.ts
+++ b/backend/execution/workflow-catalog.ts
@@ -25,7 +25,7 @@ export type AriesWorkflowDef = {
  * Client-facing `/api/marketing/jobs*` stays on the monolithic marketing
  * orchestrator path.
  */
-export const ARIES_ATOMIC_MARKETING_WORKFLOW_KEYS: AriesWorkflowKey[] = [
+export const ATOMIC_MARKETING_WORKFLOW_KEYS: AriesWorkflowKey[] = [
   'marketing_stage1_research',
   'marketing_stage2_strategy_review',
   'marketing_stage2_strategy_finalize',

--- a/tests/execution-workflow-catalog.test.ts
+++ b/tests/execution-workflow-catalog.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
-  ARIES_ATOMIC_MARKETING_WORKFLOW_KEYS,
+  ATOMIC_MARKETING_WORKFLOW_KEYS,
   ARIES_WORKFLOWS,
   getAriesWorkflow,
 } from '../backend/execution/workflow-catalog';
@@ -27,7 +27,7 @@ test('workflow catalog exposes a definition for every key with a stable shape', 
 });
 
 test('atomic marketing workflow keys are a subset of the catalog', () => {
-  for (const key of ARIES_ATOMIC_MARKETING_WORKFLOW_KEYS) {
+  for (const key of ATOMIC_MARKETING_WORKFLOW_KEYS) {
     assert.ok(Object.prototype.hasOwnProperty.call(ARIES_WORKFLOWS, key));
   }
 });


### PR DESCRIPTION
Part of the flag-hygiene cleanup pass. `ARIES_ATOMIC_MARKETING_WORKFLOW_KEYS` is an exported `AriesWorkflowKey[]` **constant**, not an env var — but the `ARIES_` prefix made it surface as a "flag" in env audits/greps. Rename → `ATOMIC_MARKETING_WORKFLOW_KEYS`.

Three references, all updated: definition (`backend/execution/workflow-catalog.ts`), barrel re-export (`backend/execution/index.ts`), and the test (`tests/execution-workflow-catalog.test.ts`). Pure rename, no behavior change. `npm run typecheck` clean; `execution-workflow-catalog.test.ts` 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)