### PR TITLE
feat(connect): surface Composio connections inside the dashboard

### DIFF
--- a/app/api/integrations/composio/handlers.ts
+++ b/app/api/integrations/composio/handlers.ts
@@ -98,7 +98,11 @@ export async function handleComposioConnect(
 
   try {
     const base = process.env.APP_BASE_URL?.replace(/\/+$/, '') ?? '';
-    const callbackUrl = base ? `${base}/connections?connected=${platform}` : undefined;
+    // Return the operator to the in-dashboard connections surface (the
+    // "Channel Integrations" nav entry) after the Composio OAuth completes.
+    const callbackUrl = base
+      ? `${base}/dashboard/settings/channel-integrations?connected=${platform}`
+      : undefined;
     const result = await provider.createConnectLink(externalUserIdFor(tenantId), platform, requestedCapability, {
       tenantId,
       callbackUrl,

--- a/app/connections/page.tsx
+++ b/app/connections/page.tsx
@@ -1,24 +1,13 @@
 import { redirect } from 'next/navigation';
 
-import { auth } from '@/auth';
-import ComposioConnectionsScreen from '@/frontend/integrations/composio-connections-screen';
-
 export const metadata = {
   title: 'Connections — Aries AI',
 };
 
-export default async function ConnectionsPage() {
-  // Server-side auth guard: send logged-out visitors to login rather than
-  // rendering page chrome. The connection APIs are independently tenant-gated;
-  // this keeps the page consistent with the rest of the authenticated app.
-  const session = await auth();
-  if (!session?.user) {
-    redirect('/login');
-  }
-
-  return (
-    <main className="min-h-screen bg-slate-950">
-      <ComposioConnectionsScreen />
-    </main>
-  );
+// The account-connections UI now lives inside the dashboard shell under the
+// "Channel Integrations" nav entry. This standalone route is kept as a stable
+// redirect so old links / bookmarks / OAuth callbacks land on the canonical
+// in-dashboard surface. The destination is auth-gated by the dashboard shell.
+export default function ConnectionsPage() {
+  redirect('/dashboard/settings/channel-integrations');
 }

--- a/app/dashboard/settings/channel-integrations/page.tsx
+++ b/app/dashboard/settings/channel-integrations/page.tsx
@@ -1,15 +1,20 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
-import AriesChannelIntegrationsScreen from '@/frontend/aries-v1/channel-integrations-screen';
+import ComposioConnectionsScreen from '@/frontend/integrations/composio-connections-screen';
 
 export const metadata = {
   title: 'Channel Integrations — Aries AI',
 };
 
+// Renders the Composio account-connections surface INSIDE the dashboard shell so
+// operators connect Facebook/Instagram (and the other toolkits) from the
+// existing "Channel Integrations" nav entry instead of a separate /connections
+// page. The legacy direct-Meta OAuth screen (AriesChannelIntegrationsScreen) and
+// its /oauth/connect routes are retained but are no longer the primary connect
+// surface now that Composio brokers connections.
 export default function DashboardChannelIntegrationsPage() {
   return (
     <AppShellLayout currentRouteId="channelIntegrations">
-      <AriesChannelIntegrationsScreen />
+      <ComposioConnectionsScreen />
     </AppShellLayout>
   );
 }
-

--- a/tests/channel-integrations-composio-surface.test.ts
+++ b/tests/channel-integrations-composio-surface.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+const channelPageSource = readFileSync(
+  path.join(PROJECT_ROOT, 'app', 'dashboard', 'settings', 'channel-integrations', 'page.tsx'),
+  'utf8',
+);
+const composioHandlersSource = readFileSync(
+  path.join(PROJECT_ROOT, 'app', 'api', 'integrations', 'composio', 'handlers.ts'),
+  'utf8',
+);
+const connectionsPageSource = readFileSync(
+  path.join(PROJECT_ROOT, 'app', 'connections', 'page.tsx'),
+  'utf8',
+);
+
+test('the dashboard Channel Integrations route renders the Composio connections surface inside the app shell', () => {
+  // The connect surface must live in the dashboard shell (the "Channel
+  // Integrations" nav entry), not only on a standalone page, so operators can
+  // connect Facebook/Instagram via Composio from the dashboard itself.
+  assert.match(channelPageSource, /ComposioConnectionsScreen/, 'page must render the Composio connections screen');
+  assert.match(channelPageSource, /AppShellLayout/, 'page must wrap the screen in the dashboard app shell');
+  assert.match(channelPageSource, /currentRouteId="channelIntegrations"/);
+});
+
+test('the Composio OAuth callback returns the operator to the in-dashboard connections surface', () => {
+  assert.match(
+    composioHandlersSource,
+    /\/dashboard\/settings\/channel-integrations\?connected=\$\{platform\}/,
+    'connect callback should land on the in-dashboard channel integrations page',
+  );
+  assert.ok(
+    !composioHandlersSource.includes('`${base}/connections?connected='),
+    'the old standalone /connections callback target should be replaced',
+  );
+});
+
+test('the standalone /connections route redirects to the canonical in-dashboard surface', () => {
+  assert.match(connectionsPageSource, /redirect\('\/dashboard\/settings\/channel-integrations'\)/);
+});


### PR DESCRIPTION
## Problem

The Composio account-connections UI (per-platform Connect buttons, **including Instagram**) only existed at a standalone `/connections` page that **isn't linked from the dashboard** — so an operator can't reach it. Meanwhile the dashboard's "Channel Integrations" nav entry renders the legacy **direct-Meta** OAuth screen, which has no Instagram-via-Composio option. Net effect: no way to connect Instagram via Composio from the dashboard (reported directly by the operator).

## Change

- `/dashboard/settings/channel-integrations` now renders `ComposioConnectionsScreen` inside `AppShellLayout` (the existing "Channel Integrations" nav entry) — the connect surface is now **in the dashboard itself**, with a Connect button per platform including Instagram.
- The Composio OAuth callback returns to `/dashboard/settings/channel-integrations?connected=<platform>` (in-shell) instead of the standalone page.
- The standalone `/connections` route now redirects to the in-dashboard surface (stable for old links / bookmarks / callbacks).
- The legacy direct-Meta screen (`AriesChannelIntegrationsScreen`) and `/oauth/connect/*` routes are **retained**, just no longer the primary connect surface.

## Tests
`tests/channel-integrations-composio-surface.test.ts` — asserts the dashboard route renders the Composio screen in the app shell, the callback lands in-dashboard, and `/connections` redirects.

`npm run verify` ✅ · typecheck ✅ · guardrails ✅. Existing CTA-link tests (onboarding-gate, settings, business-profile) still pass — the path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)