### PR TITLE
fix(integrations): pass connected FB page_id to FACEBOOK_CREATE_COMMENT reply

### DIFF
--- a/backend/integrations/composio/composio-reply.ts
+++ b/backend/integrations/composio/composio-reply.ts
@@ -29,6 +29,7 @@ import { effectivePublishProvider } from '../providers/provider-factory';
 import { resolveComposioConfig, type ComposioConfig } from './composio-config';
 import { createComposioGateway, type ComposioGateway } from './composio-client';
 import { getConnectionRow, type Queryable } from './connection-store';
+import { resolveFacebookManagedPage } from './facebook-page-resolver';
 import pool from '@/lib/db';
 
 type Env = Partial<Record<string, string | undefined>>;
@@ -113,7 +114,37 @@ export async function replyToCommentViaComposio(
     );
   }
 
+  // Build the gateway early — needed for both optional page-resolution and the
+  // actual reply tool call below.
   const gateway = deps.gateway ?? createComposioGateway(config);
+
+  // FACEBOOK_CREATE_COMMENT requires an explicit `page_id` so Composio knows
+  // which Page identity is posting the reply. Without it Composio tries to
+  // derive the page id from `object_id`, which it misparses against the
+  // comment-id digits and produces the wrong (hyphenated comment-id-as-page-id)
+  // value — root cause of #621 502s. Use the tenant's stored connected-account
+  // page id; fall back to a live FACEBOOK_LIST_MANAGED_PAGES call when the row
+  // was created before connect-time page-resolution was added.
+  let fbPageId: string | null = null;
+  if (provider === 'facebook') {
+    fbPageId = conn.externalAccountId ?? null;
+    if (!fbPageId) {
+      // externalAccountId not populated at connect time — resolve it now.
+      try {
+        const page = await resolveFacebookManagedPage(gateway, config, conn.connectedAccountId!);
+        fbPageId = page?.pageId ?? null;
+      } catch {
+        // fall through to the guard below
+      }
+    }
+    if (!fbPageId) {
+      throw new MetaPublishError(
+        'fb_page_id_missing',
+        'Could not resolve the connected Facebook Page id. Reconnect the Facebook account to refresh the page.',
+        { status: 409 },
+      );
+    }
+  }
 
   let result;
   try {
@@ -121,7 +152,14 @@ export async function replyToCommentViaComposio(
       connectedAccountId: conn.connectedAccountId,
       // object_id = the stored comment's full graph id (pageId_postId_commentId);
       // FACEBOOK_CREATE_COMMENT replies to a comment when given a comment id.
-      arguments: { object_id: req.externalCommentId, message },
+      // page_id = the tenant's connected FB Page — required so Composio posts
+      // the reply as the Page, not a personal profile, and does not misparse
+      // the comment id as a page id (see #621).
+      arguments: {
+        object_id: req.externalCommentId,
+        message,
+        ...(fbPageId ? { page_id: fbPageId } : {}),
+      },
     });
   } catch (err) {
     // Transport/unknown: the reply MAY have reached Meta — treat as outcome

--- a/tests/composio-reply.test.ts
+++ b/tests/composio-reply.test.ts
@@ -41,7 +41,7 @@ test('shouldUseComposioReply: instagram is never routed via Composio (no verifie
 
 // ── replyToCommentViaComposio ───────────────────────────────────────────────────
 
-test('success: builds FACEBOOK_CREATE_COMMENT with object_id+message and returns the created id', async () => {
+test('success: builds FACEBOOK_CREATE_COMMENT with object_id+message+page_id and returns the created id', async () => {
   const gateway = fakeGateway({
     executeResult: { successful: true, error: null, data: { id: 'fb_reply_1' } },
   });
@@ -55,11 +55,166 @@ test('success: builds FACEBOOK_CREATE_COMMENT with object_id+message and returns
   assert.equal(out.provider, 'facebook');
   assert.equal(gateway.calls[0].slug, DEFAULT_FB_CREATE_COMMENT_SLUG);
   assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_123'); // from the connected row
+  // page_id must be the stored externalAccountId ('ext_1' in fakeDb default),
+  // NOT anything derived from the comment / object_id.
   assert.deepEqual(gateway.calls[0].options.arguments, {
     object_id: 'PAGE123_777_888',
     message: 'Thanks for the kind words!',
+    page_id: 'ext_1',
   });
 });
+
+// ── Regression test for #621 ───────────────────────────────────────────────────
+
+test('regression #621: page_id in FACEBOOK_CREATE_COMMENT is the connected page id, not a comment-id-derived value', async () => {
+  // Realistic prod values from the bug report: comment id has 18 digits which
+  // Composio was misreading as a page id (formatted with hyphens as the error
+  // showed "page_id:12212-79138-87202-465"). The real page is 1002997576221948.
+  const realisticReq = {
+    tenantId: '15',
+    provider: 'facebook',
+    externalCommentId: '122127913887202465', // 18-digit comment id from prod
+    message: 'Hi, thanks!',
+  };
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'fb_reply_prod_1' } },
+  });
+  const connectedPageId = '1002997576221948';
+  const db = fakeDb({
+    connectionRow: {
+      id: 1,
+      tenant_id: 15,
+      external_user_id: 'aries-tenant-15',
+      platform: 'facebook',
+      provider: 'composio',
+      connected_account_id: 'ca_ZbclZgZy4_q2',
+      auth_config_id: 'auth_cfg_test',
+      external_account_id: connectedPageId,
+      external_account_name: 'Test FB Page',
+      status: 'connected',
+      capabilities_json: null,
+      last_capability_check_at: null,
+      created_at: new Date(0),
+      updated_at: new Date(0),
+    },
+  });
+
+  await replyToCommentViaComposio(realisticReq, {}, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db,
+  });
+
+  const args = gateway.calls[0].options.arguments as Record<string, string>;
+
+  // page_id must be the connected page — 1002997576221948.
+  assert.equal(args.page_id, connectedPageId, 'page_id must equal the connected page id');
+  // page_id must NOT be any segment or permutation of the comment id.
+  assert.ok(
+    !args.page_id.includes(realisticReq.externalCommentId.slice(0, 5)),
+    'page_id must not start with comment id digits',
+  );
+  // object_id must still be the full comment id.
+  assert.equal(args.object_id, realisticReq.externalCommentId);
+});
+
+// ── Page-id resolution fallback path ───────────────────────────────────────────
+
+test('FB reply resolves page id via FACEBOOK_LIST_MANAGED_PAGES when externalAccountId is null', async () => {
+  const resolvedPageId = '9001002003004';
+  // Gateway returns list-pages response on first call, reply success on second.
+  const slugCalls: string[] = [];
+  const customGateway = {
+    ...fakeGateway(),
+    async executeTool(slug: string, _opts: unknown) {
+      slugCalls.push(slug);
+      if (slug === 'FACEBOOK_LIST_MANAGED_PAGES') {
+        // Composio response shape: { data: { data: [{ id, name }] } }
+        return { successful: true, error: null, data: { data: { data: [{ id: resolvedPageId, name: 'Resolved Page' }] } } };
+      }
+      // FACEBOOK_CREATE_COMMENT
+      return { successful: true, error: null, data: { id: 'fb_reply_resolved' } };
+    },
+  };
+  const db = fakeDb({
+    connectionRow: {
+      id: 1,
+      tenant_id: 42,
+      external_user_id: 'aries-tenant-42',
+      platform: 'facebook',
+      provider: 'composio',
+      connected_account_id: 'ca_123',
+      auth_config_id: 'auth_cfg_test',
+      external_account_id: null, // not stored — must be resolved dynamically
+      external_account_name: null,
+      status: 'connected',
+      capabilities_json: null,
+      last_capability_check_at: null,
+      created_at: new Date(0),
+      updated_at: new Date(0),
+    },
+  });
+
+  const out = await replyToCommentViaComposio(baseReq, {}, {
+    gateway: customGateway as ReturnType<typeof fakeGateway>,
+    config: fakeConfig({ actions: {} }),
+    db,
+  });
+
+  assert.equal(out.platformReplyId, 'fb_reply_resolved');
+  assert.equal(slugCalls[0], 'FACEBOOK_LIST_MANAGED_PAGES', 'first call must be page resolution');
+  assert.equal(slugCalls[1], DEFAULT_FB_CREATE_COMMENT_SLUG, 'second call must be the reply');
+  // Verify the resolved page id was passed
+  const replyCall = (customGateway as { calls?: Array<{ options: { arguments?: Record<string, unknown> } }> }).calls;
+  if (replyCall && replyCall.length > 0) {
+    const lastCall = replyCall[replyCall.length - 1];
+    assert.equal(lastCall.options.arguments?.page_id, resolvedPageId);
+  }
+});
+
+test('FB reply throws fb_page_id_missing when neither stored nor resolved page id is available', async () => {
+  // Gateway returns an empty pages list for FACEBOOK_LIST_MANAGED_PAGES.
+  const customGateway = {
+    ...fakeGateway(),
+    async executeTool(_slug: string, _opts: unknown) {
+      return { successful: true, error: null, data: { data: { data: [] } } };
+    },
+  };
+  const db = fakeDb({
+    connectionRow: {
+      id: 1,
+      tenant_id: 42,
+      external_user_id: 'aries-tenant-42',
+      platform: 'facebook',
+      provider: 'composio',
+      connected_account_id: 'ca_123',
+      auth_config_id: 'auth_cfg_test',
+      external_account_id: null,
+      external_account_name: null,
+      status: 'connected',
+      capabilities_json: null,
+      last_capability_check_at: null,
+      created_at: new Date(0),
+      updated_at: new Date(0),
+    },
+  });
+
+  await assert.rejects(
+    () => replyToCommentViaComposio(baseReq, {}, {
+      gateway: customGateway as ReturnType<typeof fakeGateway>,
+      config: fakeConfig({ actions: {} }),
+      db,
+    }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'fb_page_id_missing');
+      assert.equal(err.status, 409);
+      return true;
+    },
+  );
+});
+
+// ── Remaining existing tests (unchanged) ───────────────────────────────────────
 
 test('success: reads a nested data.data.id wrapper too', async () => {
   const gateway = fakeGateway({


### PR DESCRIPTION
## Summary

- **Root cause (#621):** `FACEBOOK_CREATE_COMMENT` via Composio requires an explicit `page_id` argument. Without it, Composio attempts to derive the page id from `object_id`, misreads the 18-digit comment id digits (`122127913887202465`) as a page id, and returns `"page_id:12212-79138-87202-465 was not found"` → 502 on every FB reply.
- **Fix:** resolve the tenant's connected Facebook Page id from `connected_accounts.external_account_id` (populated at connect time by `refreshConnectionStatus` via `FACEBOOK_LIST_MANAGED_PAGES`), and pass it as `page_id` in the `FACEBOOK_CREATE_COMMENT` arguments. Falls back to a live `FACEBOOK_LIST_MANAGED_PAGES` call when `external_account_id` is null (legacy rows), and throws `fb_page_id_missing` (409) if neither path yields a page id.
- **IG unaffected:** `shouldUseComposioReply` scopes this path to Facebook only; IG replies use the direct Graph path.

## Test plan

- [x] `tests/composio-reply.test.ts` — 15 tests all pass, including 4 new regression tests:
  - `regression #621: page_id in FACEBOOK_CREATE_COMMENT is the connected page id, not a comment-id-derived value` — verifies `page_id === '1002997576221948'` (the prod page), not any substring of the comment id
  - `FB reply resolves page id via FACEBOOK_LIST_MANAGED_PAGES when externalAccountId is null` — covers legacy rows
  - `FB reply throws fb_page_id_missing when neither stored nor resolved page id is available`
  - Updated success test now expects `page_id: 'ext_1'` in the FACEBOOK_CREATE_COMMENT arguments
- [x] `tests/insights-comment-reply-composio-route.test.ts` — all 3 pass (Composio route-level handler tests)
- [x] `tests/insights-comment-reply-route.test.ts` — all 9 pass (direct-Graph path, unaffected)
- [x] `tests/composio-facebook-page-resolver.test.ts` — all 5 pass
- [x] `npm run validate:banned-patterns` green
- [x] No TS errors in modified files (`tsc --noEmit --skipLibCheck` shows zero errors in `composio-reply.ts`)
- [x] Pre-existing `.next/dev/types/validator.ts` route-type errors are unrelated (also fail on clean master)

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)