### PR TITLE
fix(composio): correct Facebook publish args (message + page_id) — gate 2 (#624)

### DIFF
--- a/app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/publish-facebook/handler.ts
@@ -368,6 +368,14 @@ export async function handleFacebookPublish(req: Request, jobId: string) {
         { status: error.status, headers: { 'content-type': 'application/json' } },
       );
     }
+    // Non-Meta throw (e.g. a Composio ComposioToolError) — log the real error +
+    // stack before the frontend-safe generic 500 so publish failures aren't blind.
+    console.error('[publish-facebook] unexpected publish failure', {
+      jobId,
+      platform: PLATFORM_KEY,
+      approvalId,
+      error: error instanceof Error ? (error.stack ?? error.message) : String(error),
+    });
     return new Response(
       JSON.stringify({ status: 'error', reason: 'publish_failed', message: 'An unexpected error occurred' }),
       { status: 500, headers: { 'content-type': 'application/json' } },

--- a/app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts
+++ b/app/api/marketing/jobs/[jobId]/publish-instagram/handler.ts
@@ -383,6 +383,13 @@ export async function handleInstagramPublish(req: Request, jobId: string) {
         { status: error.status, headers: { 'content-type': 'application/json' } },
       );
     }
+    // Non-Meta throw (e.g. a Composio ComposioToolError) — log the real error +
+    // stack before the frontend-safe generic 500 so publish failures aren't blind.
+    console.error('[publish-instagram] unexpected publish failure', {
+      jobId,
+      platform: PLATFORM_KEY,
+      error: error instanceof Error ? (error.stack ?? error.message) : String(error),
+    });
     return new Response(
       JSON.stringify({
         status: 'error',

--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -13,6 +13,7 @@
 import type { PublisherProvider } from '../providers/interfaces';
 import {
   isIntegrationPlatform,
+  type ConnectedAccount,
   type GetPublishStatusInput,
   type IntegrationPlatform,
   type PublishAdInput,
@@ -25,12 +26,28 @@ import { PublishGuardError } from '../providers/errors';
 import type { ComposioConfig, ComposioOperation } from './composio-config';
 import type { ComposioGateway } from './composio-client';
 import { getConnectionRow, type Queryable } from './connection-store';
+import { resolveFacebookManagedPage } from './facebook-page-resolver';
 import {
   ComposioCapabilityMissingError,
   ComposioConnectionMissingError,
   ComposioToolError,
 } from './errors';
 import pool from '@/lib/db';
+
+/**
+ * Verified Composio Facebook publish slugs (env-overridable via the publish_post
+ * / upload_media ops). FACEBOOK_CREATE_POST is text/link only; image posts MUST
+ * use FACEBOOK_CREATE_PHOTO_POST. Both require `page_id` + (`message` / `url`).
+ */
+const DEFAULT_FB_TEXT_POST_SLUG = 'FACEBOOK_CREATE_POST';
+const DEFAULT_FB_PHOTO_POST_SLUG = 'FACEBOOK_CREATE_PHOTO_POST';
+
+/** FB wants a future UTC epoch in SECONDS for scheduled posts. */
+function toUnixSecondsOrUndefined(iso?: string | null): number | undefined {
+  if (!iso) return undefined;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? undefined : Math.floor(t / 1000);
+}
 
 function pickId(data: unknown, keys: string[]): string | null {
   if (!data || typeof data !== 'object') return null;
@@ -104,6 +121,15 @@ export class ComposioPublisherProvider implements PublisherProvider {
     if (!input.approved) throw new PublishGuardError();
 
     const conn = await this.requireActiveConnection({ tenantId: input.tenantId, platform: input.platform });
+
+    // Facebook needs the Graph-native arg shape: `message` (not text/caption) +
+    // `page_id`, and the photo action (`url`) for image posts. The generic shape
+    // below is rejected ("Following fields are missing: {'message','page_id'}").
+    if (input.platform === 'facebook') {
+      return this.publishFacebookPost(input, conn);
+    }
+
+    // Instagram / other platforms: unchanged generic arg shape.
     const slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
 
     const result = await this.gateway.executeTool(slug, {
@@ -129,6 +155,88 @@ export class ComposioPublisherProvider implements PublisherProvider {
       externalCampaignId: null,
       externalAdId: null,
       status: input.scheduledFor ? 'scheduled' : 'published',
+      url: pickUrl(result.data),
+      rawResponse: result.data,
+    };
+  }
+
+  /**
+   * Resolve the Facebook Page id for publishing: the connection's
+   * external_account_id, else resolve it from Composio (FACEBOOK_LIST_MANAGED_PAGES)
+   * and back-heal connected_accounts so future publishes skip the lookup.
+   * Throws ComposioToolError (definitely-never-posted) when it cannot be resolved.
+   */
+  private async resolveFacebookPageId(conn: ConnectedAccount): Promise<string> {
+    const existing = conn.externalAccountId?.trim();
+    if (existing) return existing;
+
+    if (!conn.connectedAccountId) {
+      throw new ComposioToolError(
+        DEFAULT_FB_TEXT_POST_SLUG,
+        'No connected account id available to resolve the Facebook page id for publishing.',
+      );
+    }
+    const page = await resolveFacebookManagedPage(this.gateway, this.config, conn.connectedAccountId);
+    if (!page) {
+      throw new ComposioToolError(
+        'FACEBOOK_LIST_MANAGED_PAGES',
+        'Could not resolve a managed Facebook page id for publishing.',
+      );
+    }
+    // Best-effort back-heal so subsequent publishes skip resolution.
+    try {
+      await this.db.query(
+        `UPDATE connected_accounts
+           SET external_account_id = $1,
+               external_account_name = COALESCE($2, external_account_name),
+               updated_at = now()
+         WHERE tenant_id = $3 AND platform = 'facebook'`,
+        [page.pageId, page.pageName, conn.tenantId],
+      );
+    } catch {
+      // non-fatal — we still have the resolved page id for this publish
+    }
+    return page.pageId;
+  }
+
+  private async publishFacebookPost(input: PublishPostInput, conn: ConnectedAccount): Promise<PublishResult> {
+    const pageId = await this.resolveFacebookPageId(conn);
+    const scheduledAt = toUnixSecondsOrUndefined(input.scheduledFor);
+    const scheduled = scheduledAt !== undefined;
+    const scheduleArgs = scheduled ? { published: false, scheduled_publish_time: scheduledAt } : {};
+
+    const hasMedia = input.mediaUrls.length > 0;
+    // Image post -> FACEBOOK_CREATE_PHOTO_POST (page_id + url + message); text/link
+    // post -> FACEBOOK_CREATE_POST (page_id + message). Verified slugs are the
+    // defaults so publishing works even when the *_ACTION env vars are unset; an
+    // env override (upload_media / publish_post) still wins.
+    const slug = hasMedia
+      ? this.config.actionSlugFor('facebook', 'upload_media') ?? DEFAULT_FB_PHOTO_POST_SLUG
+      : this.config.actionSlugFor('facebook', 'publish_post') ?? DEFAULT_FB_TEXT_POST_SLUG;
+
+    const args: Record<string, unknown> = {
+      page_id: pageId,
+      message: input.content,
+      ...(hasMedia ? { url: input.mediaUrls[0] } : {}),
+      ...scheduleArgs,
+    };
+
+    const result = await this.gateway.executeTool(slug, {
+      connectedAccountId: conn.connectedAccountId!,
+      arguments: args,
+    });
+
+    if (!result.successful) {
+      throw new ComposioToolError(slug, result.error ?? 'tool reported unsuccessful');
+    }
+
+    return {
+      provider: 'composio',
+      platform: 'facebook',
+      externalPostId: pickId(result.data, ['post_id', 'id', 'media_id']),
+      externalCampaignId: null,
+      externalAdId: null,
+      status: scheduled ? 'scheduled' : 'published',
       url: pickUrl(result.data),
       rawResponse: result.data,
     };
@@ -186,9 +294,15 @@ export class ComposioPublisherProvider implements PublisherProvider {
         rawResponse: { reason: `No upload_media action configured for ${input.platform}.` },
       };
     }
+    // Facebook's photo action (FACEBOOK_CREATE_PHOTO_POST) requires page_id + url;
+    // other platforms keep the generic media_url/media_type shape.
+    const args =
+      input.platform === 'facebook'
+        ? { page_id: await this.resolveFacebookPageId(conn), url: input.mediaUrl }
+        : { media_url: input.mediaUrl, media_type: input.mediaType };
     const result = await this.gateway.executeTool(slug, {
       connectedAccountId: conn.connectedAccountId!,
-      arguments: { media_url: input.mediaUrl, media_type: input.mediaType },
+      arguments: args,
     });
     if (!result.successful) throw new ComposioToolError(slug, result.error ?? 'tool reported unsuccessful');
     return {

--- a/tests/composio-publisher.test.ts
+++ b/tests/composio-publisher.test.ts
@@ -7,9 +7,29 @@ import {
   ComposioCapabilityMissingError,
   ComposioConnectionMissingError,
 } from '@/backend/integrations/composio/errors';
+import type { ComposioGateway, GatewayToolResult } from '@/backend/integrations/composio/composio-client';
 import { fakeConfig, fakeGateway, fakeDb } from './composio/helpers';
 
 const tenantId = '42';
+
+/** Gateway that routes a canned result per slug (for the page-id resolution test). */
+function routingGateway(results: Record<string, GatewayToolResult>): ComposioGateway & {
+  calls: Array<{ slug: string; connectedAccountId?: string; arguments?: Record<string, unknown> }>;
+} {
+  const calls: Array<{ slug: string; connectedAccountId?: string; arguments?: Record<string, unknown> }> = [];
+  return {
+    calls,
+    async findOrCreateManagedAuthConfig(s: string) { return `ac_${s}`; },
+    async initiateConnection() { return { connectionRequestId: 'cr', redirectUrl: null }; },
+    async listConnections() { return []; },
+    async getConnection() { return null; },
+    async deleteConnection() {},
+    async executeTool(slug, options) {
+      calls.push({ slug, connectedAccountId: options.connectedAccountId, arguments: options.arguments });
+      return results[slug] ?? { data: {}, successful: true, error: null };
+    },
+  };
+}
 
 test('publishPost dry-run returns preview and never calls the gateway', async () => {
   const gateway = fakeGateway();
@@ -45,22 +65,90 @@ test('publishPost approved but no active connection throws connection-missing', 
   );
 });
 
-test('publishPost approved + active connection but no action slug throws capability-missing', async () => {
+test('instagram publishPost with no action slug still throws capability-missing', async () => {
+  // FB now defaults its slugs (so publishing works unconfigured); IG keeps the
+  // configured-slug-required guard.
   const provider = new ComposioPublisherProvider(fakeGateway(), fakeConfig({ actions: {} }), fakeDb());
   await assert.rejects(
-    () => provider.publishPost({ tenantId, platform: 'facebook', content: 'hi', mediaUrls: ['u'], approved: true }),
+    () => provider.publishPost({ tenantId, platform: 'instagram', content: 'hi', mediaUrls: ['u'], approved: true }),
     ComposioCapabilityMissingError,
   );
 });
 
-test('publishPost approved + slug executes and normalizes the post id', async () => {
+test('#624 FB image post sends message + page_id + url (NOT text/caption/media_urls), photo action', async () => {
   const gateway = fakeGateway({ executeResult: { data: { id: 'post_999', permalink: 'https://fb/p/999' }, successful: true, error: null } });
-  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: { publish_post: 'FB_POST' } }), fakeDb());
-  const result = await provider.publishPost({ tenantId, platform: 'facebook', content: 'hi', mediaUrls: ['u'], approved: true });
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: { upload_media: 'FB_PHOTO', publish_post: 'FB_POST' } }),
+    fakeDb(), // default connection row has external_account_id 'ext_1'
+  );
+  const result = await provider.publishPost({ tenantId, platform: 'facebook', content: 'hello world', mediaUrls: ['https://img/x.jpg'], approved: true });
+
   assert.equal(result.status, 'published');
   assert.equal(result.externalPostId, 'post_999');
   assert.equal(result.url, 'https://fb/p/999');
+
+  // Image post routes to the photo action, NOT the text publish_post slug.
+  assert.equal(gateway.calls[0].slug, 'FB_PHOTO');
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.page_id, 'ext_1');
+  assert.equal(args.message, 'hello world');
+  assert.equal(args.url, 'https://img/x.jpg');
+  // The broken generic shape must be gone.
+  assert.equal(args.text, undefined);
+  assert.equal(args.caption, undefined);
+  assert.equal(args.media_urls, undefined);
+});
+
+test('#624 FB image post works with NO configured slugs (verified photo-post default)', async () => {
+  const gateway = fakeGateway({ executeResult: { data: { id: 'p1' }, successful: true, error: null } });
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: {} }), fakeDb());
+  await provider.publishPost({ tenantId, platform: 'facebook', content: 'c', mediaUrls: ['u'], approved: true });
+  assert.equal(gateway.calls[0].slug, 'FACEBOOK_CREATE_PHOTO_POST');
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.page_id, 'ext_1');
+  assert.equal(args.message, 'c');
+  assert.equal(args.url, 'u');
+});
+
+test('#624 FB text-only post sends message + page_id (no url), text action', async () => {
+  const gateway = fakeGateway({ executeResult: { data: { id: 'post_text' }, successful: true, error: null } });
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: { publish_post: 'FB_POST' } }), fakeDb());
+  await provider.publishPost({ tenantId, platform: 'facebook', content: 'just text', mediaUrls: [], approved: true });
+
   assert.equal(gateway.calls[0].slug, 'FB_POST');
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.page_id, 'ext_1');
+  assert.equal(args.message, 'just text');
+  assert.equal(args.url, undefined);
+});
+
+test('#624 FB publish resolves + persists page_id via FACEBOOK_LIST_MANAGED_PAGES when external_account_id is null', async () => {
+  const gateway = routingGateway({
+    FACEBOOK_LIST_MANAGED_PAGES: { successful: true, error: null, data: { data: [{ id: 'PAGE777', name: 'Aries Page' }] } },
+    FACEBOOK_CREATE_PHOTO_POST: { successful: true, error: null, data: { id: 'post_42' } },
+  });
+  const db = fakeDb({
+    connectionRow: {
+      id: 9, tenant_id: 42, external_user_id: 'u', platform: 'facebook', provider: 'composio',
+      connected_account_id: 'ca_live', auth_config_id: 'ac', external_account_id: null,
+      external_account_name: null, status: 'connected', capabilities_json: null,
+      last_capability_check_at: null, created_at: new Date(0), updated_at: new Date(0),
+    },
+  });
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: {} }), db);
+
+  const result = await provider.publishPost({ tenantId, platform: 'facebook', content: 'c', mediaUrls: ['u'], approved: true });
+
+  // Resolved the page id from Composio, then posted with it.
+  assert.equal(gateway.calls[0].slug, 'FACEBOOK_LIST_MANAGED_PAGES');
+  assert.equal(gateway.calls[1].slug, 'FACEBOOK_CREATE_PHOTO_POST');
+  assert.equal((gateway.calls[1].arguments as Record<string, unknown>).page_id, 'PAGE777');
+  assert.equal(result.externalPostId, 'post_42');
+  // Back-healed connected_accounts.
+  const update = db.queries.find((q) => /UPDATE connected_accounts/i.test(q.text));
+  assert.ok(update, 'persists the resolved page id back to connected_accounts');
+  assert.equal(update!.params[0], 'PAGE777');
 });
 
 test('publishAd ALWAYS creates PAUSED and forces PAUSED status args', async () => {
@@ -82,4 +170,14 @@ test('uploadMedia with no configured slug is a documented no-op preview', async 
   const result = await provider.uploadMedia({ tenantId, platform: 'facebook', mediaUrl: 'u', mediaType: 'image' });
   assert.equal(result.status, 'preview');
   assert.equal(gateway.calls.length, 0);
+});
+
+test('#624 uploadMedia for FB sends page_id + url (not media_url) when a slug is configured', async () => {
+  const gateway = fakeGateway({ executeResult: { data: { id: 'm1' }, successful: true, error: null } });
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: { upload_media: 'FB_PHOTO' } }), fakeDb());
+  await provider.uploadMedia({ tenantId, platform: 'facebook', mediaUrl: 'https://img/y.jpg', mediaType: 'image' });
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.page_id, 'ext_1');
+  assert.equal(args.url, 'https://img/y.jpg');
+  assert.equal(args.media_url, undefined);
 });


### PR DESCRIPTION
The Composio FB **publish** path 400s before any post is created — `ComposioPublisherProvider.publishPost` sent `text`/`caption` and omitted `page_id`, so `FACEBOOK_CREATE_POST` rejects with "Following fields are missing: {'message','page_id'}". Found by the QA loop's live Composio publish (gate 2 didn't actually work). Closes #624.

## Verified arg schemas (Composio MCP)
- `FACEBOOK_CREATE_POST` (text/link): required `page_id`, `message`.
- `FACEBOOK_CREATE_PHOTO_POST` (image): required `page_id`, image via `url`, caption via `message`.
- Instagram: different actions entirely (`INSTAGRAM_POST_IG_USER_MEDIA` → `..._PUBLISH`, a two-step `ig_user_id`/`image_url`/`creation_id` flow).

## Fix
- `composio-publisher-provider.ts` `publishPost`/`uploadMedia` — Facebook now sends Graph-native args: `message` (content) + `page_id` + (`url` for image). `page_id` from `conn.externalAccountId`, falling back to `resolveFacebookManagedPage(...)` + back-healing `connected_accounts`. Image → `FACEBOOK_CREATE_PHOTO_POST`, text-only → `FACEBOOK_CREATE_POST`; verified slugs are the **defaults** (FB publish works even with the `*_ACTION` env unset). **Instagram/other platforms unchanged.**
- `publish-facebook` + `publish-instagram` handlers — `console.error` the real error+stack in the generic catch (publish failures were blind 500s).
- Outcome taxonomy preserved: a `successful:false` param-rejection stays `ComposioToolError` = definitely-never-posted (safe), never outcome-unknown (no double-post).

## IG note (separate follow-up, out of scope here)
IG publish via Composio is ALSO wrong — it needs the two-step container→publish flow (`ig_user_id`/`image_url`/`creation_id`), which a single `executeTool` can't do. Left unchanged + flagged (IG is deferred; FB is the live path).

## Tests
`tests/composio-publisher.test.ts` — FB image → `message`+`page_id`+`url` on the photo action and NOT `text`/`caption`/`media_urls`; FB works with no configured slugs (defaults); FB text-only → `message`+`page_id` no `url`; `page_id`-null → resolves + back-heals; `uploadMedia` FB → `page_id`+`url`.

`npm run verify` ✅ · typecheck ✅ · banned-patterns ✅ · guardrails ✅ · spot-checked. (Live FB publish is the QA loop's final verification.)

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)