### PR TITLE
fix(integrations): send message+page_id for FB Composio publish; log generic catch

### DIFF
--- a/app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts
@@ -368,6 +368,16 @@ export async function handleFacebookPublish(req: Request, jobId: string) {
         { status: error.status, headers: { 'content-type': 'application/json' } },
       );
     }
+    // Log before the generic 500: non-MetaPublishError exceptions from the Composio
+    // publisher path (e.g. ComposioToolError, ComposioCapabilityMissingError) are not
+    // MetaPublishError instances and would otherwise be swallowed here with no trace.
+    console.error('[publish-facebook] unexpected publish error (non-MetaPublishError)', {
+      jobId,
+      tenantId,
+      errorName: (error as Error)?.constructor?.name,
+      message: String((error as Error)?.message ?? error),
+      stack: (error as Error)?.stack,
+    });
     return new Response(
       JSON.stringify({ status: 'error', reason: 'publish_failed', message: 'An unexpected error occurred' }),
       { status: 500, headers: { 'content-type': 'application/json' } },

--- a/app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts
@@ -383,6 +383,16 @@ export async function handleInstagramPublish(req: Request, jobId: string) {
         { status: error.status, headers: { 'content-type': 'application/json' } },
       );
     }
+    // Log before the generic 500: non-MetaPublishError exceptions (e.g. Composio
+    // provider errors) are not MetaPublishError instances and would otherwise be
+    // swallowed here with no trace.
+    console.error('[publish-instagram] unexpected publish error (non-MetaPublishError)', {
+      jobId,
+      tenantId,
+      errorName: (error as Error)?.constructor?.name,
+      message: String((error as Error)?.message ?? error),
+      stack: (error as Error)?.stack,
+    });
     return new Response(
       JSON.stringify({
         status: 'error',

--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -30,6 +30,7 @@ import {
   ComposioConnectionMissingError,
   ComposioToolError,
 } from './errors';
+import { resolveFacebookManagedPage } from './facebook-page-resolver';
 import pool from '@/lib/db';
 
 function pickId(data: unknown, keys: string[]): string | null {
@@ -106,11 +107,44 @@ export class ComposioPublisherProvider implements PublisherProvider {
     const conn = await this.requireActiveConnection({ tenantId: input.tenantId, platform: input.platform });
     const slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
 
+    // Build platform-correct content arguments.
+    //
+    // Facebook (FACEBOOK_CREATE_POST) requires:
+    //   - `message` for the post text (NOT `text`/`caption` — those are ignored)
+    //   - `page_id` for the target Page (NOT optional; the action 400s without it)
+    //
+    // Instagram uses `caption` (unchanged from before).
+    //
+    // The page_id is stored at connect-time in connected_accounts.external_account_id.
+    // If that column is null (OAuth callback / account-info race), we fall back to a
+    // live FACEBOOK_LIST_MANAGED_PAGES call via resolveFacebookManagedPage and throw
+    // a clear capability error when still unable to identify the Page.
+    let platformArgs: Record<string, unknown>;
+    if (input.platform === 'facebook') {
+      let pageId = conn.externalAccountId ?? null;
+      if (!pageId) {
+        const page = await resolveFacebookManagedPage(
+          this.gateway,
+          this.config,
+          conn.connectedAccountId!,
+        );
+        pageId = page?.pageId ?? null;
+      }
+      if (!pageId) {
+        throw new ComposioCapabilityMissingError(
+          'facebook',
+          'identify the posting Page — reconnect your Facebook account to resolve this',
+        );
+      }
+      platformArgs = { message: input.content, page_id: pageId };
+    } else {
+      platformArgs = { caption: input.content };
+    }
+
     const result = await this.gateway.executeTool(slug, {
       connectedAccountId: conn.connectedAccountId!,
       arguments: {
-        text: input.content,
-        caption: input.content,
+        ...platformArgs,
         media_urls: input.mediaUrls,
         placement: input.placement ?? 'feed',
         media_type: input.mediaType ?? 'image',

--- a/tests/composio-publisher.test.ts
+++ b/tests/composio-publisher.test.ts
@@ -83,3 +83,129 @@ test('uploadMedia with no configured slug is a documented no-op preview', async 
   assert.equal(result.status, 'preview');
   assert.equal(gateway.calls.length, 0);
 });
+
+// ── Regression tests for #624: correct FB field names + page_id injection ───
+
+test('#624 FB publishPost sends `message` + `page_id` from stored external_account_id — NOT `text`/`caption`', async () => {
+  // fakeDb default has external_account_id='ext_1' — that is the page_id
+  // that must now be injected as page_id into the tool arguments.
+  const gateway = fakeGateway({ executeResult: { data: { id: 'post_1' }, successful: true, error: null } });
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: { publish_post: 'FB_POST' } }), fakeDb());
+  await provider.publishPost({ tenantId, platform: 'facebook', content: 'Hello World', mediaUrls: [], approved: true });
+
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+
+  // Must use `message` (the FB Graph / FACEBOOK_CREATE_POST field)
+  assert.equal(args.message, 'Hello World', 'content must be in `message` field');
+  // Must inject the page_id from the stored external_account_id
+  assert.equal(args.page_id, 'ext_1', 'page_id must equal the stored external_account_id');
+  // Must NOT use the old wrong field names
+  assert.equal(args.text,    undefined, '`text` must not be sent to the Facebook tool');
+  assert.equal(args.caption, undefined, '`caption` must not be sent to the Facebook tool');
+});
+
+test('#624 FB publishPost with null external_account_id falls back to resolveFacebookManagedPage', async () => {
+  // Simulate a connect-time race where external_account_id was not yet populated.
+  // The gateway is called twice: once for list_pages (FACEBOOK_LIST_MANAGED_PAGES)
+  // and once for publish_post. Both return the same executeResult here; the
+  // list_pages call is stateless and we only need it to return a valid page array.
+  const pageListResponse = {
+    data: { data: [{ id: 'page_from_api', name: 'API Page' }] },
+    successful: true,
+    error: null,
+  };
+  const publishResponse = { data: { id: 'post_999' }, successful: true, error: null };
+
+  // Sequence: call[0]=list_pages, call[1]=publish_post
+  const results = [pageListResponse, publishResponse];
+  const gateway = fakeGateway({
+    onExecute: () => {/* track only */},
+  });
+  // Override executeTool to return sequenced results
+  let callIdx = 0;
+  const origExecute = gateway.executeTool.bind(gateway);
+  gateway.executeTool = async (slug, opts) => {
+    const result = results[callIdx] ?? publishResponse;
+    callIdx++;
+    gateway.calls.push({ slug, options: opts });
+    return result;
+  };
+
+  // A row with null external_account_id
+  const nullPageRow = {
+    id: 1,
+    tenant_id: 42,
+    external_user_id: 'aries-tenant-42',
+    platform: 'facebook',
+    provider: 'composio',
+    connected_account_id: 'ca_123',
+    auth_config_id: 'auth_cfg_test',
+    external_account_id: null,
+    external_account_name: null,
+    status: 'connected',
+    capabilities_json: null,
+    last_capability_check_at: null,
+    created_at: new Date(0),
+    updated_at: new Date(0),
+  };
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: { publish_post: 'FB_POST' } }),
+    fakeDb({ connectionRow: nullPageRow }),
+  );
+  const result = await provider.publishPost({ tenantId, platform: 'facebook', content: 'hi', mediaUrls: [], approved: true });
+
+  assert.equal(result.externalPostId, 'post_999', 'publish must succeed using the API-resolved page_id');
+  // Second call is the publish; its args must carry the page_id from the API response
+  const publishCall = gateway.calls.find((c) => c.slug === 'FB_POST');
+  assert.ok(publishCall, 'FB_POST must have been called');
+  const publishArgs = publishCall!.options.arguments as Record<string, unknown>;
+  assert.equal(publishArgs.page_id, 'page_from_api', 'page_id must come from resolveFacebookManagedPage fallback');
+  assert.equal(publishArgs.message, 'hi', 'content must still be in `message`');
+});
+
+test('#624 FB publishPost with null external_account_id and no page returned throws capability-missing', async () => {
+  // Simulate: no page is returned at all (e.g. pages_show_list scope missing)
+  const noPageGateway = fakeGateway({
+    executeResult: { data: null, successful: false, error: 'access denied' },
+  });
+
+  const nullPageRow = {
+    id: 1,
+    tenant_id: 42,
+    external_user_id: 'aries-tenant-42',
+    platform: 'facebook',
+    provider: 'composio',
+    connected_account_id: 'ca_123',
+    auth_config_id: 'auth_cfg_test',
+    external_account_id: null,
+    external_account_name: null,
+    status: 'connected',
+    capabilities_json: null,
+    last_capability_check_at: null,
+    created_at: new Date(0),
+    updated_at: new Date(0),
+  };
+  const provider = new ComposioPublisherProvider(
+    noPageGateway,
+    fakeConfig({ actions: { publish_post: 'FB_POST' } }),
+    fakeDb({ connectionRow: nullPageRow }),
+  );
+  await assert.rejects(
+    () => provider.publishPost({ tenantId, platform: 'facebook', content: 'hi', mediaUrls: [], approved: true }),
+    ComposioCapabilityMissingError,
+    'must throw capability-missing when no page can be identified',
+  );
+});
+
+test('#624 IG publishPost sends `caption` (not `message`) and no `page_id`', async () => {
+  const gateway = fakeGateway({ executeResult: { data: { id: 'ig_post_42' }, successful: true, error: null } });
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: { publish_post: 'IG_POST' } }), fakeDb());
+  await provider.publishPost({ tenantId, platform: 'instagram', content: 'Hello IG', mediaUrls: ['img.jpg'], approved: true });
+
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.caption, 'Hello IG', 'Instagram must still use `caption`');
+  assert.equal(args.message,  undefined, '`message` must not be set for Instagram');
+  assert.equal(args.page_id,  undefined, '`page_id` must not be set for Instagram');
+});


### PR DESCRIPTION
## Root cause

`FACEBOOK_CREATE_POST` (the `COMPOSIO_FACEBOOK_PUBLISH_POST_ACTION` action) requires:
- `message` for the post text — the publisher was sending `text` and `caption`, which the tool ignores
- `page_id` for the target Facebook Page — completely absent from the tool arguments

The tool returned `successful: false` / `"Invalid request data provided — Following fields are missing: {'message', 'page_id'}"` on every Facebook publish attempt. The resulting `ComposioToolError` then hit the handler's generic `catch` at line 371 with **zero logging**, producing an opaque HTTP 500 `{"reason":"publish_failed","message":"An unexpected error occurred"}`. Diagnosed via a live container probe directly against the Composio gateway.

No leaked posts were created — confirmed via `FACEBOOK_GET_PAGE_POSTS` before shipping this fix.

## Changes

**`backend/integrations/composio/composio-publisher-provider.ts`** — `publishPost` argument fix
- For Facebook: send `message: input.content` (correct FB Graph field) and inject `page_id` from `conn.externalAccountId` (stored at connect-time in `connected_accounts.external_account_id`)
- Fallback: when `externalAccountId` is null (connect-time race), calls `resolveFacebookManagedPage` (already in the codebase) and throws `ComposioCapabilityMissingError` with a reconnect message if still none
- Instagram unchanged: still uses `caption`

**`app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts`** and **`publish-instagram/handler.ts`** — logging gap
- `console.error` the real error `name`/`message`/`stack` before the generic 500 return so non-`MetaPublishError` exceptions (e.g. `ComposioToolError`) can never be silently swallowed again

**`tests/composio-publisher.test.ts`** — 4 new regression tests
- FB `publishPost` sends `message` + `page_id` from stored `external_account_id`, not `text`/`caption`
- FB fallback path (`externalAccountId` null → `resolveFacebookManagedPage`) succeeds with API-resolved page
- FB no-page path throws `ComposioCapabilityMissingError`
- IG `publishPost` still uses `caption`, no `page_id`

## Test plan
- [ ] `npm run verify` passes (all 17 gates + 4 new regression tests green)
- [ ] `npm run guardrails:agent` shows unique diff, no duplicate-work warning
- [ ] No QA-captioned post exists on Page `1002997576221948` (verified pre-fix via live probe)

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)