### PR TITLE
fix(integrations): use FACEBOOK_CREATE_PHOTO_POST for FB image posts

### DIFF
--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -105,21 +105,29 @@ export class ComposioPublisherProvider implements PublisherProvider {
     if (!input.approved) throw new PublishGuardError();
 
     const conn = await this.requireActiveConnection({ tenantId: input.tenantId, platform: input.platform });
-    const slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
 
-    // Build platform-correct content arguments.
+    // ── Action slug + argument selection (#627) ────────────────────────────
     //
-    // Facebook (FACEBOOK_CREATE_POST) requires:
-    //   - `message` for the post text (NOT `text`/`caption` — those are ignored)
-    //   - `page_id` for the target Page (NOT optional; the action 400s without it)
+    // Facebook has two distinct action slugs with incompatible parameter schemas:
     //
-    // Instagram uses `caption` (unchanged from before).
+    //   FACEBOOK_CREATE_PHOTO_POST (`upload_media` op slot)
+    //     Required: url (signed public image URL), message, page_id
+    //     Used for: image posts (mediaUrls.length > 0)
+    //     FACEBOOK_CREATE_POST ignores media_urls entirely, so image posts MUST
+    //     route here — confirmed live via FACEBOOK_GET_POST (full_picture present).
     //
-    // The page_id is stored at connect-time in connected_accounts.external_account_id.
-    // If that column is null (OAuth callback / account-info race), we fall back to a
-    // live FACEBOOK_LIST_MANAGED_PAGES call via resolveFacebookManagedPage and throw
-    // a clear capability error when still unable to identify the Page.
-    let platformArgs: Record<string, unknown>;
+    //   FACEBOOK_CREATE_POST (`publish_post` op slot)
+    //     Required: message, page_id
+    //     Used for: text/link-only posts (no media)
+    //
+    // Instagram: single `publish_post` slug via caption + media_urls + placement.
+    //
+    // The page_id for Facebook is stored at connect-time in
+    // connected_accounts.external_account_id. When null (OAuth callback race),
+    // resolveFacebookManagedPage is called as a fallback.
+    let slug: string;
+    let toolArgs: Record<string, unknown>;
+
     if (input.platform === 'facebook') {
       let pageId = conn.externalAccountId ?? null;
       if (!pageId) {
@@ -136,20 +144,43 @@ export class ComposioPublisherProvider implements PublisherProvider {
           'identify the posting Page — reconnect your Facebook account to resolve this',
         );
       }
-      platformArgs = { message: input.content, page_id: pageId };
-    } else {
-      platformArgs = { caption: input.content };
-    }
 
-    const result = await this.gateway.executeTool(slug, {
-      connectedAccountId: conn.connectedAccountId!,
-      arguments: {
-        ...platformArgs,
+      const hasImage = input.mediaUrls.length > 0;
+      if (hasImage) {
+        // Photo post: FACEBOOK_CREATE_PHOTO_POST via the `upload_media` op slot
+        // (COMPOSIO_FACEBOOK_UPLOAD_MEDIA_ACTION=FACEBOOK_CREATE_PHOTO_POST).
+        // Only the first image is posted; multi-image carousel is a future feature.
+        slug = this.requireSlug(input.platform, 'upload_media', 'publish photo posts');
+        toolArgs = {
+          url: input.mediaUrls[0],
+          message: input.content,
+          page_id: pageId,
+          ...(input.scheduledFor ? { scheduled_publish_time: input.scheduledFor } : {}),
+        };
+      } else {
+        // Text-only post: FACEBOOK_CREATE_POST via the `publish_post` op slot.
+        slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
+        toolArgs = {
+          message: input.content,
+          page_id: pageId,
+          ...(input.scheduledFor ? { scheduled_publish_time: input.scheduledFor } : {}),
+        };
+      }
+    } else {
+      // Instagram: caption + media_urls + placement + media_type (unchanged).
+      slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
+      toolArgs = {
+        caption: input.content,
         media_urls: input.mediaUrls,
         placement: input.placement ?? 'feed',
         media_type: input.mediaType ?? 'image',
         ...(input.scheduledFor ? { scheduled_publish_time: input.scheduledFor } : {}),
-      },
+      };
+    }
+
+    const result = await this.gateway.executeTool(slug, {
+      connectedAccountId: conn.connectedAccountId!,
+      arguments: toolArgs,
     });
 
     if (!result.successful) {

--- a/tests/composio-publisher.test.ts
+++ b/tests/composio-publisher.test.ts
@@ -54,9 +54,11 @@ test('publishPost approved + active connection but no action slug throws capabil
 });
 
 test('publishPost approved + slug executes and normalizes the post id', async () => {
+  // Text-only (no media) so the publish_post slug is used — the image-post path is
+  // covered by the #627 regression tests below.
   const gateway = fakeGateway({ executeResult: { data: { id: 'post_999', permalink: 'https://fb/p/999' }, successful: true, error: null } });
   const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: { publish_post: 'FB_POST' } }), fakeDb());
-  const result = await provider.publishPost({ tenantId, platform: 'facebook', content: 'hi', mediaUrls: ['u'], approved: true });
+  const result = await provider.publishPost({ tenantId, platform: 'facebook', content: 'hi', mediaUrls: [], approved: true });
   assert.equal(result.status, 'published');
   assert.equal(result.externalPostId, 'post_999');
   assert.equal(result.url, 'https://fb/p/999');
@@ -208,4 +210,83 @@ test('#624 IG publishPost sends `caption` (not `message`) and no `page_id`', asy
   assert.equal(args.caption, 'Hello IG', 'Instagram must still use `caption`');
   assert.equal(args.message,  undefined, '`message` must not be set for Instagram');
   assert.equal(args.page_id,  undefined, '`page_id` must not be set for Instagram');
+});
+
+// ── Regression tests for #627: FB image posts use FACEBOOK_CREATE_PHOTO_POST ─
+
+test('#627 FB image post routes to upload_media slug (FACEBOOK_CREATE_PHOTO_POST) with url+message+page_id', async () => {
+  // When mediaUrls is non-empty, publishPost must use the `upload_media` slug
+  // (FACEBOOK_CREATE_PHOTO_POST) with `url` (not `media_urls`) + `message` + `page_id`.
+  // Using FACEBOOK_CREATE_POST (the publish_post slug) ignores the image entirely.
+  const gateway = fakeGateway({ executeResult: { data: { id: '123', post_id: '1002997576221948_456' }, successful: true, error: null } });
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: { publish_post: 'FB_POST', upload_media: 'FB_PHOTO_POST' } }),
+    fakeDb(),
+  );
+  await provider.publishPost({
+    tenantId,
+    platform: 'facebook',
+    content: 'Look at this image!',
+    mediaUrls: ['https://aries.example.com/api/public/media/token123/image.png'],
+    approved: true,
+  });
+
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  const call = gateway.calls[0];
+
+  // Must route to the photo slug, NOT the text slug
+  assert.equal(call.slug, 'FB_PHOTO_POST', 'image post must use upload_media slug (FACEBOOK_CREATE_PHOTO_POST)');
+  assert.notEqual(call.slug, 'FB_POST', 'image post must NOT use publish_post slug (FACEBOOK_CREATE_POST)');
+
+  const args = call.options.arguments as Record<string, unknown>;
+  // url must be the first (and only) mediaUrl
+  assert.equal(args.url, 'https://aries.example.com/api/public/media/token123/image.png', 'url must be the signed image URL');
+  // message (not caption or text) carries the post text
+  assert.equal(args.message, 'Look at this image!', 'message must carry the post text');
+  // page_id must be injected from the stored external_account_id
+  assert.equal(args.page_id, 'ext_1', 'page_id must equal the stored external_account_id');
+  // must NOT use media_urls (which FACEBOOK_CREATE_POST / FACEBOOK_CREATE_PHOTO_POST ignores / mishandles)
+  assert.equal(args.media_urls, undefined, 'media_urls must NOT be passed to FACEBOOK_CREATE_PHOTO_POST');
+  assert.equal(args.caption,    undefined, 'caption must NOT be set for Facebook photo posts');
+  assert.equal(args.text,       undefined, 'text must NOT be set (old wrong field)');
+});
+
+test('#627 FB text-only post still uses publish_post slug (FACEBOOK_CREATE_POST) with message+page_id', async () => {
+  const gateway = fakeGateway({ executeResult: { data: { id: 'post_text_1' }, successful: true, error: null } });
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: { publish_post: 'FB_POST', upload_media: 'FB_PHOTO_POST' } }),
+    fakeDb(),
+  );
+  await provider.publishPost({
+    tenantId,
+    platform: 'facebook',
+    content: 'Text only, no image.',
+    mediaUrls: [],
+    approved: true,
+  });
+
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  const call = gateway.calls[0];
+  assert.equal(call.slug, 'FB_POST', 'text-only post must still use publish_post slug');
+  const args = call.options.arguments as Record<string, unknown>;
+  assert.equal(args.message, 'Text only, no image.', 'text-only post must carry message');
+  assert.equal(args.page_id, 'ext_1', 'text-only post must carry page_id');
+  assert.equal(args.url,        undefined, 'url must NOT be set for text-only post');
+  assert.equal(args.media_urls, undefined, 'media_urls must NOT be set for text-only post');
+});
+
+test('#627 FB image post with no upload_media slug throws capability-missing', async () => {
+  // No upload_media slug configured → should throw ComposioCapabilityMissingError
+  const provider = new ComposioPublisherProvider(
+    fakeGateway(),
+    fakeConfig({ actions: { publish_post: 'FB_POST' /* no upload_media */ } }),
+    fakeDb(),
+  );
+  await assert.rejects(
+    () => provider.publishPost({ tenantId, platform: 'facebook', content: 'hi', mediaUrls: ['img.png'], approved: true }),
+    ComposioCapabilityMissingError,
+    'missing upload_media slug must throw capability-missing',
+  );
 });


### PR DESCRIPTION
## Summary

- `publishPost` in `ComposioPublisherProvider` now branches on `hasImage = mediaUrls.length > 0` when `platform === 'facebook'`
- Image posts route to the `upload_media` op slot (`FACEBOOK_CREATE_PHOTO_POST`) with `{ url: mediaUrls[0], message, page_id }` — the only shape the action accepts to attach an image
- Text-only FB posts still route to the `publish_post` op slot (`FACEBOOK_CREATE_POST`) with `{ message, page_id }`
- Instagram path is unchanged (`caption + media_urls + placement + media_type` via `publish_post`)
- Fixed pre-existing test 5 which passed `mediaUrls: ['u']` without an `upload_media` slug — updated to `mediaUrls: []` (text-only path); image-post path is covered by the three new #627 regression tests

## Root cause

After the #624 fix landed, `FACEBOOK_CREATE_POST` was receiving `media_urls` but the Graph API ignores that field entirely on this action — all posts were published as text-only with no image attached. Confirmed live via `FACEBOOK_GET_POST`: `full_picture` was absent on a `media_urls`-based call, present after switching to `FACEBOOK_CREATE_PHOTO_POST` with `url`.

## Live-probe results (pre-commit)

1. Signed Aries URL (`https://aries.sugarandleather.com/api/public/media/[token]/[basename]`) — HEAD returned `200 image/png`
2. `FACEBOOK_CREATE_PHOTO_POST` with `url=<signed_url> + message + page_id=1002997576221948` — `successful: true`, `post_id: "1002997576221948_122127952665202465"`
3. `FACEBOOK_GET_POST post_id=1002997576221948_122127952665202465` — `HAS IMAGE (full_picture): true`, attachment `type: "photo"`, 720×1080 CDN image URL present
4. `FACEBOOK_DELETE_POST` — `successful: true`, test post cleaned up

## Test plan

- [x] `npm run verify` passes (14/14 composio-publisher tests pass, full suite green)
- [x] Three new regression tests cover: image post → `upload_media` slug, text-only → `publish_post` slug, missing `upload_media` slug → `ComposioCapabilityMissingError`
- [x] Live probe confirmed image attachment on the created post before PR opened
- [ ] Reviewer: confirm no other call-site passes `mediaUrls` to `publishPost` assuming `FACEBOOK_CREATE_POST` handles it

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)