### PR TITLE
feat(insights): populate Facebook analytics + comments via Composio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -291,6 +291,21 @@ COMPOSIO_INSTAGRAM_PUBLISH_POST_ACTION=
 COMPOSIO_FACEBOOK_UPLOAD_MEDIA_ACTION=
 COMPOSIO_INSTAGRAM_UPLOAD_MEDIA_ACTION=
 
+# Facebook analytics + comments sync (#596/#597), read by the insights-sync
+# worker's Facebook adapter (backend/insights/adapters/facebook). The verified
+# slugs below are the CODE DEFAULTS, so analytics works with these left unset;
+# set them only to pin a different toolkit version. The adapter authenticates
+# every call with the tenant's Composio connectedAccountId.
+#   list_posts        -> FACEBOOK_GET_PAGE_POSTS   (per-post engagement source)
+#   post_insights     -> FACEBOOK_GET_POST_INSIGHTS (views; FB deprecated post
+#                        engagement metrics 2025-11-15)
+#   account_insights  -> FACEBOOK_GET_PAGE_INSIGHTS (page metrics, <=90d)
+#   list_comments     -> FACEBOOK_GET_COMMENTS     (object_id = pageId_postId)
+COMPOSIO_FACEBOOK_LIST_POSTS_ACTION=
+COMPOSIO_FACEBOOK_POST_INSIGHTS_ACTION=
+COMPOSIO_FACEBOOK_ACCOUNT_INSIGHTS_ACTION=
+COMPOSIO_FACEBOOK_LIST_COMMENTS_ACTION=
+
 # Transactional email (password reset flow) — Resend https://resend.com
 # Free tier: 100 emails/day, 3000/month. The Resend Node SDK reads
 # RESEND_API_KEY directly from process.env — don't rename it.

--- a/backend/insights/adapters/_adapter.types.ts
+++ b/backend/insights/adapters/_adapter.types.ts
@@ -75,6 +75,21 @@ export interface RawComment {
   bodyText: string;
 }
 
+// ── Adapter construction context ──────────────────────────────────────────────
+
+/**
+ * Per-tenant connection context handed to an adapter at construction time.
+ *
+ * Most adapters (e.g. YouTube, which uses its own OAuth tokens) ignore this.
+ * Composio-backed adapters (Facebook) need the per-tenant Composio
+ * `connectedAccountId` to authenticate every tool call; `pageId` is the
+ * platform-side account id (mirrors `insights_accounts.external_account_id`).
+ */
+export interface InsightsAdapterContext {
+  connectedAccountId?: string | null;
+  pageId?: string | null;
+}
+
 // ── The adapter interface ─────────────────────────────────────────────────────
 
 export interface InsightsAdapter {

--- a/backend/insights/adapters/_adapter.types.ts
+++ b/backend/insights/adapters/_adapter.types.ts
@@ -37,6 +37,14 @@ export interface RawAccountMetricsDay {
   likes: number;
   commentsCount: number;
   shares: number;
+  /**
+   * Authoritative aggregate account engagement for the day, when the platform
+   * reports a single engagement figure rather than a like/comment/share
+   * breakdown (Facebook's `page_post_engagements`). Persisted to the dedicated
+   * `engagement` column; read-api prefers it for the headline engagement and
+   * falls back to likes+comments+shares when null. Omit/null when not exposed.
+   */
+  engagement?: number | null;
   /** Original platform API response fields — stored in raw_source JSONB. */
   rawSource: Record<string, unknown>;
 }

--- a/backend/insights/adapters/facebook/index.ts
+++ b/backend/insights/adapters/facebook/index.ts
@@ -1,0 +1,393 @@
+/**
+ * backend/insights/adapters/facebook/index.ts
+ *
+ * Facebook insights adapter — backed by Composio (#596 analytics, #597 comments).
+ *
+ * Every platform call goes through the Composio gateway (`executeTool`) so the
+ * adapter depends on a small, mockable surface; tests inject a fake gateway and
+ * never touch the network. The verified Composio action slugs are the defaults,
+ * each overridable via `COMPOSIO_FACEBOOK_<OP>_ACTION` (resolved through
+ * `ComposioConfig.actionSlugFor`).
+ *
+ * Method → action:
+ *   fetchPostList     → FACEBOOK_GET_PAGE_POSTS     (source of per-post engagement)
+ *   fetchAccountMetrics → FACEBOOK_GET_PAGE_INSIGHTS + FACEBOOK_GET_PAGE_DETAILS
+ *   fetchPostMetrics  → FACEBOOK_GET_POST_INSIGHTS  (views) + cached list engagement
+ *   fetchComments     → FACEBOOK_GET_COMMENTS
+ *
+ * Deprecation note: Facebook removed post-level engagement metrics on
+ * 2025-11-15, so FACEBOOK_GET_POST_INSIGHTS now mostly returns `post_media_view`
+ * (views) only. Per-post likes/comments/shares therefore come from the
+ * `.summary(true)` counts captured during fetchPostList and cached on the
+ * adapter instance (the dispatcher reuses one adapter for the whole sync, calling
+ * fetchPostList before fetchPostMetrics).
+ */
+
+import type {
+  InsightsAdapter,
+  InsightsAdapterContext,
+  DateRange,
+  RawAccountMetricsDay,
+  RawPost,
+  RawPostMetricsDay,
+  RawComment,
+} from '../_adapter.types';
+import type { ComposioConfig, ComposioOperation } from '@/backend/integrations/composio/composio-config';
+import type { ComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { resolveComposioConfig } from '@/backend/integrations/composio/composio-config';
+import { createComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { num } from '@/backend/integrations/composio/analytics-mappers';
+
+// ── Verified default action slugs (env-overridable) ────────────────────────────
+
+const DEFAULT_SLUGS: Partial<Record<ComposioOperation, string>> = {
+  list_posts: 'FACEBOOK_GET_PAGE_POSTS',
+  post_insights: 'FACEBOOK_GET_POST_INSIGHTS',
+  account_insights: 'FACEBOOK_GET_PAGE_INSIGHTS',
+  account_info: 'FACEBOOK_GET_PAGE_DETAILS',
+  list_comments: 'FACEBOOK_GET_COMMENTS',
+};
+
+/** Page-level metrics to request (≤90d window). Engagement/follower oriented. */
+const FB_PAGE_METRICS =
+  'page_media_view,page_video_views,page_post_engagements,page_follows,page_daily_follows_unique,page_daily_unfollows_unique';
+
+/** Fields that carry per-post engagement summary counts + display metadata. */
+const FB_POST_FIELDS =
+  'id,message,created_time,permalink_url,full_picture,status_type,attachments,reactions.summary(true),comments.summary(true),shares';
+
+const FB_COMMENT_FIELDS = 'id,message,created_time,from';
+
+// ── Response unwrapping helpers ────────────────────────────────────────────────
+
+/**
+ * Descend through Composio's `{ data: <toolPayload> }` envelope wrappers. The
+ * exact nesting (one vs two `.data` layers) varies by tool/SDK version, so we
+ * peel object-with-`data` wrappers until we hit an array or a leaf object.
+ */
+function unwrap(raw: unknown): unknown {
+  let cur = raw;
+  for (let i = 0; i < 3; i += 1) {
+    if (!cur || typeof cur !== 'object' || Array.isArray(cur)) break;
+    const obj = cur as Record<string, unknown>;
+    if (!('data' in obj)) break;
+    cur = obj.data;
+  }
+  return cur;
+}
+
+/** Resolve a Graph list response into its row array, however it is nested. */
+function unwrapToArray(raw: unknown): Array<Record<string, unknown>> {
+  const peeled = unwrap(raw);
+  if (Array.isArray(peeled)) return peeled as Array<Record<string, unknown>>;
+  if (peeled && typeof peeled === 'object' && Array.isArray((peeled as Record<string, unknown>).data)) {
+    return (peeled as Record<string, unknown>).data as Array<Record<string, unknown>>;
+  }
+  return [];
+}
+
+/** Resolve a Graph single-object response (e.g. page details). */
+function unwrapToObject(raw: unknown): Record<string, unknown> {
+  const peeled = unwrap(raw);
+  if (peeled && typeof peeled === 'object' && !Array.isArray(peeled)) {
+    return peeled as Record<string, unknown>;
+  }
+  return {};
+}
+
+function summaryCount(node: unknown): number | null {
+  if (!node || typeof node !== 'object') return null;
+  const summary = (node as Record<string, unknown>).summary;
+  if (summary && typeof summary === 'object') {
+    return num((summary as Record<string, unknown>).total_count);
+  }
+  return null;
+}
+
+function sharesCount(node: unknown): number | null {
+  if (!node || typeof node !== 'object') return null;
+  return num((node as Record<string, unknown>).count);
+}
+
+function toDate(value: unknown): Date {
+  if (typeof value === 'string' && value.trim()) {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date(0);
+}
+
+function dateStr(value: unknown): string {
+  return toDate(value).toISOString().split('T')[0];
+}
+
+function fbMediaType(post: Record<string, unknown>): RawPost['mediaType'] {
+  const status = typeof post.status_type === 'string' ? post.status_type.toLowerCase() : '';
+  const attachments = unwrapToArray(post.attachments);
+  const first = attachments[0] ?? {};
+  const mediaType = typeof first.media_type === 'string' ? first.media_type.toLowerCase() : '';
+  const type = typeof first.type === 'string' ? first.type.toLowerCase() : '';
+  if (mediaType === 'video' || type.includes('video') || status.includes('video')) return 'video';
+  if (type === 'album' || mediaType === 'album') return 'carousel';
+  const sub = unwrapToArray((first as Record<string, unknown>).subattachments);
+  if (sub.length > 1) return 'carousel';
+  return 'image';
+}
+
+// ── Adapter ────────────────────────────────────────────────────────────────────
+
+export class FacebookInsightsAdapter implements InsightsAdapter {
+  readonly platform = 'facebook' as const;
+
+  /** Per-post engagement summary captured in fetchPostList, read in fetchPostMetrics. */
+  private readonly engagementCache = new Map<
+    string,
+    { likes: number | null; comments: number | null; shares: number | null }
+  >();
+
+  constructor(
+    private readonly gateway: ComposioGateway,
+    private readonly config: ComposioConfig,
+    private readonly ctx: InsightsAdapterContext = {},
+  ) {}
+
+  private slugFor(op: ComposioOperation): string {
+    const override = this.config.actionSlugFor('facebook', op);
+    const slug = override ?? DEFAULT_SLUGS[op];
+    if (!slug) throw new Error(`No Composio Facebook action slug configured for "${op}".`);
+    return slug;
+  }
+
+  private connectedAccountId(): string {
+    const id = this.ctx.connectedAccountId?.trim();
+    if (!id) {
+      throw new Error('FacebookInsightsAdapter: no Composio connectedAccountId in context.');
+    }
+    return id;
+  }
+
+  /** Execute a tool; throw on a hard (successful=false) failure so the sync run
+   * is marked failed while already-committed rows are preserved. */
+  private async exec(op: ComposioOperation, args: Record<string, unknown>): Promise<unknown> {
+    const result = await this.gateway.executeTool(this.slugFor(op), {
+      connectedAccountId: this.connectedAccountId(),
+      arguments: args,
+    });
+    if (!result.successful) {
+      throw new Error(result.error ?? `Composio Facebook ${op} call reported unsuccessful.`);
+    }
+    return result.data ?? null;
+  }
+
+  async fetchPostList(externalAccountId: string, publishedAfter?: Date): Promise<RawPost[]> {
+    const args: Record<string, unknown> = {
+      page_id: externalAccountId,
+      limit: 100,
+      fields: FB_POST_FIELDS,
+    };
+    if (publishedAfter) args.since = String(Math.floor(publishedAfter.getTime() / 1000));
+
+    const data = await this.exec('list_posts', args);
+    const rows = unwrapToArray(data);
+
+    const posts: RawPost[] = [];
+    for (const row of rows) {
+      const externalPostId = typeof row.id === 'string' ? row.id : null;
+      if (!externalPostId) continue;
+
+      this.engagementCache.set(externalPostId, {
+        likes: summaryCount(row.reactions),
+        comments: summaryCount(row.comments),
+        shares: sharesCount(row.shares),
+      });
+
+      posts.push({
+        externalPostId,
+        publishedAt: toDate(row.created_time),
+        mediaType: fbMediaType(row),
+        title: null,
+        caption: typeof row.message === 'string' ? row.message : null,
+        permalink: typeof row.permalink_url === 'string' ? row.permalink_url : null,
+        thumbnailUrl: typeof row.full_picture === 'string' ? row.full_picture : null,
+        durationSeconds: null,
+      });
+    }
+    return posts;
+  }
+
+  async fetchAccountMetrics(
+    externalAccountId: string,
+    range: DateRange,
+  ): Promise<RawAccountMetricsDay[]> {
+    const insightsData = await this.exec('account_insights', {
+      page_id: externalAccountId,
+      metrics: FB_PAGE_METRICS,
+      period: 'day',
+      since: range.from,
+      until: range.to,
+    });
+
+    // Followers snapshot is best-effort: a failure here must not drop the daily
+    // engagement series we already fetched.
+    let followersCount: number | null = null;
+    try {
+      const details = unwrapToObject(
+        await this.exec('account_info', {
+          page_id: externalAccountId,
+          fields: 'followers_count,fan_count',
+        }),
+      );
+      followersCount = num(details.followers_count) ?? num(details.fan_count);
+    } catch {
+      followersCount = null;
+    }
+
+    // Pivot the per-metric time series into one record per day.
+    type Day = {
+      views: number;
+      followers: number;
+      follows: number;
+      unfollows: number;
+      engagements: number;
+      videoViews: number;
+    };
+    const byDay = new Map<string, Day>();
+    const ensure = (date: string): Day => {
+      let d = byDay.get(date);
+      if (!d) {
+        d = { views: 0, followers: 0, follows: 0, unfollows: 0, engagements: 0, videoViews: 0 };
+        byDay.set(date, d);
+      }
+      return d;
+    };
+
+    for (const metric of unwrapToArray(insightsData)) {
+      const name = typeof metric.name === 'string' ? metric.name : null;
+      if (!name) continue;
+      const values = Array.isArray(metric.values) ? (metric.values as Array<Record<string, unknown>>) : [];
+      for (const v of values) {
+        const value = num(v.value);
+        if (value === null) continue;
+        const date = dateStr(v.end_time);
+        const day = ensure(date);
+        switch (name) {
+          case 'page_media_view': day.views = value; break;
+          case 'page_video_views': day.videoViews = value; break;
+          case 'page_follows': day.follows = value; break;
+          case 'page_daily_follows_unique': day.follows = day.follows || value; day.followers = value; break;
+          case 'page_daily_unfollows_unique': day.unfollows = value; break;
+          case 'page_post_engagements': day.engagements = value; break;
+          default: break;
+        }
+      }
+    }
+
+    // Stamp the current follower count on the most recent day (range.to) so the
+    // dashboard has a real "current followers" reading even when the daily
+    // page_follows series is sparse.
+    if (followersCount !== null) {
+      ensure(range.to).followers = followersCount;
+    }
+
+    const out: RawAccountMetricsDay[] = [];
+    for (const [date, d] of byDay) {
+      out.push({
+        date,
+        views: d.views,
+        watchTimeMinutes: 0,
+        followers: d.follows || d.followers || 0,
+        followersDelta: d.follows && d.unfollows ? d.follows - d.unfollows : 0,
+        likes: 0,
+        commentsCount: 0,
+        shares: 0,
+        rawSource: {
+          source: 'FACEBOOK_GET_PAGE_INSIGHTS',
+          page_media_view: d.views,
+          page_video_views: d.videoViews,
+          page_post_engagements: d.engagements,
+          page_follows: d.follows,
+          page_daily_unfollows_unique: d.unfollows,
+          followers_count: followersCount,
+        },
+      });
+    }
+    return out;
+  }
+
+  async fetchPostMetrics(externalPostId: string, _range?: DateRange): Promise<RawPostMetricsDay[]> {
+    const data = await this.exec('post_insights', { post_id: externalPostId, metrics: 'post_media_view' });
+
+    let views: number | null = null;
+    for (const metric of unwrapToArray(data)) {
+      if (metric.name !== 'post_media_view') continue;
+      const values = Array.isArray(metric.values) ? (metric.values as Array<Record<string, unknown>>) : [];
+      for (let i = values.length - 1; i >= 0; i -= 1) {
+        const v = num(values[i]?.value);
+        if (v !== null) { views = v; break; }
+      }
+    }
+
+    const engagement = this.engagementCache.get(externalPostId) ?? null;
+
+    // Only emit a row when there is a real signal — never fabricate a zero row
+    // for a post we have no data on.
+    if (views === null && !engagement) return [];
+
+    const date = new Date().toISOString().split('T')[0];
+    return [
+      {
+        date,
+        views: views ?? 0,
+        watchTimeMinutes: 0,
+        avgViewDurationSec: 0,
+        avgViewPercentage: 0,
+        likes: engagement?.likes ?? 0,
+        commentsCount: engagement?.comments ?? 0,
+        shares: engagement?.shares ?? 0,
+        rawSource: {
+          source: 'FACEBOOK_GET_POST_INSIGHTS',
+          post_media_view: views,
+          engagement_from_post_list: engagement,
+        },
+      },
+    ];
+  }
+
+  async fetchComments(externalPostId: string, limit = 100): Promise<RawComment[]> {
+    const data = await this.exec('list_comments', {
+      object_id: externalPostId,
+      limit: Math.min(Math.max(limit, 1), 100),
+      order: 'reverse_chronological',
+      fields: FB_COMMENT_FIELDS,
+      filter: 'stream',
+    });
+
+    const out: RawComment[] = [];
+    for (const row of unwrapToArray(data)) {
+      const externalCommentId = typeof row.id === 'string' ? row.id : null;
+      if (!externalCommentId) continue;
+      const from = (row.from ?? null) as Record<string, unknown> | null;
+      out.push({
+        externalCommentId,
+        receivedAt: toDate(row.created_time),
+        authorHandle: from && typeof from.name === 'string' ? from.name : null,
+        bodyText: typeof row.message === 'string' ? row.message : '',
+      });
+    }
+    return out;
+  }
+}
+
+/**
+ * Build a context-bound Facebook adapter wired to the live Composio gateway.
+ * Throws (via createComposioGateway) when Composio is enabled but no API key is
+ * configured — the dispatcher catches that and marks the sync run failed.
+ */
+export function createFacebookInsightsAdapter(
+  ctx: InsightsAdapterContext = {},
+  env: NodeJS.ProcessEnv = process.env,
+): FacebookInsightsAdapter {
+  const config = resolveComposioConfig(env);
+  const gateway = createComposioGateway(config);
+  return new FacebookInsightsAdapter(gateway, config!, ctx);
+}

--- a/backend/insights/adapters/facebook/index.ts
+++ b/backend/insights/adapters/facebook/index.ts
@@ -242,20 +242,23 @@ export class FacebookInsightsAdapter implements InsightsAdapter {
       followersCount = null;
     }
 
-    // Pivot the per-metric time series into one record per day.
+    // Pivot the per-metric time series into one record per day. Each field
+    // tracks its OWN source metric so cumulative and daily signals are never
+    // conflated (see the follower math below). null = the metric had no value
+    // that day (never coerced to a fabricated 0).
     type Day = {
-      views: number;
-      followers: number;
-      follows: number;
-      unfollows: number;
-      engagements: number;
-      videoViews: number;
+      mediaView: number | null;      // page_media_view (content views)
+      videoViews: number | null;     // page_video_views
+      engagements: number | null;    // page_post_engagements (DAILY engagement count)
+      pageFollows: number | null;    // page_follows (ABSOLUTE cumulative follower total)
+      dailyFollows: number | null;   // page_daily_follows_unique (DAILY new follows)
+      dailyUnfollows: number | null; // page_daily_unfollows_unique (DAILY unfollows)
     };
     const byDay = new Map<string, Day>();
     const ensure = (date: string): Day => {
       let d = byDay.get(date);
       if (!d) {
-        d = { views: 0, followers: 0, follows: 0, unfollows: 0, engagements: 0, videoViews: 0 };
+        d = { mediaView: null, videoViews: null, engagements: null, pageFollows: null, dailyFollows: null, dailyUnfollows: null };
         byDay.set(date, d);
       }
       return d;
@@ -268,45 +271,60 @@ export class FacebookInsightsAdapter implements InsightsAdapter {
       for (const v of values) {
         const value = num(v.value);
         if (value === null) continue;
-        const date = dateStr(v.end_time);
-        const day = ensure(date);
+        const day = ensure(dateStr(v.end_time));
         switch (name) {
-          case 'page_media_view': day.views = value; break;
+          case 'page_media_view': day.mediaView = value; break;
           case 'page_video_views': day.videoViews = value; break;
-          case 'page_follows': day.follows = value; break;
-          case 'page_daily_follows_unique': day.follows = day.follows || value; day.followers = value; break;
-          case 'page_daily_unfollows_unique': day.unfollows = value; break;
           case 'page_post_engagements': day.engagements = value; break;
+          case 'page_follows': day.pageFollows = value; break;
+          case 'page_daily_follows_unique': day.dailyFollows = value; break;
+          case 'page_daily_unfollows_unique': day.dailyUnfollows = value; break;
           default: break;
         }
       }
     }
 
-    // Stamp the current follower count on the most recent day (range.to) so the
-    // dashboard has a real "current followers" reading even when the daily
-    // page_follows series is sparse.
-    if (followersCount !== null) {
-      ensure(range.to).followers = followersCount;
-    }
+    // Ensure the most recent day exists so the authoritative PAGE_DETAILS
+    // follower count below has a row to land on.
+    const latestDate = range.to;
+    if (followersCount !== null) ensure(latestDate);
 
     const out: RawAccountMetricsDay[] = [];
     for (const [date, d] of byDay) {
+      // Absolute follower count: the cumulative page_follows for that day; on the
+      // latest day prefer the authoritative PAGE_DETAILS followers_count. NEVER
+      // derived from a daily follows/unfollows value.
+      const absoluteFollowers =
+        (date === latestDate && followersCount !== null ? followersCount : null) ?? d.pageFollows;
+      // Daily net change: new follows − unfollows, BOTH daily metrics. Computed
+      // only when at least one daily signal exists, so a day with no signal is 0
+      // (no change) rather than a bogus cumulative-minus-daily subtraction.
+      const followersDelta =
+        d.dailyFollows !== null || d.dailyUnfollows !== null
+          ? (d.dailyFollows ?? 0) - (d.dailyUnfollows ?? 0)
+          : 0;
+
       out.push({
         date,
-        views: d.views,
+        views: d.mediaView ?? 0,
         watchTimeMinutes: 0,
-        followers: d.follows || d.followers || 0,
-        followersDelta: d.follows && d.unfollows ? d.follows - d.unfollows : 0,
+        followers: absoluteFollowers ?? 0,
+        followersDelta,
+        // FB exposes no like/comment/share breakdown at the page level — only the
+        // aggregate page_post_engagements, surfaced via the dedicated `engagement`
+        // field (read-api uses it for the headline engagement, not these zeros).
         likes: 0,
         commentsCount: 0,
         shares: 0,
+        engagement: d.engagements,
         rawSource: {
           source: 'FACEBOOK_GET_PAGE_INSIGHTS',
-          page_media_view: d.views,
+          page_media_view: d.mediaView,
           page_video_views: d.videoViews,
           page_post_engagements: d.engagements,
-          page_follows: d.follows,
-          page_daily_unfollows_unique: d.unfollows,
+          page_follows: d.pageFollows,
+          page_daily_follows_unique: d.dailyFollows,
+          page_daily_unfollows_unique: d.dailyUnfollows,
           followers_count: followersCount,
         },
       });

--- a/backend/insights/read-api.ts
+++ b/backend/insights/read-api.ts
@@ -65,6 +65,7 @@ export async function handleGetInsightsSummary(
       total_comments:           string;
       total_shares:             string;
       total_watch_time_minutes: string;
+      total_engagement:         string;
     }>(
       `SELECT
          COALESCE(SUM(views), 0)              AS total_views,
@@ -73,7 +74,15 @@ export async function handleGetInsightsSummary(
          COALESCE(SUM(likes), 0)              AS total_likes,
          COALESCE(SUM(comments_count), 0)     AS total_comments,
          COALESCE(SUM(shares), 0)             AS total_shares,
-         COALESCE(SUM(watch_time_minutes), 0) AS total_watch_time_minutes
+         COALESCE(SUM(watch_time_minutes), 0) AS total_watch_time_minutes,
+         -- Prefer the authoritative aggregate engagement column (Facebook's
+         -- page_post_engagements) when present; fall back to the like/comment/
+         -- share breakdown for platforms that report one. Never a fake 0 when a
+         -- real aggregate exists.
+         COALESCE(SUM(
+           COALESCE(engagement,
+                    COALESCE(likes, 0) + COALESCE(comments_count, 0) + COALESCE(shares, 0))
+         ), 0)                                AS total_engagement
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
          AND date >= $2
@@ -92,7 +101,7 @@ export async function handleGetInsightsSummary(
       totalComments:         Number(row.total_comments),
       totalShares:           Number(row.total_shares),
       totalWatchTimeMinutes: Number(row.total_watch_time_minutes),
-      totalEngagement:       Number(row.total_likes) + Number(row.total_comments) + Number(row.total_shares),
+      totalEngagement:       Number(row.total_engagement),
     });
   } finally {
     client.release();

--- a/backend/insights/sync/adapter-factory.ts
+++ b/backend/insights/sync/adapter-factory.ts
@@ -18,24 +18,49 @@ import type { Platform } from '../platforms/registry';
 import type { InsightsAdapter, InsightsAdapterContext } from '../adapters/_adapter.types';
 import { youTubeInsightsAdapter } from '../adapters/youtube/index';
 import { createFacebookInsightsAdapter } from '../adapters/facebook/index';
+import { analyticsProviderSelector } from '@/backend/integrations/providers/integration-config';
 
 type AdapterBuilder = (ctx: InsightsAdapterContext) => InsightsAdapter;
 
+/**
+ * Real off-switch for the Composio-backed Facebook insights path: only active
+ * when ANALYTICS_PROVIDER=composio. When it is anything else (the default
+ * direct_meta), the FB adapter never activates and no Composio analytics tool
+ * is ever executed.
+ */
+export function isFacebookInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return analyticsProviderSelector(env) === 'composio';
+}
+
 const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
   youtube: () => youTubeInsightsAdapter,
-  facebook: (ctx) => createFacebookInsightsAdapter(ctx),
+  facebook: (ctx) => {
+    if (!isFacebookInsightsEnabled()) {
+      throw new Error(
+        'Facebook insights adapter is disabled: set ANALYTICS_PROVIDER=composio ' +
+        'to enable Composio-backed Facebook analytics.',
+      );
+    }
+    return createFacebookInsightsAdapter(ctx);
+  },
   // instagram: (ctx) => createInstagramInsightsAdapter(ctx),  ← out of scope (#596/#597 = FB only)
 };
 
-/** Returns true only if a builder is registered for the platform. */
-export function hasAdapter(platform: Platform): boolean {
+/**
+ * Returns true only if a live adapter is available for the platform. For
+ * Facebook this also honors the ANALYTICS_PROVIDER=composio off-switch, so
+ * callers (e.g. the integrations-sync handler) never route to a disabled path.
+ */
+export function hasAdapter(platform: Platform, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (platform === 'facebook') return isFacebookInsightsEnabled(env);
   return platform in REGISTRY && REGISTRY[platform] != null;
 }
 
 /**
  * Returns the adapter for a given platform, bound to the supplied connection
  * context (Composio-backed adapters need it; others ignore it).
- * Throws if no adapter has been registered for the platform.
+ * Throws if no adapter is registered, or if the platform's adapter is disabled
+ * by its off-switch (e.g. Facebook without ANALYTICS_PROVIDER=composio).
  */
 export function getAdapter(
   platform: Platform,

--- a/backend/insights/sync/adapter-factory.ts
+++ b/backend/insights/sync/adapter-factory.ts
@@ -1,41 +1,52 @@
 /**
  * backend/insights/sync/adapter-factory.ts
  *
- * Maps a platform string to its singleton InsightsAdapter instance.
+ * Maps a platform string to its InsightsAdapter instance.
+ *
+ * Adapters are produced by per-platform builder functions so a platform that
+ * needs per-tenant connection context (e.g. Facebook via Composio, which needs
+ * the Composio `connectedAccountId`) can be constructed bound to that context,
+ * while context-free adapters (YouTube) return a shared singleton.
  *
  * To add a new platform:
  *   1. Create backend/insights/adapters/<platform>/index.ts
- *   2. Register it in REGISTRY below.
+ *   2. Register a builder in REGISTRY below.
  *   3. TypeScript will flag anything that needs updating.
  */
 
 import type { Platform } from '../platforms/registry';
-import type { InsightsAdapter } from '../adapters/_adapter.types';
+import type { InsightsAdapter, InsightsAdapterContext } from '../adapters/_adapter.types';
 import { youTubeInsightsAdapter } from '../adapters/youtube/index';
+import { createFacebookInsightsAdapter } from '../adapters/facebook/index';
 
-const REGISTRY: Partial<Record<Platform, InsightsAdapter>> = {
-  youtube: youTubeInsightsAdapter,
-  // instagram: instagramInsightsAdapter,  ← Phase 4+
-  // facebook:  facebookInsightsAdapter,   ← Phase 4+
+type AdapterBuilder = (ctx: InsightsAdapterContext) => InsightsAdapter;
+
+const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
+  youtube: () => youTubeInsightsAdapter,
+  facebook: (ctx) => createFacebookInsightsAdapter(ctx),
+  // instagram: (ctx) => createInstagramInsightsAdapter(ctx),  ← out of scope (#596/#597 = FB only)
 };
 
-/** Returns true only if a live adapter is registered for the platform. */
+/** Returns true only if a builder is registered for the platform. */
 export function hasAdapter(platform: Platform): boolean {
   return platform in REGISTRY && REGISTRY[platform] != null;
 }
 
 /**
- * Returns the adapter for a given platform.
- * Throws if no adapter has been registered (e.g. a platform in the DB
- * that doesn't have an adapter yet).
+ * Returns the adapter for a given platform, bound to the supplied connection
+ * context (Composio-backed adapters need it; others ignore it).
+ * Throws if no adapter has been registered for the platform.
  */
-export function getAdapter(platform: Platform): InsightsAdapter {
-  const adapter = REGISTRY[platform];
-  if (!adapter) {
+export function getAdapter(
+  platform: Platform,
+  ctx: InsightsAdapterContext = {},
+): InsightsAdapter {
+  const builder = REGISTRY[platform];
+  if (!builder) {
     throw new Error(
       `No insights adapter registered for platform "${platform}". ` +
       `Add one to backend/insights/sync/adapter-factory.ts.`,
     );
   }
-  return adapter;
+  return builder(ctx);
 }

--- a/backend/insights/sync/dispatcher.ts
+++ b/backend/insights/sync/dispatcher.ts
@@ -26,12 +26,31 @@
  */
 
 import pool from '@/lib/db';
-import { isSupportedPlatform } from '../platforms/registry';
+import { isSupportedPlatform, type Platform } from '../platforms/registry';
 import { getAdapter } from './adapter-factory';
-import type { DateRange } from '../adapters/_adapter.types';
+import type { DateRange, InsightsAdapter, InsightsAdapterContext } from '../adapters/_adapter.types';
 import type { SyncTrigger, SyncStatus } from '../types';
 import { getConnectionRow } from '@/backend/integrations/composio/connection-store';
 import { isIntegrationPlatform } from '@/backend/integrations/providers/types';
+
+// ── Injection seam (production defaults to the global pool + real factory) ──────
+// Lets the leg-isolation regression test drive syncAccountForTenant against an
+// in-memory fake pool + adapter, with no live database. Production callers never
+// pass deps.
+interface SyncClient {
+  query<T = Record<string, unknown>>(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: T[]; rowCount: number | null }>;
+  release(): void;
+}
+interface SyncPool {
+  connect(): Promise<SyncClient>;
+}
+export interface SyncDeps {
+  pool?: SyncPool;
+  resolveAdapter?: (platform: Platform, ctx: InsightsAdapterContext) => InsightsAdapter;
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -99,8 +118,11 @@ export async function syncAccountForTenant(
   tenantId: number,
   accountId: number,
   trigger: SyncTrigger = 'handler',
+  deps: SyncDeps = {},
 ): Promise<SyncResult> {
-  const client = await pool.connect();
+  const db: SyncPool = deps.pool ?? (pool as unknown as SyncPool);
+  const resolveAdapter = deps.resolveAdapter ?? getAdapter;
+  const client = await db.connect();
   let syncRunId = -1;
   let platform = 'unknown';
 
@@ -152,16 +174,27 @@ export async function syncAccountForTenant(
       const conn = await getConnectionRow(String(tenantId), platform, client).catch(() => null);
       connectedAccountId = conn?.connectedAccountId ?? null;
     }
-    const adapter = getAdapter(platform, { connectedAccountId, pageId: externalAccountId });
+    const adapter = resolveAdapter(platform, { connectedAccountId, pageId: externalAccountId });
     const range30 = lastNDaysRange(30);
 
     let postsSeen = 0;
     let commentsSeen = 0;
     let apiUnitsUsed = 0;
+    // Each adapter leg below is isolated: one platform call failing (e.g. a
+    // POST_INSIGHTS error for one post) is recorded here and the remaining legs
+    // still run + persist. A non-empty list downgrades the run to 'partial'
+    // instead of failing the whole sync — so #597 comments can never be zeroed
+    // by a #596 metrics error, and vice-versa.
+    const legErrors: string[] = [];
 
     // 3. Post list
-    const rawPosts = await adapter.fetchPostList(externalAccountId);
-    apiUnitsUsed++;
+    let rawPosts: Awaited<ReturnType<typeof adapter.fetchPostList>> = [];
+    try {
+      rawPosts = await adapter.fetchPostList(externalAccountId);
+      apiUnitsUsed++;
+    } catch (err) {
+      legErrors.push(`fetchPostList: ${err instanceof Error ? err.message : String(err)}`);
+    }
 
     for (const rp of rawPosts) {
       await client.query(
@@ -188,28 +221,32 @@ export async function syncAccountForTenant(
     }
 
     // 4. Account-level daily metrics (last 30 days)
-    const accountMetrics = await adapter.fetchAccountMetrics(externalAccountId, range30);
-    apiUnitsUsed++;
+    try {
+      const accountMetrics = await adapter.fetchAccountMetrics(externalAccountId, range30);
+      apiUnitsUsed++;
 
-    for (const m of accountMetrics) {
-      await client.query(
-        `INSERT INTO insights_account_metrics_daily
-           (tenant_id, account_id, platform, date,
-            views, watch_time_minutes, followers, followers_delta,
-            likes, comments_count, shares,
-            platform_data, raw_source)
-         VALUES ($1, $2, $3, $4,
-                 $5, $6, $7, $8,
-                 $9, $10, $11,
-                 '{}', $12)
-         ON CONFLICT (tenant_id, account_id, date) DO NOTHING`,
-        [
-          tenantId, accountId, platform, m.date,
-          m.views, m.watchTimeMinutes, m.followers, m.followersDelta,
-          m.likes, m.commentsCount, m.shares,
-          JSON.stringify(m.rawSource),
-        ],
-      );
+      for (const m of accountMetrics) {
+        await client.query(
+          `INSERT INTO insights_account_metrics_daily
+             (tenant_id, account_id, platform, date,
+              views, watch_time_minutes, followers, followers_delta,
+              likes, comments_count, shares, engagement,
+              platform_data, raw_source)
+           VALUES ($1, $2, $3, $4,
+                   $5, $6, $7, $8,
+                   $9, $10, $11, $12,
+                   '{}', $13)
+           ON CONFLICT (tenant_id, account_id, date) DO NOTHING`,
+          [
+            tenantId, accountId, platform, m.date,
+            m.views, m.watchTimeMinutes, m.followers, m.followersDelta,
+            m.likes, m.commentsCount, m.shares, m.engagement ?? null,
+            JSON.stringify(m.rawSource),
+          ],
+        );
+      }
+    } catch (err) {
+      legErrors.push(`fetchAccountMetrics: ${err instanceof Error ? err.message : String(err)}`);
     }
 
     // 5. Per-post daily metrics
@@ -233,36 +270,44 @@ export async function syncAccountForTenant(
     );
 
     for (const post of postsToSync.rows) {
-      const postMetrics = await adapter.fetchPostMetrics(post.external_post_id, range30);
-      apiUnitsUsed++;
+      try {
+        const postMetrics = await adapter.fetchPostMetrics(post.external_post_id, range30);
+        apiUnitsUsed++;
 
-      for (const pm of postMetrics) {
+        for (const pm of postMetrics) {
+          await client.query(
+            `INSERT INTO insights_post_metrics_daily
+               (tenant_id, post_id, platform, date,
+                views, watch_time_minutes,
+                avg_view_duration_sec, avg_view_percentage,
+                likes, comments_count, shares,
+                platform_data, raw_source)
+             VALUES ($1, $2, $3, $4,
+                     $5, $6, $7, $8,
+                     $9, $10, $11,
+                     '{}', $12)
+             ON CONFLICT (tenant_id, post_id, date) DO NOTHING`,
+            [
+              tenantId, post.id, platform, pm.date,
+              pm.views, pm.watchTimeMinutes,
+              pm.avgViewDurationSec, pm.avgViewPercentage,
+              pm.likes, pm.commentsCount, pm.shares,
+              JSON.stringify(pm.rawSource),
+            ],
+          );
+        }
+
         await client.query(
-          `INSERT INTO insights_post_metrics_daily
-             (tenant_id, post_id, platform, date,
-              views, watch_time_minutes,
-              avg_view_duration_sec, avg_view_percentage,
-              likes, comments_count, shares,
-              platform_data, raw_source)
-           VALUES ($1, $2, $3, $4,
-                   $5, $6, $7, $8,
-                   $9, $10, $11,
-                   '{}', $12)
-           ON CONFLICT (tenant_id, post_id, date) DO NOTHING`,
-          [
-            tenantId, post.id, platform, pm.date,
-            pm.views, pm.watchTimeMinutes,
-            pm.avgViewDurationSec, pm.avgViewPercentage,
-            pm.likes, pm.commentsCount, pm.shares,
-            JSON.stringify(pm.rawSource),
-          ],
+          `UPDATE insights_posts SET last_metrics_fetched_at = now() WHERE id = $1`,
+          [post.id],
+        );
+      } catch (err) {
+        // One post's metrics failing must not skip the rest of the loop OR the
+        // comments leg below.
+        legErrors.push(
+          `fetchPostMetrics(${post.external_post_id}): ${err instanceof Error ? err.message : String(err)}`,
         );
       }
-
-      await client.query(
-        `UPDATE insights_posts SET last_metrics_fetched_at = now() WHERE id = $1`,
-        [post.id],
-      );
     }
 
     // 6. Comments — last 30 days of posts, up to 100 comments per post
@@ -281,32 +326,54 @@ export async function syncAccountForTenant(
     );
 
     for (const post of recentPosts.rows) {
-      const comments = await adapter.fetchComments(post.external_post_id, 100);
-      apiUnitsUsed++;
+      try {
+        const comments = await adapter.fetchComments(post.external_post_id, 100);
+        apiUnitsUsed++;
 
-      for (const c of comments) {
-        await client.query(
-          `INSERT INTO insights_comments
-             (tenant_id, post_id, platform, external_comment_id,
-              received_at, author_handle, body_text, platform_data)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, '{}')
-           ON CONFLICT (tenant_id, platform, external_comment_id) DO NOTHING`,
-          [
-            tenantId, post.id, platform, c.externalCommentId,
-            c.receivedAt, c.authorHandle, c.bodyText,
-          ],
+        for (const c of comments) {
+          await client.query(
+            `INSERT INTO insights_comments
+               (tenant_id, post_id, platform, external_comment_id,
+                received_at, author_handle, body_text, platform_data)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, '{}')
+             ON CONFLICT (tenant_id, platform, external_comment_id) DO NOTHING`,
+            [
+              tenantId, post.id, platform, c.externalCommentId,
+              c.receivedAt, c.authorHandle, c.bodyText,
+            ],
+          );
+          commentsSeen++;
+        }
+      } catch (err) {
+        legErrors.push(
+          `fetchComments(${post.external_post_id}): ${err instanceof Error ? err.message : String(err)}`,
         );
-        commentsSeen++;
       }
     }
 
     // ── 7. Finish sync_run record + update account ─────────────────────────
-    await client.query(SYNC_RUN_TERMINAL_OK_SQL, [
-      postsSeen,
-      commentsSeen,
-      apiUnitsUsed,
-      syncRunId,
-    ]);
+    // A leg that threw is isolated (captured in legErrors) and downgrades the
+    // run to 'partial' — the legs that succeeded still persisted. Only a clean
+    // run takes the 'ok' fast path (which also clears any mid-flight sweep abort
+    // message via SYNC_RUN_TERMINAL_OK_SQL).
+    const status: SyncStatus = legErrors.length > 0 ? 'partial' : 'ok';
+    if (status === 'ok') {
+      await client.query(SYNC_RUN_TERMINAL_OK_SQL, [
+        postsSeen,
+        commentsSeen,
+        apiUnitsUsed,
+        syncRunId,
+      ]);
+    } else {
+      await client.query(
+        `UPDATE insights_sync_runs
+         SET status = 'partial', finished_at = now(),
+             posts_seen = $1, comments_seen = $2, api_units_used = $3,
+             error_message = $4
+         WHERE id = $5`,
+        [postsSeen, commentsSeen, apiUnitsUsed, legErrors.join(' | ').slice(0, 2000), syncRunId],
+      );
+    }
 
     await client.query(
       `UPDATE insights_accounts SET last_sync_at = now() WHERE id = $1`,
@@ -315,8 +382,9 @@ export async function syncAccountForTenant(
 
     return {
       syncRunId, accountId, platform,
-      status: 'ok',
+      status,
       postsSeen, commentsSeen, apiUnitsUsed,
+      ...(legErrors.length > 0 ? { errorMessage: legErrors.join(' | ') } : {}),
     };
 
   } catch (err) {

--- a/backend/insights/sync/dispatcher.ts
+++ b/backend/insights/sync/dispatcher.ts
@@ -30,6 +30,8 @@ import { isSupportedPlatform } from '../platforms/registry';
 import { getAdapter } from './adapter-factory';
 import type { DateRange } from '../adapters/_adapter.types';
 import type { SyncTrigger, SyncStatus } from '../types';
+import { getConnectionRow } from '@/backend/integrations/composio/connection-store';
+import { isIntegrationPlatform } from '@/backend/integrations/providers/types';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -141,7 +143,16 @@ export async function syncAccountForTenant(
     syncRunId = runRes.rows[0].id;
 
     // ── 3–6. Call adapter ──────────────────────────────────────────────────
-    const adapter = getAdapter(platform);
+    // Composio-backed adapters (Facebook) need the per-tenant Composio
+    // connectedAccountId; resolve it from the connection store (reusing this
+    // pooled client). YouTube ignores the context. A missing/failed lookup
+    // leaves the context empty so the adapter surfaces a clear error.
+    let connectedAccountId: string | null = null;
+    if (isIntegrationPlatform(platform)) {
+      const conn = await getConnectionRow(String(tenantId), platform, client).catch(() => null);
+      connectedAccountId = conn?.connectedAccountId ?? null;
+    }
+    const adapter = getAdapter(platform, { connectedAccountId, pageId: externalAccountId });
     const range30 = lastNDaysRange(30);
 
     let postsSeen = 0;

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -1,0 +1,71 @@
+/**
+ * backend/insights/sync/ensure-account.ts
+ *
+ * Bridge: connected_accounts (the integration/Composio connection store) →
+ * insights_accounts (what the sync worker fans out over).
+ *
+ * Nothing else inserts into insights_accounts, so without this bridge the sync
+ * worker's `SELECT DISTINCT tenant_id FROM insights_accounts` is always empty
+ * and the whole analytics pipeline no-ops even though a tenant has a connected
+ * Facebook account. This runs once per worker tick and idempotently upserts one
+ * insights_accounts row per tenant that has a connected, Composio-backed
+ * Facebook connection (mapping connected_accounts.external_account_id → the
+ * page id stored in insights_accounts.external_account_id).
+ *
+ * Instagram is intentionally out of scope (#596/#597 are Facebook-only); add
+ * platforms to BRIDGED_PLATFORMS when their adapter lands.
+ */
+
+import pool from '@/lib/db';
+import type { Queryable } from '@/backend/integrations/composio/connection-store';
+
+/** Platforms whose Composio connections should be projected into insights_accounts. */
+export const BRIDGED_PLATFORMS = ['facebook'] as const;
+
+interface BridgeRow {
+  tenant_id: string | number;
+  platform: string;
+  external_account_id: string;
+  external_account_name: string | null;
+}
+
+export interface EnsureAccountsResult {
+  /** Number of connected source connections considered. */
+  considered: number;
+  /** Number of insights_accounts rows upserted (inserted or refreshed). */
+  upserted: number;
+}
+
+/**
+ * Idempotently upsert insights_accounts rows from connected Composio
+ * connections. Safe to call every tick: the UNIQUE (tenant_id, platform,
+ * external_account_id) constraint collapses re-runs onto the existing row.
+ */
+export async function ensureInsightsAccountsForConnectedPlatforms(
+  db: Queryable = pool,
+): Promise<EnsureAccountsResult> {
+  const placeholders = BRIDGED_PLATFORMS.map((_, i) => `$${i + 1}`).join(', ');
+  const sources = await db.query<BridgeRow>(
+    `SELECT tenant_id, platform, external_account_id, external_account_name
+       FROM connected_accounts
+      WHERE status = 'connected'
+        AND connected_account_id IS NOT NULL
+        AND external_account_id IS NOT NULL
+        AND platform IN (${placeholders})`,
+    [...BRIDGED_PLATFORMS],
+  );
+
+  let upserted = 0;
+  for (const row of sources.rows) {
+    const res = await db.query(
+      `INSERT INTO insights_accounts (tenant_id, platform, external_account_id, display_name)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (tenant_id, platform, external_account_id) DO UPDATE
+         SET display_name = COALESCE(EXCLUDED.display_name, insights_accounts.display_name)`,
+      [row.tenant_id, row.platform, row.external_account_id, row.external_account_name],
+    );
+    upserted += res.rowCount ?? 0;
+  }
+
+  return { considered: sources.rows.length, upserted };
+}

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -18,6 +18,7 @@
 
 import pool from '@/lib/db';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
+import { analyticsProviderSelector } from '@/backend/integrations/providers/integration-config';
 
 /** Platforms whose Composio connections should be projected into insights_accounts. */
 export const BRIDGED_PLATFORMS = ['facebook'] as const;
@@ -34,21 +35,33 @@ export interface EnsureAccountsResult {
   considered: number;
   /** Number of insights_accounts rows upserted (inserted or refreshed). */
   upserted: number;
+  /** Set when the bridge no-opped because the off-switch is off. */
+  skippedReason?: string;
 }
 
 /**
  * Idempotently upsert insights_accounts rows from connected Composio
  * connections. Safe to call every tick: the UNIQUE (tenant_id, platform,
  * external_account_id) constraint collapses re-runs onto the existing row.
+ *
+ * Gated by the same off-switch as the adapter (ANALYTICS_PROVIDER=composio):
+ * when analytics is not on Composio this is a no-op, so nothing is populated and
+ * the worker stays a clean no-op (no failed sync runs for a disabled path).
  */
 export async function ensureInsightsAccountsForConnectedPlatforms(
   db: Queryable = pool,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<EnsureAccountsResult> {
+  if (analyticsProviderSelector(env) !== 'composio') {
+    return { considered: 0, upserted: 0, skippedReason: 'analytics_provider_not_composio' };
+  }
+
   const placeholders = BRIDGED_PLATFORMS.map((_, i) => `$${i + 1}`).join(', ');
   const sources = await db.query<BridgeRow>(
     `SELECT tenant_id, platform, external_account_id, external_account_name
        FROM connected_accounts
       WHERE status = 'connected'
+        AND provider = 'composio'
         AND connected_account_id IS NOT NULL
         AND external_account_id IS NOT NULL
         AND platform IN (${placeholders})`,

--- a/backend/integrations/composio/analytics-mappers.ts
+++ b/backend/integrations/composio/analytics-mappers.ts
@@ -43,7 +43,12 @@ export interface PlatformAnalyticsMapper {
 
 // --- response helpers -------------------------------------------------------
 
-function num(v: unknown): number | null {
+/**
+ * Coerce a loose value (number or numeric string) to a finite number, else null.
+ * Exported so the insights Facebook adapter parses the same Graph payloads with
+ * the identical numeric semantics (no fabricated zeros).
+ */
+export function num(v: unknown): number | null {
   if (typeof v === 'number' && Number.isFinite(v)) return v;
   if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) return Number(v);
   return null;
@@ -62,7 +67,7 @@ function payload(raw: unknown): Record<string, unknown> {
  * `[{ name, total_value: { value } }]`) into name -> number. Handles the
  * extra `.data` wrap FB/IG tools add (payload().data is the array).
  */
-function graphInsights(raw: unknown): Record<string, number> {
+export function graphInsights(raw: unknown): Record<string, number> {
   const r = (raw ?? {}) as Record<string, unknown>;
   // The InsightMetric array lands at raw.data (Composio tool payload) or
   // raw.data.data (extra wrap on some tools).

--- a/backend/integrations/composio/composio-config.ts
+++ b/backend/integrations/composio/composio-config.ts
@@ -37,7 +37,9 @@ export type ComposioOperation =
   | 'create_ad'
   | 'list_ad_accounts'
   | 'list_pages'
-  | 'account_info';
+  | 'account_info'
+  | 'list_posts'
+  | 'list_comments';
 
 /**
  * Env override key for a given platform+operation action slug, e.g.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -435,11 +435,13 @@ services:
       # 'running' insights_sync_runs row. Widen before any long-running
       # sync path (e.g. a backfill script) ships.
       ARIES_INSIGHTS_SWEEP_GRACE_MINUTES: ${ARIES_INSIGHTS_SWEEP_GRACE_MINUTES:-60}
-      # Composio analytics (#596/#597): the worker's Facebook adapter executes
-      # Composio tools, so this sidecar needs the same Composio credentials as
-      # the app. Without these the FB adapter cannot authenticate and every sync
-      # is marked failed. The *_ACTION slugs are optional (verified code
-      # defaults); ANALYTICS_PROVIDER=composio selects the Composio path.
+      # Composio analytics (#596/#597). ACTIVATION: the Facebook insights path
+      # (account bridge + adapter) turns on ONLY when ANALYTICS_PROVIDER=composio.
+      # With the default (direct_meta) the bridge no-ops, the adapter never
+      # activates, and no Composio analytics tool runs. When enabled, the adapter
+      # executes Composio tools, so this sidecar needs the same Composio
+      # credentials as the app (COMPOSIO_API_KEY etc.); the *_ACTION slugs are
+      # optional (verified code defaults).
       ANALYTICS_PROVIDER: ${ANALYTICS_PROVIDER:-direct_meta}
       COMPOSIO_ENABLED: ${COMPOSIO_ENABLED:-false}
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,12 @@ services:
       COMPOSIO_INSTAGRAM_PUBLISH_POST_ACTION: ${COMPOSIO_INSTAGRAM_PUBLISH_POST_ACTION:-}
       COMPOSIO_FACEBOOK_UPLOAD_MEDIA_ACTION: ${COMPOSIO_FACEBOOK_UPLOAD_MEDIA_ACTION:-}
       COMPOSIO_INSTAGRAM_UPLOAD_MEDIA_ACTION: ${COMPOSIO_INSTAGRAM_UPLOAD_MEDIA_ACTION:-}
+      # Facebook analytics + comments sync slugs (#596/#597). Optional — the
+      # adapter falls back to the verified code defaults when unset.
+      COMPOSIO_FACEBOOK_LIST_POSTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_POSTS_ACTION:-}
+      COMPOSIO_FACEBOOK_POST_INSIGHTS_ACTION: ${COMPOSIO_FACEBOOK_POST_INSIGHTS_ACTION:-}
+      COMPOSIO_FACEBOOK_ACCOUNT_INSIGHTS_ACTION: ${COMPOSIO_FACEBOOK_ACCOUNT_INSIGHTS_ACTION:-}
+      COMPOSIO_FACEBOOK_LIST_COMMENTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_COMMENTS_ACTION:-}
       PUBLISH_PROVIDER: ${PUBLISH_PROVIDER:-direct_meta}
       ANALYTICS_PROVIDER: ${ANALYTICS_PROVIDER:-direct_meta}
       AUTH_URL: ${AUTH_URL}
@@ -429,6 +435,20 @@ services:
       # 'running' insights_sync_runs row. Widen before any long-running
       # sync path (e.g. a backfill script) ships.
       ARIES_INSIGHTS_SWEEP_GRACE_MINUTES: ${ARIES_INSIGHTS_SWEEP_GRACE_MINUTES:-60}
+      # Composio analytics (#596/#597): the worker's Facebook adapter executes
+      # Composio tools, so this sidecar needs the same Composio credentials as
+      # the app. Without these the FB adapter cannot authenticate and every sync
+      # is marked failed. The *_ACTION slugs are optional (verified code
+      # defaults); ANALYTICS_PROVIDER=composio selects the Composio path.
+      ANALYTICS_PROVIDER: ${ANALYTICS_PROVIDER:-direct_meta}
+      COMPOSIO_ENABLED: ${COMPOSIO_ENABLED:-false}
+      COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
+      COMPOSIO_FACEBOOK_AUTH_CONFIG_ID: ${COMPOSIO_FACEBOOK_AUTH_CONFIG_ID:-}
+      COMPOSIO_DEFAULT_AUTH_CONFIG_ID: ${COMPOSIO_DEFAULT_AUTH_CONFIG_ID:-}
+      COMPOSIO_FACEBOOK_LIST_POSTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_POSTS_ACTION:-}
+      COMPOSIO_FACEBOOK_POST_INSIGHTS_ACTION: ${COMPOSIO_FACEBOOK_POST_INSIGHTS_ACTION:-}
+      COMPOSIO_FACEBOOK_ACCOUNT_INSIGHTS_ACTION: ${COMPOSIO_FACEBOOK_ACCOUNT_INSIGHTS_ACTION:-}
+      COMPOSIO_FACEBOOK_LIST_COMMENTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_COMMENTS_ACTION:-}
     restart: unless-stopped
     networks:
       - docker_stack

--- a/migrations/20260617000000_insights_account_engagement.sql
+++ b/migrations/20260617000000_insights_account_engagement.sql
@@ -1,0 +1,15 @@
+-- Adds an authoritative aggregate account-engagement column to
+-- insights_account_metrics_daily.
+--
+-- Facebook's page insights expose a single aggregate engagement metric
+-- (page_post_engagements) rather than a like/comment/share breakdown, so the
+-- per-component columns are 0 for FB account rows. Writing 0 to the breakdown
+-- and computing engagement = likes+comments+shares surfaced a misleading
+-- totalEngagement=0 on the dashboard. This column stores the real aggregate;
+-- read-api prefers it for the headline engagement and falls back to
+-- likes+comments_count+shares when NULL (e.g. platforms with a breakdown).
+--
+-- Idempotent + safe to re-run. Matches scripts/init-db.js.
+
+ALTER TABLE insights_account_metrics_daily
+  ADD COLUMN IF NOT EXISTS engagement BIGINT;

--- a/scripts/automations/insights-sync-worker.ts
+++ b/scripts/automations/insights-sync-worker.ts
@@ -29,6 +29,7 @@ import { pathToFileURL } from 'node:url';
 import pool from '@/lib/db';
 import { syncAllAccountsForTenant } from '@/backend/insights/sync/dispatcher';
 import { sweepAbandonedSyncRuns } from '@/backend/insights/sync/sweep-stranded-runs';
+import { ensureInsightsAccountsForConnectedPlatforms } from '@/backend/insights/sync/ensure-account';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -164,6 +165,27 @@ export async function tickSafe(
   }
 }
 
+/**
+ * Project connected Composio accounts into insights_accounts, then run a sync
+ * tick. The bridge is best-effort and isolated: nothing populates
+ * insights_accounts otherwise (so the sync would no-op), but a bridge failure
+ * must never cost the existing accounts their sync window.
+ */
+export async function bridgeAndTick(
+  dbPool: TickPool = pool,
+  syncFn: SyncAllAccountsFn = syncAllAccountsForTenant,
+): Promise<void> {
+  try {
+    const res = await ensureInsightsAccountsForConnectedPlatforms();
+    if (res.upserted > 0) {
+      log({ event: 'insights_sync_accounts_bridged', upserted: res.upserted, considered: res.considered });
+    }
+  } catch (err) {
+    log({ event: 'insights_sync_bridge_failed', error: describeError(err) });
+  }
+  await tickSafe(dbPool, syncFn);
+}
+
 /** Keep the stack when there is one — `String(err)` drops it. */
 function describeError(err: unknown): string {
   return err instanceof Error ? (err.stack ?? err.message) : String(err);
@@ -181,11 +203,13 @@ function main(): void {
   log({ event: 'insights_sync_worker_start', intervalMs: INTERVAL_MS });
 
   // Run the first tick immediately on startup, then every INTERVAL_MS.
-  // tickSafe never rejects: failures are logged as insights_sync_fatal and the
-  // overlap guard is released so the next interval retries.
-  void tickSafe(pool);
+  // bridgeAndTick first projects connected Composio accounts into
+  // insights_accounts (otherwise the sync no-ops), then runs tickSafe — which
+  // never rejects: failures are logged as insights_sync_fatal and the overlap
+  // guard is released so the next interval retries.
+  void bridgeAndTick(pool);
 
-  const intervalHandle = setInterval(() => void tickSafe(pool), INTERVAL_MS);
+  const intervalHandle = setInterval(() => void bridgeAndTick(pool), INTERVAL_MS);
 
   // ── Graceful shutdown ───────────────────────────────────────────────────────
 

--- a/scripts/automations/insights-sync-worker.ts
+++ b/scripts/automations/insights-sync-worker.ts
@@ -30,6 +30,7 @@ import pool from '@/lib/db';
 import { syncAllAccountsForTenant } from '@/backend/insights/sync/dispatcher';
 import { sweepAbandonedSyncRuns } from '@/backend/insights/sync/sweep-stranded-runs';
 import { ensureInsightsAccountsForConnectedPlatforms } from '@/backend/insights/sync/ensure-account';
+import type { Queryable } from '@/backend/integrations/composio/connection-store';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -172,11 +173,13 @@ export async function tickSafe(
  * must never cost the existing accounts their sync window.
  */
 export async function bridgeAndTick(
-  dbPool: TickPool = pool,
+  dbPool: TickPool & Queryable = pool,
   syncFn: SyncAllAccountsFn = syncAllAccountsForTenant,
 ): Promise<void> {
   try {
-    const res = await ensureInsightsAccountsForConnectedPlatforms();
+    // Pass the SAME pool the tick uses — so a test injecting a fake pool never
+    // silently reaches the real database through the bridge.
+    const res = await ensureInsightsAccountsForConnectedPlatforms(dbPool);
     if (res.upserted > 0) {
       log({ event: 'insights_sync_accounts_bridged', upserted: res.upserted, considered: res.considered });
     }

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -918,12 +918,20 @@ async function initDb() {
         comments_count         INT,
         shares                 INT,
         saves                  INT,
+        -- Authoritative aggregate account engagement for the day (e.g. Facebook
+        -- page_post_engagements) for platforms that report a single engagement
+        -- figure instead of a like/comment/share breakdown. NULL = not exposed;
+        -- read-api prefers this for the headline, falling back to
+        -- likes+comments_count+shares.
+        engagement             BIGINT,
         platform_data          JSONB NOT NULL DEFAULT '{}',
         raw_source             JSONB NOT NULL,
         PRIMARY KEY (tenant_id, account_id, date)
       );
       CREATE INDEX IF NOT EXISTS idx_insights_account_metrics_daily_tenant_platform_date
         ON insights_account_metrics_daily (tenant_id, platform, date DESC);
+      -- Backfill for tables created before the engagement column existed.
+      ALTER TABLE insights_account_metrics_daily ADD COLUMN IF NOT EXISTS engagement BIGINT;
 
       -- Daily time-series for post-level metrics.
       CREATE TABLE IF NOT EXISTS insights_post_metrics_daily (

--- a/tests/auth/integrations-tenant-context.test.ts
+++ b/tests/auth/integrations-tenant-context.test.ts
@@ -292,11 +292,17 @@ test('integrations sync uses authenticated tenant context and rejects missing te
     });
 
     try {
+      // Use a non-insights provider (tiktok) so this asserts the Hermes
+      // integrations_sync path's tenant-context security. Insights platforms
+      // (facebook/instagram/youtube) now route to the insights sync dispatcher
+      // — a direct DB write loop with no Hermes submission (#596/#597) — which
+      // takes the authenticated Number(tenantId) directly, so the forged
+      // tenant_id can never reach it either.
       const accepted = await handleIntegrationsSync(
         new Request('http://localhost/api/integrations/sync', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ platform: 'facebook', tenant_id: 'forged_tenant' }),
+          body: JSON.stringify({ platform: 'tiktok', tenant_id: 'forged_tenant' }),
         }),
         async () => ({
           userId: 'user_123',

--- a/tests/auth/workflow-route-tenant-context.test.ts
+++ b/tests/auth/workflow-route-tenant-context.test.ts
@@ -233,13 +233,17 @@ test('publish dispatch ignores forged tenant_id and rejects missing tenant conte
 test('integrations sync ignores forged tenant_id and uses repo-managed workflow metadata', async () => {
   const stub = installHermesFetchStub();
   try {
+    // tiktok is a non-insights provider, so it still routes through the Hermes
+    // integrations_sync workflow this test asserts on. Insights platforms
+    // (facebook/instagram/youtube) now sync via the insights dispatcher
+    // (#596/#597), a direct DB write loop keyed on the authenticated tenant id.
     const response = await handleIntegrationsSync(
       new Request('http://localhost/api/integrations/sync', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           tenant_id: 'forged_tenant',
-          platform: 'facebook',
+          platform: 'tiktok',
         }),
       }),
       async () => ({

--- a/tests/insights-dispatcher-leg-isolation.test.ts
+++ b/tests/insights-dispatcher-leg-isolation.test.ts
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { syncAccountForTenant } from '@/backend/insights/sync/dispatcher';
+import type { InsightsAdapter } from '@/backend/insights/adapters/_adapter.types';
+
+/**
+ * M3 regression: a per-post fetchPostMetrics throw must NOT skip the comments
+ * leg (#597). Drives the dispatcher against an in-memory fake pool + a fake
+ * adapter whose fetchPostMetrics always throws, and asserts comments still
+ * ingest and the run is downgraded to 'partial' (not 'failed', not 'ok').
+ */
+
+interface Recorded { text: string; params: unknown[] }
+
+function fakePool(recorded: Recorded[]) {
+  const client = {
+    async query<T = Record<string, unknown>>(text: string, params: unknown[] = []) {
+      recorded.push({ text, params });
+      const rows = (): T[] => [] as T[];
+
+      if (/FROM insights_accounts\s+WHERE id/i.test(text)) {
+        return { rows: [{ id: 7, platform: 'facebook', external_account_id: 'PAGE123' }] as unknown as T[], rowCount: 1 };
+      }
+      if (/FROM connected_accounts/i.test(text)) {
+        return {
+          rows: [{
+            id: 1, tenant_id: 42, external_user_id: 'u', platform: 'facebook', provider: 'composio',
+            connected_account_id: 'ca_1', auth_config_id: 'ac', external_account_id: 'PAGE123',
+            external_account_name: 'Page', status: 'connected', capabilities_json: null,
+            last_capability_check_at: null, created_at: new Date(0), updated_at: new Date(0),
+          }] as unknown as T[],
+          rowCount: 1,
+        };
+      }
+      if (/INSERT INTO insights_sync_runs/i.test(text)) {
+        return { rows: [{ id: 99 }] as unknown as T[], rowCount: 1 };
+      }
+      if (/SELECT id, external_post_id\s+FROM insights_posts/i.test(text)) {
+        // Serves BOTH the post-metrics (postsToSync) and the comments (recentPosts) selects.
+        return { rows: [{ id: 10, external_post_id: 'PAGE123_1' }] as unknown as T[], rowCount: 1 };
+      }
+      return { rows: rows(), rowCount: 0 };
+    },
+    release() {},
+  };
+  return { async connect() { return client; } };
+}
+
+const throwingPostMetricsAdapter: InsightsAdapter = {
+  platform: 'facebook',
+  fetchPostList: async () => [],
+  fetchAccountMetrics: async () => [],
+  fetchPostMetrics: async () => {
+    throw new Error('POST_INSIGHTS 500');
+  },
+  fetchComments: async () => [
+    { externalCommentId: 'PAGE123_1_99', receivedAt: new Date('2026-06-11T00:00:00Z'), authorHandle: 'Jane', bodyText: 'hi' },
+  ],
+};
+
+test('M3: comments still ingest when fetchPostMetrics throws; run is partial, not failed/ok', async () => {
+  const recorded: Recorded[] = [];
+  const result = await syncAccountForTenant(42, 7, 'interval', {
+    pool: fakePool(recorded),
+    resolveAdapter: () => throwingPostMetricsAdapter,
+  });
+
+  // The comments leg ran despite the post-metrics throw.
+  const commentInserts = recorded.filter((q) => /INSERT INTO insights_comments/i.test(q.text));
+  assert.equal(commentInserts.length, 1, 'a comment was inserted even though fetchPostMetrics threw');
+  assert.equal(result.commentsSeen, 1);
+
+  // The run is downgraded to partial (leg isolated), never the ok fast-path,
+  // never a hard failure that would zero everything.
+  assert.equal(result.status, 'partial');
+  assert.match(String(result.errorMessage), /fetchPostMetrics/);
+  assert.match(String(result.errorMessage), /POST_INSIGHTS 500/);
+
+  const partialUpdate = recorded.find((q) => /UPDATE insights_sync_runs[\s\S]*status = 'partial'/i.test(q.text));
+  assert.ok(partialUpdate, 'the sync run is closed out as partial');
+  const okTerminal = recorded.find((q) => /UPDATE insights_sync_runs[\s\S]*status\s*=\s*'ok'/i.test(q.text));
+  assert.equal(okTerminal, undefined, 'the ok fast-path must not run when a leg failed');
+});
+
+test('M3: a clean run (no leg errors) still takes the ok path', async () => {
+  const recorded: Recorded[] = [];
+  const cleanAdapter: InsightsAdapter = {
+    ...throwingPostMetricsAdapter,
+    fetchPostMetrics: async () => [],
+  };
+  const result = await syncAccountForTenant(42, 7, 'interval', {
+    pool: fakePool(recorded),
+    resolveAdapter: () => cleanAdapter,
+  });
+  assert.equal(result.status, 'ok');
+  assert.equal(result.errorMessage, undefined);
+});

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ensureInsightsAccountsForConnectedPlatforms,
+  BRIDGED_PLATFORMS,
+} from '@/backend/insights/sync/ensure-account';
+import type { Queryable } from '@/backend/integrations/composio/connection-store';
+import { getAdapter, hasAdapter } from '@/backend/insights/sync/adapter-factory';
+import { FacebookInsightsAdapter } from '@/backend/insights/adapters/facebook/index';
+
+interface RecordedQuery {
+  text: string;
+  params: unknown[];
+}
+
+function recordingDb(connectedRows: Array<Record<string, unknown>>): Queryable & { queries: RecordedQuery[] } {
+  const queries: RecordedQuery[] = [];
+  return {
+    queries,
+    async query<T = Record<string, unknown>>(text: string, params: unknown[] = []) {
+      queries.push({ text, params });
+      if (/^\s*select/i.test(text) && /connected_accounts/i.test(text)) {
+        return { rows: connectedRows as T[], rowCount: connectedRows.length };
+      }
+      // INSERT ... ON CONFLICT — report one row affected.
+      return { rows: [] as T[], rowCount: 1 };
+    },
+  };
+}
+
+test('the bridge upserts an insights_accounts row from a connected Composio FB connection', async () => {
+  const db = recordingDb([
+    {
+      tenant_id: 15,
+      platform: 'facebook',
+      external_account_id: 'PAGE123',
+      external_account_name: 'Sugar & Leather',
+    },
+  ]);
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db);
+
+  assert.equal(result.considered, 1);
+  assert.equal(result.upserted, 1);
+
+  const select = db.queries[0];
+  assert.match(select.text, /FROM connected_accounts/);
+  assert.match(select.text, /status = 'connected'/);
+  assert.match(select.text, /connected_account_id IS NOT NULL/);
+  assert.match(select.text, /external_account_id IS NOT NULL/);
+  assert.deepEqual(select.params, [...BRIDGED_PLATFORMS]);
+
+  const insert = db.queries[1];
+  assert.match(insert.text, /INSERT INTO insights_accounts/);
+  assert.match(insert.text, /ON CONFLICT \(tenant_id, platform, external_account_id\) DO UPDATE/);
+  // page id (external_account_id) is mapped through unchanged.
+  assert.deepEqual(insert.params, [15, 'facebook', 'PAGE123', 'Sugar & Leather']);
+});
+
+test('Instagram is out of scope: the bridge only queries the bridged (FB) platforms', async () => {
+  assert.deepEqual([...BRIDGED_PLATFORMS], ['facebook']);
+  const db = recordingDb([]);
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db);
+  assert.equal(result.considered, 0);
+  assert.equal(result.upserted, 0);
+  // no INSERT issued when there are no connected source rows
+  assert.equal(db.queries.length, 1);
+});
+
+test('facebook is registered in the adapter factory and getAdapter binds the connection context', async () => {
+  assert.equal(hasAdapter('facebook'), true);
+
+  // getAdapter must build a real Composio gateway, which needs an API key.
+  const prevKey = process.env.COMPOSIO_API_KEY;
+  process.env.COMPOSIO_API_KEY = 'test-key';
+  try {
+    const adapter = getAdapter('facebook', { connectedAccountId: 'ca_x', pageId: 'PAGE123' });
+    assert.ok(adapter instanceof FacebookInsightsAdapter);
+    assert.equal(adapter.platform, 'facebook');
+  } finally {
+    if (prevKey === undefined) delete process.env.COMPOSIO_API_KEY;
+    else process.env.COMPOSIO_API_KEY = prevKey;
+  }
+});

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -6,13 +6,16 @@ import {
   BRIDGED_PLATFORMS,
 } from '@/backend/insights/sync/ensure-account';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
-import { getAdapter, hasAdapter } from '@/backend/insights/sync/adapter-factory';
+import { getAdapter, hasAdapter, isFacebookInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
 import { FacebookInsightsAdapter } from '@/backend/insights/adapters/facebook/index';
 
 interface RecordedQuery {
   text: string;
   params: unknown[];
 }
+
+const COMPOSIO_ENV = { ANALYTICS_PROVIDER: 'composio' } as unknown as NodeJS.ProcessEnv;
+const DIRECT_ENV = { ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv;
 
 function recordingDb(connectedRows: Array<Record<string, unknown>>): Queryable & { queries: RecordedQuery[] } {
   const queries: RecordedQuery[] = [];
@@ -39,7 +42,7 @@ test('the bridge upserts an insights_accounts row from a connected Composio FB c
     },
   ]);
 
-  const result = await ensureInsightsAccountsForConnectedPlatforms(db);
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV);
 
   assert.equal(result.considered, 1);
   assert.equal(result.upserted, 1);
@@ -47,6 +50,7 @@ test('the bridge upserts an insights_accounts row from a connected Composio FB c
   const select = db.queries[0];
   assert.match(select.text, /FROM connected_accounts/);
   assert.match(select.text, /status = 'connected'/);
+  assert.match(select.text, /provider = 'composio'/); // L1: only Composio-backed connections
   assert.match(select.text, /connected_account_id IS NOT NULL/);
   assert.match(select.text, /external_account_id IS NOT NULL/);
   assert.deepEqual(select.params, [...BRIDGED_PLATFORMS]);
@@ -61,25 +65,55 @@ test('the bridge upserts an insights_accounts row from a connected Composio FB c
 test('Instagram is out of scope: the bridge only queries the bridged (FB) platforms', async () => {
   assert.deepEqual([...BRIDGED_PLATFORMS], ['facebook']);
   const db = recordingDb([]);
-  const result = await ensureInsightsAccountsForConnectedPlatforms(db);
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV);
   assert.equal(result.considered, 0);
   assert.equal(result.upserted, 0);
   // no INSERT issued when there are no connected source rows
   assert.equal(db.queries.length, 1);
 });
 
-test('facebook is registered in the adapter factory and getAdapter binds the connection context', async () => {
-  assert.equal(hasAdapter('facebook'), true);
+test('M4 off-switch: the bridge no-ops (no DB query) when ANALYTICS_PROVIDER != composio', async () => {
+  const db = recordingDb([
+    { tenant_id: 15, platform: 'facebook', external_account_id: 'PAGE123', external_account_name: 'X' },
+  ]);
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, DIRECT_ENV);
+  assert.equal(result.upserted, 0);
+  assert.equal(result.skippedReason, 'analytics_provider_not_composio');
+  assert.equal(db.queries.length, 0, 'no DB query at all when the path is disabled');
+});
 
-  // getAdapter must build a real Composio gateway, which needs an API key.
-  const prevKey = process.env.COMPOSIO_API_KEY;
-  process.env.COMPOSIO_API_KEY = 'test-key';
+test('M4 off-switch: hasAdapter(facebook) honors ANALYTICS_PROVIDER, getAdapter throws when off', () => {
+  assert.equal(isFacebookInsightsEnabled(COMPOSIO_ENV), true);
+  assert.equal(isFacebookInsightsEnabled(DIRECT_ENV), false);
+  assert.equal(hasAdapter('facebook', COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('facebook', DIRECT_ENV), false);
+
+  const prev = process.env.ANALYTICS_PROVIDER;
+  process.env.ANALYTICS_PROVIDER = 'direct_meta';
   try {
+    assert.throws(() => getAdapter('facebook', { connectedAccountId: 'ca_x' }), /ANALYTICS_PROVIDER=composio/);
+  } finally {
+    if (prev === undefined) delete process.env.ANALYTICS_PROVIDER;
+    else process.env.ANALYTICS_PROVIDER = prev;
+  }
+});
+
+test('facebook is registered in the adapter factory and getAdapter binds the connection context', () => {
+  // getAdapter builds a real Composio gateway (needs an API key) AND requires
+  // the ANALYTICS_PROVIDER=composio off-switch to be on.
+  const prevKey = process.env.COMPOSIO_API_KEY;
+  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  process.env.COMPOSIO_API_KEY = 'test-key';
+  process.env.ANALYTICS_PROVIDER = 'composio';
+  try {
+    assert.equal(hasAdapter('facebook'), true);
     const adapter = getAdapter('facebook', { connectedAccountId: 'ca_x', pageId: 'PAGE123' });
     assert.ok(adapter instanceof FacebookInsightsAdapter);
     assert.equal(adapter.platform, 'facebook');
   } finally {
     if (prevKey === undefined) delete process.env.COMPOSIO_API_KEY;
     else process.env.COMPOSIO_API_KEY = prevKey;
+    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
+    else process.env.ANALYTICS_PROVIDER = prevProvider;
   }
 });

--- a/tests/insights-facebook-adapter.test.ts
+++ b/tests/insights-facebook-adapter.test.ts
@@ -165,6 +165,82 @@ test('fetchAccountMetrics: pivots PAGE_INSIGHTS per day + folds in PAGE_DETAILS 
   assert.equal(d10?.followers, 1234); // PAGE_DETAILS stamped on the most recent day
 });
 
+test('M2: follower total stays the cumulative page_follows; delta = daily follows − daily unfollows', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_PAGE_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { name: 'page_follows', values: [{ value: 900, end_time: '2026-06-10T07:00:00+0000' }] },
+          { name: 'page_daily_follows_unique', values: [{ value: 12, end_time: '2026-06-10T07:00:00+0000' }] },
+          { name: 'page_daily_unfollows_unique', values: [{ value: 5, end_time: '2026-06-10T07:00:00+0000' }] },
+        ],
+      },
+    },
+    // PAGE_DETAILS unavailable, so the page_follows path is exercised purely
+    // (not the PAGE_DETAILS override).
+    FACEBOOK_GET_PAGE_DETAILS: { successful: true, error: null, data: { data: {} } },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const days = await adapter.fetchAccountMetrics('PAGE123', { from: '2026-06-10', to: '2026-06-10' });
+  const d = days.find((x) => x.date === '2026-06-10');
+  assert.ok(d);
+  // followers is the CUMULATIVE page_follows (900) — NEVER the daily new-follows
+  // value (12) and NEVER cumulative-minus-daily (900 − 5 = 895).
+  assert.equal(d?.followers, 900);
+  assert.notEqual(d?.followers, 12);
+  assert.notEqual(d?.followers, 895);
+  // delta is daily follows − daily unfollows = 12 − 5 = 7.
+  assert.equal(d?.followersDelta, 7);
+});
+
+test('M2: a day with only daily-unfollows yields a negative delta, follower total untouched', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_PAGE_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { name: 'page_follows', values: [{ value: 900, end_time: '2026-06-10T07:00:00+0000' }] },
+          { name: 'page_daily_unfollows_unique', values: [{ value: 5, end_time: '2026-06-10T07:00:00+0000' }] },
+        ],
+      },
+    },
+    FACEBOOK_GET_PAGE_DETAILS: { successful: true, error: null, data: { data: {} } },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const days = await adapter.fetchAccountMetrics('PAGE123', { from: '2026-06-10', to: '2026-06-10' });
+  const d = days.find((x) => x.date === '2026-06-10');
+  // 0 daily follows − 5 daily unfollows = -5 (delta uses daily metrics only).
+  assert.equal(d?.followersDelta, -5);
+  // The follower TOTAL is the cumulative page_follows, NOT reduced by the daily unfollow.
+  assert.equal(d?.followers, 900);
+});
+
+test('M1: account engagement comes from page_post_engagements (engagement field), not a fabricated 0', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_PAGE_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [{ name: 'page_post_engagements', values: [{ value: 256, end_time: '2026-06-10T07:00:00+0000' }] }],
+      },
+    },
+    FACEBOOK_GET_PAGE_DETAILS: { successful: true, error: null, data: { data: {} } },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const days = await adapter.fetchAccountMetrics('PAGE123', { from: '2026-06-10', to: '2026-06-10' });
+  const d = days.find((x) => x.date === '2026-06-10');
+  assert.equal(d?.engagement, 256); // real aggregate, surfaced via the dedicated column
+  assert.equal(d?.likes, 0); // FB exposes no like/comment/share breakdown at page level
+  assert.equal(d?.commentsCount, 0);
+  assert.equal(d?.shares, 0);
+});
+
 test('fetchComments: maps GET_COMMENTS rows, stores full graph comment id for the reply endpoint', async () => {
   const gateway = routingGateway({
     FACEBOOK_GET_COMMENTS: {

--- a/tests/insights-facebook-adapter.test.ts
+++ b/tests/insights-facebook-adapter.test.ts
@@ -1,0 +1,221 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { FacebookInsightsAdapter } from '@/backend/insights/adapters/facebook/index';
+import type {
+  ComposioGateway,
+  GatewayToolResult,
+} from '@/backend/integrations/composio/composio-client';
+import { fakeConfig } from './composio/helpers';
+
+interface RecordedCall {
+  slug: string;
+  connectedAccountId?: string;
+  arguments?: Record<string, unknown>;
+}
+
+/** Gateway that routes a canned result per action slug and records every call. */
+function routingGateway(
+  results: Record<string, GatewayToolResult>,
+): ComposioGateway & { calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    async findOrCreateManagedAuthConfig(s: string) { return `ac_${s}`; },
+    async initiateConnection() { return { connectionRequestId: 'cr', redirectUrl: null }; },
+    async listConnections() { return []; },
+    async getConnection() { return null; },
+    async deleteConnection() {},
+    async executeTool(slug, options) {
+      calls.push({ slug, connectedAccountId: options.connectedAccountId, arguments: options.arguments });
+      return results[slug] ?? { data: { data: [] }, successful: true, error: null };
+    },
+  };
+}
+
+const ctx = { connectedAccountId: 'ca_fb_1', pageId: 'PAGE123' };
+
+test('fetchPostList: builds GET_PAGE_POSTS, stores full pageId_postId, captures engagement summary', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_PAGE_POSTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          {
+            id: 'PAGE123_777',
+            message: 'Hello world',
+            created_time: '2026-06-10T12:00:00+0000',
+            permalink_url: 'https://facebook.com/PAGE123_777',
+            full_picture: 'https://img/x.jpg',
+            status_type: 'added_photos',
+            attachments: { data: [{ media_type: 'photo', type: 'photo' }] },
+            reactions: { summary: { total_count: 42 } },
+            comments: { summary: { total_count: 7 } },
+            shares: { count: 3 },
+          },
+        ],
+      },
+    },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const posts = await adapter.fetchPostList('PAGE123');
+  assert.equal(gateway.calls[0].slug, 'FACEBOOK_GET_PAGE_POSTS');
+  assert.equal(gateway.calls[0].connectedAccountId, 'ca_fb_1');
+  assert.equal(gateway.calls[0].arguments?.page_id, 'PAGE123');
+  assert.match(String(gateway.calls[0].arguments?.fields), /reactions\.summary\(true\)/);
+  assert.match(String(gateway.calls[0].arguments?.fields), /comments\.summary\(true\)/);
+
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].externalPostId, 'PAGE123_777'); // full graph id
+  assert.equal(posts[0].mediaType, 'image');
+  assert.equal(posts[0].caption, 'Hello world');
+  assert.equal(posts[0].permalink, 'https://facebook.com/PAGE123_777');
+  assert.equal(posts[0].thumbnailUrl, 'https://img/x.jpg');
+});
+
+test('fetchPostMetrics: deprecated path — views from POST_INSIGHTS, engagement from cached post-list summary', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_PAGE_POSTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          {
+            id: 'PAGE123_777',
+            created_time: '2026-06-10T12:00:00+0000',
+            reactions: { summary: { total_count: 42 } },
+            comments: { summary: { total_count: 7 } },
+            shares: { count: 3 },
+          },
+        ],
+      },
+    },
+    FACEBOOK_GET_POST_INSIGHTS: {
+      successful: true,
+      error: null,
+      // Post-2025-11-15: only post_media_view survives.
+      data: { data: [{ name: 'post_media_view', values: [{ value: 555 }] }] },
+    },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  // Prime the engagement cache via the list call (the dispatcher always runs
+  // fetchPostList before fetchPostMetrics on the same adapter instance).
+  await adapter.fetchPostList('PAGE123');
+  const metrics = await adapter.fetchPostMetrics('PAGE123_777');
+
+  const insightsCall = gateway.calls.find((c) => c.slug === 'FACEBOOK_GET_POST_INSIGHTS');
+  assert.ok(insightsCall, 'calls FACEBOOK_GET_POST_INSIGHTS');
+  assert.equal(insightsCall?.arguments?.post_id, 'PAGE123_777');
+  assert.equal(insightsCall?.connectedAccountId, 'ca_fb_1');
+
+  assert.equal(metrics.length, 1);
+  assert.equal(metrics[0].views, 555); // from POST_INSIGHTS
+  assert.equal(metrics[0].likes, 42); // from cached post-list summary
+  assert.equal(metrics[0].commentsCount, 7);
+  assert.equal(metrics[0].shares, 3);
+});
+
+test('fetchPostMetrics: a post with no insights and no cached engagement yields no fabricated row', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_POST_INSIGHTS: { successful: true, error: null, data: { data: [] } },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  const metrics = await adapter.fetchPostMetrics('PAGE123_999');
+  assert.deepEqual(metrics, [], 'no data → empty, never a zero row');
+});
+
+test('fetchAccountMetrics: pivots PAGE_INSIGHTS per day + folds in PAGE_DETAILS followers', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_PAGE_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { name: 'page_media_view', values: [{ value: 100, end_time: '2026-06-09T07:00:00+0000' }, { value: 120, end_time: '2026-06-10T07:00:00+0000' }] },
+          { name: 'page_follows', values: [{ value: 900, end_time: '2026-06-09T07:00:00+0000' }] },
+        ],
+      },
+    },
+    FACEBOOK_GET_PAGE_DETAILS: {
+      successful: true,
+      error: null,
+      data: { data: { followers_count: 1234, fan_count: 1000 } },
+    },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const days = await adapter.fetchAccountMetrics('PAGE123', { from: '2026-06-09', to: '2026-06-10' });
+
+  const insightsCall = gateway.calls.find((c) => c.slug === 'FACEBOOK_GET_PAGE_INSIGHTS');
+  assert.equal(insightsCall?.arguments?.page_id, 'PAGE123');
+  assert.equal(insightsCall?.arguments?.since, '2026-06-09');
+  assert.equal(insightsCall?.arguments?.until, '2026-06-10');
+
+  const detailsCall = gateway.calls.find((c) => c.slug === 'FACEBOOK_GET_PAGE_DETAILS');
+  assert.ok(detailsCall, 'fetches followers via PAGE_DETAILS');
+
+  const d9 = days.find((d) => d.date === '2026-06-09');
+  const d10 = days.find((d) => d.date === '2026-06-10');
+  assert.equal(d9?.views, 100);
+  assert.equal(d9?.followers, 900); // from page_follows series
+  assert.equal(d10?.views, 120);
+  assert.equal(d10?.followers, 1234); // PAGE_DETAILS stamped on the most recent day
+});
+
+test('fetchComments: maps GET_COMMENTS rows, stores full graph comment id for the reply endpoint', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_COMMENTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { id: 'PAGE123_777_888', message: 'nice!', created_time: '2026-06-11T09:00:00+0000', from: { id: 'u1', name: 'Jane Doe' } },
+          { id: 'PAGE123_777_889', message: 'where to buy?', created_time: '2026-06-11T10:00:00+0000', from: { id: 'u2', name: 'John Roe' } },
+        ],
+      },
+    },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const comments = await adapter.fetchComments('PAGE123_777', 50);
+  const call = gateway.calls[0];
+  assert.equal(call.slug, 'FACEBOOK_GET_COMMENTS');
+  assert.equal(call.arguments?.object_id, 'PAGE123_777'); // full pageId_postId
+  assert.equal(call.arguments?.limit, 50);
+
+  assert.equal(comments.length, 2);
+  assert.equal(comments[0].externalCommentId, 'PAGE123_777_888'); // full graph id
+  assert.equal(comments[0].authorHandle, 'Jane Doe');
+  assert.equal(comments[0].bodyText, 'nice!');
+});
+
+test('an env override replaces the default action slug', async () => {
+  const gateway = routingGateway({
+    CUSTOM_LIST_POSTS: { successful: true, error: null, data: { data: [] } },
+  });
+  const adapter = new FacebookInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: { list_posts: 'CUSTOM_LIST_POSTS' } }),
+    ctx,
+  );
+  await adapter.fetchPostList('PAGE123');
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_LIST_POSTS');
+});
+
+test('an unsuccessful tool call throws (so the sync run is marked failed, partial rows preserved)', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_GET_COMMENTS: { successful: false, error: 'rate limited (code 4)', data: null },
+  });
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  await assert.rejects(() => adapter.fetchComments('PAGE123_777'), /rate limited/);
+});
+
+test('a missing connectedAccountId is a clear error, never a silent unauthenticated call', async () => {
+  const gateway = routingGateway({});
+  const adapter = new FacebookInsightsAdapter(gateway, fakeConfig({ actions: {} }), { pageId: 'PAGE123' });
+  await assert.rejects(() => adapter.fetchPostList('PAGE123'), /connectedAccountId/);
+  assert.equal(gateway.calls.length, 0, 'no tool call without a connected account');
+});


### PR DESCRIPTION
Backend foundation for **#596 (Facebook analytics)** and **#597 (Facebook comments)** via Composio — Instagram out of scope (deferred). This makes the `insights_*` tables populate from the Composio Facebook connection; the consuming dashboard UIs land in follow-up PRs (so this does not yet close the issues).

## What this fixes (root causes the planner found)
- **Nothing populated `insights_accounts`** → the sync worker no-op'd. New idempotent bridge (`backend/insights/sync/ensure-account.ts`) upserts an `insights_accounts` row per tenant with a connected Composio Facebook `connected_accounts` row (filtered `provider='composio'`).
- **FB insights adapter was an unimplemented stub.** New `backend/insights/adapters/facebook/index.ts` over the Composio gateway: `fetchPostList`→`FACEBOOK_GET_PAGE_POSTS` (engagement summary counts), `fetchAccountMetrics`→`FACEBOOK_GET_PAGE_INSIGHTS`+`FACEBOOK_GET_PAGE_DETAILS`, `fetchPostMetrics`→`FACEBOOK_GET_POST_INSIGHTS`, `fetchComments`→`FACEBOOK_GET_COMMENTS`. Slugs are code defaults, env-overridable.
- **Adapter seam** now threads per-tenant Composio context (`getAdapter(platform, ctx)` → `{connectedAccountId, pageId}`); YouTube unchanged.
- **Worker compose env**: `aries-insights-sync-worker` gets `COMPOSIO_*` + `ANALYTICS_PROVIDER` (two-place rule).

## Correctness (from adversarial review — all fixed before ship)
- Real account engagement: new `engagement` column (`migrations/20260617000000_insights_account_engagement.sql`) carries FB `page_post_engagements`; read-api prefers it (no fabricated `0` engagement).
- Follower math: absolute followers only from PAGE_DETAILS/cumulative `page_follows`; daily delta only from `page_daily_follows_unique − page_daily_unfollows_unique` (never mix cumulative with daily).
- **Leg isolation**: each adapter leg (post-list / account / per-post metrics / comments) is independently try/caught in the dispatcher → one leg's failure can't starve **comments** (#597) or zero the others; run downgrades to `partial`.
- Real kill-switch `isFacebookInsightsEnabled` (`ANALYTICS_PROVIDER==='composio'`): off → bridge no-ops, adapter disabled.

## Tests
New: `insights-dispatcher-leg-isolation` (comments ingest when post-metrics throw), expanded `insights-facebook-adapter` (follower total/delta, engagement, off-switch) + `insights-ensure-account` (provider filter). `npm run verify` ✅ · typecheck ✅ · banned-patterns ✅ · guardrails ✅ · adversarially reviewed (SHIP-WITH-NITS → all MED/cheap-LOW resolved).

> Known follow-up (noted, not blocking): the live Composio response-envelope nesting is handled defensively but unexercised against the real API; the first prod sync / QA pass validates it. Post-list pagination caps at 100 (SMB-scale fine).

Part of #596, #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)