### PR TITLE
feat(connect): recognize Composio connected_accounts in the onboarding gate (#600)

### DIFF
--- a/lib/onboarding-gate.ts
+++ b/lib/onboarding-gate.ts
@@ -81,12 +81,25 @@ export async function countConnectedMetaPlatforms(
     return 0;
   }
 
+  // Count a Meta connection in EITHER store: oauth_connections (direct-Meta
+  // OAuth) OR connected_accounts (Composio). Composio brokers its own OAuth and
+  // persists to connected_accounts, so a Composio-connected tenant was invisible
+  // to the onboarding gate / publish precheck and short-circuited to
+  // "requires_channel_connection" (#600/#605). The oauth_connections branch is
+  // unchanged, so direct-Meta recognition is fully preserved; connected_accounts
+  // requires status='connected' (a pending Composio link does not count).
   const result = await client.query(
-    `SELECT COUNT(*)::int AS connected_count
-     FROM oauth_connections
-     WHERE tenant_id = $1
-       AND status = 'connected'
-       AND provider IN ('facebook', 'instagram')`,
+    `SELECT (
+       (SELECT COUNT(*) FROM oauth_connections
+          WHERE tenant_id = $1
+            AND status = 'connected'
+            AND provider IN ('facebook', 'instagram'))
+       +
+       (SELECT COUNT(*) FROM connected_accounts
+          WHERE tenant_id = $1
+            AND status = 'connected'
+            AND platform IN ('facebook', 'instagram'))
+     )::int AS connected_count`,
     [numericTenantId],
   );
 

--- a/tests/onboarding-gate.test.ts
+++ b/tests/onboarding-gate.test.ts
@@ -90,6 +90,27 @@ test('countConnectedMetaPlatforms returns count from query result', async () => 
   assert.equal(await countConnectedMetaPlatforms(queryable, '42'), 2);
 });
 
+test('countConnectedMetaPlatforms counts Composio connected_accounts as well as direct-Meta (#600/#605)', async () => {
+  let capturedSql = '';
+  const queryable = makeQueryable((sql, params) => {
+    capturedSql = sql;
+    assert.equal(params[0], 42, 'tenant id passed as numeric param');
+    return { rows: [{ connected_count: 1 }], rowCount: 1 };
+  });
+  const count = await countConnectedMetaPlatforms(queryable, '42');
+  assert.equal(count, 1);
+  // Recognition must read BOTH stores so a Composio-connected tenant isn't
+  // treated as unconnected — while direct-Meta (oauth_connections) is preserved.
+  assert.ok(capturedSql.includes('FROM oauth_connections'), 'still counts direct-Meta oauth_connections');
+  assert.ok(capturedSql.includes('FROM connected_accounts'), 'also counts Composio connected_accounts');
+  assert.ok(
+    capturedSql.includes("platform IN ('facebook', 'instagram')"),
+    'connected_accounts scoped to FB/IG platforms',
+  );
+  // Both branches require a fully-connected status (a pending link never counts).
+  assert.ok((capturedSql.match(/status = 'connected'/g) ?? []).length >= 2, "both stores require status='connected'");
+});
+
 test('countConnectedMetaPlatforms returns 0 when query returns empty rows', async () => {
   const queryable = makeQueryable(() => ({ rows: [], rowCount: 0 }));
   assert.equal(await countConnectedMetaPlatforms(queryable, '42'), 0);


### PR DESCRIPTION
**B1 of the Composio-instead-of-direct-Meta switch (#600).** Keeps direct-Meta fully intact.

`countConnectedMetaPlatforms` — the single "is this tenant connected to Meta?" check (onboarding gate, meta-not-connected banner, orchestrator publish precheck, weekly trigger) — read `oauth_connections` **only**. Composio brokers its own OAuth into `connected_accounts`, so a Composio-connected tenant read as "not connected" everywhere and publish short-circuited to `requires_channel_connection`.

- `lib/onboarding-gate.ts`: count a Meta connection in **either** store. The `oauth_connections` branch is unchanged (direct-Meta preserved); add a `connected_accounts` branch (`status='connected'`, `platform IN (facebook,instagram)`). A pending Composio link doesn't count.
- test asserts both stores are read with the right predicates.

**Validated:** `verify` ✓ · onboarding-gate 16/16 ✓ · typecheck ✓.

Remaining Composio-switch work (separate PRs): **B2** wire the live publish dispatch through the provider factory (today it hardwires `publishToMetaGraph`, so `PUBLISH_PROVIDER=composio` is inert); **B3** wire the `COMPOSIO_*_PUBLISH_POST_ACTION` slug env into compose (**needs the slug values from the Composio account**); **B4** expose the `/connections` Composio connect UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)