### PR TITLE
fix(insights): resolve FB Page id so the Composio analytics bridge populates

### DIFF
--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -12,6 +12,14 @@
  * Facebook connection (mapping connected_accounts.external_account_id → the
  * page id stored in insights_accounts.external_account_id).
  *
+ * Page-id back-heal: the Facebook Page id is not part of the Composio connection
+ * metadata, so legacy rows can have `external_account_id IS NULL` (the prod
+ * 2026-06-04 connection). For such rows the bridge resolves the Page id from
+ * Composio (FACEBOOK_LIST_MANAGED_PAGES) using the connection's
+ * connected_account_id, persists it back to connected_accounts so it is captured
+ * once, then upserts insights_accounts. Resolution is fail-safe: an error or no
+ * Page logs + skips that tenant — never throws (the worker tick must not wedge).
+ *
  * Instagram is intentionally out of scope (#596/#597 are Facebook-only); add
  * platforms to BRIDGED_PLATFORMS when their adapter lands.
  */
@@ -19,15 +27,20 @@
 import pool from '@/lib/db';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
 import { analyticsProviderSelector } from '@/backend/integrations/providers/integration-config';
+import { resolveComposioConfig, type ComposioConfig } from '@/backend/integrations/composio/composio-config';
+import { createComposioGateway, type ComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { resolveFacebookManagedPage } from '@/backend/integrations/composio/facebook-page-resolver';
 
 /** Platforms whose Composio connections should be projected into insights_accounts. */
 export const BRIDGED_PLATFORMS = ['facebook'] as const;
 
 interface BridgeRow {
+  id: string | number;
   tenant_id: string | number;
   platform: string;
-  external_account_id: string;
+  external_account_id: string | null;
   external_account_name: string | null;
+  connected_account_id: string | null;
 }
 
 export interface EnsureAccountsResult {
@@ -35,8 +48,23 @@ export interface EnsureAccountsResult {
   considered: number;
   /** Number of insights_accounts rows upserted (inserted or refreshed). */
   upserted: number;
+  /** Number of rows whose Page id was resolved from Composio + back-healed. */
+  resolved: number;
+  /** Rows skipped because their Page id could not be resolved. */
+  skippedNoPage: number;
   /** Set when the bridge no-opped because the off-switch is off. */
   skippedReason?: string;
+}
+
+/** Injectable Composio surface so tests drive resolution with a fake gateway. */
+export interface EnsureAccountsDeps {
+  gateway?: ComposioGateway;
+  config?: ComposioConfig | null;
+}
+
+function log(obj: Record<string, unknown>): void {
+  // NDJSON, same shape the worker emits, so log aggregators key on `event`.
+  console.log(JSON.stringify({ ts: new Date().toISOString(), ...obj }));
 }
 
 /**
@@ -51,34 +79,97 @@ export interface EnsureAccountsResult {
 export async function ensureInsightsAccountsForConnectedPlatforms(
   db: Queryable = pool,
   env: NodeJS.ProcessEnv = process.env,
+  deps: EnsureAccountsDeps = {},
 ): Promise<EnsureAccountsResult> {
   if (analyticsProviderSelector(env) !== 'composio') {
-    return { considered: 0, upserted: 0, skippedReason: 'analytics_provider_not_composio' };
+    return { considered: 0, upserted: 0, resolved: 0, skippedNoPage: 0, skippedReason: 'analytics_provider_not_composio' };
   }
 
   const placeholders = BRIDGED_PLATFORMS.map((_, i) => `$${i + 1}`).join(', ');
+  // NOTE: external_account_id is intentionally NOT filtered here — a null Page id
+  // is back-healed below rather than skipped (the prod connection data gap).
   const sources = await db.query<BridgeRow>(
-    `SELECT tenant_id, platform, external_account_id, external_account_name
+    `SELECT id, tenant_id, platform, external_account_id, external_account_name, connected_account_id
        FROM connected_accounts
       WHERE status = 'connected'
         AND provider = 'composio'
         AND connected_account_id IS NOT NULL
-        AND external_account_id IS NOT NULL
         AND platform IN (${placeholders})`,
     [...BRIDGED_PLATFORMS],
   );
 
+  // Build the Composio gateway lazily — only when a row actually needs Page-id
+  // resolution, and only once. A null config (no API key) means resolution is
+  // unavailable; such rows are skipped fail-safe.
+  let resolverDeps: { gateway: ComposioGateway; config: ComposioConfig } | null | undefined;
+  const getResolver = (): { gateway: ComposioGateway; config: ComposioConfig } | null => {
+    if (resolverDeps !== undefined) return resolverDeps;
+    const config = deps.config !== undefined ? deps.config : resolveComposioConfig(env);
+    if (!config) {
+      resolverDeps = null;
+      return null;
+    }
+    try {
+      const gateway = deps.gateway ?? createComposioGateway(config);
+      resolverDeps = { gateway, config };
+    } catch {
+      resolverDeps = null;
+    }
+    return resolverDeps;
+  };
+
   let upserted = 0;
+  let resolved = 0;
+  let skippedNoPage = 0;
+
   for (const row of sources.rows) {
+    let pageId = row.external_account_id?.trim() || null;
+    let pageName = row.external_account_name;
+
+    if (!pageId) {
+      // Back-heal: resolve the Page id from Composio and persist it once.
+      const r = getResolver();
+      if (!r || !row.connected_account_id) {
+        skippedNoPage++;
+        log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, reason: r ? 'no_connected_account' : 'composio_unavailable' });
+        continue;
+      }
+      let page: Awaited<ReturnType<typeof resolveFacebookManagedPage>> = null;
+      try {
+        page = await resolveFacebookManagedPage(r.gateway, r.config, row.connected_account_id);
+      } catch (err) {
+        page = null;
+        log({ event: 'insights_bridge_page_resolve_error', tenantId: row.tenant_id, error: err instanceof Error ? err.message : String(err) });
+      }
+      if (!page) {
+        skippedNoPage++;
+        log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, reason: 'no_managed_page' });
+        continue;
+      }
+      pageId = page.pageId;
+      pageName = pageName ?? page.pageName;
+      // Persist back so the Page id is captured once (future ticks skip resolution).
+      await db.query(
+        `UPDATE connected_accounts
+           SET external_account_id = $1,
+               external_account_name = COALESCE($2, external_account_name),
+               updated_at = now()
+         WHERE id = $3`,
+        [pageId, page.pageName, row.id],
+      );
+      resolved++;
+      log({ event: 'insights_bridge_page_resolved', tenantId: row.tenant_id, pageId, managedCount: page.managedCount });
+    }
+
     const res = await db.query(
       `INSERT INTO insights_accounts (tenant_id, platform, external_account_id, display_name)
        VALUES ($1, $2, $3, $4)
        ON CONFLICT (tenant_id, platform, external_account_id) DO UPDATE
          SET display_name = COALESCE(EXCLUDED.display_name, insights_accounts.display_name)`,
-      [row.tenant_id, row.platform, row.external_account_id, row.external_account_name],
+      [row.tenant_id, row.platform, pageId, pageName],
     );
     upserted += res.rowCount ?? 0;
   }
 
-  return { considered: sources.rows.length, upserted };
+  return { considered: sources.rows.length, upserted, resolved, skippedNoPage };
 }

--- a/backend/integrations/composio/composio-account-provider.ts
+++ b/backend/integrations/composio/composio-account-provider.ts
@@ -30,6 +30,7 @@ import {
 } from './connection-store';
 import { ComposioConfigError } from './errors';
 import { isActiveStatus, mapComposioStatus } from './status-map';
+import { resolveFacebookManagedPage } from './facebook-page-resolver';
 import pool from '@/lib/db';
 
 export class ComposioAccountProvider implements AccountConnectionProvider {
@@ -155,6 +156,25 @@ export class ComposioAccountProvider implements AccountConnectionProvider {
       return getConnectionRow(tenantId, platform, this.db) ?? notConnectedAccount(tenantId, externalUserId, platform, 'composio');
     }
 
+    // The Facebook Page id is not part of the connection metadata, so
+    // active.externalAccountId is usually null for FB. Resolve + capture it here
+    // so future connections store the Page id at connect time (the bridge's
+    // back-heal then only covers legacy rows). Best-effort: a failure leaves it
+    // null and the bridge resolves it later.
+    let externalAccountId = active.externalAccountId;
+    let externalAccountName = active.externalAccountName;
+    if (!externalAccountId && platform === 'facebook' && active.id && isActiveStatus(active.status)) {
+      try {
+        const page = await resolveFacebookManagedPage(this.gateway, this.config, active.id);
+        if (page) {
+          externalAccountId = page.pageId;
+          externalAccountName = externalAccountName ?? page.pageName;
+        }
+      } catch {
+        // best-effort — leave null, the sync bridge will back-heal it
+      }
+    }
+
     return upsertConnection(
       {
         tenantId,
@@ -163,8 +183,8 @@ export class ComposioAccountProvider implements AccountConnectionProvider {
         provider: 'composio',
         connectedAccountId: active.id,
         authConfigId: active.authConfigId ?? authConfigId ?? null,
-        externalAccountId: active.externalAccountId,
-        externalAccountName: active.externalAccountName,
+        externalAccountId,
+        externalAccountName,
         status: mapComposioStatus(active.status),
       },
       this.db,

--- a/backend/integrations/composio/facebook-page-resolver.ts
+++ b/backend/integrations/composio/facebook-page-resolver.ts
@@ -1,0 +1,65 @@
+/**
+ * Resolve a tenant's Facebook Page id from Composio.
+ *
+ * The Facebook Page id (needed for analytics/comments) is NOT part of the
+ * Composio connection metadata, so connect-time reconciliation can leave
+ * connected_accounts.external_account_id null. This helper calls the verified
+ * FACEBOOK_LIST_MANAGED_PAGES action (env-overridable via the `list_pages` op)
+ * using the connection's connectedAccountId and returns the managed Page.
+ *
+ * Single-page SMB case = the one Page. When several are managed we pick the
+ * first deterministically and report the full set so the caller can log it.
+ *
+ * Fail-safe: returns null on an unsuccessful tool call or when no Page is
+ * returned (e.g. missing pages_show_list scope, which silently returns []).
+ * Throwing is the caller's call to make — this never invents a Page.
+ *
+ * Response shape (verified via Composio MCP 2026-06-17):
+ *   { data: { data: [ { id, name, ... } ], paging }, successful, error }
+ */
+
+import type { ComposioGateway } from './composio-client';
+import type { ComposioConfig } from './composio-config';
+
+export interface ResolvedFacebookPage {
+  pageId: string;
+  pageName: string | null;
+  /** Total managed pages returned (>1 means we picked the first). */
+  managedCount: number;
+}
+
+/** Default verified slug; overridable via COMPOSIO_FACEBOOK_LIST_PAGES_ACTION. */
+export const DEFAULT_LIST_MANAGED_PAGES_SLUG = 'FACEBOOK_LIST_MANAGED_PAGES';
+
+/** Peel Composio's `{ data: <toolPayload> }` wrappers until we hit the row array. */
+function unwrapToArray(raw: unknown): Array<Record<string, unknown>> {
+  let cur = raw;
+  for (let i = 0; i < 3; i += 1) {
+    if (Array.isArray(cur)) return cur as Array<Record<string, unknown>>;
+    if (!cur || typeof cur !== 'object' || !('data' in (cur as Record<string, unknown>))) break;
+    cur = (cur as Record<string, unknown>).data;
+  }
+  return Array.isArray(cur) ? (cur as Array<Record<string, unknown>>) : [];
+}
+
+export async function resolveFacebookManagedPage(
+  gateway: ComposioGateway,
+  config: ComposioConfig,
+  connectedAccountId: string,
+): Promise<ResolvedFacebookPage | null> {
+  const slug = config.actionSlugFor('facebook', 'list_pages') ?? DEFAULT_LIST_MANAGED_PAGES_SLUG;
+  const result = await gateway.executeTool(slug, {
+    connectedAccountId,
+    arguments: { user_id: 'me', limit: 25, fields: 'id,name' },
+  });
+  if (!result.successful) return null;
+
+  const pages = unwrapToArray(result.data);
+  for (const page of pages) {
+    const id = typeof page.id === 'string' && page.id.trim() ? page.id.trim() : null;
+    if (!id) continue;
+    const name = typeof page.name === 'string' && page.name.trim() ? page.name.trim() : null;
+    return { pageId: id, pageName: name, managedCount: pages.length };
+  }
+  return null;
+}

--- a/scripts/automations/insights-sync-worker.ts
+++ b/scripts/automations/insights-sync-worker.ts
@@ -180,8 +180,14 @@ export async function bridgeAndTick(
     // Pass the SAME pool the tick uses — so a test injecting a fake pool never
     // silently reaches the real database through the bridge.
     const res = await ensureInsightsAccountsForConnectedPlatforms(dbPool);
-    if (res.upserted > 0) {
-      log({ event: 'insights_sync_accounts_bridged', upserted: res.upserted, considered: res.considered });
+    if (res.upserted > 0 || res.resolved > 0 || res.skippedNoPage > 0) {
+      log({
+        event: 'insights_sync_accounts_bridged',
+        upserted: res.upserted,
+        considered: res.considered,
+        resolved: res.resolved,
+        skippedNoPage: res.skippedNoPage,
+      });
     }
   } catch (err) {
     log({ event: 'insights_sync_bridge_failed', error: describeError(err) });

--- a/tests/composio-facebook-page-resolver.test.ts
+++ b/tests/composio-facebook-page-resolver.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveFacebookManagedPage,
+  DEFAULT_LIST_MANAGED_PAGES_SLUG,
+} from '@/backend/integrations/composio/facebook-page-resolver';
+import { fakeConfig, fakeGateway } from './composio/helpers';
+
+test('resolves the first managed page (deterministic) and reports the managed count', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: [{ id: 'P1', name: 'Primary' }, { id: 'P2', name: 'Second' }] },
+    },
+  });
+  const page = await resolveFacebookManagedPage(gateway, fakeConfig({ actions: {} }), 'ca_1');
+  assert.deepEqual(page, { pageId: 'P1', pageName: 'Primary', managedCount: 2 });
+  assert.equal(gateway.calls[0].slug, DEFAULT_LIST_MANAGED_PAGES_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_1');
+  assert.equal((gateway.calls[0].options.arguments as Record<string, unknown>).user_id, 'me');
+});
+
+test('honors the COMPOSIO_FACEBOOK_LIST_PAGES_ACTION override slug', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: [{ id: 'P1', name: 'X' }] } },
+  });
+  await resolveFacebookManagedPage(gateway, fakeConfig({ actions: { list_pages: 'CUSTOM_PAGES' } }), 'ca_1');
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_PAGES');
+});
+
+test('returns null on an unsuccessful tool call (never invents a page)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: false, error: 'scope missing', data: null } });
+  const page = await resolveFacebookManagedPage(gateway, fakeConfig({ actions: {} }), 'ca_1');
+  assert.equal(page, null);
+});
+
+test('returns null when no managed pages are returned (empty data)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: { data: [] } } });
+  const page = await resolveFacebookManagedPage(gateway, fakeConfig({ actions: {} }), 'ca_1');
+  assert.equal(page, null);
+});
+
+test('skips entries without a string id and picks the first valid one', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: [{ name: 'no id' }, { id: 'P9', name: 'Valid' }] },
+    },
+  });
+  const page = await resolveFacebookManagedPage(gateway, fakeConfig({ actions: {} }), 'ca_1');
+  assert.equal(page?.pageId, 'P9');
+});

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -8,6 +8,8 @@ import {
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
 import { getAdapter, hasAdapter, isFacebookInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
 import { FacebookInsightsAdapter } from '@/backend/insights/adapters/facebook/index';
+import { DEFAULT_LIST_MANAGED_PAGES_SLUG } from '@/backend/integrations/composio/facebook-page-resolver';
+import { fakeConfig, fakeGateway } from './composio/helpers';
 
 interface RecordedQuery {
   text: string;
@@ -32,27 +34,38 @@ function recordingDb(connectedRows: Array<Record<string, unknown>>): Queryable &
   };
 }
 
-test('the bridge upserts an insights_accounts row from a connected Composio FB connection', async () => {
+test('the bridge upserts an insights_accounts row from a connected Composio FB connection (id present, no resolution)', async () => {
   const db = recordingDb([
     {
+      id: 5,
       tenant_id: 15,
       platform: 'facebook',
       external_account_id: 'PAGE123',
       external_account_name: 'Sugar & Leather',
+      connected_account_id: 'ca_1',
     },
   ]);
+  // A gateway that would throw if called — proves no resolution happens when the
+  // page id is already present.
+  const gateway = fakeGateway();
 
-  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV);
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+  });
 
   assert.equal(result.considered, 1);
   assert.equal(result.upserted, 1);
+  assert.equal(result.resolved, 0);
+  assert.equal(gateway.calls.length, 0, 'no Composio call when external_account_id is present');
 
   const select = db.queries[0];
   assert.match(select.text, /FROM connected_accounts/);
   assert.match(select.text, /status = 'connected'/);
   assert.match(select.text, /provider = 'composio'/); // L1: only Composio-backed connections
   assert.match(select.text, /connected_account_id IS NOT NULL/);
-  assert.match(select.text, /external_account_id IS NOT NULL/);
+  // The external_account_id filter is intentionally GONE so null rows are back-healed.
+  assert.doesNotMatch(select.text, /external_account_id IS NOT NULL/);
   assert.deepEqual(select.params, [...BRIDGED_PLATFORMS]);
 
   const insert = db.queries[1];
@@ -60,6 +73,103 @@ test('the bridge upserts an insights_accounts row from a connected Composio FB c
   assert.match(insert.text, /ON CONFLICT \(tenant_id, platform, external_account_id\) DO UPDATE/);
   // page id (external_account_id) is mapped through unchanged.
   assert.deepEqual(insert.params, [15, 'facebook', 'PAGE123', 'Sugar & Leather']);
+});
+
+test('the bridge resolves + persists the Page id from Composio when external_account_id is null', async () => {
+  const db = recordingDb([
+    {
+      id: 9,
+      tenant_id: 15,
+      platform: 'facebook',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_live',
+    },
+  ]);
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: [{ id: 'PAGE777', name: 'Aries Page' }] },
+    },
+  });
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+  });
+
+  assert.equal(result.resolved, 1);
+  assert.equal(result.upserted, 1);
+  assert.equal(result.skippedNoPage, 0);
+
+  // It called FACEBOOK_LIST_MANAGED_PAGES with the connection's connectedAccountId.
+  assert.equal(gateway.calls[0].slug, DEFAULT_LIST_MANAGED_PAGES_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_live');
+
+  // It persisted the resolved Page id back to connected_accounts.
+  const update = db.queries.find((q) => /UPDATE connected_accounts/i.test(q.text));
+  assert.ok(update, 'persists the resolved page id back to connected_accounts');
+  assert.equal(update!.params[0], 'PAGE777');
+  assert.equal(update!.params[2], 9); // keyed on the connection row id
+
+  // And upserted insights_accounts with the resolved Page id + name.
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.deepEqual(insert!.params, [15, 'facebook', 'PAGE777', 'Aries Page']);
+});
+
+test('the bridge skips safely (no upsert, no throw) when Composio returns no managed page', async () => {
+  const db = recordingDb([
+    {
+      id: 9,
+      tenant_id: 15,
+      platform: 'facebook',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_live',
+    },
+  ]);
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: [] } },
+  });
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+  });
+
+  assert.equal(result.resolved, 0);
+  assert.equal(result.upserted, 0);
+  assert.equal(result.skippedNoPage, 1);
+  assert.equal(db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text)), undefined);
+  assert.equal(db.queries.find((q) => /UPDATE connected_accounts/i.test(q.text)), undefined);
+});
+
+test('the bridge does not throw when Composio resolution errors — it skips the tenant', async () => {
+  const db = recordingDb([
+    {
+      id: 9,
+      tenant_id: 15,
+      platform: 'facebook',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_live',
+    },
+  ]);
+  const throwingGateway = {
+    ...fakeGateway(),
+    async executeTool() {
+      throw new Error('Composio 500');
+    },
+  };
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV, {
+    gateway: throwingGateway,
+    config: fakeConfig({ actions: {} }),
+  });
+
+  assert.equal(result.skippedNoPage, 1);
+  assert.equal(result.upserted, 0);
 });
 
 test('Instagram is out of scope: the bridge only queries the bridged (FB) platforms', async () => {


### PR DESCRIPTION
Follow-up to #615. The FB insights sync was a no-op in prod: the connected Composio Facebook `connected_accounts` row has `external_account_id = NULL` (the Page id was never captured at connect, 2026-06-04), and the bridge required it — so `insights_accounts` stayed empty and the worker logged `insights_sync_noop: no_connected_accounts`.

## Fix
- New `backend/integrations/composio/facebook-page-resolver.ts` → calls `FACEBOOK_LIST_MANAGED_PAGES` (env-overridable `COMPOSIO_FACEBOOK_LIST_PAGES_ACTION`) via the connection's `connectedAccountId`, returns the managed Page (`id`+`name`; first deterministically when several). Fail-safe: null on unsuccessful/empty — never invents a Page.
- `ensure-account.ts` bridge: drops the `external_account_id IS NOT NULL` filter; for a connected FB row with a null Page id it resolves from Composio, **persists it back to `connected_accounts`** (scoped `WHERE id=$1`, COALESCE on name), then upserts `insights_accounts`. Resolution errors / no-page → log + skip the tenant (never throws → worker tick can't wedge). **Self-heals the existing prod row on the next tick — no manual backfill.**
- `composio-account-provider.refreshConnectionStatus` also captures the Page id at connect time for future connections (best-effort; bridge back-heals otherwise).

## Tests
`tests/composio-facebook-page-resolver.test.ts` (first-page pick + managedCount, override slug, unsuccessful/empty→null, skips id-less entries) + expanded `tests/insights-ensure-account.test.ts` (resolves+persists when null incl. the back-heal UPDATE → flows into insights_accounts; uses existing id with zero Composio calls; skips safely on no-page; never throws on resolution error).

`npm run verify` ✅ · typecheck ✅ · banned-patterns ✅ · guardrails ✅. Adversarially-reviewed parent (#615); back-heal write spot-checked (row-scoped, no cross-tenant clobber).

Part of #596, #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)