### PR TITLE
fix(composio): pass toolkit version on tools.execute (unblocks publish + insights)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,6 +256,12 @@ REDDIT_USER_AGENT=AriesOAuthBroker/1.0
 # direct Meta everywhere, no Composio code loaded. See docs/integrations/composio.md.
 COMPOSIO_ENABLED=false
 COMPOSIO_API_KEY=
+# Toolkit version for manual (by-slug) Composio tool execution — publishing,
+# analytics, AND comments all go through tools.execute, which the @composio/core
+# SDK rejects without a toolkit version. Default 'latest' (the gateway pairs it
+# with dangerouslySkipVersionCheck). Pin a concrete version (e.g. 20250909_00)
+# to avoid silent "latest" drift in production.
+COMPOSIO_TOOLKIT_VERSION=latest
 # Default auth config used for any platform without a specific config below.
 COMPOSIO_DEFAULT_AUTH_CONFIG_ID=
 COMPOSIO_METAADS_AUTH_CONFIG_ID=

--- a/backend/integrations/composio/composio-client.ts
+++ b/backend/integrations/composio/composio-client.ts
@@ -62,6 +62,37 @@ export interface ComposioGateway {
   ): Promise<GatewayToolResult>;
 }
 
+export interface ToolExecuteInput {
+  userId?: string;
+  connectedAccountId?: string;
+  arguments?: Record<string, unknown>;
+}
+
+/**
+ * Build the params object handed to `composio.tools.execute`. The @composio/core
+ * SDK requires a toolkit version for manual (by-slug) execution: an unset or
+ * "latest" version throws ComposioToolVersionRequiredError unless the version
+ * check is skipped. We therefore always pass an explicit `version` and, when it
+ * is "latest" (the default), `dangerouslySkipVersionCheck: true`. A concrete
+ * pinned version (e.g. "20250909_00") is passed as-is with NO skip flag.
+ *
+ * Exported so the gateway test asserts the exact arg the real client receives.
+ */
+export function buildToolExecuteOptions(
+  options: ToolExecuteInput,
+  toolkitVersion?: string,
+): ToolExecuteInput & { version: string; dangerouslySkipVersionCheck?: boolean } {
+  const version = (toolkitVersion?.trim() || 'latest');
+  const params: ToolExecuteInput & { version: string; dangerouslySkipVersionCheck?: boolean } = {
+    ...options,
+    version,
+  };
+  if (version.toLowerCase() === 'latest') {
+    params.dangerouslySkipVersionCheck = true;
+  }
+  return params;
+}
+
 // --- helpers to normalize the loosely-typed SDK model -----------------------
 
 function pickExternalAccountId(data: Record<string, unknown> | null | undefined): string | null {
@@ -108,22 +139,31 @@ function toGatewayConnection(model: {
  * The real gateway backed by @composio/core, loaded lazily so the package is
  * only required when Composio is enabled AND selected.
  */
-class LiveComposioGateway implements ComposioGateway {
+export class LiveComposioGateway implements ComposioGateway {
   private clientPromise: Promise<import('@composio/core').Composio> | null = null;
 
-  constructor(private readonly config: ComposioConfig) {}
+  /**
+   * @param clientFactory test-only seam to inject a fake @composio/core client.
+   *   Production leaves it undefined and the real SDK is lazy-imported.
+   */
+  constructor(
+    private readonly config: ComposioConfig,
+    private readonly clientFactory?: () => Promise<import('@composio/core').Composio>,
+  ) {}
 
   private async client(): Promise<import('@composio/core').Composio> {
     if (!this.clientPromise) {
-      this.clientPromise = (async () => {
-        let mod: typeof import('@composio/core');
-        try {
-          mod = await import('@composio/core');
-        } catch {
-          throw new ComposioSdkMissingError();
-        }
-        return new mod.Composio({ apiKey: this.config.apiKey });
-      })();
+      this.clientPromise = this.clientFactory
+        ? this.clientFactory()
+        : (async () => {
+            let mod: typeof import('@composio/core');
+            try {
+              mod = await import('@composio/core');
+            } catch {
+              throw new ComposioSdkMissingError();
+            }
+            return new mod.Composio({ apiKey: this.config.apiKey });
+          })();
     }
     return this.clientPromise;
   }
@@ -197,7 +237,10 @@ class LiveComposioGateway implements ComposioGateway {
     options: { userId?: string; connectedAccountId?: string; arguments?: Record<string, unknown> },
   ): Promise<GatewayToolResult> {
     const composio = await this.client();
-    const result = await composio.tools.execute(slug, options);
+    // Always pass the toolkit version — the SDK rejects manual execution without
+    // one ("Toolkit version not specified ..."). buildToolExecuteOptions defaults
+    // to 'latest' + dangerouslySkipVersionCheck.
+    const result = await composio.tools.execute(slug, buildToolExecuteOptions(options, this.config.toolkitVersion));
     return {
       data: result.data ?? null,
       successful: result.successful !== false,
@@ -206,11 +249,14 @@ class LiveComposioGateway implements ComposioGateway {
   }
 }
 
-export function createComposioGateway(config: ComposioConfig | null): ComposioGateway {
+export function createComposioGateway(
+  config: ComposioConfig | null,
+  clientFactory?: () => Promise<import('@composio/core').Composio>,
+): ComposioGateway {
   if (!config) {
     throw new ComposioConfigError('Composio is enabled but COMPOSIO_API_KEY is not set.');
   }
-  return new LiveComposioGateway(config);
+  return new LiveComposioGateway(config, clientFactory);
 }
 
 export { toGatewayConnection };

--- a/backend/integrations/composio/composio-config.ts
+++ b/backend/integrations/composio/composio-config.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IntegrationPlatform } from '../providers/types';
-import { composioApiKey, composioAuthConfigId } from '../providers/integration-config';
+import { composioApiKey, composioAuthConfigId, composioToolkitVersion } from '../providers/integration-config';
 
 /** Stable Composio toolkit slug per platform. */
 export const TOOLKIT_SLUG: Record<IntegrationPlatform, string> = {
@@ -60,6 +60,11 @@ export function actionSlug(
 
 export interface ComposioConfig {
   apiKey: string;
+  /**
+   * Toolkit version for manual tool execution (gateway.executeTool). Optional so
+   * test doubles can omit it — the gateway defaults to 'latest' + skip-check.
+   */
+  toolkitVersion?: string;
   authConfigIdFor(platform: IntegrationPlatform): string | null;
   toolkitSlugFor(platform: IntegrationPlatform): string;
   actionSlugFor(platform: IntegrationPlatform, op: ComposioOperation): string | null;
@@ -75,6 +80,7 @@ export function resolveComposioConfig(env: NodeJS.ProcessEnv = process.env): Com
   if (!apiKey) return null;
   return {
     apiKey,
+    toolkitVersion: composioToolkitVersion(env),
     authConfigIdFor: (platform) => composioAuthConfigId(platform, env),
     toolkitSlugFor: (platform) => TOOLKIT_SLUG[platform],
     actionSlugFor: (platform, op) => actionSlug(platform, op, env),

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -65,6 +65,19 @@ export function composioApiKey(env: NodeJS.ProcessEnv = process.env): string | n
 }
 
 /**
+ * Toolkit version used for manual (by-slug) Composio tool execution. The
+ * @composio/core SDK requires a toolkit version for `tools.execute`; an
+ * unspecified/"latest" version throws ComposioToolVersionRequiredError unless
+ * the version check is skipped. Default 'latest' (the gateway pairs it with
+ * dangerouslySkipVersionCheck). Pin a concrete version (e.g. '20250909_00') via
+ * COMPOSIO_TOOLKIT_VERSION to opt out of "latest" drift in production.
+ */
+export function composioToolkitVersion(env: NodeJS.ProcessEnv = process.env): string {
+  const v = env.COMPOSIO_TOOLKIT_VERSION?.trim();
+  return v || 'latest';
+}
+
+/**
  * Full snapshot of the resolved config — handy for the capability/status UI and
  * for tests that want to assert flag behavior without poking process.env keys
  * one at a time.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,10 @@ services:
       # restart. See docs/integrations/composio.md.
       COMPOSIO_ENABLED: ${COMPOSIO_ENABLED:-false}
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
+      # Toolkit version for manual Composio tool execution (publish/analytics/
+      # comments). The SDK rejects by-slug execution without one; default 'latest'
+      # (gateway pairs it with a skip-check). Pin a concrete version to avoid drift.
+      COMPOSIO_TOOLKIT_VERSION: ${COMPOSIO_TOOLKIT_VERSION:-latest}
       COMPOSIO_DEFAULT_AUTH_CONFIG_ID: ${COMPOSIO_DEFAULT_AUTH_CONFIG_ID:-}
       COMPOSIO_METAADS_AUTH_CONFIG_ID: ${COMPOSIO_METAADS_AUTH_CONFIG_ID:-}
       COMPOSIO_FACEBOOK_AUTH_CONFIG_ID: ${COMPOSIO_FACEBOOK_AUTH_CONFIG_ID:-}
@@ -445,6 +449,8 @@ services:
       ANALYTICS_PROVIDER: ${ANALYTICS_PROVIDER:-direct_meta}
       COMPOSIO_ENABLED: ${COMPOSIO_ENABLED:-false}
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
+      # Toolkit version for manual Composio tool execution (see aries-app above).
+      COMPOSIO_TOOLKIT_VERSION: ${COMPOSIO_TOOLKIT_VERSION:-latest}
       COMPOSIO_FACEBOOK_AUTH_CONFIG_ID: ${COMPOSIO_FACEBOOK_AUTH_CONFIG_ID:-}
       COMPOSIO_DEFAULT_AUTH_CONFIG_ID: ${COMPOSIO_DEFAULT_AUTH_CONFIG_ID:-}
       COMPOSIO_FACEBOOK_LIST_POSTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_POSTS_ACTION:-}

--- a/tests/composio-client-toolkit-version.test.ts
+++ b/tests/composio-client-toolkit-version.test.ts
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildToolExecuteOptions,
+  createComposioGateway,
+} from '@/backend/integrations/composio/composio-client';
+import type { ComposioConfig } from '@/backend/integrations/composio/composio-config';
+
+// ── buildToolExecuteOptions (pure) ──────────────────────────────────────────────
+// This is exactly the params object the gateway hands to composio.tools.execute,
+// which the @composio/core SDK rejects without a toolkit version.
+
+test('default (no configured version) → version="latest" + dangerouslySkipVersionCheck', () => {
+  const out = buildToolExecuteOptions({ connectedAccountId: 'ca_1', arguments: { a: 1 } });
+  assert.equal(out.version, 'latest');
+  assert.equal(out.dangerouslySkipVersionCheck, true);
+  assert.equal(out.connectedAccountId, 'ca_1');
+  assert.deepEqual(out.arguments, { a: 1 });
+});
+
+test('a pinned concrete version is passed as-is with NO skip flag', () => {
+  const out = buildToolExecuteOptions({ connectedAccountId: 'ca_1' }, '20250909_00');
+  assert.equal(out.version, '20250909_00');
+  assert.equal(out.dangerouslySkipVersionCheck, undefined);
+});
+
+test('explicit "latest" (any case) still pairs with the skip flag', () => {
+  assert.equal(buildToolExecuteOptions({}, 'latest').dangerouslySkipVersionCheck, true);
+  assert.equal(buildToolExecuteOptions({}, 'LATEST').dangerouslySkipVersionCheck, true);
+});
+
+test('blank/whitespace version falls back to latest', () => {
+  const out = buildToolExecuteOptions({}, '   ');
+  assert.equal(out.version, 'latest');
+  assert.equal(out.dangerouslySkipVersionCheck, true);
+});
+
+// ── executeTool wiring (asserts the arg the real client receives) ───────────────
+
+function configWith(toolkitVersion?: string): ComposioConfig {
+  return {
+    apiKey: 'test-key',
+    toolkitVersion,
+    authConfigIdFor: () => null,
+    toolkitSlugFor: (p) => p,
+    actionSlugFor: () => null,
+  };
+}
+
+/** A fake @composio/core client recording the tools.execute call. */
+function fakeClient() {
+  const calls: Array<{ slug: string; options: Record<string, unknown> }> = [];
+  const client = {
+    tools: {
+      async execute(slug: string, options: Record<string, unknown>) {
+        calls.push({ slug, options });
+        return { data: { ok: true }, successful: true, error: null };
+      },
+    },
+  };
+  return { client, calls };
+}
+
+test('executeTool forwards version + dangerouslySkipVersionCheck to composio.tools.execute (latest default)', async () => {
+  const { client, calls } = fakeClient();
+  const gateway = createComposioGateway(
+    configWith('latest'),
+    async () => client as unknown as import('@composio/core').Composio,
+  );
+
+  const res = await gateway.executeTool('FACEBOOK_LIST_MANAGED_PAGES', {
+    connectedAccountId: 'ca_live',
+    arguments: { user_id: 'me' },
+  });
+
+  assert.equal(res.successful, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].slug, 'FACEBOOK_LIST_MANAGED_PAGES');
+  // The fix: the SDK call carries a toolkit version (else "Toolkit version not specified").
+  assert.equal(calls[0].options.version, 'latest');
+  assert.equal(calls[0].options.dangerouslySkipVersionCheck, true);
+  assert.equal(calls[0].options.connectedAccountId, 'ca_live');
+  assert.deepEqual(calls[0].options.arguments, { user_id: 'me' });
+});
+
+test('executeTool forwards a pinned concrete version (no skip flag)', async () => {
+  const { client, calls } = fakeClient();
+  const gateway = createComposioGateway(
+    configWith('20250909_00'),
+    async () => client as unknown as import('@composio/core').Composio,
+  );
+
+  await gateway.executeTool('FACEBOOK_CREATE_POST', { connectedAccountId: 'ca_1', arguments: { message: 'hi' } });
+
+  assert.equal(calls[0].options.version, '20250909_00');
+  assert.equal(calls[0].options.dangerouslySkipVersionCheck, undefined);
+});


### PR DESCRIPTION
Live prod verification of the FB insights sync surfaced a gateway bug that breaks **all** Composio action execution: `composio.tools.execute` was called with **no toolkit version**, so `@composio/core@0.10.0` throws `ComposioToolVersionRequiredError` ("Toolkit version not specified. For manual execution of the tool please pass a specific toolkit version"). This affected every manual execution — **publishing (`FACEBOOK_CREATE_POST`, the live `PUBLISH_PROVIDER=composio` cutover), analytics, and comments** — identically. The fake-gateway unit tests never exercised the real SDK, so it slipped through.

## Fix
- `composio-client.ts`: new exported pure `buildToolExecuteOptions(options, toolkitVersion)` — always sets an explicit `version`; for the default `"latest"` it also sets `dangerouslySkipVersionCheck: true`; a pinned concrete version (e.g. `20250909_00`) passes through with no skip flag. `executeTool` (the single shared `tools.execute` path) now uses it.
- `ComposioConfig.toolkitVersion` from new `COMPOSIO_TOOLKIT_VERSION` env (default `latest`), wired into **both** `aries-app` and `aries-insights-sync-worker` (docker-compose + .env.example, two-place rule).
- SDK client factory made injectable for tests.

`executeTool` is the only call needing the version (connection link/list/get/delete + authConfigs are unchanged). One fix unblocks publish + analytics + comments.

## Tests
`tests/composio-client-toolkit-version.test.ts` — `buildToolExecuteOptions` cases (default→latest+skip, pinned→no skip, blank→latest) and `executeTool` through an **injected fake `@composio/core` client** asserting the real `tools.execute` carries `version` + `dangerouslySkipVersionCheck`.

`npm run verify` ✅ · typecheck ✅ · banned-patterns ✅ · guardrails ✅ · gateway change spot-checked.

Part of #596, #597; also restores the Facebook `PUBLISH_PROVIDER=composio` publish path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)