### PR TITLE
fix(dashboard): null evicted Hermes previews at the served-projection convergence (#599 re-fix)

### DIFF
--- a/backend/marketing/hermes-media-presence.ts
+++ b/backend/marketing/hermes-media-presence.ts
@@ -151,6 +151,44 @@ export function availableHermesMediaUrl(
   return isMissingHermesMedia(url, now) ? null : url;
 }
 
+/**
+ * READ-TIME sanitizer for dashboard asset previews (qa-defect #599 re-fix).
+ *
+ * The build-time `availableHermesMediaUrl` wrap in `createAssets` only fires
+ * when the social-content dashboard projection is (re)built. But the Posts page
+ * (`/api/marketing/posts` → `getWorkflowAwareDashboardContentForTenant`) serves
+ * the *persisted* `dashboard_list_projection.listRow.dashboard.assets` O(1)
+ * whenever its baked `sourceUpdatedAt` still matches the runtime doc — which is
+ * the steady state for old jobs whose runtime docs never change again. Those
+ * blobs were baked weeks ago, when the Hermes-cache files still existed, so the
+ * basename-addressed `artifact_url` previews they carry now 404 in the browser
+ * after the cache evicted the files. The build-time wrap can never reach them.
+ *
+ * This nulls `previewUrl`/`thumbnailUrl` on each asset whose basename is
+ * confirmed missing from the readable mount, at the moment the assets are
+ * served — so the UI placeholder fallback fires instead of a dead `<img>`.
+ * Fail-open and pure pass-through for live media (one cached `readdir` amortised
+ * across the whole render, O(1) per URL — CLAUDE.md guardrail #1): an asset
+ * whose preview is present, non-hermes, id/UUID-addressed, or unverifiable is
+ * returned byte-identical.
+ */
+export function sanitizeAssetPreviewsForMissingMedia<
+  T extends { previewUrl?: string | null; thumbnailUrl?: string | null },
+>(assets: readonly T[], now: number = Date.now()): T[] {
+  return assets.map((asset) => {
+    const previewMissing = isMissingHermesMedia(asset.previewUrl, now);
+    const thumbnailMissing = isMissingHermesMedia(asset.thumbnailUrl, now);
+    if (!previewMissing && !thumbnailMissing) {
+      return asset;
+    }
+    return {
+      ...asset,
+      previewUrl: previewMissing ? null : asset.previewUrl,
+      thumbnailUrl: thumbnailMissing ? null : asset.thumbnailUrl,
+    };
+  });
+}
+
 /** Test-only: clear the mount listing cache so a test can swap the mount dir. */
 export function __resetHermesMediaPresenceCacheForTests(): void {
   cachedListing = null;

--- a/backend/marketing/workspace-views.ts
+++ b/backend/marketing/workspace-views.ts
@@ -26,6 +26,7 @@ import { createSocialContentJobFacts, type MarketingJobFacts } from './job-facts
 import { recordMatchesCurrentSource, sourceFingerprintFromRecord } from './brand-identity';
 import { sanitizeBrandKitSummaryText } from './brand-kit';
 import { buildSocialContentDashboardProjection } from '@/backend/social-content/dashboard-projection';
+import { sanitizeAssetPreviewsForMissingMedia } from './hermes-media-presence';
 import { getMarketingDashboardSocialContentJobContent } from './dashboard-content';
 import { countPublishedPostsForJob } from './published-posts-count';
 import { loadSocialContentJobRuntime, listSocialContentJobIdsForTenant, resolveStageOutput, type SocialContentJobRuntimeDocument } from './runtime-state';
@@ -1757,5 +1758,16 @@ export async function getWorkflowAwareDashboardContentForTenant(tenantId: string
     items.push(item);
   }
 
-  return mergeDashboardContent(items);
+  const merged = mergeDashboardContent(items);
+  // qa-defect #599 re-fix: this endpoint serves the PERSISTED
+  // dashboard_list_projection assets O(1) (fast path above) — blobs baked weeks
+  // ago when the Hermes-cache files still existed. The build-time wrap in
+  // `createAssets` can never reach those stale rows, so basename-addressed
+  // previews whose files the cache has since evicted are emitted here as dead
+  // `<img>` URLs that 404. Null them at read time so the UI placeholder fires;
+  // live/non-hermes/id-addressed previews pass through byte-identical.
+  return {
+    ...merged,
+    assets: sanitizeAssetPreviewsForMissingMedia(merged.assets),
+  };
 }

--- a/tests/marketing/hermes-media-presence.test.ts
+++ b/tests/marketing/hermes-media-presence.test.ts
@@ -9,6 +9,7 @@ import {
   availableHermesMediaUrl,
   hermesMediaBasenameFromUrl,
   isMissingHermesMedia,
+  sanitizeAssetPreviewsForMissingMedia,
 } from '../../backend/marketing/hermes-media-presence';
 
 const APP = 'https://aries.sugarandleather.com';
@@ -140,6 +141,62 @@ test('the mount listing cache honours its TTL on the same root (stale within win
     else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
     __resetHermesMediaPresenceCacheForTests();
     await rm(mount, { recursive: true, force: true });
+  }
+});
+
+test('sanitizeAssetPreviewsForMissingMedia nulls dead previews, preserves live + non-hermes, byte-identical when nothing missing', async () => {
+  await withMount(async () => {
+    const idUrl = `${HERMES}/123e4567-e89b-42d3-a456-426614174000`;
+    const jobAsset = `${APP}/api/marketing/jobs/j/assets/a`;
+    const dataUri = 'data:image/svg+xml;base64,AAAA';
+    const assets = [
+      { id: 'dead', previewUrl: `${HERMES}/${MISSING}`, thumbnailUrl: `${HERMES}/${MISSING}` },
+      { id: 'live', previewUrl: `${HERMES}/${PRESENT}`, thumbnailUrl: `${HERMES}/${PRESENT}` },
+      { id: 'id-addressed', previewUrl: idUrl, thumbnailUrl: idUrl },
+      { id: 'job-asset', previewUrl: jobAsset, thumbnailUrl: jobAsset },
+      { id: 'placeholder', previewUrl: dataUri, thumbnailUrl: dataUri },
+    ];
+
+    const out = sanitizeAssetPreviewsForMissingMedia(assets);
+
+    // Dead hermes-media basename → both fields nulled so the UI placeholder fires.
+    assert.deepEqual(
+      out.find((a) => a.id === 'dead'),
+      { id: 'dead', previewUrl: null, thumbnailUrl: null },
+    );
+    // Live + non-hermes + id-addressed + placeholder are returned byte-identical
+    // (same object reference, since nothing was missing).
+    for (const id of ['live', 'id-addressed', 'job-asset', 'placeholder']) {
+      const before = assets.find((a) => a.id === id);
+      const after = out.find((a) => a.id === id);
+      assert.equal(after, before, `${id} must be the unchanged object reference`);
+    }
+  });
+});
+
+test('sanitizeAssetPreviewsForMissingMedia nulls only the missing side when preview/thumbnail differ', async () => {
+  await withMount(async () => {
+    const [out] = sanitizeAssetPreviewsForMissingMedia([
+      { id: 'mixed', previewUrl: `${HERMES}/${PRESENT}`, thumbnailUrl: `${HERMES}/${MISSING}` },
+    ]);
+    assert.equal(out.previewUrl, `${HERMES}/${PRESENT}`);
+    assert.equal(out.thumbnailUrl, null);
+  });
+});
+
+test('sanitizeAssetPreviewsForMissingMedia fails open (assets untouched) when the mount is unconfigured', () => {
+  const prev = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    const assets = [{ id: 'dead', previewUrl: `${HERMES}/${MISSING}`, thumbnailUrl: `${HERMES}/${MISSING}` }];
+    const out = sanitizeAssetPreviewsForMissingMedia(assets);
+    assert.equal(out[0], assets[0]);
+    assert.equal(out[0].previewUrl, `${HERMES}/${MISSING}`);
+  } finally {
+    if (prev === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prev;
+    __resetHermesMediaPresenceCacheForTests();
   }
 });
 

--- a/tests/marketing/posts-preview-stale-projection.test.ts
+++ b/tests/marketing/posts-preview-stale-projection.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { getWorkflowAwareDashboardContentForTenant } from '../../backend/marketing/workspace-views';
+import { __resetHermesMediaPresenceCacheForTests } from '../../backend/marketing/hermes-media-presence';
+
+// qa-defect #599 (REOPENED): the Posts page (`/api/marketing/posts` →
+// getWorkflowAwareDashboardContentForTenant) serves the PERSISTED
+// `dashboard_list_projection.listRow.dashboard.assets` O(1) whenever its baked
+// `sourceUpdatedAt` still matches the runtime doc — the steady state for old
+// jobs. Those blobs were baked weeks ago, when the Hermes-cache files still
+// existed, so the basename-addressed `/api/internal/hermes/media/<basename>`
+// previews they carry now 404 after the cache evicted the files. The build-time
+// `createAssets` wrap (PR #612) can NEVER reach those stale rows. This proves
+// the read-time sanitizer nulls evicted previews at the serving point while
+// leaving live previews byte-identical.
+
+const TENANT = 'tenant_599_readpath';
+const JOB = 'mkt_599_readpath';
+const UPDATED_AT = '2026-05-19T00:00:00.000Z';
+const LIVE = 'openai_codex_gpt-image-2-low_20260520_live.png';
+const EVICTED = 'openai_codex_gpt-image-2-medium_20260519_evicted.png';
+const mediaUrl = (basename: string) =>
+  `https://aries.sugarandleather.com/api/internal/hermes/media/${basename}`;
+
+function emptyCounts() {
+  return {
+    draft: 0,
+    in_review: 0,
+    ready: 0,
+    ready_to_publish: 0,
+    published_to_meta_paused: 0,
+    scheduled: 0,
+    live: 0,
+  };
+}
+
+function runtimeDoc() {
+  return {
+    schema_name: 'marketing_job_state_schema',
+    job_id: JOB,
+    tenant_id: TENANT,
+    created_at: UPDATED_AT,
+    updated_at: UPDATED_AT,
+    current_stage: 'publish',
+    stage_order: ['research', 'strategy', 'production', 'publish'],
+    inputs: { request: { jobType: 'weekly_social_content' } },
+    stages: { research: { status: 'completed' } },
+  };
+}
+
+function asset(id: string, basename: string) {
+  return {
+    id,
+    postId: JOB,
+    jobId: JOB,
+    type: 'image_ad',
+    title: id,
+    summary: id,
+    platform: 'social',
+    platformLabel: 'Social content',
+    postName: 'Weekly social content',
+    funnelStage: 'weekly_content',
+    objective: 'Weekly social content',
+    destinationUrl: null,
+    previewUrl: mediaUrl(basename),
+    thumbnailUrl: mediaUrl(basename),
+    contentType: 'image/png',
+    status: 'ready',
+    createdAt: UPDATED_AT,
+    relatedPostIds: [],
+    relatedPublishItemIds: [],
+    provenance: {
+      sourceKind: 'creative_output',
+      sourceStage: 'production',
+      sourceRunId: null,
+      isDerivedSchedule: true,
+      isPlatformNative: false,
+    },
+  };
+}
+
+// A FRESH persisted projection (sourceUpdatedAt === runtimeDoc.updated_at) so the
+// fast path serves it verbatim — exactly the production steady state.
+function workspaceRecord() {
+  const dashboard = {
+    posts: [],
+    assets: [asset('live-asset', LIVE), asset('evicted-asset', EVICTED)],
+    publishItems: [],
+    calendarEvents: [],
+    statuses: { countsByStatus: emptyCounts() },
+  };
+  return {
+    schema_name: 'marketing_campaign_workspace',
+    job_id: JOB,
+    tenant_id: TENANT,
+    dashboard_list_projection: {
+      post: null,
+      sourceUpdatedAt: UPDATED_AT,
+      listRow: { dashboard },
+    },
+  };
+}
+
+async function withSeededDataRoot<T>(run: () => Promise<T>): Promise<T> {
+  const prevMount = process.env.HERMES_IMAGE_CACHE_MOUNT;
+  const prevDataRoot = process.env.DATA_ROOT;
+  const mount = await mkdtemp(path.join(tmpdir(), 'aries-599-mount-'));
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-599-data-'));
+  // Mount holds ONLY the live file; the evicted basename is absent.
+  await writeFile(path.join(mount, LIVE), 'png-bytes');
+
+  const jobsDir = path.join(dataRoot, 'generated', 'draft', 'marketing-jobs');
+  const wsDir = path.join(dataRoot, 'generated', 'draft', 'marketing-workspaces', JOB);
+  await mkdir(jobsDir, { recursive: true });
+  await mkdir(wsDir, { recursive: true });
+  await writeFile(path.join(jobsDir, `${JOB}.json`), JSON.stringify(runtimeDoc()));
+  await writeFile(path.join(wsDir, 'workspace.json'), JSON.stringify(workspaceRecord()));
+
+  process.env.HERMES_IMAGE_CACHE_MOUNT = mount;
+  process.env.DATA_ROOT = dataRoot;
+  __resetHermesMediaPresenceCacheForTests();
+  try {
+    return await run();
+  } finally {
+    if (prevMount === undefined) delete process.env.HERMES_IMAGE_CACHE_MOUNT;
+    else process.env.HERMES_IMAGE_CACHE_MOUNT = prevMount;
+    if (prevDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = prevDataRoot;
+    __resetHermesMediaPresenceCacheForTests();
+    await rm(mount, { recursive: true, force: true });
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+test('#599: Posts page nulls evicted Hermes-media previews served from a fresh persisted projection', async () => {
+  await withSeededDataRoot(async () => {
+    const content = await getWorkflowAwareDashboardContentForTenant(TENANT);
+
+    const evicted = content.assets.find((a) => a.id === 'evicted-asset');
+    const live = content.assets.find((a) => a.id === 'live-asset');
+    assert.ok(evicted, 'expected the evicted asset to be present in the response');
+    assert.ok(live, 'expected the live asset to be present in the response');
+
+    // The evicted-media preview must be nulled so the UI placeholder fires
+    // instead of a dead <img> → 404.
+    assert.equal(evicted.previewUrl, null);
+    assert.equal(evicted.thumbnailUrl, null);
+
+    // The live media URL is untouched (byte-identical pass-through).
+    assert.equal(live.previewUrl, mediaUrl(LIVE));
+    assert.equal(live.thumbnailUrl, mediaUrl(LIVE));
+
+    // No asset in the served response carries a dead hermes-media basename URL.
+    const stillDead = content.assets.filter(
+      (a) =>
+        a.previewUrl?.includes(`/hermes/media/${EVICTED}`) ||
+        a.thumbnailUrl?.includes(`/hermes/media/${EVICTED}`),
+    );
+    assert.equal(stillDead.length, 0, 'no served asset may reference the evicted media basename');
+  });
+});


### PR DESCRIPTION
Re-fix for **#599** (reopened by the QA loop 2026-06-17 — still 404ing after PR #612).

## Why #612 missed it
PR #612 wrapped `createAssets` in `backend/social-content/dashboard-projection.ts`, which only runs on a (re)build. But `/dashboard/posts` → `getWorkflowAwareDashboardContentForTenant` serves the **persisted `dashboard_list_projection` blob O(1)** whenever its baked `sourceUpdatedAt` still matches the runtime doc — the steady state for old jobs whose docs never change. Those blobs were baked weeks ago (files present then), so they serve dead basename URLs verbatim; the build-time wrap can never reach them. **Live ground-truth (tenant 15): 110 dead `/api/internal/hermes/media/<basename>` previews served from FRESH cached projections, 0 from stale** — proving the bypass.

## Fix (read-time, at the real convergence point)
- `backend/marketing/hermes-media-presence.ts` — `sanitizeAssetPreviewsForMissingMedia(assets)`: nulls `previewUrl`/`thumbnailUrl` for assets whose basename is confirmed missing from the mount; pure pass-through (same ref) for live / non-hermes / id-addressed / placeholder / unverifiable. Reuses the existing cached `readdir` (O(1) per URL, guardrail #1) + fail-open.
- `backend/marketing/workspace-views.ts:1771` — applied to `merged.assets` at the convergence point of `getWorkflowAwareDashboardContentForTenant`, **downstream of the fast-path (cached) / healed / rebuilt branches** — so the cached fast-path #612 missed is covered. Posts/publishItems derive their preview from the linked asset, so nulling the asset covers them.

## Live before/after (same prod data)
dead served previews **110 → 0**, live preserved **122 → 122**. `PASS`.

## Tests
`tests/marketing/hermes-media-presence.test.ts` (+ sanitizer unit cases: nulls dead, preserves live/non-hermes/id/placeholder, fail-open) and `tests/marketing/posts-preview-stale-projection.test.ts` (disk-backed integration of the REAL emitter: seeds a fresh persisted projection with one evicted + one live asset, asserts evicted nulled / live unchanged).

`npm run verify` ✅ · typecheck ✅ · guardrails ✅. Live-verified this time (the gap that let #612 ship ineffective).

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)