### PR TITLE
feat(dashboard): analytics + comments surfaces for Composio insights (#596/#597)

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,0 +1,14 @@
+import AppShellLayout from '@/frontend/app-shell/layout';
+import AriesAnalyticsScreen from '@/frontend/aries-v1/analytics-screen';
+
+export const metadata = {
+  title: 'Analytics — Aries AI',
+};
+
+export default function DashboardAnalyticsPage() {
+  return (
+    <AppShellLayout currentRouteId="analytics" loginRedirectPath="/dashboard/analytics">
+      <AriesAnalyticsScreen />
+    </AppShellLayout>
+  );
+}

--- a/app/dashboard/comments/page.tsx
+++ b/app/dashboard/comments/page.tsx
@@ -1,0 +1,14 @@
+import AppShellLayout from '@/frontend/app-shell/layout';
+import AriesCommentsScreen from '@/frontend/aries-v1/comments-screen';
+
+export const metadata = {
+  title: 'Comments — Aries AI',
+};
+
+export default function DashboardCommentsPage() {
+  return (
+    <AppShellLayout currentRouteId="comments" loginRedirectPath="/dashboard/comments">
+      <AriesCommentsScreen />
+    </AppShellLayout>
+  );
+}

--- a/backend/insights/read-api.ts
+++ b/backend/insights/read-api.ts
@@ -319,6 +319,8 @@ export async function handleGetInsightsComments(
       author_handle:    string | null;
       body_text:        string;
       received_at:      Date;
+      is_replied:       boolean | null;
+      replied_at:       Date | null;
       post_title:       string | null;
       post_permalink:   string | null;
     }>(
@@ -329,6 +331,8 @@ export async function handleGetInsightsComments(
          c.author_handle,
          c.body_text,
          c.received_at,
+         c.is_replied,
+         c.replied_at,
          p.title      AS post_title,
          p.permalink  AS post_permalink
        FROM insights_comments c
@@ -348,6 +352,8 @@ export async function handleGetInsightsComments(
       authorHandle:  row.author_handle,
       bodyText:      row.body_text,
       receivedAt:    row.received_at,
+      isReplied:     Boolean(row.is_replied),
+      repliedAt:     row.replied_at,
       postTitle:     row.post_title,
       postPermalink: row.post_permalink,
     }));

--- a/components/redesign/layout/app-shell-client.tsx
+++ b/components/redesign/layout/app-shell-client.tsx
@@ -15,12 +15,14 @@ import {
   Layers3,
   LayoutDashboard,
   Menu,
+  MessageCircle,
   LogOut,
   PenSquare,
   Send,
   Rocket,
   Settings,
   Sparkles,
+  TrendingUp,
 } from 'lucide-react';
 
 import { AriesMark } from '@/frontend/donor/ui';
@@ -40,6 +42,8 @@ const ICONS: Record<AppRouteId, typeof LayoutDashboard> = {
   posts: FileStack,
   calendar: Calendar,
   results: BarChart3,
+  analytics: TrendingUp,
+  comments: MessageCircle,
   review: CheckCheck,
   businessProfile: Settings,
   channelIntegrations: Rocket,
@@ -102,6 +106,8 @@ export default function AppShellClient({
       { type: 'link', routeId: 'posts' },
       { type: 'link', routeId: 'calendar' },
       { type: 'link', routeId: 'results' },
+      { type: 'link', routeId: 'analytics' },
+      { type: 'link', routeId: 'comments' },
     ],
     [],
   );

--- a/frontend/app-shell/routes.ts
+++ b/frontend/app-shell/routes.ts
@@ -9,6 +9,8 @@ export type AppRouteId =
   | 'posts'
   | 'calendar'
   | 'results'
+  | 'analytics'
+  | 'comments'
   | 'review'
   | 'businessProfile'
   | 'channelIntegrations'
@@ -92,6 +94,20 @@ export const APP_ROUTES: readonly AppRoute[] = [
     href: '/dashboard/results',
     section: 'utility',
     description: 'Business-readable reporting and recommended next actions.'
+  },
+  {
+    id: 'analytics',
+    title: 'Analytics',
+    href: '/dashboard/analytics',
+    section: 'utility',
+    description: 'Facebook performance: views, followers, engagement, and per-post metrics.'
+  },
+  {
+    id: 'comments',
+    title: 'Comments',
+    href: '/dashboard/comments',
+    section: 'utility',
+    description: 'Facebook comment inbox grouped by post, with native reply when enabled.'
   },
   {
     id: 'review',

--- a/frontend/aries-v1/analytics-screen.tsx
+++ b/frontend/aries-v1/analytics-screen.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { InsightsAccountMetricPoint, InsightsPostItem } from '@/lib/api/aries-v1';
+import { useInsightsAnalytics } from '@/hooks/use-insights-analytics';
+
+import { customerSafeUiErrorMessage } from './customer-safe-copy';
+import { EmptyStatePanel, LoadingStateGrid, MetricCard, ShellPanel } from './components';
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return '0';
+  return Math.round(value).toLocaleString('en-US');
+}
+
+function formatDay(value: string): string {
+  // Account-metric `date` is already a YYYY-MM-DD string; posts `publishedAt`
+  // is an ISO timestamp. Keep just the day to avoid locale/hydration drift.
+  if (typeof value !== 'string') return '—';
+  return value.slice(0, 10) || '—';
+}
+
+export default function AriesAnalyticsScreen() {
+  const analytics = useInsightsAnalytics({ autoLoad: true, platform: 'facebook' });
+  const data = analytics.data;
+
+  const summary = data?.summary;
+  const series: InsightsAccountMetricPoint[] = data?.accountMetrics.series ?? [];
+  const posts: InsightsPostItem[] = data?.posts.posts ?? [];
+
+  const hasData = Boolean(
+    summary &&
+      (summary.totalViews > 0 ||
+        summary.currentFollowers > 0 ||
+        summary.followersGained > 0 ||
+        summary.totalEngagement > 0 ||
+        summary.totalLikes > 0 ||
+        summary.totalComments > 0 ||
+        summary.totalShares > 0 ||
+        series.length > 0 ||
+        posts.length > 0),
+  );
+
+  return (
+    <div className="space-y-5">
+      <ShellPanel eyebrow="Analytics" title="Facebook performance">
+        <p className="max-w-3xl text-sm leading-7 text-white/65">
+          Views, followers, and engagement from your connected Facebook Page, plus per-post results.
+          Numbers populate here after Aries syncs analytics from Meta.
+        </p>
+      </ShellPanel>
+
+      {analytics.isLoading ? (
+        <LoadingStateGrid />
+      ) : analytics.error ? (
+        <div className="rounded-[1.5rem] border border-red-500/20 bg-red-500/10 p-5 text-red-100">
+          <p>{customerSafeUiErrorMessage(analytics.error.message, 'Analytics are not available right now.')}</p>
+          <button
+            type="button"
+            onClick={() => void analytics.load()}
+            className="mt-3 inline-flex items-center gap-2 rounded-lg border border-red-400/40 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-50 transition hover:bg-red-500/20"
+          >
+            Try again
+          </button>
+        </div>
+      ) : !hasData || !summary ? (
+        <EmptyStatePanel
+          title="No analytics yet"
+          description="Once your Facebook posts are live and Aries has synced performance data from Meta, your views, followers, and per-post results will appear here."
+        />
+      ) : (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <MetricCard label="Views" value={formatNumber(summary.totalViews)} detail={`Last ${summary.period.days} days`} />
+            <MetricCard
+              label="Followers"
+              value={formatNumber(summary.currentFollowers)}
+              detail={`${summary.followersGained >= 0 ? '+' : ''}${formatNumber(summary.followersGained)} in period`}
+              tone={summary.followersGained > 0 ? 'good' : 'default'}
+            />
+            <MetricCard label="Engagement" value={formatNumber(summary.totalEngagement)} detail="Likes + comments + shares" />
+            <MetricCard label="Likes" value={formatNumber(summary.totalLikes)} detail={`Last ${summary.period.days} days`} />
+            <MetricCard label="Comments" value={formatNumber(summary.totalComments)} detail={`Last ${summary.period.days} days`} />
+            <MetricCard label="Shares" value={formatNumber(summary.totalShares)} detail={`Last ${summary.period.days} days`} />
+          </div>
+
+          <ShellPanel eyebrow="Trend" title="Followers and views over time">
+            {series.length > 0 ? (
+              <div className="h-72 w-full">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={series} margin={{ top: 12, right: 12, left: -12, bottom: 0 }}>
+                    <CartesianGrid stroke="rgba(255,255,255,0.08)" vertical={false} />
+                    <XAxis dataKey="date" tick={{ fill: 'rgba(255,255,255,0.55)', fontSize: 12 }} tickFormatter={formatDay} />
+                    <YAxis tick={{ fill: 'rgba(255,255,255,0.55)', fontSize: 12 }} width={48} />
+                    <Tooltip
+                      contentStyle={{
+                        background: '#0f151b',
+                        border: '1px solid rgba(255,255,255,0.12)',
+                        borderRadius: 12,
+                        color: '#fff',
+                      }}
+                      labelFormatter={(label) => formatDay(String(label))}
+                    />
+                    <Line type="monotone" dataKey="followers" name="Followers" stroke="#a78bfa" strokeWidth={2} dot={false} />
+                    <Line type="monotone" dataKey="views" name="Views" stroke="#34d399" strokeWidth={2} dot={false} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <p className="text-sm text-white/55">No daily trend data for this window yet.</p>
+            )}
+          </ShellPanel>
+
+          <ShellPanel eyebrow="Posts" title="Per-post performance">
+            {posts.length > 0 ? (
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[640px] border-collapse text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-white/10 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+                      <th className="py-3 pr-4 font-semibold">Post</th>
+                      <th className="py-3 pr-4 font-semibold">Published</th>
+                      <th className="py-3 pr-4 text-right font-semibold">Views</th>
+                      <th className="py-3 pr-4 text-right font-semibold">Likes</th>
+                      <th className="py-3 pr-4 text-right font-semibold">Comments</th>
+                      <th className="py-3 text-right font-semibold">Shares</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {posts.map((post) => (
+                      <tr key={post.id} className="border-b border-white/[0.06] text-white/75">
+                        <td className="max-w-[18rem] truncate py-3 pr-4 text-white/90">
+                          {post.title?.trim() || post.externalPostId}
+                        </td>
+                        <td className="py-3 pr-4 text-white/55">{formatDay(post.publishedAt)}</td>
+                        <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalViews)}</td>
+                        <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalLikes)}</td>
+                        <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalComments)}</td>
+                        <td className="py-3 text-right">{formatNumber(post.metrics.totalShares)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="text-sm text-white/55">No post-level metrics yet.</p>
+            )}
+          </ShellPanel>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/aries-v1/comments-screen.tsx
+++ b/frontend/aries-v1/comments-screen.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import type { InsightsCommentItem } from '@/lib/api/aries-v1';
+import { useInsightsComments, type CommentReplyOutcome } from '@/hooks/use-insights-comments';
+
+import { customerSafeUiErrorMessage } from './customer-safe-copy';
+import { EmptyStatePanel, LoadingStateGrid, ShellPanel } from './components';
+
+function formatDay(value: string): string {
+  if (typeof value !== 'string') return '';
+  return value.slice(0, 10);
+}
+
+type PostGroup = {
+  postId: number;
+  postTitle: string | null;
+  postPermalink: string | null;
+  comments: InsightsCommentItem[];
+};
+
+function groupByPost(comments: InsightsCommentItem[]): PostGroup[] {
+  const order: number[] = [];
+  const groups = new Map<number, PostGroup>();
+  for (const comment of comments) {
+    let group = groups.get(comment.postId);
+    if (!group) {
+      group = {
+        postId: comment.postId,
+        postTitle: comment.postTitle,
+        postPermalink: comment.postPermalink,
+        comments: [],
+      };
+      groups.set(comment.postId, group);
+      order.push(comment.postId);
+    }
+    group.comments.push(comment);
+  }
+  return order.map((id) => groups.get(id)!);
+}
+
+export default function AriesCommentsScreen() {
+  const inbox = useInsightsComments({ autoLoad: true, platform: 'facebook' });
+  const comments = inbox.data?.comments ?? [];
+  const groups = useMemo(() => groupByPost(comments), [comments]);
+
+  // Per-comment client state, keyed by comment id.
+  const [drafts, setDrafts] = useState<Record<number, string>>({});
+  const [submittingId, setSubmittingId] = useState<number | null>(null);
+  const [outcomes, setOutcomes] = useState<Record<number, CommentReplyOutcome>>({});
+  const [repliedNow, setRepliedNow] = useState<Record<number, boolean>>({});
+
+  async function handleReply(commentId: number) {
+    const text = (drafts[commentId] ?? '').trim();
+    if (!text || submittingId !== null) return;
+    setSubmittingId(commentId);
+    const outcome = await inbox.reply(commentId, text);
+    setOutcomes((prev) => ({ ...prev, [commentId]: outcome }));
+    if (outcome.kind === 'replied') {
+      setRepliedNow((prev) => ({ ...prev, [commentId]: true }));
+      setDrafts((prev) => ({ ...prev, [commentId]: '' }));
+    }
+    setSubmittingId(null);
+  }
+
+  return (
+    <div className="space-y-5">
+      <ShellPanel eyebrow="Comments" title="Facebook comment inbox">
+        <p className="max-w-3xl text-sm leading-7 text-white/65">
+          Comments on your Facebook posts, grouped by the post they belong to. Reply directly from
+          Aries when native reply is enabled for your account.
+        </p>
+      </ShellPanel>
+
+      {inbox.isLoading ? (
+        <LoadingStateGrid />
+      ) : inbox.error ? (
+        <div className="rounded-[1.5rem] border border-red-500/20 bg-red-500/10 p-5 text-red-100">
+          <p>{customerSafeUiErrorMessage(inbox.error.message, 'Comments are not available right now.')}</p>
+          <button
+            type="button"
+            onClick={() => void inbox.load()}
+            className="mt-3 inline-flex items-center gap-2 rounded-lg border border-red-400/40 bg-red-500/10 px-3 py-1.5 text-sm font-medium text-red-50 transition hover:bg-red-500/20"
+          >
+            Try again
+          </button>
+        </div>
+      ) : groups.length === 0 ? (
+        <EmptyStatePanel
+          title="No comments yet"
+          description="When people comment on your live Facebook posts, their messages will appear here so you can read and reply."
+        />
+      ) : (
+        <div className="space-y-5">
+          {groups.map((group) => (
+            <ShellPanel
+              key={group.postId}
+              eyebrow="Post"
+              title={group.postTitle?.trim() || `Post #${group.postId}`}
+            >
+              <div className="space-y-4">
+                {group.comments.map((comment) => {
+                  const outcome = outcomes[comment.id];
+                  const isReplied = comment.isReplied || Boolean(repliedNow[comment.id]);
+                  const isSubmitting = submittingId === comment.id;
+                  return (
+                    <div
+                      key={comment.id}
+                      className="rounded-[1.25rem] border border-white/8 bg-black/20 px-4 py-4"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="text-sm font-medium text-white">
+                          {comment.authorHandle?.trim() || 'Facebook user'}
+                        </p>
+                        <div className="flex items-center gap-3">
+                          <span className="text-xs text-white/45">{formatDay(comment.receivedAt)}</span>
+                          {isReplied ? (
+                            <span className="inline-flex items-center rounded-full border border-emerald-400/25 bg-emerald-400/10 px-2.5 py-1 text-xs font-medium text-emerald-100">
+                              Replied
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-white/75">{comment.bodyText}</p>
+
+                      {isReplied ? null : outcome?.kind === 'not_enabled' ? (
+                        <p className="mt-3 text-xs text-white/45">
+                          Native reply isn’t enabled for your account yet. You can still reply from
+                          Facebook directly.
+                        </p>
+                      ) : (
+                        <div className="mt-3 space-y-2">
+                          <textarea
+                            value={drafts[comment.id] ?? ''}
+                            onChange={(event) =>
+                              setDrafts((prev) => ({ ...prev, [comment.id]: event.target.value }))
+                            }
+                            placeholder="Write a reply…"
+                            rows={2}
+                            className="w-full rounded-[0.9rem] border border-white/10 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/28 focus:border-white/20 focus:outline-none"
+                          />
+                          <div className="flex items-center justify-between gap-3">
+                            {outcome?.kind === 'error' ? (
+                              <p className="text-xs text-red-200">{outcome.message}</p>
+                            ) : (
+                              <span />
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => void handleReply(comment.id)}
+                              disabled={isSubmitting || !(drafts[comment.id] ?? '').trim()}
+                              className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-[#11161c] transition enabled:hover:translate-y-[-1px] disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              {isSubmitting ? 'Sending…' : 'Reply'}
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </ShellPanel>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/use-insights-analytics.ts
+++ b/hooks/use-insights-analytics.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+
+import {
+  createAriesV1Api,
+  type InsightsAccountMetricsResponse,
+  type InsightsPostsResponse,
+  type InsightsSummaryResponse,
+} from '@/lib/api/aries-v1';
+
+import { useRequestState } from './use-request-state';
+
+export type InsightsAnalyticsData = {
+  summary: InsightsSummaryResponse;
+  accountMetrics: InsightsAccountMetricsResponse;
+  posts: InsightsPostsResponse;
+};
+
+/**
+ * Loads the three read-only insights endpoints (#596) for the analytics screen.
+ * Facebook-only: the platform filter defaults to `facebook` (Instagram is
+ * deferred). The three fetches are independent client-side GETs, so they run in
+ * parallel — this is the browser issuing three HTTP requests, NOT a server-side
+ * DB fan-out within one endpoint (the pool-contention guardrail does not apply).
+ * Any failure surfaces as a single error+retry; an all-zero/empty payload is a
+ * valid success the screen renders as an empty state.
+ */
+export function useInsightsAnalytics(
+  options: { baseUrl?: string; autoLoad?: boolean; platform?: string; days?: number } = {},
+) {
+  const baseUrl = options.baseUrl;
+  const autoLoad = options.autoLoad;
+  const platform = options.platform ?? 'facebook';
+  const days = options.days;
+
+  const api = useMemo(() => createAriesV1Api({ baseUrl }), [baseUrl]);
+  const state = useRequestState<InsightsAnalyticsData>();
+  const { setError, setLoading, setSuccess } = state;
+
+  const load = useCallback(async () => {
+    setLoading();
+    try {
+      const [summary, accountMetrics, posts] = await Promise.all([
+        api.getInsightsSummary({ platform, days }),
+        api.getInsightsAccountMetrics({ platform, days }),
+        api.getInsightsPosts({ platform }),
+      ]);
+      const data: InsightsAnalyticsData = { summary, accountMetrics, posts };
+      setSuccess(data);
+      return data;
+    } catch (error) {
+      setError(error, 'Failed to load analytics.');
+      return null;
+    }
+  }, [api, platform, days, setError, setLoading, setSuccess]);
+
+  useEffect(() => {
+    if (autoLoad === false) return;
+    void load();
+  }, [load, autoLoad]);
+
+  return { ...state, load };
+}

--- a/hooks/use-insights-comments.ts
+++ b/hooks/use-insights-comments.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { createAriesV1Api, type InsightsCommentsResponse } from '@/lib/api/aries-v1';
+import { ApiRequestError } from '@/lib/api/http';
+import { customerSafeActionErrorMessage } from '@/frontend/aries-v1/customer-safe-copy';
+
+import { useRequestState } from './use-request-state';
+
+/**
+ * Outcome of a single native-reply attempt (#597). The reply endpoint is gated
+ * behind ARIES_NATIVE_REPLY_ENABLED and returns a real 404 when off — that case
+ * maps to `not_enabled` so the inbox can show a subtle "native reply not
+ * enabled" state instead of an error. `needs_attention` covers the 502
+ * needs_manual_reconciliation / auth-reconnect classes the operator must act on.
+ */
+export type CommentReplyOutcome =
+  | { kind: 'replied'; repliedAt: string | null }
+  | { kind: 'not_enabled' }
+  | { kind: 'error'; message: string };
+
+export function useInsightsComments(
+  options: { baseUrl?: string; autoLoad?: boolean; platform?: string } = {},
+) {
+  const baseUrl = options.baseUrl;
+  const autoLoad = options.autoLoad;
+  const platform = options.platform ?? 'facebook';
+
+  const api = useMemo(() => createAriesV1Api({ baseUrl }), [baseUrl]);
+  const state = useRequestState<InsightsCommentsResponse>();
+  const { setError, setLoading, setSuccess } = state;
+
+  const load = useCallback(async () => {
+    setLoading();
+    try {
+      const response = await api.getInsightsComments({ platform });
+      setSuccess(response);
+      return response;
+    } catch (error) {
+      setError(error, 'Failed to load comments.');
+      return null;
+    }
+  }, [api, platform, setError, setLoading, setSuccess]);
+
+  useEffect(() => {
+    if (autoLoad === false) return;
+    void load();
+  }, [load, autoLoad]);
+
+  const reply = useCallback(
+    async (commentId: number, replyText: string): Promise<CommentReplyOutcome> => {
+      try {
+        const result = await api.replyToInsightComment(commentId, replyText);
+        return {
+          kind: 'replied',
+          repliedAt: result.status === 'replied' ? result.replied_at : null,
+        };
+      } catch (error) {
+        // Flag off (or comment no longer exists) → the route is invisible (404).
+        // Treat as "native reply not enabled" rather than a hard error.
+        if (error instanceof ApiRequestError && error.status === 404) {
+          return { kind: 'not_enabled' };
+        }
+        const message =
+          error instanceof Error
+            ? customerSafeActionErrorMessage(error.message, 'Reply could not be sent right now.')
+            : 'Reply could not be sent right now.';
+        return { kind: 'error', message };
+      }
+    },
+    [api],
+  );
+
+  return { ...state, load, reply };
+}

--- a/lib/api/aries-v1.ts
+++ b/lib/api/aries-v1.ts
@@ -351,6 +351,92 @@ export type OnboardingDraftPatch = {
   materializedJobId?: string | null;
 };
 
+// ── Insights / analytics (#596, #597) ─────────────────────────────────────────
+// Shapes mirror backend/insights/read-api.ts exactly. Facebook-only in the UI
+// (Instagram is deferred); the screens pass platform=facebook.
+export type InsightsSummaryResponse = {
+  period: { days: number; from: string };
+  platform: string | null;
+  totalViews: number;
+  currentFollowers: number;
+  followersGained: number;
+  totalLikes: number;
+  totalComments: number;
+  totalShares: number;
+  totalWatchTimeMinutes: number;
+  totalEngagement: number;
+};
+
+export type InsightsAccountMetricPoint = {
+  date: string;
+  platform: string;
+  views: number;
+  watchTimeMinutes: number;
+  followers: number;
+  followersDelta: number;
+  likes: number;
+  commentsCount: number;
+  shares: number;
+};
+export type InsightsAccountMetricsResponse = {
+  period: { days: number; from: string };
+  platform: string | null;
+  series: InsightsAccountMetricPoint[];
+};
+
+export type InsightsPostMetrics = {
+  totalViews: number;
+  totalLikes: number;
+  totalComments: number;
+  totalShares: number;
+  avgViewPercentage: number | null;
+};
+export type InsightsPostItem = {
+  id: number;
+  platform: string;
+  externalPostId: string;
+  title: string | null;
+  mediaType: string;
+  publishedAt: string;
+  permalink: string | null;
+  durationSeconds: number | null;
+  thumbnailUrl: string | null;
+  metrics: InsightsPostMetrics;
+};
+export type InsightsPostsResponse = {
+  posts: InsightsPostItem[];
+  limit: number;
+  offset: number;
+  count: number;
+};
+
+export type InsightsCommentItem = {
+  id: number;
+  postId: number;
+  platform: string;
+  authorHandle: string | null;
+  bodyText: string;
+  receivedAt: string;
+  isReplied: boolean;
+  repliedAt: string | null;
+  postTitle: string | null;
+  postPermalink: string | null;
+};
+export type InsightsCommentsResponse = {
+  comments: InsightsCommentItem[];
+  limit: number;
+  count: number;
+};
+
+/**
+ * Success shape of POST /api/insights/comments/:id/reply. Non-2xx responses
+ * (flag-off 404, needs_manual_reconciliation 502, validation 4xx) surface as a
+ * thrown ApiRequestError carrying `.status`/`.code`, handled by the caller.
+ */
+export type InsightsCommentReplyResponse =
+  | { status: 'replied'; comment_id: number; platform_reply_id: string; replied_at: string }
+  | { status: 'already_replied'; comment_id: number };
+
 export type AriesAssetVersion = RuntimeReviewItem['currentVersion'];
 export type AriesRecommendation = {
   id: string;
@@ -429,6 +515,49 @@ export function createAriesV1Api(options: ApiClientOptions = {}) {
     },
     getReviews() {
       return requestJson<ReviewQueueResponse>('/api/marketing/reviews', { method: 'GET', timeoutMs: 30000 }, options);
+    },
+    getInsightsSummary(params: { platform?: string; days?: number } = {}) {
+      return requestJson<InsightsSummaryResponse>(
+        '/api/insights/summary',
+        { method: 'GET', query: { platform: params.platform, days: params.days }, timeoutMs: 30000 },
+        options,
+      );
+    },
+    getInsightsAccountMetrics(params: { platform?: string; days?: number } = {}) {
+      return requestJson<InsightsAccountMetricsResponse>(
+        '/api/insights/account-metrics',
+        { method: 'GET', query: { platform: params.platform, days: params.days }, timeoutMs: 30000 },
+        options,
+      );
+    },
+    getInsightsPosts(params: { platform?: string; limit?: number; offset?: number } = {}) {
+      return requestJson<InsightsPostsResponse>(
+        '/api/insights/posts',
+        {
+          method: 'GET',
+          query: { platform: params.platform, limit: params.limit, offset: params.offset },
+          timeoutMs: 30000,
+        },
+        options,
+      );
+    },
+    getInsightsComments(params: { platform?: string; postId?: number; limit?: number } = {}) {
+      return requestJson<InsightsCommentsResponse>(
+        '/api/insights/comments',
+        {
+          method: 'GET',
+          query: { platform: params.platform, postId: params.postId, limit: params.limit },
+          timeoutMs: 30000,
+        },
+        options,
+      );
+    },
+    replyToInsightComment(commentId: number, replyText: string) {
+      return requestJson<InsightsCommentReplyResponse>(
+        `/api/insights/comments/${encodeURIComponent(String(commentId))}/reply`,
+        { method: 'POST', body: JSON.stringify({ reply_text: replyText }) },
+        options,
+      );
     },
     getPosts() {
       return requestJson<PostsInventoryResponse>('/api/marketing/posts', { method: 'GET', timeoutMs: 30000 }, options);

--- a/tests/insights-dashboard-ui.test.ts
+++ b/tests/insights-dashboard-ui.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+import { APP_ROUTES, getRouteById } from '../frontend/app-shell/routes';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+function read(...segments: string[]): string {
+  return readFileSync(path.join(PROJECT_ROOT, ...segments), 'utf8');
+}
+
+const analyticsPage = read('app', 'dashboard', 'analytics', 'page.tsx');
+const commentsPage = read('app', 'dashboard', 'comments', 'page.tsx');
+const analyticsScreen = read('frontend', 'aries-v1', 'analytics-screen.tsx');
+const commentsScreen = read('frontend', 'aries-v1', 'comments-screen.tsx');
+const analyticsHook = read('hooks', 'use-insights-analytics.ts');
+const commentsHook = read('hooks', 'use-insights-comments.ts');
+const apiClient = read('lib', 'api', 'aries-v1.ts');
+const appShellClient = read('components', 'redesign', 'layout', 'app-shell-client.tsx');
+const readApi = read('backend', 'insights', 'read-api.ts');
+
+test('analytics + comments nav routes are registered as reachable utility entries', () => {
+  const analytics = getRouteById('analytics');
+  const comments = getRouteById('comments');
+
+  assert.equal(analytics.href, '/dashboard/analytics');
+  assert.equal(analytics.section, 'utility');
+  assert.equal(comments.href, '/dashboard/comments');
+  assert.equal(comments.section, 'utility');
+
+  // Both must actually be in the exported route table (not just resolvable).
+  assert.ok(APP_ROUTES.some((r) => r.id === 'analytics' && r.href === '/dashboard/analytics'));
+  assert.ok(APP_ROUTES.some((r) => r.id === 'comments' && r.href === '/dashboard/comments'));
+});
+
+test('app shell wires the new routes into icons and the utility nav list', () => {
+  // Icon map is a Record<AppRouteId, ...>; missing keys would not even compile,
+  // but assert the entries exist so the nav renders a glyph for each.
+  assert.match(appShellClient, /analytics:\s*TrendingUp/);
+  assert.match(appShellClient, /comments:\s*MessageCircle/);
+  // Sidebar utility list must include both so they are clickable from the shell.
+  assert.match(appShellClient, /routeId:\s*'analytics'/);
+  assert.match(appShellClient, /routeId:\s*'comments'/);
+});
+
+test('analytics page renders the analytics screen inside the app shell', () => {
+  assert.match(analyticsPage, /import AppShellLayout from '@\/frontend\/app-shell\/layout'/);
+  assert.match(analyticsPage, /import AriesAnalyticsScreen from '@\/frontend\/aries-v1\/analytics-screen'/);
+  assert.match(analyticsPage, /currentRouteId="analytics"/);
+  assert.match(analyticsPage, /<AriesAnalyticsScreen \/>/);
+});
+
+test('comments page renders the comments screen inside the app shell', () => {
+  assert.match(commentsPage, /import AppShellLayout from '@\/frontend\/app-shell\/layout'/);
+  assert.match(commentsPage, /import AriesCommentsScreen from '@\/frontend\/aries-v1\/comments-screen'/);
+  assert.match(commentsPage, /currentRouteId="comments"/);
+  assert.match(commentsPage, /<AriesCommentsScreen \/>/);
+});
+
+test('api client targets the real /api/insights/* endpoints (Facebook scoped by the screens)', () => {
+  assert.match(apiClient, /'\/api\/insights\/summary'/);
+  assert.match(apiClient, /'\/api\/insights\/account-metrics'/);
+  assert.match(apiClient, /'\/api\/insights\/posts'/);
+  assert.match(apiClient, /'\/api\/insights\/comments'/);
+  assert.match(apiClient, /\/api\/insights\/comments\/\$\{encodeURIComponent\(String\(commentId\)\)\}\/reply/);
+});
+
+test('analytics screen consumes the analytics hook, charts the series, and keeps the empty state', () => {
+  assert.match(analyticsScreen, /useInsightsAnalytics/);
+  assert.match(analyticsScreen, /platform:\s*'facebook'/);
+  // Headline tiles for the real summary fields.
+  assert.match(analyticsScreen, /summary\.totalViews/);
+  assert.match(analyticsScreen, /summary\.currentFollowers/);
+  assert.match(analyticsScreen, /summary\.totalEngagement/);
+  assert.match(analyticsScreen, /summary\.totalLikes/);
+  assert.match(analyticsScreen, /summary\.totalComments/);
+  assert.match(analyticsScreen, /summary\.totalShares/);
+  // Trend chart over the account-metrics series + per-post table.
+  assert.match(analyticsScreen, /LineChart/);
+  assert.match(analyticsScreen, /post\.metrics\.totalViews/);
+  // Empty state preserved for the zero/empty payload.
+  assert.match(analyticsScreen, /EmptyStatePanel/);
+  assert.match(analyticsScreen, /No analytics yet/);
+});
+
+test('analytics hook reads summary, account-metrics, and posts and defaults to Facebook', () => {
+  assert.match(analyticsHook, /getInsightsSummary/);
+  assert.match(analyticsHook, /getInsightsAccountMetrics/);
+  assert.match(analyticsHook, /getInsightsPosts/);
+  assert.match(analyticsHook, /options\.platform\s*\?\?\s*'facebook'/);
+});
+
+test('comments screen groups by post, shows replied state, and surfaces a reply box', () => {
+  assert.match(commentsScreen, /useInsightsComments/);
+  assert.match(commentsScreen, /platform:\s*'facebook'/);
+  assert.match(commentsScreen, /groupByPost/);
+  assert.match(commentsScreen, /comment\.authorHandle/);
+  assert.match(commentsScreen, /comment\.bodyText/);
+  assert.match(commentsScreen, /comment\.receivedAt/);
+  assert.match(commentsScreen, /Replied/);
+  assert.match(commentsScreen, /<textarea/);
+  assert.match(commentsScreen, /handleReply/);
+  // Empty state preserved.
+  assert.match(commentsScreen, /No comments yet/);
+});
+
+test('reply path is treated as flag-gated: a 404 maps to a subtle not-enabled state, not an error', () => {
+  // Hook maps the flag-off 404 to a not_enabled outcome.
+  assert.match(commentsHook, /replyToInsightComment/);
+  assert.match(commentsHook, /error\.status === 404/);
+  assert.match(commentsHook, /not_enabled/);
+  // Screen renders the subtle not-enabled copy instead of erroring.
+  assert.match(commentsScreen, /not_enabled/);
+  assert.match(commentsScreen, /enabled for your account yet/);
+});
+
+test('comments read-api exposes replied state so the inbox can render it', () => {
+  assert.match(readApi, /c\.is_replied/);
+  assert.match(readApi, /c\.replied_at/);
+  assert.match(readApi, /isReplied:/);
+  assert.match(readApi, /repliedAt:/);
+});


### PR DESCRIPTION
Renders the Facebook analytics (#596) and comments (#597) the backend now syncs via Composio. New dashboard surfaces consuming the existing `/api/insights/*` endpoints.

## What
- **`/dashboard/analytics`** (nav: utility) — 6 headline tiles (views, followers, engagement, likes/comments/shares from the real `summary` fields), a recharts followers+views trend over `account-metrics.series`, and a per-post metrics table. Hook fetches summary + account-metrics + posts (browser-side, `platform=facebook`).
- **`/dashboard/comments`** (nav: utility) — inbox grouped by post (author/text/received/replied chip) with a per-comment reply box POSTing to `/api/insights/comments/[id]/reply`.
- Graceful **empty-state** on zero/empty payloads (steady state until sync runs) + error/retry. **Reply-flag-off**: the endpoint's 404 maps to a subtle "native reply not enabled" note, not an error.
- Additive read-api change: `is_replied`/`replied_at` added to the comments SELECT (columns already exist via migration `20260616000000`; tenant-scoping unchanged; `platform_reply_id` deliberately NOT exposed).

## Tests
`tests/insights-dashboard-ui.test.ts` (10/10): pages render the right screens in the app shell, nav entries exist, screens reference the correct `/api/insights/*` endpoints, reply gated.

`npm run verify` ✅ · typecheck ✅ · adversarially reviewed (SHIP-WITH-NITS; no high/med — tenant-safe, reply flow leak-free, real field names, no fan-out). LOW nits (stale JSDoc, 404 copy nuance, all-or-nothing analytics fetch, single-flight reply) tracked as follow-ups.

Part of #596, #597 (closed after live data is verified rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)