### PR TITLE
fix(reply): wire ARIES_NATIVE_REPLY_ENABLED into docker-compose (#598)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,14 @@ SLACK_SIGNING_SECRET=
 # SLACK_SINGLE_TENANT_CHANNEL=
 # SLACK_CLIENT_ID=
 # SLACK_CLIENT_SECRET=
+#
+# Native comment reply (qa-defect #598): when on, POST /api/insights/comments/
+# [commentId]/reply posts an operator reply to Meta (IG /replies, FB /comments)
+# and marks insights_comments.is_replied + platform_reply_id. Default OFF (the
+# route 404s while dark). Wired into the aries-app service environment: block, so
+# set it HERE and run `docker compose up -d`. Only effective once the Meta
+# instagram_manage_comments / pages_manage_engagement scopes are granted.
+# ARIES_NATIVE_REPLY_ENABLED=1
 # 16+ chars; rotates tenant workspace pseudonyms if changed.
 ARIES_TENANT_PSEUDONYM_SALT=replace-with-32-plus-char-secret-minimum-sixteen
 # Set to 1 when Hermes exposes the aries-research webhook and Honcho is reachable. Marketing research stage submits a bounded job + memoryContext.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,13 @@ services:
       # distributed unlisted; each tenant installs it. Empty by default.
       SLACK_CLIENT_ID: ${SLACK_CLIENT_ID:-}
       SLACK_CLIENT_SECRET: ${SLACK_CLIENT_SECRET:-}
+      # qa-defect #598 — native comment reply backend (POST
+      # /api/insights/comments/[commentId]/reply → Meta Graph reply). Default OFF;
+      # the route 404s while dark. Flip to 1 only after the Meta
+      # instagram_manage_comments / pages_manage_engagement scopes are granted (App
+      # Review). The Hermes reconciler + all route handlers run in this container,
+      # so only aries-app needs it.
+      ARIES_NATIVE_REPLY_ENABLED: ${ARIES_NATIVE_REPLY_ENABLED:-0}
       # 2026-05-23: flipped ON per TODOS rollout. Narrow first-name-denylist
       # heuristic replaces the legacy /[A-Z][a-z]+\s+[A-Z][a-z]+/ regex in
       # backend/memory/write-events.ts::scrubPreferenceLabelForHoncho. Effect:


### PR DESCRIPTION
The #598 reply-backend PR documented `ARIES_NATIVE_REPLY_ENABLED` in CLAUDE.md but **never wired it into the `aries-app` service's `environment:` block** in docker-compose.yml. Since docker-compose has no `env_file`, an env var must be in BOTH the host `.env` AND the compose `environment:` block (`${...}` interpolation) to reach the container.

**Impact:** setting `ARIES_NATIVE_REPLY_ENABLED=1` in the prod `.env` did nothing — the reply route stayed dark (404) with no way to enable it. (Confirmed live: the flag is absent from the running `aries-app` container's env.)

- `docker-compose.yml`: add `ARIES_NATIVE_REPLY_ENABLED: ${ARIES_NATIVE_REPLY_ENABLED:-0}` to the `aries-app` env block.
- `.env.example`: document the flag.

Config-only, no code change. Still default OFF + 404 until set AND the Meta `instagram_manage_comments` / `pages_manage_engagement` scopes are granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)