### PR TITLE
chore(marketing): remove dead ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -286,12 +286,6 @@ LOG_LEVEL=info
 # ARTIFACT_STAGE3_CACHE_DIR=/data/hermes-stage3-cache
 # ARTIFACT_STAGE4_CACHE_DIR=/data/hermes-stage4-cache
 
-# PR #302 migration gate. Set to 1 to allow READ from the legacy
-# <cacheRoot>/<runId>/... layout that predates tenant-scoped paths. New
-# writes always go to <cacheRoot>/<tenantId>/<runId>/... regardless of
-# this flag.
-# ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1
-
 # Test-harness only (never read by the app runtime, never set by CI). Opt in to
 # running the requires-infra (live-Postgres) test split locally: set this plus all
 # five DB_* vars to a reachable Postgres, then `npm run test:requires-infra`.

--- a/backend/marketing/artifact-store.ts
+++ b/backend/marketing/artifact-store.ts
@@ -62,18 +62,6 @@ export function stageCacheRootForTenant(
   return path.join(stageCacheRoot(stage), normalized);
 }
 
-/**
- * Legacy fallback read gate. When set to "1", reads will fall back to the
- * pre-tenant-segment layout `<cacheRoot>/<runId>/<step>.json` if the tenant-
- * scoped path misses. Writes are NEVER routed to the legacy layout.
- *
- * TODO(stage-cache-tenant-prefix): remove this gate after the next full
- * pipeline cycle for all tenants has populated tenant-scoped caches.
- */
-export function legacyStageCacheReadFallbackEnabled(): boolean {
-  return stringValue(process.env.ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK) === '1';
-}
-
 export function hostOutputMount(): string {
   return path.normalize(stringValue(process.env.ARIES_HOST_ARTIFACT_OUTPUT_MOUNT) || DEFAULT_HOST_OUTPUT_MOUNT);
 }

--- a/backend/marketing/publish-review.ts
+++ b/backend/marketing/publish-review.ts
@@ -6,7 +6,6 @@ import path from 'node:path';
 import type { MarketingJobFacts } from './job-facts';
 import { resolveStageOutput, type SocialContentJobRuntimeDocument, type MarketingVideoStageArtifact } from './runtime-state';
 import { readMarketingStageStepPayload } from './stage-artifact-resolution';
-import { legacyStageCacheReadFallbackEnabled } from './artifact-store';
 import {
   ARTIFACT_INCOMPLETE_TEXT,
   ARTIFACT_UNAVAILABLE_TEXT,
@@ -138,9 +137,6 @@ async function readExactPublishStepPayload(runtimeDoc: SocialContentJobRuntimeDo
   const tenantScopedCandidates = [
     path.join(stage4CacheRoot, tenantId, runId, `${stepName}.json`),
   ];
-  if (legacyStageCacheReadFallbackEnabled()) {
-    tenantScopedCandidates.push(path.join(stage4CacheRoot, runId, `${stepName}.json`));
-  }
 
   for (const cachePath of tenantScopedCandidates) {
     const cached = await readJsonIfExists(cachePath);

--- a/backend/marketing/stage-artifact-resolution.ts
+++ b/backend/marketing/stage-artifact-resolution.ts
@@ -3,7 +3,6 @@ import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
-  legacyStageCacheReadFallbackEnabled,
   artifactOutputRoots,
   stageCacheRoot,
   stageCacheRootForTenant,
@@ -235,22 +234,6 @@ export async function readMarketingStageStepPayload(
         payload: cached,
         source: 'cache',
       };
-    }
-
-    // Legacy on-disk caches at `<cacheRoot>/<runId>/<step>.json` (no tenant
-    // segment) remain readable as a last resort while operators migrate. New
-    // writes always go to the tenant-scoped path; this branch only reads.
-    if (legacyStageCacheReadFallbackEnabled()) {
-      const legacyCachePath = path.join(stageCacheRoot(stage), runId, `${stepName}.json`);
-      const legacyCached = await readJsonIfExists(legacyCachePath);
-      if (legacyCached) {
-        return {
-          runId,
-          path: legacyCachePath,
-          payload: legacyCached,
-          source: 'cache',
-        };
-      }
     }
 
     for (const outputRoot of artifactOutputRoots()) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,6 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       ARIES_EXECUTION_PROVIDER: ${ARIES_EXECUTION_PROVIDER:-hermes}
       ARIES_MARKETING_EXECUTION_PROVIDER: ${ARIES_MARKETING_EXECUTION_PROVIDER:-hermes}
-      # Migration gate for PR #302 stage-cache tenant-prefix work. Enables
-      # READS from the legacy <cacheRoot>/<runId>/... layout during the
-      # one-pipeline-cycle soak period. New writes always go to the
-      # tenant-scoped path regardless. Remove after migration completes.
-      ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: ${ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK:-}
       HERMES_GATEWAY_URL: ${HERMES_GATEWAY_URL:-}
       HERMES_API_SERVER_KEY: ${HERMES_API_SERVER_KEY:-}
       HERMES_SESSION_KEY: ${HERMES_SESSION_KEY:-main}

--- a/tests/marketing-stage-cache-tenant-isolation.test.ts
+++ b/tests/marketing-stage-cache-tenant-isolation.test.ts
@@ -6,9 +6,10 @@
 //      tenant-scoped scan.
 //   3. readMarketingAssetWithinAllowedRoots denies cross-tenant stage cache
 //      reads when called with the wrong tenantId.
-//   4. The legacy fallback gate (ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK=1)
-//      allows reads of pre-migration on-disk caches.
-//   5. Writes are NEVER routed to the legacy layout — only reads tolerated.
+//   4. Pre-migration flat caches (`<cacheRoot>/<runId>/<step>.json`, no tenant
+//      segment) are NEVER read — tenant-scoped reads are unconditional (the
+//      legacy read fallback has been removed).
+//   5. Writes are NEVER routed to the legacy layout.
 //
 // All paths run through tsx --test; this file matches the style of
 // tests/marketing-stage-* peers.
@@ -21,7 +22,6 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
-  legacyStageCacheReadFallbackEnabled,
   stageCacheRoot,
   stageCacheRootForTenant,
 } from '../backend/marketing/artifact-store';
@@ -101,7 +101,7 @@ test('stageCacheRootForTenant fails closed when tenantId is empty', () => {
 
 test('readMarketingStageStepPayload writes go to tenant-scoped path only', async () => {
   await withScratch(async ({ stage1 }) => {
-    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: undefined }, async () => {
+    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1 }, async () => {
       const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
       doc.stages.research.run_id = 'nike-com-abc12345';
 
@@ -123,7 +123,7 @@ test('readMarketingStageStepPayload writes go to tenant-scoped path only', async
 
 test('inferMarketingStageRunId rejects sibling-tenant runId by tenant-scoped scan', async () => {
   await withScratch(async ({ stage1 }) => {
-    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: undefined }, async () => {
+    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1 }, async () => {
       // Tenant A and B both target nike.com. Tenant B has a cache run on disk.
       const tenantBRun = path.join(stage1, 'tenant-b', 'nike-com-bbbbbbbb');
       await mkdir(tenantBRun, { recursive: true });
@@ -175,10 +175,11 @@ test('cross-tenant readMarketingAssetWithinAllowedRoots is denied for stage cach
   });
 });
 
-test('legacy fallback gate enables reading pre-migration caches', async () => {
+test('pre-migration flat caches are never read (tenant-scoped reads are unconditional)', async () => {
   await withScratch(async ({ stage1 }) => {
-    // Off by default: legacy cache invisible.
-    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: undefined }, async () => {
+    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1 }, async () => {
+      // A pre-migration flat cache at <cacheRoot>/<runId>/<step>.json (no tenant
+      // segment). With the legacy read fallback removed, this is never surfaced.
       const legacyDir = path.join(stage1, 'nike-com-cccccccc');
       await mkdir(legacyDir, { recursive: true });
       await writeFile(path.join(legacyDir, 'step.json'), JSON.stringify({ legacy: true }));
@@ -186,34 +187,22 @@ test('legacy fallback gate enables reading pre-migration caches', async () => {
       const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
       doc.stages.research.run_id = 'nike-com-cccccccc';
 
-      const off = await readMarketingStageStepPayload(doc, 1, 'step');
-      assert.equal(off.source, 'none', 'legacy read must be off by default');
-      assert.equal(legacyStageCacheReadFallbackEnabled(), false);
-    });
-
-    // Gate on: legacy cache visible.
-    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: '1' }, async () => {
-      const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
-      doc.stages.research.run_id = 'nike-com-cccccccc';
-
-      const on = await readMarketingStageStepPayload(doc, 1, 'step');
-      assert.equal(on.source, 'cache', 'legacy fallback should surface the legacy cache');
-      assert.deepEqual(on.payload, { legacy: true });
-      assert.equal(legacyStageCacheReadFallbackEnabled(), true);
+      const resolution = await readMarketingStageStepPayload(doc, 1, 'step');
+      assert.equal(resolution.source, 'none', 'a flat (non-tenant-scoped) cache must never be read');
     });
   });
 });
 
-test('legacy fallback never writes to the shared root', async () => {
-  // The codebase has no writer for these caches in TypeScript (Lobster
-  // populates them out-of-band), so this is a structural assertion: the
-  // tenant-scoped path is the only write target we ever construct.
+test('a stage-cache read never creates directories at the shared root', async () => {
+  // The codebase has no writer for these caches in TypeScript (they are
+  // populated out-of-band), so this is a structural assertion: a read must not
+  // implicitly create the shared cache root.
   await withScratch(async ({ stage1 }) => {
-    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1, ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK: '1' }, async () => {
+    await withEnv({ ARTIFACT_STAGE1_CACHE_DIR: stage1 }, async () => {
       const doc = makeRuntimeDoc('tenant-a', 'job-a', 'https://nike.com');
       doc.stages.research.run_id = 'nike-com-cccccccc';
 
-      // Read a non-existent path with the fallback gate on. No side-effects expected.
+      // Read a non-existent path. No side-effects expected.
       await readMarketingStageStepPayload(doc, 1, 'absent-step');
 
       const entries = existsSync(stage1) ? await readdir(stage1) : [];


### PR DESCRIPTION
**DRAFT — merge-gated on a one-line prod check (below).** Final piece of the flag-hygiene pass; the one flag the audit found genuinely removable.

## What
`ARIES_STAGE_CACHE_LEGACY_READ_FALLBACK` (the PR #302 stage-cache tenant-prefix migration gate) lets stage-cache **reads** fall back to the pre-tenant-segment layout `<cacheRoot>/<runId>/<step>.json`. It ships **OFF** (`docker-compose.yml` `:-` empty; `.env.example` commented), so prod already runs the tenant-scoped-only read path — **the ON branch is dead in prod**. Writes were never routed to the legacy layout.

This removes the gate and makes tenant-scoped reads unconditional:
- delete `legacyStageCacheReadFallbackEnabled` (`artifact-store.ts`)
- drop the legacy ON-branch + import (`stage-artifact-resolution.ts`)
- drop the legacy candidate push + import (`publish-review.ts`)
- remove the env surface (`docker-compose.yml`, `.env.example`)
- rewrite the tenant-isolation test: "fallback reads flat cache" → "a flat (non-tenant-scoped) cache is **never** read"; drop the helper import + stale env overrides

## Safety
- `npm run typecheck` clean; `marketing-stage-cache-tenant-isolation.test.ts` **7/7**; `npm run verify` **passed**.
- prod runs the OFF branch today, so the code change is behavior-neutral **iff** no flat-layout caches remain on the live `DATA_ROOT`.

## ⛔ Merge gate (run on the prod box first)
Confirm no pre-migration flat caches remain — every step JSON must sit under a `<tenantId>/<runId>/` path, not directly under the stage-cache root:
```bash
find /data/hermes-stage[1-4]-cache -maxdepth 2 -name '*.json' -printf '%P\n' 2>/dev/null
# expect ONLY <tenantId>/<runId> dirs at depth 1-2; any `<runId>/<step>.json`
# directly under a stage-cache root means a flat cache still exists.
```
If clean (single-tenant VM, tenant 15, many cycles since the 2026-05-12 migration → very likely), mark ready + merge. If any flat cache remains, those runs would lose their cache hit and recompute (no data loss) — let them age out first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)