### PR TITLE
fix(dashboard): placeholder when Hermes preview media is evicted (#599)

### DIFF
--- a/backend/marketing/hermes-media-presence.ts
+++ b/backend/marketing/hermes-media-presence.ts
@@ -1,0 +1,157 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Read-time availability check for browser-facing Hermes media preview URLs.
+ *
+ * The marketing pipeline bakes an absolute `artifact_url`
+ * (`${APP_BASE_URL}/api/internal/hermes/media/<basename>`) into the runtime job
+ * docs when a creative is generated. The dashboard projection surfaces that URL
+ * as an `<img src>` preview. The Hermes image cache (the read-only mount this
+ * route serves from) evicts old files, so a ~weeks-old `artifact_url` can point
+ * at a basename that is no longer on disk — the browser then 404s and the
+ * operator sees a broken thumbnail instead of the graceful placeholder
+ * (qa-defect #599: "ready-to-publish inventory references missing Hermes media").
+ *
+ * The gc-missing-hermes-assets worker only marks `creative_assets` rows
+ * (`storage_kind='runtime_asset'`); it never touches the runtime job docs, which
+ * is where these preview URLs actually come from — so it cannot clear #599.
+ * Re-materialising is impossible (the source bytes are gone). The correct,
+ * lowest-risk fix is to treat an evicted-media preview URL as absent at read
+ * time so the existing placeholder fallback fires.
+ *
+ * This check is deliberately FAIL-OPEN: if the mount is unconfigured or
+ * unreadable (tests, misconfigured env), every URL passes through unchanged so
+ * behaviour is byte-identical to today. It only ever nulls a basename-addressed
+ * hermes-media URL whose file is *confirmed missing* from a *readable* mount.
+ */
+
+// Matches a canonical creative_assets UUID (the id-addressed media form). Those
+// resolve through the DB (and are tracked by `orphaned_at`), not by a flat
+// basename on the mount, so we never null them here — only the legacy
+// basename-addressed form, which is the actual #599 culprit.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const HERMES_MEDIA_PATH_PREFIX = '/api/internal/hermes/media/';
+
+// One readdir of the (small, ~hundreds of files) mount is amortised across all
+// previews in a dashboard render via this short-lived listing cache. Membership
+// is then O(1) per URL — no per-URL stat fan-out on the customer-facing list
+// endpoint (CLAUDE.md guardrail #1). The window is short so a freshly-generated
+// image is hidden for at most this long before the cache refreshes.
+const LISTING_TTL_MS = 15_000;
+
+let cachedListing: { root: string; names: Set<string>; expiresAt: number } | null = null;
+
+function mountRoot(): string | null {
+  const mount = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  if (!mount || !mount.trim()) {
+    return null;
+  }
+  return path.normalize(mount.trim());
+}
+
+/**
+ * The set of basenames currently on the Hermes mount, or `null` when the mount
+ * is unconfigured/unreadable (caller then fails open). Cached for LISTING_TTL_MS
+ * and keyed by mount root so an env change (e.g. between tests) invalidates it.
+ */
+function mountListing(now: number): Set<string> | null {
+  const root = mountRoot();
+  if (!root) {
+    return null;
+  }
+  if (cachedListing && cachedListing.root === root && cachedListing.expiresAt > now) {
+    return cachedListing.names;
+  }
+  try {
+    // NOTE: a readable-but-WRONG mount (e.g. an existing empty dir from a
+    // misconfigured HERMES_IMAGE_CACHE_MOUNT — the same failure CLAUDE.md flags
+    // for ingestion) yields an empty Set, so every live preview reads as missing
+    // and falls back to the placeholder for up to the TTL. That is strictly nicer
+    // than today's behaviour: the media route reads the same mount, so the same
+    // misconfig already 404s those `<img>` requests in the browser.
+    const names = new Set(readdirSync(root));
+    cachedListing = { root, names, expiresAt: now + LISTING_TTL_MS };
+    return names;
+  } catch {
+    // Unreadable mount — fail open (do not hide media we cannot verify).
+    cachedListing = null;
+    return null;
+  }
+}
+
+/**
+ * Extracts the flat Hermes-cache basename a URL addresses, or `null` if the URL
+ * is not a basename-addressed `/api/internal/hermes/media/<basename>` reference
+ * (non-hermes URLs, id/UUID-addressed media, nested paths all return null).
+ * Accepts absolute or relative URLs.
+ */
+export function hermesMediaBasenameFromUrl(url: string): string | null {
+  let pathname: string;
+  try {
+    // Base only used to parse relative URLs; absolute URLs ignore it.
+    pathname = new URL(url, 'http://internal.invalid').pathname;
+  } catch {
+    return null;
+  }
+  if (!pathname.startsWith(HERMES_MEDIA_PATH_PREFIX)) {
+    return null;
+  }
+  const rest = pathname.slice(HERMES_MEDIA_PATH_PREFIX.length);
+  if (!rest || rest.includes('/')) {
+    return null;
+  }
+  let basename: string;
+  try {
+    basename = decodeURIComponent(rest);
+  } catch {
+    basename = rest;
+  }
+  if (!basename || UUID_RE.test(basename)) {
+    return null;
+  }
+  return basename;
+}
+
+/**
+ * True only when `url` is a basename-addressed hermes-media URL whose file is
+ * confirmed missing from a readable mount. Fails open (false) for every other
+ * case: empty/non-hermes/id-addressed URLs, and any URL when the mount is
+ * unconfigured or unreadable.
+ */
+export function isMissingHermesMedia(url: string | null | undefined, now: number = Date.now()): boolean {
+  if (!url) {
+    return false;
+  }
+  const basename = hermesMediaBasenameFromUrl(url);
+  if (!basename) {
+    return false;
+  }
+  const listing = mountListing(now);
+  if (!listing) {
+    return false;
+  }
+  return !listing.has(basename);
+}
+
+/**
+ * Returns `url` unchanged unless it is a basename-addressed hermes-media URL
+ * whose file is confirmed missing from the mount, in which case it returns
+ * `null` so the caller's placeholder fallback can fire. Pure pass-through for
+ * `null`/non-hermes/unverifiable URLs.
+ */
+export function availableHermesMediaUrl(
+  url: string | null | undefined,
+  now: number = Date.now(),
+): string | null {
+  if (!url) {
+    return null;
+  }
+  return isMissingHermesMedia(url, now) ? null : url;
+}
+
+/** Test-only: clear the mount listing cache so a test can swap the mount dir. */
+export function __resetHermesMediaPresenceCacheForTests(): void {
+  cachedListing = null;
+}

--- a/backend/social-content/dashboard-projection.ts
+++ b/backend/social-content/dashboard-projection.ts
@@ -11,6 +11,7 @@ import type {
   MarketingDashboardItemStatus,
   MarketingDashboardPublishItem,
 } from '@/backend/marketing/dashboard-content';
+import { availableHermesMediaUrl } from '@/backend/marketing/hermes-media-presence';
 import type { SocialContentJobRuntimeDocument } from '@/backend/marketing/runtime-state';
 import { redactTokenLikeString } from '@/backend/social-content/payload';
 import { sanitizeServedAssetRef } from '@/validators/creative-memory';
@@ -738,7 +739,10 @@ function createAssets(input: {
   const imageAssets = input.projection.weekly_content_plan.image_creatives.map((creative, index) => {
     const id = imageAssetId(input.doc, creative, index);
     const title = tenantSafeString(input.doc, creative.title) || `Weekly image creative ${index + 1}`;
-    const previewUrl = safeImagePreviewUrl(input.doc, creative.artifact_url) || socialPreviewDataUri({
+    // availableHermesMediaUrl nulls an `artifact_url` whose Hermes-cache file has
+    // been evicted (qa-defect #599) so the placeholder data-URI fallback fires
+    // instead of a dead `<img src>` → 404. Pure pass-through for live media.
+    const previewUrl = availableHermesMediaUrl(safeImagePreviewUrl(input.doc, creative.artifact_url)) || socialPreviewDataUri({
       doc: input.doc,
       creative,
       index,

--- a/tests/marketing/dashboard-projection-stale-media.test.ts
+++ b/tests/marketing/dashboard-projection-stale-media.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { buildSocialContentDashboardProjection } from '../../backend/social-content/dashboard-projection';
+import { __resetHermesMediaPresenceCacheForTests } from '../../backend/marketing/hermes-media-presence';
+import type { MarketingDashboardAsset } from '../../backend/marketing/dashboard-content';
+import type { SocialContentJobRuntimeDocument } from '../../backend/marketing/runtime-state';
+
+// qa-defect #599: the ready-to-publish inventory rendered preview `<img src>` of
+// `/api/internal/hermes/media/<basename>` for creatives whose Hermes-cache bytes
+// had been evicted → 404 broken thumbnails. The projection must now fall back to
+// the placeholder data-URI when the media file is absent from the mount.
+
+const HERMES_BASENAME = 'openai_codex_gpt-image-2-medium_20260519_evicted.png';
+const ARTIFACT_URL = `https://aries.sugarandleather.com/api/internal/hermes/media/${HERMES_BASENAME}`;
+
+function emptyDashboard() {
+  return {
+    post: null,
+    posts: [],
+    assets: [],
+    publishItems: [],
+    calendarEvents: [],
+    statuses: {
+      countsByStatus: {
+        draft: 0,
+        in_review: 0,
+        ready: 0,
+        ready_to_publish: 0,
+        published_to_meta_paused: 0,
+        scheduled: 0,
+        live: 0,
+      },
+    },
+  };
+}
+
+function runtimeDoc(): SocialContentJobRuntimeDocument {
+  return {
+    tenant_id: 'tenant_stale_media',
+    job_id: 'mkt_stale_media',
+    created_at: '2026-05-19T00:00:00.000Z',
+    updated_at: '2026-05-19T00:00:00.000Z',
+    inputs: { brand_url: 'https://brand.example' },
+    brand_kit: { brand_name: 'Bright Studio' },
+    social_content_runtime: {
+      currentStage: 'creative_review',
+      stageOrder: ['planning', 'creative_review', 'publish_review'],
+      stages: {
+        planning: {
+          output: {
+            weekly_content_plan: {
+              window_days: 7,
+              posts: [
+                {
+                  id: 'creative-1',
+                  day: 'Day 1',
+                  platforms: ['instagram'],
+                  post_type: 'static',
+                  title: 'Founder story',
+                  caption: 'Caption.',
+                  creative_brief_id: 'creative-1',
+                  status: 'approved',
+                },
+              ],
+              image_creatives: [
+                {
+                  id: 'creative-1',
+                  title: 'Founder story image',
+                  aspect_ratio: '4:5',
+                  prompt: 'Warm studio portrait.',
+                  status: 'generated',
+                  artifact_url: ARTIFACT_URL,
+                },
+              ],
+              video_scripts: [],
+            },
+          },
+        },
+      },
+      publishingRequested: true,
+    },
+  } as unknown as SocialContentJobRuntimeDocument;
+}
+
+function imageAsset(): MarketingDashboardAsset {
+  const dashboard = buildSocialContentDashboardProjection(runtimeDoc(), emptyDashboard());
+  const asset = dashboard.assets.find((a) => a.type === 'image_ad');
+  assert.ok(asset, 'expected an image_ad asset in the projection');
+  return asset;
+}
+
+async function withMount<T>(seedBasename: string | null, run: () => Promise<T>): Promise<T> {
+  const prevMount = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  const prevDataRoot = process.env.DATA_ROOT;
+  const mount = await mkdtemp(path.join(tmpdir(), 'aries-stale-media-mount-'));
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-stale-media-data-'));
+  if (seedBasename) {
+    await writeFile(path.join(mount, seedBasename), 'png-bytes');
+  }
+  process.env.HERMES_IMAGE_CACHE_MOUNT = mount;
+  process.env.DATA_ROOT = dataRoot;
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    return await run();
+  } finally {
+    if (prevMount === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prevMount;
+    if (prevDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = prevDataRoot;
+    __resetHermesMediaPresenceCacheForTests();
+    await rm(mount, { recursive: true, force: true });
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+test('#599: image preview falls back to the placeholder data-URI when the Hermes media file is evicted', async () => {
+  await withMount(null, async () => {
+    const asset = imageAsset();
+    assert.ok(
+      asset.previewUrl?.startsWith('data:'),
+      `expected a placeholder data-URI preview, got: ${asset.previewUrl}`,
+    );
+    // thumbnailUrl mirrors previewUrl, so it must not reference the dead media either.
+    assert.equal(asset.thumbnailUrl, asset.previewUrl);
+    assert.ok(!asset.previewUrl?.includes('/api/internal/hermes/media/'));
+    // contentType is derived from previewUrl; the placeholder is an SVG data-URI.
+    assert.equal(asset.contentType, 'image/svg+xml');
+  });
+});
+
+test('#599: image preview keeps the Hermes media URL when the file is present on the mount', async () => {
+  await withMount(HERMES_BASENAME, async () => {
+    const asset = imageAsset();
+    assert.equal(asset.previewUrl, ARTIFACT_URL);
+    assert.equal(asset.thumbnailUrl, ARTIFACT_URL);
+  });
+});
+
+test('#599: image preview is byte-identical (passes the live URL) when the mount is unconfigured', async () => {
+  const prevMount = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  const prevDataRoot = process.env.DATA_ROOT;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-stale-media-data-'));
+  delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+  process.env.DATA_ROOT = dataRoot;
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    const asset = imageAsset();
+    assert.equal(asset.previewUrl, ARTIFACT_URL);
+  } finally {
+    if (prevMount === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prevMount;
+    if (prevDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = prevDataRoot;
+    __resetHermesMediaPresenceCacheForTests();
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/marketing/hermes-media-presence.test.ts
+++ b/tests/marketing/hermes-media-presence.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  __resetHermesMediaPresenceCacheForTests,
+  availableHermesMediaUrl,
+  hermesMediaBasenameFromUrl,
+  isMissingHermesMedia,
+} from '../../backend/marketing/hermes-media-presence';
+
+const APP = 'https://aries.sugarandleather.com';
+const HERMES = `${APP}/api/internal/hermes/media`;
+const PRESENT = 'openai_codex_gpt-image-2-low_20260520_present.png';
+const MISSING = 'openai_codex_gpt-image-2-medium_20260519_missing.png';
+
+async function withMount<T>(run: (mount: string) => Promise<T>): Promise<T> {
+  const prev = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  const mount = await mkdtemp(path.join(tmpdir(), 'aries-hermes-mount-'));
+  await writeFile(path.join(mount, PRESENT), 'png-bytes');
+  process.env.HERMES_IMAGE_CACHE_MOUNT = mount;
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    return await run(mount);
+  } finally {
+    if (prev === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
+    __resetHermesMediaPresenceCacheForTests();
+    await rm(mount, { recursive: true, force: true });
+  }
+}
+
+test('hermesMediaBasenameFromUrl extracts the basename only for basename-addressed hermes-media URLs', () => {
+  assert.equal(hermesMediaBasenameFromUrl(`${HERMES}/${PRESENT}`), PRESENT);
+  // relative form is accepted too
+  assert.equal(hermesMediaBasenameFromUrl(`/api/internal/hermes/media/${PRESENT}`), PRESENT);
+  // id/UUID-addressed media is DB-resolved, not a flat basename → null (never nulled here)
+  assert.equal(
+    hermesMediaBasenameFromUrl(`${HERMES}/123e4567-e89b-42d3-a456-426614174000`),
+    null,
+  );
+  // non-hermes URLs → null
+  assert.equal(hermesMediaBasenameFromUrl(`${APP}/api/marketing/jobs/j/assets/a`), null);
+  assert.equal(hermesMediaBasenameFromUrl('https://example.com/a.png'), null);
+  // nested path under the media prefix → null (route only serves a single segment)
+  assert.equal(hermesMediaBasenameFromUrl(`${HERMES}/sub/${PRESENT}`), null);
+  // junk → null
+  assert.equal(hermesMediaBasenameFromUrl('not a url'), null);
+});
+
+test('availableHermesMediaUrl passes through a present basename and nulls a missing one', async () => {
+  await withMount(async () => {
+    assert.equal(availableHermesMediaUrl(`${HERMES}/${PRESENT}`), `${HERMES}/${PRESENT}`);
+    assert.equal(availableHermesMediaUrl(`${HERMES}/${MISSING}`), null);
+    assert.equal(isMissingHermesMedia(`${HERMES}/${MISSING}`), true);
+    assert.equal(isMissingHermesMedia(`${HERMES}/${PRESENT}`), false);
+  });
+});
+
+test('availableHermesMediaUrl is a pure pass-through for null/non-hermes/id-addressed URLs', async () => {
+  await withMount(async () => {
+    assert.equal(availableHermesMediaUrl(null), null);
+    assert.equal(availableHermesMediaUrl(''), null);
+    const jobAsset = `${APP}/api/marketing/jobs/j/assets/a`;
+    assert.equal(availableHermesMediaUrl(jobAsset), jobAsset);
+    const external = 'https://cdn.example.com/x.png';
+    assert.equal(availableHermesMediaUrl(external), external);
+    // id-addressed hermes URL is never nulled even when absent from the mount
+    const idUrl = `${HERMES}/123e4567-e89b-42d3-a456-426614174000`;
+    assert.equal(availableHermesMediaUrl(idUrl), idUrl);
+  });
+});
+
+test('availableHermesMediaUrl fails open (URL unchanged) when the mount is unconfigured', () => {
+  const prev = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    const url = `${HERMES}/${MISSING}`;
+    assert.equal(availableHermesMediaUrl(url), url);
+    assert.equal(isMissingHermesMedia(url), false);
+  } finally {
+    if (prev === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
+    __resetHermesMediaPresenceCacheForTests();
+  }
+});
+
+test('availableHermesMediaUrl fails open when the mount path is unreadable', () => {
+  const prev = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  process.env.HERMES_IMAGE_CACHE_MOUNT = path.join(tmpdir(), `aries-nonexistent-mount-${process.pid}`);
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    const url = `${HERMES}/${MISSING}`;
+    assert.equal(availableHermesMediaUrl(url), url);
+  } finally {
+    if (prev === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
+    __resetHermesMediaPresenceCacheForTests();
+  }
+});
+
+test('a percent-encoded basename round-trips and matches the on-disk (decoded) name', async () => {
+  const encodedName = 'openai codex 20260520+v2.png'; // space + plus → encoded in the URL path
+  const prev = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  const mount = await mkdtemp(path.join(tmpdir(), 'aries-hermes-enc-'));
+  await writeFile(path.join(mount, encodedName), 'png-bytes');
+  process.env.HERMES_IMAGE_CACHE_MOUNT = mount;
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    const encodedUrl = `${HERMES}/${encodeURIComponent(encodedName)}`;
+    assert.equal(hermesMediaBasenameFromUrl(encodedUrl), encodedName);
+    assert.equal(availableHermesMediaUrl(encodedUrl), encodedUrl);
+  } finally {
+    if (prev === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
+    __resetHermesMediaPresenceCacheForTests();
+    await rm(mount, { recursive: true, force: true });
+  }
+});
+
+test('the mount listing cache honours its TTL on the same root (stale within window, refreshed after)', async () => {
+  const prev = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  const mount = await mkdtemp(path.join(tmpdir(), 'aries-hermes-ttl-'));
+  process.env.HERMES_IMAGE_CACHE_MOUNT = mount;
+  __resetHermesMediaPresenceCacheForTests();
+  const url = `${HERMES}/${MISSING}`;
+  try {
+    // t=0: file absent → cached as missing (nulled).
+    assert.equal(availableHermesMediaUrl(url, 0), null);
+    // File appears, but within the 15s window the cached listing is still served → stale-missing.
+    await writeFile(path.join(mount, MISSING), 'png-bytes');
+    assert.equal(availableHermesMediaUrl(url, 10_000), null);
+    // After the TTL elapses the listing is re-read → now present.
+    assert.equal(availableHermesMediaUrl(url, 16_000), url);
+  } finally {
+    if (prev === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
+    __resetHermesMediaPresenceCacheForTests();
+    await rm(mount, { recursive: true, force: true });
+  }
+});
+
+test('the mount listing cache refreshes when the mount root changes', async () => {
+  // First mount: MISSING is absent → nulled.
+  await withMount(async () => {
+    assert.equal(availableHermesMediaUrl(`${HERMES}/${MISSING}`), null);
+  });
+  // Second mount that DOES contain MISSING → cache keyed by root re-reads → present.
+  const prev = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  const mount2 = await mkdtemp(path.join(tmpdir(), 'aries-hermes-mount2-'));
+  await writeFile(path.join(mount2, MISSING), 'png-bytes');
+  process.env.HERMES_IMAGE_CACHE_MOUNT = mount2;
+  try {
+    // No explicit reset: the cache must invalidate on its own because the root changed.
+    assert.equal(availableHermesMediaUrl(`${HERMES}/${MISSING}`), `${HERMES}/${MISSING}`);
+  } finally {
+    if (prev === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
+    __resetHermesMediaPresenceCacheForTests();
+    await rm(mount2, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem (qa-defect #599)

The operator **ready-to-publish inventory** (`/dashboard/posts`) rendered image previews straight from the runtime job doc's `image_creatives[].artifact_url` — an absolute `${APP_BASE_URL}/api/internal/hermes/media/<basename>` URL. The Hermes image cache (read-only mount) evicts old files, so a weeks-old `artifact_url` 404s in the browser → broken thumbnail instead of the existing placeholder.

The `gc-missing-hermes-assets` worker only marks `creative_assets` rows (`storage_kind='runtime_asset'`) — it never touches the **runtime docs**, which is where these preview URLs come from. Confirmed against prod: gc dry-run = 0 candidates, while **85 of 210** doc-referenced `openai_codex_*` basenames are evicted from the mount. The bytes are gone, so re-materialising is impossible.

The QA loop independently reached the same root cause: *"404s are runtime projection not creative_assets."*

## Fix (read-time mark-stale, no prod-data mutation)

New `backend/marketing/hermes-media-presence.ts` — a pure, **fail-open** `availableHermesMediaUrl(url)`:
- nulls a **basename-addressed** hermes-media URL whose file is **confirmed missing** from a **readable** `HERMES_IMAGE_CACHE_MOUNT`
- passes through everything else: `null`, non-hermes URLs, id/UUID-addressed media, and **any** URL when the mount is unconfigured/unreadable
- one mount `readdir` amortised across a render via a 15s root-keyed listing cache → O(1) per URL, no fan-out on the customer-facing list endpoint (guardrail #1)

One call site in `backend/social-content/dashboard-projection.ts` (`createAssets`) wraps `safeImagePreviewUrl(...)` with it, so an evicted-media preview falls back to the existing `socialPreviewDataUri` placeholder. Live media, `/api/marketing/jobs/.../assets/...` URLs, and video assets are **byte-identical**.

## Tests
- `tests/marketing/hermes-media-presence.test.ts` — present passes through, missing nulls, fail-open (unconfigured + unreadable), id-URL never nulled, percent-encoded basename round-trips, TTL expiry + root-change cache invalidation.
- `tests/marketing/dashboard-projection-stale-media.test.ts` — projection falls back to the `data:` placeholder (contentType `image/svg+xml`) on eviction, keeps the live URL when present, and is byte-identical when the mount is unconfigured.

`npm run verify` ✅ · typecheck ✅ · banned-patterns ✅ · adversarially reviewed (SHIP, no high/med findings).

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)