### PR TITLE
fix(integrations): publish Reddit posts via Composio REDDIT_CREATE_REDDIT_POST behind ARIES_REDDIT_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -261,6 +261,11 @@ COMPOSIO_API_KEY=
 # unsupported_platform 400 as today. Flip to true once the X auth-config below
 # is provisioned in Composio.
 ARIES_X_ENABLED=false
+# Reddit publish rollout flag. Default OFF — ships the publish path dormant
+# (Reddit already CONNECTS via Composio; this flag gates publish only). When OFF,
+# a `reddit` schedule still 400s invalid_platforms and dispatch 400s
+# unsupported_provider. Flip to true once the Reddit publish action below is set.
+ARIES_REDDIT_ENABLED=false
 # Toolkit version for manual (by-slug) Composio tool execution — publishing,
 # analytics, AND comments all go through tools.execute, which the @composio/core
 # SDK rejects without a toolkit version. Default 'latest' (the gateway pairs it
@@ -304,12 +309,21 @@ ANALYTICS_PROVIDER=direct_meta
 # and PUBLISH_POST creates the tweet with the returned media id.
 #   COMPOSIO_X_PUBLISH_POST_ACTION=TWITTER_CREATION_OF_A_POST
 #   COMPOSIO_X_UPLOAD_MEDIA_ACTION=TWITTER_UPLOAD_MEDIA
+# Reddit publish (#641) — only consulted when ARIES_REDDIT_ENABLED=true and
+# PUBLISH_PROVIDER=composio/auto. ONE action (no media-upload — an image is the
+# kind=link url). TARGET_SUBREDDIT is optional: unset → the post goes to the
+# connected user's own profile (u_<username>). FLAIR_ID is an optional
+# passthrough for subreddits that require a post flair.
+#   COMPOSIO_REDDIT_PUBLISH_POST_ACTION=REDDIT_CREATE_REDDIT_POST
 COMPOSIO_FACEBOOK_PUBLISH_POST_ACTION=
 COMPOSIO_INSTAGRAM_PUBLISH_POST_ACTION=
 COMPOSIO_FACEBOOK_UPLOAD_MEDIA_ACTION=
 COMPOSIO_INSTAGRAM_UPLOAD_MEDIA_ACTION=
 COMPOSIO_X_PUBLISH_POST_ACTION=
 COMPOSIO_X_UPLOAD_MEDIA_ACTION=
+COMPOSIO_REDDIT_PUBLISH_POST_ACTION=
+COMPOSIO_REDDIT_TARGET_SUBREDDIT=
+COMPOSIO_REDDIT_FLAIR_ID=
 
 # Facebook analytics + comments sync (#596/#597), read by the insights-sync
 # worker's Facebook adapter (backend/insights/adapters/facebook). The verified

--- a/app/api/internal/publishing/scheduled-dispatch/route.ts
+++ b/app/api/internal/publishing/scheduled-dispatch/route.ts
@@ -6,7 +6,7 @@ import {
   type MetaPublishFailureKind,
 } from '@/backend/integrations/meta-publishing';
 import { dispatchPublish } from '@/backend/integrations/publish-dispatch';
-import { isXEnabled } from '@/backend/integrations/providers/integration-config';
+import { isRedditEnabled, isXEnabled } from '@/backend/integrations/providers/integration-config';
 import { toSignedPublicUrl } from '@/app/api/publish/dispatch/handler';
 import { resolveSignableBasename } from '@/backend/marketing/signable-basename';
 import { recomputeAndPersistPendingApprovalCount } from '@/backend/marketing/runtime-views';
@@ -260,11 +260,13 @@ export async function POST(req: Request): Promise<Response> {
   let firstPublishedPostId: string | null = null;
 
   for (const platform of platforms) {
-    // X (Twitter) is a Composio-only publish target (no direct-Meta path), so it
-    // is not an `isMetaProvider`; accept it only when the rollout flag is on. OFF
-    // (default) keeps the exact `unsupported_provider` terminal result as before.
+    // X (Twitter) and Reddit are Composio-only publish targets (no direct-Meta
+    // path), so neither is an `isMetaProvider`; accept each only when its rollout
+    // flag is on. OFF (default) keeps the exact `unsupported_provider` terminal
+    // result as before.
     const isXPublish = platform.trim().toLowerCase() === 'x' && isXEnabled();
-    if (!isMetaProvider(platform) && !isXPublish) {
+    const isRedditPublish = platform.trim().toLowerCase() === 'reddit' && isRedditEnabled();
+    if (!isMetaProvider(platform) && !isXPublish && !isRedditPublish) {
       // Unsupported provider can never succeed — terminal, not retryable.
       results.push({ provider: platform, ok: false, error: 'unsupported_provider', retryable: false, kind: 'permanent' });
       continue;

--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -22,6 +22,7 @@ import {
   type UploadMediaResult,
 } from '../providers/types';
 import { PublishGuardError } from '../providers/errors';
+import { redditTargetSubreddit } from '../providers/integration-config';
 import type { ComposioConfig, ComposioOperation } from './composio-config';
 import type { ComposioFileDescriptor, ComposioGateway } from './composio-client';
 import { getConnectionRow, type Queryable } from './connection-store';
@@ -41,8 +42,9 @@ function pickId(data: unknown, keys: string[]): string | null {
     if (typeof v === 'string' && v.trim()) return v.trim();
     if (typeof v === 'number') return String(v);
   }
-  // Some tools nest the payload under data/response.
-  for (const nestKey of ['data', 'response', 'result']) {
+  // Some tools nest the payload under data/response/result, and Reddit nests the
+  // created object under `json` (data.json.data.name → the t3_ fullname).
+  for (const nestKey of ['data', 'response', 'result', 'json']) {
     const nested = obj[nestKey];
     if (nested && typeof nested === 'object') {
       const found = pickId(nested, keys);
@@ -54,6 +56,29 @@ function pickId(data: unknown, keys: string[]): string | null {
 
 function pickUrl(data: unknown): string | null {
   return pickId(data, ['permalink', 'permalink_url', 'url', 'link']);
+}
+
+/** The id keys used for the shared post-id extraction unless a branch overrides. */
+const DEFAULT_POST_ID_KEYS = ['post_id', 'id', 'media_id'];
+
+const REDDIT_TITLE_MAX = 300;
+const REDDIT_FALLBACK_TITLE = 'New post';
+
+/**
+ * Reddit requires a non-empty `title` (it rejects an empty one) ≤ 300 chars. Take
+ * the first non-empty line of the post content, collapse internal whitespace, and
+ * truncate with an ellipsis. Falls back to a stable label when content is empty.
+ * Pure — no I/O — so it is trivially unit-testable.
+ */
+function redditTitleFromContent(content: string): string {
+  const firstLine = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  const collapsed = (firstLine ?? '').replace(/\s+/g, ' ').trim();
+  if (!collapsed) return REDDIT_FALLBACK_TITLE;
+  if (collapsed.length <= REDDIT_TITLE_MAX) return collapsed;
+  return `${collapsed.slice(0, REDDIT_TITLE_MAX - 1)}…`;
 }
 
 export class ComposioPublisherProvider implements PublisherProvider {
@@ -127,6 +152,9 @@ export class ComposioPublisherProvider implements PublisherProvider {
     // resolveFacebookManagedPage is called as a fallback.
     let slug: string;
     let toolArgs: Record<string, unknown>;
+    // The created post id lives at different keys per platform; a branch may
+    // override before the shared extraction at the end of publishPost.
+    let idKeys = DEFAULT_POST_ID_KEYS;
 
     if (input.platform === 'facebook') {
       let pageId = conn.externalAccountId ?? null;
@@ -221,6 +249,60 @@ export class ComposioPublisherProvider implements PublisherProvider {
         text: input.content,
         ...(mediaId ? { media_media_ids: [mediaId] } : {}),
       };
+    } else if (input.platform === 'reddit') {
+      // Reddit: a SINGLE REDDIT_CREATE_REDDIT_POST call. There is NO media-upload
+      // action — an image is posted as a `kind='link'` whose url IS the image
+      // (Reddit fetches it), never a pre-staged upload. So unlike X, there is no
+      // pre-publish step: this is exactly the FB-style single-call,
+      // outcome-unknown boundary (a transport drop after dispatch may have
+      // posted). Every PRE-call failure here (no subreddit, no slug, no
+      // connection) throws BEFORE the shared executeTool below → classified
+      // definitely-never-posted → safe rollback + worker re-claim. Reddit is
+      // rate-limited and posts can be silently automod-removed; we deliberately
+      // do NOT retry-loop a create — a rate-limited create surfaces as
+      // never-posted and the standing worker re-claims the row.
+      //
+      // Subreddit target (never guessed): an explicit
+      // COMPOSIO_REDDIT_TARGET_SUBREDDIT, else the connected user's own profile
+      // (`u_<username>` self-post), else refuse with a capability error.
+      let subreddit = redditTargetSubreddit();
+      if (!subreddit && conn.externalAccountName) {
+        subreddit = `u_${conn.externalAccountName}`;
+      }
+      if (!subreddit) {
+        throw new ComposioCapabilityMissingError(
+          'reddit',
+          'configure a target subreddit (COMPOSIO_REDDIT_TARGET_SUBREDDIT) or reconnect Reddit',
+        );
+      }
+
+      slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
+      // Reddit returns a fullname id (`t3_<base36>`) at data.json.data.name — NOT
+      // in the shared default keys (and under a `json` nest), so override here.
+      idKeys = ['name', 'id', 'post_id'];
+
+      const title = redditTitleFromContent(input.content);
+      const flairId = process.env.COMPOSIO_REDDIT_FLAIR_ID?.trim();
+      if (input.mediaUrls.length > 0) {
+        // Image post: the image IS the link target (kind='link'); not dropped,
+        // not pre-uploaded.
+        toolArgs = {
+          subreddit,
+          title,
+          kind: 'link',
+          url: input.mediaUrls[0],
+          ...(flairId ? { flair_id: flairId } : {}),
+        };
+      } else {
+        // Text post: kind='self' with the body as `text`.
+        toolArgs = {
+          subreddit,
+          title,
+          kind: 'self',
+          text: input.content,
+          ...(flairId ? { flair_id: flairId } : {}),
+        };
+      }
     } else {
       // Instagram: caption + media_urls + placement + media_type (unchanged).
       slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
@@ -245,7 +327,7 @@ export class ComposioPublisherProvider implements PublisherProvider {
     return {
       provider: 'composio',
       platform: input.platform,
-      externalPostId: pickId(result.data, ['post_id', 'id', 'media_id']),
+      externalPostId: pickId(result.data, idKeys),
       externalCampaignId: null,
       externalAdId: null,
       status: input.scheduledFor ? 'scheduled' : 'published',

--- a/backend/integrations/providers/index.ts
+++ b/backend/integrations/providers/index.ts
@@ -15,6 +15,7 @@ export {
   parseFlag,
   isComposioEnabled,
   isXEnabled,
+  isRedditEnabled,
   connectablePlatforms,
   publishProviderSelector,
   analyticsProviderSelector,

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -37,6 +37,25 @@ export function isXEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
+ * Reddit publish rollout flag. Default OFF — ships the publish path dormant
+ * (Reddit already *connects* via Composio; this flag gates publish only, so it
+ * is deliberately NOT wired into `connectablePlatforms`).
+ */
+export function isRedditEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseFlag(env.ARIES_REDDIT_ENABLED);
+}
+
+/**
+ * Explicit target subreddit for Reddit publish (COMPOSIO_REDDIT_TARGET_SUBREDDIT).
+ * Returns null when unset/empty so the publisher falls back to the connected
+ * user's own profile (`u_<username>`) and never guesses a community.
+ */
+export function redditTargetSubreddit(env: NodeJS.ProcessEnv = process.env): string | null {
+  const v = env.COMPOSIO_REDDIT_TARGET_SUBREDDIT?.trim();
+  return v || null;
+}
+
+/**
  * Platforms an operator can actually connect right now. The single dormancy
  * chokepoint for flag-gated platforms: when `ARIES_X_ENABLED` is OFF, `'x'` is
  * filtered out everywhere (connect/capabilities/disconnect gate + the UI list),

--- a/backend/integrations/publish-dispatch.ts
+++ b/backend/integrations/publish-dispatch.ts
@@ -34,14 +34,16 @@ import { publishNeverReachedPlatform } from './publish-outcome';
 
 function metaPlatform(provider: string): IntegrationPlatform {
   // Map the dispatch request's provider string to the integration platform the
-  // provider seam services. X (Twitter) is its own Composio-only platform;
-  // Instagram maps to instagram; everything else maps to facebook (the direct
-  // route's two-way split). Without the explicit X case, 'x' would fall through
-  // to 'facebook' and an X post would be sent to a Facebook Page. X never reaches
-  // the direct_meta fast path (normalizeMetaProvider('x') throws a terminal 400),
-  // and DirectMetaProvider.supports('x') is false, so it can never post to FB.
+  // provider seam services. X (Twitter) and Reddit are each their own
+  // Composio-only platform; Instagram maps to instagram; everything else maps to
+  // facebook (the direct route's two-way split). Without the explicit cases, 'x'
+  // or 'reddit' would fall through to 'facebook' and be sent to a Facebook Page.
+  // Neither reaches the direct_meta fast path (normalizeMetaProvider throws a
+  // terminal 400), and DirectMetaProvider.supports('x'|'reddit') is false, so
+  // they can never post to FB.
   const normalized = provider.trim().toLowerCase();
   if (normalized === 'x') return 'x';
+  if (normalized === 'reddit') return 'reddit';
   if (normalized === 'instagram') return 'instagram';
   return 'facebook';
 }

--- a/backend/social-content/scheduled-posts.ts
+++ b/backend/social-content/scheduled-posts.ts
@@ -1,4 +1,4 @@
-import { isXEnabled } from '@/backend/integrations/providers/integration-config';
+import { isRedditEnabled, isXEnabled } from '@/backend/integrations/providers/integration-config';
 
 export type ScheduledPostQueryable = {
   query: (
@@ -107,19 +107,22 @@ export class ScheduledPostTenantMismatchError extends Error {
   }
 }
 
-export const ALLOWED_TARGET_PLATFORMS = ['facebook', 'instagram', 'x'] as const;
+export const ALLOWED_TARGET_PLATFORMS = ['facebook', 'instagram', 'x', 'reddit'] as const;
 export type AllowedTargetPlatform = (typeof ALLOWED_TARGET_PLATFORMS)[number];
 
 /**
- * The platforms an operator can schedule a post to RIGHT NOW. `'x'` (Twitter) is
- * a valid target only while the `ARIES_X_ENABLED` rollout flag is on; when OFF
- * (the default) the allowed set is byte-identical to facebook+instagram, so an
- * `x` schedule request still fails `invalid_platforms` exactly as before.
+ * The platforms an operator can schedule a post to RIGHT NOW. `'x'` (Twitter)
+ * and `'reddit'` are each valid targets only while their rollout flag
+ * (`ARIES_X_ENABLED` / `ARIES_REDDIT_ENABLED`) is on; computed at call time so a
+ * flag flip takes effect without a restart. When both are OFF (the default) the
+ * allowed set is byte-identical to facebook+instagram, so an `x`/`reddit`
+ * schedule request still fails `invalid_platforms` exactly as before.
  */
 function allowedTargetPlatforms(): ReadonlySet<AllowedTargetPlatform> {
-  return isXEnabled()
-    ? new Set<AllowedTargetPlatform>(ALLOWED_TARGET_PLATFORMS)
-    : new Set<AllowedTargetPlatform>(['facebook', 'instagram']);
+  const allowed = new Set<AllowedTargetPlatform>(['facebook', 'instagram']);
+  if (isXEnabled()) allowed.add('x');
+  if (isRedditEnabled()) allowed.add('reddit');
+  return allowed;
 }
 
 export function normalizeTargetPlatforms(value: unknown): AllowedTargetPlatform[] | null {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,10 @@ services:
       # X (Twitter) connect rollout flag — default OFF ships the platform dormant
       # (card hidden; connect/capabilities 400 unsupported_platform as today).
       ARIES_X_ENABLED: ${ARIES_X_ENABLED:-false}
+      # Reddit publish rollout flag — default OFF ships the publish path dormant
+      # (Reddit already connects; this gates publish only). When OFF a reddit
+      # schedule/dispatch is rejected exactly as today.
+      ARIES_REDDIT_ENABLED: ${ARIES_REDDIT_ENABLED:-false}
       # Toolkit version for manual Composio tool execution (publish/analytics/
       # comments). The SDK rejects by-slug execution without one; default 'latest'
       # (gateway pairs it with a skip-check). Pin a concrete version to avoid drift.
@@ -226,6 +230,15 @@ services:
       #   COMPOSIO_X_UPLOAD_MEDIA_ACTION=TWITTER_UPLOAD_MEDIA
       COMPOSIO_X_PUBLISH_POST_ACTION: ${COMPOSIO_X_PUBLISH_POST_ACTION:-}
       COMPOSIO_X_UPLOAD_MEDIA_ACTION: ${COMPOSIO_X_UPLOAD_MEDIA_ACTION:-}
+      # Reddit publish (#641) — only consulted when ARIES_REDDIT_ENABLED=true and
+      # PUBLISH_PROVIDER=composio/auto. Publish runs in the app process (the
+      # scheduled-posts-worker only POSTs to the route), so these live here only.
+      # No media-upload action (image is the kind=link url). TARGET_SUBREDDIT
+      # unset → the connected user's own profile (u_<username>); FLAIR_ID optional.
+      #   COMPOSIO_REDDIT_PUBLISH_POST_ACTION=REDDIT_CREATE_REDDIT_POST
+      COMPOSIO_REDDIT_PUBLISH_POST_ACTION: ${COMPOSIO_REDDIT_PUBLISH_POST_ACTION:-}
+      COMPOSIO_REDDIT_TARGET_SUBREDDIT: ${COMPOSIO_REDDIT_TARGET_SUBREDDIT:-}
+      COMPOSIO_REDDIT_FLAIR_ID: ${COMPOSIO_REDDIT_FLAIR_ID:-}
       # Facebook analytics + comments sync slugs (#596/#597). Optional — the
       # adapter falls back to the verified code defaults when unset.
       COMPOSIO_FACEBOOK_LIST_POSTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_POSTS_ACTION:-}

--- a/tests/composio-reddit-publisher.test.ts
+++ b/tests/composio-reddit-publisher.test.ts
@@ -1,0 +1,894 @@
+/**
+ * Regression coverage for #641: Reddit publish dispatched through Composio
+ * REDDIT_CREATE_REDDIT_POST, gated behind ARIES_REDDIT_ENABLED.
+ *
+ * Failure modes locked:
+ *  1. Image post (flag ON, subreddit env set): dispatches REDDIT_CREATE_REDDIT_POST
+ *     with {subreddit, title, kind:'link', url}; externalPostId = t3_ name from
+ *     nested json.data.name.
+ *  2. Text-only post: kind='self', text=content (no url field).
+ *  3. Subreddit resolution: env set → that subreddit; env unset + externalAccountName
+ *     → u_<name>; both unset → ComposioCapabilityMissingError (never-posted).
+ *  4. Title derivation: multi-line → first non-empty line; >300 chars → truncated
+ *     with ellipsis; empty content → 'New post'.
+ *  5. Slug unset → ComposioCapabilityMissingError. Dry-run → no gateway calls.
+ *     Not-approved → PublishGuardError. executeTool successful:false →
+ *     ComposioToolError (never-posted).
+ *  6. normalizeTargetPlatforms: flag OFF → ['reddit'] returns null; flag ON →
+ *     ['reddit'] accepted.
+ *  7. Dispatch-guard predicate: isMetaProvider('reddit') false; combined guard
+ *     rejects reddit as unsupported when flag off, passes when on.
+ *  8. post-id extraction: t3_ fullname extracted from nested json.data.name shape;
+ *     media_key not grabbed.
+ *  9. metaPlatform routing: provider='reddit' reaches the seam with platform='reddit',
+ *     NOT coerced to 'facebook'.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ComposioPublisherProvider } from '@/backend/integrations/composio/composio-publisher-provider';
+import { PublishGuardError } from '@/backend/integrations/providers/errors';
+import {
+  ComposioCapabilityMissingError,
+  ComposioConnectionMissingError,
+  ComposioToolError,
+} from '@/backend/integrations/composio/errors';
+import { publishNeverReachedPlatform } from '@/backend/integrations/publish-outcome';
+import { isMetaProvider } from '@/backend/integrations/meta-publishing';
+import { isRedditEnabled } from '@/backend/integrations/providers/integration-config';
+import { normalizeTargetPlatforms } from '@/backend/social-content/scheduled-posts';
+import { dispatchPublish } from '@/backend/integrations/publish-dispatch';
+import type { ComposioGateway, GatewayToolResult } from '@/backend/integrations/composio/composio-client';
+import type { PublisherProvider } from '@/backend/integrations/providers/interfaces';
+import type { PublishPostInput } from '@/backend/integrations/providers/types';
+import type { RecordedExecute } from './composio/helpers';
+import { fakeConfig, fakeDb } from './composio/helpers';
+
+const tenantId = '42';
+
+// ── withEnv helper ────────────────────────────────────────────────────────────
+
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  const prev = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(vars)) {
+    prev.set(k, process.env[k]);
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  return Promise.resolve(fn()).finally(() => {
+    for (const [k, original] of prev) {
+      if (original === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = original;
+      }
+    }
+  });
+}
+
+// ── Simple gateway (no uploadFile for Reddit — no pre-upload step) ────────────
+
+function makeRedditGateway(opts?: {
+  defaultResult?: GatewayToolResult;
+  shouldThrow?: Error;
+}): ComposioGateway & { calls: RecordedExecute[] } {
+  const calls: RecordedExecute[] = [];
+  const defaultResult: GatewayToolResult =
+    opts?.defaultResult ?? { data: {}, successful: true, error: null };
+
+  return {
+    calls,
+    async findOrCreateManagedAuthConfig(toolkitSlug) {
+      return `ac_${toolkitSlug}`;
+    },
+    async initiateConnection() {
+      return { connectionRequestId: 'cr_1', redirectUrl: null };
+    },
+    async listConnections() {
+      return [];
+    },
+    async getConnection() {
+      return null;
+    },
+    async deleteConnection() {
+      /* no-op */
+    },
+    async executeTool(slug, options) {
+      const rec = { slug, options };
+      calls.push(rec);
+      if (opts?.shouldThrow) throw opts.shouldThrow;
+      return defaultResult;
+    },
+    async uploadFile(_input) {
+      // Reddit does NOT call uploadFile — if this is ever reached the test should fail.
+      throw new Error('uploadFile must never be called for a Reddit publish');
+    },
+  };
+}
+
+// ── Actions config for Reddit ─────────────────────────────────────────────────
+
+const REDDIT_ACTIONS = {
+  publish_post: 'REDDIT_CREATE_REDDIT_POST',
+} as const;
+
+// ── fakeDb with a reddit connected account ────────────────────────────────────
+
+function redditDb(opts?: { externalAccountName?: string | null; noRow?: boolean }) {
+  const name = opts?.externalAccountName === undefined ? 'someuser' : opts.externalAccountName;
+  return fakeDb({
+    connectionRow: opts?.noRow
+      ? null
+      : {
+          id: 1,
+          tenant_id: 42,
+          external_user_id: 'aries-tenant-42',
+          platform: 'reddit',
+          provider: 'composio',
+          connected_account_id: 'ca_reddit_123',
+          auth_config_id: 'auth_cfg_test',
+          external_account_id: null,
+          external_account_name: name,
+          status: 'connected',
+          capabilities_json: null,
+          last_capability_check_at: null,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+        },
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 1. Image post (flag ON, subreddit env set)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 Reddit image post: single REDDIT_CREATE_REDDIT_POST call with {subreddit, title, kind:link, url}', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/testcommunity', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const createPostResult: GatewayToolResult = {
+        // Reddit wraps the created post id in data.json.data.name (t3_ fullname)
+        data: { json: { data: { name: 't3_abc123', url: 'https://reddit.com/r/testcommunity/comments/abc123' } } },
+        successful: true,
+        error: null,
+      };
+      const gateway = makeRedditGateway({ defaultResult: createPostResult });
+
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      const result = await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'Hello\nbody text that should NOT be the title',
+        mediaUrls: ['https://img.example.com/photo.png'],
+        approved: true,
+      });
+
+      // Exactly one executeTool call (no uploadFile step for Reddit)
+      assert.equal(gateway.calls.length, 1, 'exactly one executeTool call for Reddit image post');
+      const call = gateway.calls[0];
+      assert.equal(call.slug, 'REDDIT_CREATE_REDDIT_POST', 'must call the reddit publish action slug');
+
+      const args = call.options.arguments as Record<string, unknown>;
+      assert.equal(args.subreddit, 'r/testcommunity', 'subreddit must come from COMPOSIO_REDDIT_TARGET_SUBREDDIT');
+      assert.equal(args.title, 'Hello', 'title must be the first non-empty line of content');
+      assert.equal(args.kind, 'link', 'image post must use kind=link');
+      assert.equal(args.url, 'https://img.example.com/photo.png', 'url must be the first mediaUrl');
+      assert.equal(args.text, undefined, 'text must NOT be present for an image (link-kind) post');
+
+      // Result
+      assert.equal(result.status, 'published');
+      assert.equal(result.externalPostId, 't3_abc123', 'externalPostId must be the t3_ fullname from json.data.name');
+      assert.equal(result.platform, 'reddit');
+      assert.equal(result.provider, 'composio');
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 2. Text-only post
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 Reddit text-only post: kind=self, text=content, no url field', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/testcommunity', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const createPostResult: GatewayToolResult = {
+        data: { json: { data: { name: 't3_textonly' } } },
+        successful: true,
+        error: null,
+      };
+      const gateway = makeRedditGateway({ defaultResult: createPostResult });
+
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      const result = await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'Just text, no image at all',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      assert.equal(gateway.calls.length, 1, 'exactly one executeTool call for text-only');
+      const call = gateway.calls[0];
+      assert.equal(call.slug, 'REDDIT_CREATE_REDDIT_POST');
+
+      const args = call.options.arguments as Record<string, unknown>;
+      assert.equal(args.kind, 'self', 'text-only post must use kind=self');
+      assert.equal(args.text, 'Just text, no image at all', 'text must be the full content');
+      assert.equal(args.url, undefined, 'url must NOT be present for a text (self-kind) post');
+      assert.equal(args.subreddit, 'r/testcommunity');
+      assert.equal(args.title, 'Just text, no image at all', 'title should be the first line');
+
+      assert.equal(result.status, 'published');
+      assert.equal(result.externalPostId, 't3_textonly');
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 3. Subreddit resolution
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 subreddit: env set → uses COMPOSIO_REDDIT_TARGET_SUBREDDIT', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/mysubreddit', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_sr' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb({ externalAccountName: 'ignored_user' }),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'test',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(args.subreddit, 'r/mysubreddit', 'env value must take precedence over username fallback');
+    },
+  );
+});
+
+test('#641 subreddit: env unset + externalAccountName → u_<name>', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: undefined, ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_profile' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb({ externalAccountName: 'someuser' }),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'profile post',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(
+        args.subreddit,
+        'u_someuser',
+        'should fall back to u_<externalAccountName> when env is unset',
+      );
+    },
+  );
+});
+
+test('#641 subreddit: both unset → ComposioCapabilityMissingError AND publishNeverReachedPlatform=true', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: undefined, ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway();
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb({ externalAccountName: null }), // no externalAccountName
+      );
+
+      let caught: unknown;
+      try {
+        await provider.publishPost({
+          tenantId,
+          platform: 'reddit',
+          content: 'no subreddit',
+          mediaUrls: [],
+          approved: true,
+        });
+        assert.fail('expected rejection');
+      } catch (e) {
+        caught = e;
+      }
+
+      assert.ok(
+        caught instanceof ComposioCapabilityMissingError,
+        'both-unset subreddit must throw ComposioCapabilityMissingError',
+      );
+      assert.equal(
+        publishNeverReachedPlatform(caught),
+        true,
+        'subreddit-missing error must be classified as definitely-never-posted (safe rollback)',
+      );
+      // No executeTool call was made
+      assert.equal(gateway.calls.length, 0, 'executeTool must not be called when subreddit is missing');
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 4. Title derivation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 title: multi-line content → first non-empty line used as title', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_multi' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: '\n\nFirst actual line\nSecond line\nThird line',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(
+        args.title,
+        'First actual line',
+        'title must be the first non-empty line, skipping blank lines',
+      );
+    },
+  );
+});
+
+test('#641 title: content >300 chars → truncated to 300 chars with ellipsis', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const longContent = 'A'.repeat(400);
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_long' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: longContent,
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      const title = args.title as string;
+      assert.ok(
+        title.length <= 300,
+        `title must be ≤300 chars; got ${title.length}`,
+      );
+      assert.ok(
+        title.endsWith('…'),
+        'truncated title must end with ellipsis character',
+      );
+      // The truncation: 299 chars of content + '…' = 300
+      assert.equal(title.length, 300, 'truncated title must be exactly 300 chars');
+    },
+  );
+});
+
+test('#641 title: empty content → fallback "New post"', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_empty' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: '',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(args.title, 'New post', 'empty content must produce the fallback title');
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 5. Guard conditions: slug unset, dry-run, not-approved, tool failure
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 Reddit publish_post slug unset → ComposioCapabilityMissingError (never guess a slug)', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const provider = new ComposioPublisherProvider(
+        makeRedditGateway(),
+        fakeConfig({ actions: {} /* no publish_post */ }),
+        redditDb(),
+      );
+
+      await assert.rejects(
+        () =>
+          provider.publishPost({
+            tenantId,
+            platform: 'reddit',
+            content: 'hello',
+            mediaUrls: [],
+            approved: true,
+          }),
+        ComposioCapabilityMissingError,
+        'missing publish_post slug must throw ComposioCapabilityMissingError',
+      );
+    },
+  );
+});
+
+test('#641 Reddit dry-run returns preview without calling the gateway', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway();
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      const result = await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'preview',
+        mediaUrls: ['https://img.example.com/photo.png'],
+        dryRun: true,
+      });
+
+      assert.equal(result.status, 'preview', 'dry-run must return preview status');
+      assert.equal(gateway.calls.length, 0, 'dry-run must not call executeTool');
+    },
+  );
+});
+
+test('#641 Reddit not-approved throws PublishGuardError', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const provider = new ComposioPublisherProvider(
+        makeRedditGateway(),
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await assert.rejects(
+        () =>
+          provider.publishPost({
+            tenantId,
+            platform: 'reddit',
+            content: 'not approved',
+            mediaUrls: [],
+            approved: false,
+          }),
+        PublishGuardError,
+        'unapproved Reddit post must throw PublishGuardError',
+      );
+    },
+  );
+});
+
+test('#641 Reddit executeTool successful:false → ComposioToolError (never-posted)', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: null, successful: false, error: 'SUBREDDIT_NOEXIST' },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      let caught: unknown;
+      try {
+        await provider.publishPost({
+          tenantId,
+          platform: 'reddit',
+          content: 'fail',
+          mediaUrls: [],
+          approved: true,
+        });
+        assert.fail('expected rejection');
+      } catch (e) {
+        caught = e;
+      }
+
+      assert.ok(caught instanceof ComposioToolError, 'unsuccessful executeTool must throw ComposioToolError');
+      assert.equal(
+        publishNeverReachedPlatform(caught),
+        true,
+        'tool-unsuccessful must be classified as definitely-never-posted (safe to roll back)',
+      );
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 6. normalizeTargetPlatforms dormancy
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 normalizeTargetPlatforms: flag OFF → [\'reddit\'] returns null (reddit not accepted)', async () => {
+  await withEnv({ ARIES_REDDIT_ENABLED: undefined }, () => {
+    const result = normalizeTargetPlatforms(['reddit']);
+    assert.equal(
+      result,
+      null,
+      "['reddit'] must return null when ARIES_REDDIT_ENABLED is unset (schedule request would 400)",
+    );
+  });
+});
+
+test('#641 normalizeTargetPlatforms: flag OFF → [\'facebook\', \'instagram\'] still accepted', async () => {
+  await withEnv({ ARIES_REDDIT_ENABLED: undefined }, () => {
+    const result = normalizeTargetPlatforms(['facebook', 'instagram']);
+    assert.deepEqual(result, ['facebook', 'instagram'], 'facebook+instagram must work regardless of reddit flag');
+  });
+});
+
+test('#641 normalizeTargetPlatforms: flag ON → [\'reddit\'] accepted', async () => {
+  await withEnv({ ARIES_REDDIT_ENABLED: '1' }, () => {
+    const result = normalizeTargetPlatforms(['reddit']);
+    assert.deepEqual(result, ['reddit'], "['reddit'] must be accepted when ARIES_REDDIT_ENABLED=1");
+  });
+});
+
+test('#641 normalizeTargetPlatforms: flag ON → [\'facebook\', \'instagram\', \'reddit\'] accepted', async () => {
+  await withEnv({ ARIES_REDDIT_ENABLED: '1' }, () => {
+    const result = normalizeTargetPlatforms(['facebook', 'instagram', 'reddit']);
+    assert.deepEqual(result, ['facebook', 'instagram', 'reddit'], 'all three platforms valid when reddit flag ON');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 7. Dispatch-guard predicates
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 dispatch guard: isMetaProvider(reddit) is false — reddit is never routed via the direct-Meta fast path', () => {
+  assert.equal(
+    isMetaProvider('reddit'),
+    false,
+    "reddit must not be a Meta provider — a bug here would route Reddit posts to a Facebook Page",
+  );
+});
+
+test('#641 dispatch guard flag-OFF: combined predicate rejects reddit as unsupported_provider', async () => {
+  // Replicates the exact condition in scheduled-dispatch/route.ts:
+  //   const isRedditPublish = platform === 'reddit' && isRedditEnabled();
+  //   if (!isMetaProvider(platform) && !isXPublish && !isRedditPublish) → push unsupported_provider
+  await withEnv({ ARIES_REDDIT_ENABLED: undefined }, () => {
+    const platform = 'reddit';
+    const isRedditPublish = platform === 'reddit' && isRedditEnabled();
+    const shouldReject = !isMetaProvider(platform) && !isRedditPublish;
+    assert.equal(
+      shouldReject,
+      true,
+      'reddit must be rejected (unsupported_provider) when ARIES_REDDIT_ENABLED is unset',
+    );
+  });
+});
+
+test('#641 dispatch guard flag-ON: combined predicate passes reddit through to dispatchPublish', async () => {
+  await withEnv({ ARIES_REDDIT_ENABLED: '1' }, () => {
+    const platform = 'reddit';
+    const isRedditPublish = platform === 'reddit' && isRedditEnabled();
+    const shouldReject = !isMetaProvider(platform) && !isRedditPublish;
+    assert.equal(
+      shouldReject,
+      false,
+      'reddit must NOT be rejected when ARIES_REDDIT_ENABLED=1',
+    );
+  });
+});
+
+test('#641 dispatch guard: facebook/instagram pass regardless of reddit flag (no regression)', async () => {
+  for (const platform of ['facebook', 'instagram'] as const) {
+    assert.equal(
+      isMetaProvider(platform),
+      true,
+      `${platform} must remain a Meta provider unaffected by the Reddit flag`,
+    );
+    assert.equal(!isMetaProvider(platform), false, `${platform} must pass the Meta guard`);
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 8. post-id extraction robustness
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 post-id extraction: t3_ fullname extracted from nested json.data.name shape', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      // The Reddit API response nests the created post under data.json.data.name
+      // (the t3_ fullname). The idKeys override in the reddit branch must recurse
+      // through 'json' to find 'name'.
+      const gateway = makeRedditGateway({
+        defaultResult: {
+          data: {
+            // Intentionally add a media_key at the top level — must NOT be picked up
+            media_key: 'MEDIA_KEY_SHOULD_NOT_BE_ID',
+            json: {
+              data: {
+                name: 't3_xyz789',
+                url: 'https://reddit.com/r/test/comments/xyz789',
+              },
+            },
+          },
+          successful: true,
+          error: null,
+        },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      const result = await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'id extraction test',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      assert.equal(
+        result.externalPostId,
+        't3_xyz789',
+        'externalPostId must be the t3_ fullname from json.data.name, not media_key',
+      );
+      assert.notEqual(
+        result.externalPostId,
+        'MEDIA_KEY_SHOULD_NOT_BE_ID',
+        'media_key at top level must NOT be mistaken for the post id',
+      );
+    },
+  );
+});
+
+test('#641 post-id extraction: flat id field also works (fallback shape)', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      // Some Composio tool versions may return a flat {id: 't3_flat'} shape
+      const gateway = makeRedditGateway({
+        defaultResult: {
+          data: { id: 't3_flat' },
+          successful: true,
+          error: null,
+        },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      const result = await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'flat shape test',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      assert.equal(result.externalPostId, 't3_flat', 'flat id field must also be accepted');
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 9. metaPlatform routing: provider='reddit' reaches the seam with platform='reddit'
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 metaPlatform routing: provider=reddit reaches the seam with platform=reddit, NOT coerced to facebook', async () => {
+  // Before the fix, metaPlatform('reddit') would fall through to 'facebook' (the else branch).
+  // A Reddit post would silently dispatch to a Facebook Page via the Composio seam.
+  const calls: PublishPostInput[] = [];
+  const provider: PublisherProvider = {
+    kind: 'composio',
+    supports: () => true,
+    publishPost: async (input: PublishPostInput) => {
+      calls.push(input);
+      return {
+        provider: 'composio',
+        platform: 'reddit' as const,
+        externalPostId: 't3_routed_correctly',
+        externalCampaignId: null,
+        externalAdId: null,
+        status: 'published' as const,
+        url: 'https://reddit.com/r/test/comments/routed_correctly',
+        rawResponse: {},
+      };
+    },
+    publishAd: async () => {
+      throw new Error('not implemented');
+    },
+    uploadMedia: async () => {
+      throw new Error('not implemented');
+    },
+    getPublishStatus: async () => {
+      throw new Error('not implemented');
+    },
+  } as unknown as PublisherProvider;
+
+  const out = await dispatchPublish(
+    { tenantId: '42', provider: 'reddit', content: 'hello reddit', mediaUrls: [], scheduledFor: null },
+    {
+      selector: () => 'composio',
+      directPublish: async () => {
+        throw new Error('reddit must never reach the direct-Meta path');
+      },
+      publisherProvider: () => provider,
+    },
+  );
+
+  assert.equal(calls.length, 1, 'exactly one publishPost call');
+  assert.equal(
+    calls[0].platform,
+    'reddit',
+    'reddit provider must reach the seam with platform=reddit (NOT coerced to facebook)',
+  );
+  assert.notEqual(calls[0].platform, 'facebook', 'reddit must NOT be coerced to facebook');
+  assert.equal(out.platformPostId, 't3_routed_correctly');
+  // connectionId is composio:<platform>; must reference 'reddit' not 'facebook'
+  assert.ok(
+    out.connectionId.includes(':reddit'),
+    `connectionId must reference 'reddit', got: ${out.connectionId}`,
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 10. Connection missing
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 Reddit with no active connection throws ComposioConnectionMissingError', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const provider = new ComposioPublisherProvider(
+        makeRedditGateway(),
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb({ noRow: true }),
+      );
+
+      await assert.rejects(
+        () =>
+          provider.publishPost({
+            tenantId,
+            platform: 'reddit',
+            content: 'no connection',
+            mediaUrls: [],
+            approved: true,
+          }),
+        ComposioConnectionMissingError,
+        'missing Reddit connection must throw ComposioConnectionMissingError',
+      );
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 11. flair_id is included when COMPOSIO_REDDIT_FLAIR_ID is set
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('#641 flair_id included when COMPOSIO_REDDIT_FLAIR_ID is set', async () => {
+  await withEnv(
+    {
+      COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test',
+      COMPOSIO_REDDIT_FLAIR_ID: 'flair-abc-123',
+      ARIES_REDDIT_ENABLED: '1',
+    },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_flair' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'flair test',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(args.flair_id, 'flair-abc-123', 'flair_id must be included when env var is set');
+    },
+  );
+});
+
+test('#641 flair_id omitted when COMPOSIO_REDDIT_FLAIR_ID is unset', async () => {
+  await withEnv(
+    {
+      COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test',
+      COMPOSIO_REDDIT_FLAIR_ID: undefined,
+      ARIES_REDDIT_ENABLED: '1',
+    },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_noflair' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'no flair test',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(args.flair_id, undefined, 'flair_id must be omitted when env var is not set');
+    },
+  );
+});


### PR DESCRIPTION
Closes #641

## What changed
Reddit becomes a publishable target, dispatched through Composio `REDDIT_CREATE_REDDIT_POST`, mirroring the just-merged X publish path (#651). Ships **DORMANT** behind `ARIES_REDDIT_ENABLED` (default OFF).

Four publish chokepoints are flag-gated on `isRedditEnabled()`:
- `ALLOWED_TARGET_PLATFORMS` / `allowedTargetPlatforms()` (scheduled-posts allow-list, computed at call time)
- the scheduled-dispatch route guard (`isRedditPublish`)
- `metaPlatform()` (`'reddit' -> 'reddit'`, never coerced to `'facebook'`)
- the `ComposioPublisherProvider.publishPost` `reddit` branch

The deliberate exclusions hold: `isMetaProvider`/`META_PROVIDERS` and `DirectMetaProvider`'s `DIRECT_ORGANIC_PLATFORMS` both exclude reddit, so a Reddit post can never fall through to a Facebook Page or the direct-Meta path.

## Root cause / contract
Reddit is a SINGLE `REDDIT_CREATE_REDDIT_POST` call (no media-upload step — an image is posted as `kind='link'` whose `url` IS the image). This is the FB-style single-call, outcome-unknown boundary:
- Subreddit is never guessed: explicit `COMPOSIO_REDDIT_TARGET_SUBREDDIT` -> `u_<externalAccountName>` -> `ComposioCapabilityMissingError`.
- Title is the first non-empty line of the content, whitespace-collapsed, <=300 chars (ellipsis-truncated), empty -> `New post`.
- `kind='link'` (+`url`) for an image; `kind='self'` (+`text`) for a text post; optional `flair_id` passthrough.
- Post id is the `t3_<base36>` fullname extracted via the branch-local `idKeys=['name','id','post_id']` recursing through the new `json` nest (`data.json.data.name`).
- Slug resolves via `actionSlugFor('reddit','publish_post')` -> capability-missing when unset (never a guessed slug).

Every PRE-call failure (no subreddit / no slug / no connection) and an explicit `successful:false` throw a definitely-never-posted error -> safe rollback + standing-worker re-claim. No retry/cooldown loop and no `Promise.all` added, so a rate-limited create surfaces as never-posted and the row is re-claimed, never lost.

## Test evidence
- New `tests/composio-reddit-publisher.test.ts` (26 assertions): image/text branch, subreddit resolution, title derivation, slug/dry-run/not-approved/tool-unsuccessful guards, dormancy of `normalizeTargetPlatforms`, dispatch-guard predicate, `t3_` id extraction (and `media_key` NOT picked), `metaPlatform` routing, connection-missing, flair passthrough.
- `npm run verify` green; `npm run validate:execution-provider` 52/52; full composio suite 129/129 (no FB/IG/X regression from the additive `json` nest key).

## To activate in prod (human, agent is blocked from prod secrets)
Set `ARIES_REDDIT_ENABLED=1`, `PUBLISH_PROVIDER=composio` (or `auto`), `COMPOSIO_REDDIT_PUBLISH_POST_ACTION=REDDIT_CREATE_REDDIT_POST`, `COMPOSIO_REDDIT_TARGET_SUBREDDIT=<a subreddit you control>` (+ optional `COMPOSIO_REDDIT_FLAIR_ID`), and connect Reddit via Composio.

## Residual risk
The exact nested path of the Reddit post id (`data.json.data.name`) is worth a single live-call confirmation when first enabled. If it is wrong, the row strands safely as `provider_publish_missing_id` (outcome-unknown, no double-post), never a silent bad write.

Later Reddit gates (connect #640 / comments #643 / reply #644 / analytics #642) are separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)