### PR TITLE
fix(integrations): make X a Composio-connectable platform behind ARIES_X_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,6 +256,11 @@ REDDIT_USER_AGENT=AriesOAuthBroker/1.0
 # direct Meta everywhere, no Composio code loaded. See docs/integrations/composio.md.
 COMPOSIO_ENABLED=false
 COMPOSIO_API_KEY=
+# X (Twitter) connect rollout flag. Default OFF — ships the platform dormant:
+# the X card is hidden and connect/capabilities/disconnect return the same
+# unsupported_platform 400 as today. Flip to true once the X auth-config below
+# is provisioned in Composio.
+ARIES_X_ENABLED=false
 # Toolkit version for manual (by-slug) Composio tool execution — publishing,
 # analytics, AND comments all go through tools.execute, which the @composio/core
 # SDK rejects without a toolkit version. Default 'latest' (the gateway pairs it
@@ -271,6 +276,8 @@ COMPOSIO_TIKTOK_AUTH_CONFIG_ID=
 COMPOSIO_YOUTUBE_AUTH_CONFIG_ID=
 COMPOSIO_LINKEDIN_AUTH_CONFIG_ID=
 COMPOSIO_REDDIT_AUTH_CONFIG_ID=
+# X (Twitter) — only consulted when ARIES_X_ENABLED=true (Composio toolkit 'twitter').
+COMPOSIO_X_AUTH_CONFIG_ID=
 
 # Provider selection. Allowed: direct_meta | composio | auto
 #   direct_meta -> existing Meta flow (default)

--- a/app/api/integrations/composio/handlers.ts
+++ b/app/api/integrations/composio/handlers.ts
@@ -13,13 +13,13 @@
 
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 import {
-  INTEGRATION_PLATFORMS,
   isIntegrationPlatform,
   isRequestedCapability,
   type IntegrationPlatform,
   type RequestedCapability,
 } from '@/backend/integrations/providers/types';
 import {
+  connectablePlatforms,
   getAccountConnectionProvider,
   getCapabilityProvider,
   resolveIntegrationConfig,
@@ -43,7 +43,10 @@ function errorResponse(error: unknown): Response {
 }
 
 function platformOr400(raw: string): IntegrationPlatform | Response {
-  if (!isIntegrationPlatform(raw)) {
+  // isIntegrationPlatform narrows the type; connectablePlatforms() is the flag
+  // gate. A recognized-but-not-enabled platform (e.g. 'x' while ARIES_X_ENABLED
+  // is OFF) yields the IDENTICAL unsupported_platform 400 as an unknown one.
+  if (!isIntegrationPlatform(raw) || !connectablePlatforms().includes(raw)) {
     return json({ status: 'error', reason: 'unsupported_platform', message: `Unsupported platform: ${raw}` }, 400);
   }
   return raw;
@@ -151,7 +154,7 @@ export async function handleComposioList(loader?: TenantContextLoader): Promise<
   // Merge stored rows with not-connected placeholders so the UI can render
   // every supported platform regardless of whether a row exists yet.
   const byPlatform = new Map(stored.map((c) => [c.platform, c]));
-  const connections = INTEGRATION_PLATFORMS.map(
+  const connections = connectablePlatforms().map(
     (platform) => byPlatform.get(platform) ?? notConnectedAccount(tenantId, externalUserId, platform, 'composio'),
   );
 

--- a/backend/integrations/composio/composio-config.ts
+++ b/backend/integrations/composio/composio-config.ts
@@ -26,6 +26,9 @@ export const TOOLKIT_SLUG: Record<IntegrationPlatform, string> = {
   youtube: 'youtube',
   linkedin: 'linkedin',
   reddit: 'reddit',
+  // Composio's toolkit for X is 'twitter'; Aries' platform key stays 'x'
+  // (so its action/auth env keys are COMPOSIO_X_*).
+  x: 'twitter',
 };
 
 export type ComposioOperation =

--- a/backend/integrations/providers/index.ts
+++ b/backend/integrations/providers/index.ts
@@ -14,6 +14,8 @@ export * from './errors';
 export {
   parseFlag,
   isComposioEnabled,
+  isXEnabled,
+  connectablePlatforms,
   publishProviderSelector,
   analyticsProviderSelector,
   composioAuthConfigId,

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -10,7 +10,7 @@
  * (`1` | `true` | `yes` | `on`); see CLAUDE.md "Optional safety flags".
  */
 
-import type { IntegrationPlatform } from './types';
+import { INTEGRATION_PLATFORMS, type IntegrationPlatform } from './types';
 
 export type ProviderSelector = 'direct_meta' | 'composio' | 'auto';
 
@@ -29,6 +29,23 @@ function parseSelector(raw: string | undefined | null, fallback: ProviderSelecto
 /** Composio is only ever active when explicitly enabled. Default OFF. */
 export function isComposioEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return parseFlag(env.COMPOSIO_ENABLED);
+}
+
+/** X (Twitter) connect rollout flag. Default OFF — ships the platform dormant. */
+export function isXEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseFlag(env.ARIES_X_ENABLED);
+}
+
+/**
+ * Platforms an operator can actually connect right now. The single dormancy
+ * chokepoint for flag-gated platforms: when `ARIES_X_ENABLED` is OFF, `'x'` is
+ * filtered out everywhere (connect/capabilities/disconnect gate + the UI list),
+ * so the platform is byte-for-byte invisible until the flag flips on.
+ */
+export function connectablePlatforms(
+  env: NodeJS.ProcessEnv = process.env,
+): readonly IntegrationPlatform[] {
+  return isXEnabled(env) ? INTEGRATION_PLATFORMS : INTEGRATION_PLATFORMS.filter((p) => p !== 'x');
 }
 
 export function publishProviderSelector(env: NodeJS.ProcessEnv = process.env): ProviderSelector {
@@ -52,6 +69,7 @@ export function composioAuthConfigId(
     youtube: env.COMPOSIO_YOUTUBE_AUTH_CONFIG_ID,
     linkedin: env.COMPOSIO_LINKEDIN_AUTH_CONFIG_ID,
     reddit: env.COMPOSIO_REDDIT_AUTH_CONFIG_ID,
+    x: env.COMPOSIO_X_AUTH_CONFIG_ID,
   };
   const specific = perPlatform[platform]?.trim();
   if (specific) return specific;

--- a/backend/integrations/providers/types.ts
+++ b/backend/integrations/providers/types.ts
@@ -25,7 +25,8 @@ export type IntegrationPlatform =
   | 'tiktok'
   | 'youtube'
   | 'linkedin'
-  | 'reddit';
+  | 'reddit'
+  | 'x';
 
 export const INTEGRATION_PLATFORMS: readonly IntegrationPlatform[] = [
   'facebook',
@@ -35,6 +36,7 @@ export const INTEGRATION_PLATFORMS: readonly IntegrationPlatform[] = [
   'youtube',
   'linkedin',
   'reddit',
+  'x',
 ] as const;
 
 export function isIntegrationPlatform(value: string): value is IntegrationPlatform {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,9 @@ services:
       # restart. See docs/integrations/composio.md.
       COMPOSIO_ENABLED: ${COMPOSIO_ENABLED:-false}
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
+      # X (Twitter) connect rollout flag — default OFF ships the platform dormant
+      # (card hidden; connect/capabilities 400 unsupported_platform as today).
+      ARIES_X_ENABLED: ${ARIES_X_ENABLED:-false}
       # Toolkit version for manual Composio tool execution (publish/analytics/
       # comments). The SDK rejects by-slug execution without one; default 'latest'
       # (gateway pairs it with a skip-check). Pin a concrete version to avoid drift.
@@ -207,6 +210,8 @@ services:
       COMPOSIO_YOUTUBE_AUTH_CONFIG_ID: ${COMPOSIO_YOUTUBE_AUTH_CONFIG_ID:-}
       COMPOSIO_LINKEDIN_AUTH_CONFIG_ID: ${COMPOSIO_LINKEDIN_AUTH_CONFIG_ID:-}
       COMPOSIO_REDDIT_AUTH_CONFIG_ID: ${COMPOSIO_REDDIT_AUTH_CONFIG_ID:-}
+      # X (Twitter) auth config — only consulted when ARIES_X_ENABLED=true.
+      COMPOSIO_X_AUTH_CONFIG_ID: ${COMPOSIO_X_AUTH_CONFIG_ID:-}
       # Composio action slugs (COMPOSIO_<PLATFORM>_<OPERATION>_ACTION). Required
       # for Composio-routed publishing — a missing slug is refused with a clear
       # capability error, never executed against a guessed action.

--- a/frontend/integrations/composio-connections-screen.tsx
+++ b/frontend/integrations/composio-connections-screen.tsx
@@ -46,6 +46,7 @@ const PLATFORM_LABEL: Record<string, string> = {
   youtube: 'YouTube',
   linkedin: 'LinkedIn',
   reddit: 'Reddit',
+  x: 'X',
 };
 
 function statusText(status: Connection['status'], caps: Capabilities | null): { label: string; tone: string } {

--- a/tests/composio-x-connect.test.ts
+++ b/tests/composio-x-connect.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Regression coverage for #630: X (Twitter) as a Composio-connectable platform
+ * gated by ARIES_X_ENABLED.
+ *
+ * Failure modes locked:
+ *  - Flag OFF: 'x' absent from connectablePlatforms, platformOr400 returns 400
+ *    unsupported_platform, list endpoint returns 7 slots (no x).
+ *  - Flag ON:  'x' present in connectablePlatforms, platformOr400 passes through,
+ *    list endpoint returns 8 slots including x.
+ *  - Config: TOOLKIT_SLUG.x === 'twitter'; COMPOSIO_X_AUTH_CONFIG_ID read correctly.
+ *  - Regression guard: all 7 original platforms remain byte-identical.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  connectablePlatforms,
+  isXEnabled,
+  composioAuthConfigId,
+  isIntegrationPlatform,
+} from '@/backend/integrations/providers';
+import { TOOLKIT_SLUG } from '@/backend/integrations/composio/composio-config';
+import {
+  handleComposioConnect,
+  handleComposioList,
+} from '@/app/api/integrations/composio/handlers';
+import type { TenantRole } from '@/lib/tenant-context';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal NodeJS.ProcessEnv from a plain object. */
+const mkEnv = (o: Record<string, string>): NodeJS.ProcessEnv =>
+  o as unknown as NodeJS.ProcessEnv;
+
+/**
+ * Set/restore a subset of process.env keys around an async callback.
+ * Pass `undefined` as the value to delete the key during the callback.
+ */
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prev = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(vars)) {
+    prev.set(k, process.env[k]);
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  return fn().finally(() => {
+    for (const [k, original] of prev) {
+      if (original === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = original;
+      }
+    }
+  });
+}
+
+/**
+ * Fake tenant loader — matches the TenantContextLoader signature used by the
+ * handlers. Composio tests in this file do not exercise auth logic, so any
+ * valid tenant shape is sufficient.
+ */
+const tenantLoader = async () => ({
+  userId: 'user_1',
+  tenantId: '1',
+  tenantSlug: 'test-tenant',
+  role: 'tenant_admin' as TenantRole,
+});
+
+// ── 1. Dormancy: flag OFF / unset ────────────────────────────────────────────
+
+test('connectablePlatforms flag-OFF: does not include x', () => {
+  const platforms = connectablePlatforms(mkEnv({}));
+  assert.ok(
+    !platforms.includes('x'),
+    "'x' must not be in connectablePlatforms when ARIES_X_ENABLED is unset",
+  );
+  assert.equal(platforms.length, 7, 'exactly 7 platforms when flag is off');
+});
+
+test('isXEnabled: returns false when ARIES_X_ENABLED is unset', () => {
+  assert.equal(isXEnabled(mkEnv({})), false);
+});
+
+test('isXEnabled: returns false for non-truthy values', () => {
+  for (const v of ['0', 'false', 'no', 'off', '']) {
+    assert.equal(
+      isXEnabled(mkEnv({ ARIES_X_ENABLED: v })),
+      false,
+      `isXEnabled must be false for ARIES_X_ENABLED=${JSON.stringify(v)}`,
+    );
+  }
+});
+
+test('handleComposioConnect x flag-OFF: returns 400 unsupported_platform', async () => {
+  // platformOr400 is called before tenant loading; no loader needed for flag-OFF.
+  await withEnv({ ARIES_X_ENABLED: undefined }, async () => {
+    const req = new Request(
+      'https://aries.example.com/api/integrations/composio/x/connect',
+      {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+    const response = await handleComposioConnect(req, 'x');
+    const body = (await response.json()) as { reason: string; message: string };
+    assert.equal(response.status, 400);
+    assert.equal(body.reason, 'unsupported_platform');
+  });
+});
+
+test('handleComposioList flag-OFF: response connections do not include x', async () => {
+  await withEnv({ ARIES_X_ENABLED: undefined }, async () => {
+    const response = await handleComposioList(tenantLoader);
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      connections: Array<{ platform: string }>;
+    };
+    const platforms = body.connections.map((c) => c.platform);
+    assert.ok(
+      !platforms.includes('x'),
+      "x must not appear in connection list when ARIES_X_ENABLED is off",
+    );
+    assert.equal(platforms.length, 7, '7 connection slots when flag is off');
+  });
+});
+
+// ── 2. Fix proof: flag ON ────────────────────────────────────────────────────
+
+test('connectablePlatforms flag-ON: includes x (8 total)', () => {
+  const platforms = connectablePlatforms(mkEnv({ ARIES_X_ENABLED: '1' }));
+  assert.ok(
+    platforms.includes('x'),
+    "'x' must be in connectablePlatforms when ARIES_X_ENABLED=1",
+  );
+  assert.equal(platforms.length, 8, '8 platforms when flag is on');
+});
+
+test('isXEnabled: true for all canonical truthy values', () => {
+  for (const v of ['1', 'true', 'yes', 'on']) {
+    assert.equal(
+      isXEnabled(mkEnv({ ARIES_X_ENABLED: v })),
+      true,
+      `isXEnabled must be true for ARIES_X_ENABLED=${v}`,
+    );
+  }
+});
+
+test('handleComposioConnect x flag-ON: passes the platform gate (no 400 unsupported_platform)', async () => {
+  // With the flag ON, platformOr400 lets 'x' through. Without Composio configured
+  // (COMPOSIO_ENABLED unset), the handler returns 409 composio_disabled — but the
+  // point is it must NOT return 400 unsupported_platform.
+  await withEnv({ ARIES_X_ENABLED: '1' }, async () => {
+    const req = new Request(
+      'https://aries.example.com/api/integrations/composio/x/connect',
+      {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+    const response = await handleComposioConnect(req, 'x', tenantLoader);
+    const body = (await response.json()) as { reason?: string };
+    assert.notEqual(
+      response.status,
+      400,
+      'status must not be 400 when x is enabled',
+    );
+    assert.notEqual(
+      body.reason,
+      'unsupported_platform',
+      'reason must not be unsupported_platform when x is enabled',
+    );
+  });
+});
+
+test('handleComposioList flag-ON: response connections include x (8 slots)', async () => {
+  await withEnv({ ARIES_X_ENABLED: '1' }, async () => {
+    const response = await handleComposioList(tenantLoader);
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      connections: Array<{ platform: string }>;
+    };
+    const platforms = body.connections.map((c) => c.platform);
+    assert.ok(
+      platforms.includes('x'),
+      "x must appear in connection list when ARIES_X_ENABLED=1",
+    );
+    assert.equal(platforms.length, 8, '8 connection slots when flag is on');
+  });
+});
+
+// ── 3. Config wiring ─────────────────────────────────────────────────────────
+
+test('TOOLKIT_SLUG.x === twitter (Composio toolkit name for X)', () => {
+  assert.equal(TOOLKIT_SLUG.x, 'twitter');
+});
+
+test('composioAuthConfigId x: reads COMPOSIO_X_AUTH_CONFIG_ID', () => {
+  assert.equal(
+    composioAuthConfigId('x', mkEnv({ COMPOSIO_X_AUTH_CONFIG_ID: 'ac_x_test' })),
+    'ac_x_test',
+  );
+});
+
+test('composioAuthConfigId x: returns null when neither x-specific nor default key is set', () => {
+  // Mirror existing platform behavior: unset → null.
+  assert.equal(composioAuthConfigId('x', mkEnv({})), null);
+  // Symmetry assertion: facebook behaves identically when unset.
+  assert.equal(composioAuthConfigId('facebook', mkEnv({})), null);
+});
+
+test('composioAuthConfigId x: falls back to COMPOSIO_DEFAULT_AUTH_CONFIG_ID when x-specific key absent', () => {
+  assert.equal(
+    composioAuthConfigId('x', mkEnv({ COMPOSIO_DEFAULT_AUTH_CONFIG_ID: 'ac_default' })),
+    'ac_default',
+  );
+});
+
+// ── 4. Regression guard: the other 7 platforms remain byte-identical ─────────
+
+test('connectablePlatforms flag-OFF: all 7 original platforms still present', () => {
+  const off = connectablePlatforms(mkEnv({}));
+  const original7 = [
+    'facebook',
+    'instagram',
+    'meta_ads',
+    'tiktok',
+    'youtube',
+    'linkedin',
+    'reddit',
+  ] as const;
+  for (const p of original7) {
+    assert.ok(off.includes(p), `${p} must be present with flag OFF`);
+  }
+});
+
+test('connectablePlatforms flag-ON: all 8 platforms present (original 7 + x)', () => {
+  const on = connectablePlatforms(mkEnv({ ARIES_X_ENABLED: '1' }));
+  const all8 = [
+    'facebook',
+    'instagram',
+    'meta_ads',
+    'tiktok',
+    'youtube',
+    'linkedin',
+    'reddit',
+    'x',
+  ] as const;
+  for (const p of all8) {
+    assert.ok(on.includes(p), `${p} must be present with flag ON`);
+  }
+});
+
+test('isIntegrationPlatform x: always true regardless of flag (pure type guard)', () => {
+  // The type guard checks INTEGRATION_PLATFORMS array membership, not the env flag.
+  // The dormancy chokepoint is connectablePlatforms(), not this predicate.
+  assert.equal(isIntegrationPlatform('x'), true);
+});
+
+test('isIntegrationPlatform: unknown value is false (guard soundness)', () => {
+  assert.equal(isIntegrationPlatform('unknown_platform'), false);
+  assert.equal(isIntegrationPlatform(''), false);
+  assert.equal(isIntegrationPlatform('twitter'), false, "'twitter' is a toolkit slug, not an Aries platform key");
+});


### PR DESCRIPTION
Closes #630

## What
Adds **X (Twitter)** as a first-class Composio-connectable platform, gated behind `ARIES_X_ENABLED` (default OFF → ships dormant). Mirrors the existing FB/YouTube/Reddit Composio template.

## Root cause / scope
X was simply not in the `IntegrationPlatform` union, so the connect/capabilities/disconnect routes and the connections list had no way to surface it. This widens the union by `'x'` and wires the Composio toolkit (`twitter`) + auth-config env, with a single dormancy chokepoint so nothing is visible until the flag flips.

## Changes
- `backend/integrations/providers/types.ts` — add `'x'` to `IntegrationPlatform` + `INTEGRATION_PLATFORMS`.
- `backend/integrations/providers/integration-config.ts` — new `isXEnabled()` + `connectablePlatforms()` (the **single dormancy chokepoint**); `composioAuthConfigId` reads `COMPOSIO_X_AUTH_CONFIG_ID`.
- `app/api/integrations/composio/handlers.ts` — `platformOr400` and `handleComposioList` both route through `connectablePlatforms()`, so a recognized-but-disabled `'x'` returns the **byte-identical** `400 {"status":"error","reason":"unsupported_platform","message":"Unsupported platform: x"}` and the list stays at 7 cards while OFF.
- `backend/integrations/composio/composio-config.ts` — `TOOLKIT_SLUG.x = 'twitter'` (Composio's toolkit name; Aries' platform key stays `'x'`).
- `frontend/integrations/composio-connections-screen.tsx` — `X` label (inert until a row is surfaced).
- `.env.example` + `docker-compose.yml` (aries-app block) — wire `ARIES_X_ENABLED` (`:-false`) and `COMPOSIO_X_AUTH_CONFIG_ID` (`:-`) with safe defaults (two-place env rule satisfied).

## Dormancy proof
- Default genuinely OFF: `parseFlag(undefined) === false` → `connectablePlatforms()` filters `'x'` out.
- `tests/composio-x-connect.test.ts` (17 assertions) locks both states: flag OFF → 7 slots, connect 400 `unsupported_platform`; flag ON → 8 slots, connect passes the platform gate. The other 7 platforms remain byte-identical.

## Test evidence
- `npm run typecheck` clean (union-widening: both exhaustive `Record<IntegrationPlatform>` maps updated; partial map unaffected).
- New focused test 17/17 pass; `npm run verify` green; `npm run validate:social-content` 92/92; `validate:banned-patterns` clean.

## Activation (human, in prod `.env`)
Ships dormant. To activate: provision `COMPOSIO_X_AUTH_CONFIG_ID` in Composio and set `ARIES_X_ENABLED=1` in the prod `.env`.

## Residual risk
Connect-only. Later X gates (publish / analytics / comments / reply) are **separate issues** — the FB-specific publish/reply/page-resolution branches correctly do not match `'x'`, so X stays dormant on those paths by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)