### PR TITLE
fix(integrations): resolve+persist LinkedIn person URN at connect behind ARIES_LINKEDIN_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -266,6 +266,13 @@ ARIES_X_ENABLED=false
 # a `reddit` schedule still 400s invalid_platforms and dispatch 400s
 # unsupported_provider. Flip to true once the Reddit publish action below is set.
 ARIES_REDDIT_ENABLED=false
+# LinkedIn rollout flag. Default OFF — ships the connect-time person-URN lookup
+# dormant. LinkedIn already connects via Composio; this only gates the extra
+# LINKEDIN_GET_MY_INFO call that resolves + persists the member's
+# urn:li:person:<id> as external_account_id (so LinkedIn publish #646 has an
+# `author`). Flip to true once a LinkedIn auth-config granting openid/profile is
+# provisioned (COMPOSIO_LINKEDIN_AUTH_CONFIG_ID) and the user re-connects.
+ARIES_LINKEDIN_ENABLED=false
 # Toolkit version for manual (by-slug) Composio tool execution — publishing,
 # analytics, AND comments all go through tools.execute, which the @composio/core
 # SDK rejects without a toolkit version. Default 'latest' (the gateway pairs it
@@ -324,6 +331,14 @@ COMPOSIO_X_UPLOAD_MEDIA_ACTION=
 COMPOSIO_REDDIT_PUBLISH_POST_ACTION=
 COMPOSIO_REDDIT_TARGET_SUBREDDIT=
 COMPOSIO_REDDIT_FLAIR_ID=
+
+# LinkedIn member identity (#645) — only consulted when ARIES_LINKEDIN_ENABLED=true.
+# account_info resolves the authenticated member at connect time so we can persist
+# their urn:li:person:<id> as the author for LinkedIn publish (#646). The verified
+# LINKEDIN_GET_MY_INFO slug is the code default, so it works left unset; set it
+# only to pin a different toolkit version.
+#   account_info      -> LINKEDIN_GET_MY_INFO (member id -> urn:li:person:<id>)
+COMPOSIO_LINKEDIN_ACCOUNT_INFO_ACTION=
 
 # Facebook analytics + comments sync (#596/#597), read by the insights-sync
 # worker's Facebook adapter (backend/insights/adapters/facebook). The verified

--- a/backend/integrations/composio/composio-account-provider.ts
+++ b/backend/integrations/composio/composio-account-provider.ts
@@ -31,6 +31,8 @@ import {
 import { ComposioConfigError } from './errors';
 import { isActiveStatus, mapComposioStatus } from './status-map';
 import { resolveFacebookManagedPage } from './facebook-page-resolver';
+import { resolveLinkedInAuthorUrn } from './linkedin-author-resolver';
+import { isLinkedInEnabled } from '../providers/integration-config';
 import pool from '@/lib/db';
 
 export class ComposioAccountProvider implements AccountConnectionProvider {
@@ -172,6 +174,28 @@ export class ComposioAccountProvider implements AccountConnectionProvider {
         }
       } catch {
         // best-effort — leave null, the sync bridge will back-heal it
+      }
+    } else if (
+      // LinkedIn's member person URN is likewise absent from the connection
+      // metadata. Resolve it via LINKEDIN_GET_MY_INFO and store the FULL
+      // `urn:li:person:<id>` so the publisher (#646) reads it straight into
+      // `author`. Gated by ARIES_LINKEDIN_ENABLED (default OFF → no executeTool
+      // call, connect byte-identical). Best-effort: a 429 throttle / empty
+      // payload leaves it null and never breaks connect.
+      !externalAccountId &&
+      platform === 'linkedin' &&
+      isLinkedInEnabled() &&
+      active.id &&
+      isActiveStatus(active.status)
+    ) {
+      try {
+        const author = await resolveLinkedInAuthorUrn(this.gateway, this.config, active.id);
+        if (author) {
+          externalAccountId = author.urn;
+          externalAccountName = externalAccountName ?? author.name;
+        }
+      } catch {
+        // best-effort — leave null, never break connect
       }
     }
 

--- a/backend/integrations/composio/linkedin-author-resolver.ts
+++ b/backend/integrations/composio/linkedin-author-resolver.ts
@@ -1,0 +1,98 @@
+/**
+ * Resolve a tenant's LinkedIn member person URN from Composio.
+ *
+ * The LinkedIn author URN (needed as the `author` for LINKEDIN_CREATE_LINKED_IN_POST,
+ * #646) is NOT part of the Composio connection metadata, so connect-time
+ * reconciliation leaves connected_accounts.external_account_id null. This helper
+ * calls the verified LINKEDIN_GET_MY_INFO action (env-overridable via the
+ * `account_info` op) using the connection's connectedAccountId and derives the
+ * member's `urn:li:person:{id}`.
+ *
+ * The publisher (#646) reads connected_accounts.external_account_id straight into
+ * `author`, so we persist the COMPLETE `urn:li:person:<id>` string here — never a
+ * bare id (no reformatting downstream).
+ *
+ * Fail-safe: returns null on an unsuccessful tool call, a wrapper response that
+ * is not `successful`, or when no member id is present (e.g. an APPLICATION DAY
+ * 429 throttle, which can return an error/empty payload). Never invents a URN.
+ * Self-only — the returned profile fields can be minimal (often id + localized
+ * names; picture may be null), so the display name is best-effort.
+ *
+ * Response shape (verified via the live Composio catalog 2026-06-18):
+ *   { data: { id, localizedFirstName, localizedLastName, ... }, successful, error }
+ * Some toolkit versions wrap/batch the payload:
+ *   { data: { results: [ { response: { data: { id, ... }, successful } } ] }, successful }
+ */
+
+import type { ComposioGateway } from './composio-client';
+import type { ComposioConfig } from './composio-config';
+
+export interface ResolvedLinkedInAuthor {
+  /** The full author URN, e.g. `urn:li:person:abc123` — stored verbatim. */
+  urn: string;
+  /** Best-effort display name; may be null when the profile is minimal. */
+  name: string | null;
+}
+
+/** Default verified slug; overridable via COMPOSIO_LINKEDIN_ACCOUNT_INFO_ACTION. */
+export const DEFAULT_GET_MY_INFO_SLUG = 'LINKEDIN_GET_MY_INFO';
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function trimmedString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Pull the member profile object out of either the direct (`data`) shape or the
+ * wrapper/batch (`data.results[0].response.data`) shape. The wrapper carries its
+ * own `successful` flag, so an unsuccessful inner response yields no profile.
+ */
+function extractProfile(rawData: unknown): Record<string, unknown> | null {
+  const data = asRecord(rawData);
+  if (!data) return null;
+
+  // Direct shape: id sits on data itself.
+  if (trimmedString(data.id)) return data;
+
+  // Wrapper/batch shape: data.results[0].response.{ data, successful }.
+  const results = data.results;
+  if (Array.isArray(results) && results.length > 0) {
+    const response = asRecord(asRecord(results[0])?.response);
+    if (response) {
+      if (response.successful === false) return null;
+      const inner = asRecord(response.data);
+      if (inner && trimmedString(inner.id)) return inner;
+    }
+  }
+  return null;
+}
+
+/** Best-effort display name: joined localized first/last, else name/localizedName. */
+function extractName(profile: Record<string, unknown>): string | null {
+  const first = trimmedString(profile.localizedFirstName);
+  const last = trimmedString(profile.localizedLastName);
+  const joined = [first, last].filter(Boolean).join(' ').trim();
+  if (joined) return joined;
+  return trimmedString(profile.name) ?? trimmedString(profile.localizedName);
+}
+
+export async function resolveLinkedInAuthorUrn(
+  gateway: ComposioGateway,
+  config: ComposioConfig,
+  connectedAccountId: string,
+): Promise<ResolvedLinkedInAuthor | null> {
+  const slug = config.actionSlugFor('linkedin', 'account_info') ?? DEFAULT_GET_MY_INFO_SLUG;
+  const result = await gateway.executeTool(slug, { connectedAccountId, arguments: {} });
+  if (!result.successful) return null;
+
+  const profile = extractProfile(result.data);
+  if (!profile) return null;
+
+  const id = trimmedString(profile.id);
+  if (!id) return null; // never invent a URN
+
+  return { urn: `urn:li:person:${id}`, name: extractName(profile) };
+}

--- a/backend/integrations/provider-registry.ts
+++ b/backend/integrations/provider-registry.ts
@@ -50,7 +50,17 @@ export const PROVIDER_REGISTRY: Record<ProviderKey, ProviderConfig> = {
     ],
     adapter: 'meta',
   },
-  linkedin: { key: 'linkedin', family: 'linkedin', display_name: 'LinkedIn', default_scopes: ['w_member_social'], adapter: 'linkedin' },
+  linkedin: {
+    key: 'linkedin',
+    family: 'linkedin',
+    display_name: 'LinkedIn',
+    // openid/profile are required for LINKEDIN_GET_MY_INFO to return the member
+    // id we derive the person URN from (#645); email rounds out the basic
+    // profile; w_member_social authorizes the member post (#646). Org analytics'
+    // rw_organization_admin is intentionally NOT added here (separate org track).
+    default_scopes: ['openid', 'profile', 'email', 'w_member_social'],
+    adapter: 'linkedin',
+  },
   x: {
     key: 'x',
     family: 'x',

--- a/backend/integrations/providers/index.ts
+++ b/backend/integrations/providers/index.ts
@@ -16,6 +16,7 @@ export {
   isComposioEnabled,
   isXEnabled,
   isRedditEnabled,
+  isLinkedInEnabled,
   connectablePlatforms,
   publishProviderSelector,
   analyticsProviderSelector,

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -56,6 +56,17 @@ export function redditTargetSubreddit(env: NodeJS.ProcessEnv = process.env): str
 }
 
 /**
+ * LinkedIn rollout flag. Default OFF. Gates the connect-time person-URN
+ * resolution (and, later, LinkedIn publish #646); LinkedIn is already a
+ * connectable platform, so this flag does NOT gate connectability — only the
+ * extra `LINKEDIN_GET_MY_INFO` author-URN lookup. When OFF the connect path is
+ * byte-identical to today (no executeTool call).
+ */
+export function isLinkedInEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseFlag(env.ARIES_LINKEDIN_ENABLED);
+}
+
+/**
  * Platforms an operator can actually connect right now. The single dormancy
  * chokepoint for flag-gated platforms: when `ARIES_X_ENABLED` is OFF, `'x'` is
  * filtered out everywhere (connect/capabilities/disconnect gate + the UI list),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,9 @@ services:
       # (Reddit already connects; this gates publish only). When OFF a reddit
       # schedule/dispatch is rejected exactly as today.
       ARIES_REDDIT_ENABLED: ${ARIES_REDDIT_ENABLED:-false}
+      # LinkedIn rollout flag — default OFF ships the connect-time person-URN
+      # lookup dormant (no LINKEDIN_GET_MY_INFO call; connect byte-identical).
+      ARIES_LINKEDIN_ENABLED: ${ARIES_LINKEDIN_ENABLED:-false}
       # Toolkit version for manual Composio tool execution (publish/analytics/
       # comments). The SDK rejects by-slug execution without one; default 'latest'
       # (gateway pairs it with a skip-check). Pin a concrete version to avoid drift.
@@ -239,6 +242,11 @@ services:
       COMPOSIO_REDDIT_PUBLISH_POST_ACTION: ${COMPOSIO_REDDIT_PUBLISH_POST_ACTION:-}
       COMPOSIO_REDDIT_TARGET_SUBREDDIT: ${COMPOSIO_REDDIT_TARGET_SUBREDDIT:-}
       COMPOSIO_REDDIT_FLAIR_ID: ${COMPOSIO_REDDIT_FLAIR_ID:-}
+      # LinkedIn member-identity slug (#645) — only consulted when
+      # ARIES_LINKEDIN_ENABLED=true. Optional; defaults to the verified
+      # LINKEDIN_GET_MY_INFO slug. Resolves the member's urn:li:person:<id> at
+      # connect so LinkedIn publish (#646) has an author. App-process only.
+      COMPOSIO_LINKEDIN_ACCOUNT_INFO_ACTION: ${COMPOSIO_LINKEDIN_ACCOUNT_INFO_ACTION:-}
       # Facebook analytics + comments sync slugs (#596/#597). Optional — the
       # adapter falls back to the verified code defaults when unset.
       COMPOSIO_FACEBOOK_LIST_POSTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_POSTS_ACTION:-}

--- a/tests/composio-linkedin-author-resolver.test.ts
+++ b/tests/composio-linkedin-author-resolver.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for resolveLinkedInAuthorUrn (#645).
+ *
+ * Locked behaviors:
+ *  - Direct data shape  → { urn, name }
+ *  - Wrapper/batch shape → { urn, name } (second toolkit-version format)
+ *  - !successful        → null  (never invents a URN)
+ *  - Missing / empty id → null
+ *  - Wrapper inner !successful → null
+ *  - Slug override via COMPOSIO_LINKEDIN_ACCOUNT_INFO_ACTION
+ *
+ * Entirely self-contained: fake gateway + config, no Postgres, no Composio SDK.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveLinkedInAuthorUrn,
+  DEFAULT_GET_MY_INFO_SLUG,
+} from '@/backend/integrations/composio/linkedin-author-resolver';
+import { fakeConfig, fakeGateway } from './composio/helpers';
+
+// ── 1. Direct shape (flat data object with id on data) ───────────────────────
+
+test('direct shape: resolves urn + full localized name', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { id: 'abc123', localizedFirstName: 'Jane', localizedLastName: 'Doe' },
+    },
+  });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_1');
+  assert.deepEqual(result, { urn: 'urn:li:person:abc123', name: 'Jane Doe' });
+});
+
+test('direct shape: uses DEFAULT_GET_MY_INFO_SLUG and passes connectedAccountId', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'abc123' } },
+  });
+  await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_42');
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  assert.equal(gateway.calls[0].slug, DEFAULT_GET_MY_INFO_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_li_42');
+});
+
+test('honors COMPOSIO_LINKEDIN_ACCOUNT_INFO_ACTION action-slug override', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'abc123' } },
+  });
+  await resolveLinkedInAuthorUrn(
+    gateway,
+    fakeConfig({ actions: { account_info: 'CUSTOM_LINKEDIN_INFO_V2' } }),
+    'ca_li_1',
+  );
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_LINKEDIN_INFO_V2');
+});
+
+// ── 2. Wrapper / batch shape ─────────────────────────────────────────────────
+
+test('wrapper shape: resolves URN from results[0].response.data.id', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: {
+        results: [
+          {
+            response: {
+              successful: true,
+              data: { id: 'xyz789', localizedFirstName: 'Bob', localizedLastName: 'Smith' },
+            },
+          },
+        ],
+      },
+    },
+  });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_2');
+  assert.equal(result?.urn, 'urn:li:person:xyz789');
+  assert.equal(result?.name, 'Bob Smith');
+});
+
+test('wrapper shape: successful:false on inner response → null (never invents URN)', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: {
+        results: [
+          {
+            response: {
+              successful: false,
+              data: { id: 'xyz789' },
+            },
+          },
+        ],
+      },
+    },
+  });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_2');
+  assert.equal(result, null);
+});
+
+// ── 3. Fail-safe: must return null, never invent a URN ───────────────────────
+
+test('unsuccessful top-level result → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: false, error: 'unauthorized', data: null },
+  });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data is null → null', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: null } });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data is empty object (no id) → null', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: {} } });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_1');
+  assert.equal(result, null);
+});
+
+test('successful result but id is a blank string → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: '   ' } },
+  });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_1');
+  assert.equal(result, null);
+});
+
+test('successful result with id but no name fields → name is null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'minimal_id' } },
+  });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_1');
+  assert.equal(result?.urn, 'urn:li:person:minimal_id');
+  assert.equal(result?.name, null);
+});
+
+// ── 4. URN format: always full urn:li:person:<id> ────────────────────────────
+
+test('URN is always the full urn:li:person:<id> prefix (never a bare id)', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'rawid99' } },
+  });
+  const result = await resolveLinkedInAuthorUrn(gateway, fakeConfig(), 'ca_li_1');
+  assert.ok(result?.urn.startsWith('urn:li:person:'), 'urn must include the urn:li:person: prefix');
+  assert.equal(result?.urn, 'urn:li:person:rawid99');
+});

--- a/tests/composio-linkedin-connect.test.ts
+++ b/tests/composio-linkedin-connect.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Regression coverage for #645: LinkedIn connect resolves + persists the member
+ * person URN behind ARIES_LINKEDIN_ENABLED.
+ *
+ * Locked behaviors:
+ *  1. Flag ON + active LinkedIn conn (direct data shape) → URN persisted in
+ *     external_account_id; LINKEDIN_GET_MY_INFO called exactly once.
+ *  2. Flag ON + wrapper-nested id shape → URN persisted correctly.
+ *  3. Flag OFF (default) → NO executeTool call; external_account_id null;
+ *     connect path byte-identical to pre-fix.
+ *  4. Flag ON but executeTool returns unsuccessful → connect still succeeds
+ *     (fail-soft), row upserted, external_account_id null, no throw.
+ *  5. Platform isolation: LINKEDIN_GET_MY_INFO is NOT called for a facebook conn.
+ *
+ * Self-contained: fake gateway/config/db, no real Postgres, no Composio SDK.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ComposioAccountProvider } from '@/backend/integrations/composio/composio-account-provider';
+import type { GatewayConnection } from '@/backend/integrations/composio/composio-client';
+import { fakeConfig, fakeGateway, fakeDb } from './composio/helpers';
+
+const tenantId = '42';
+const userId = 'aries-tenant-42';
+
+/**
+ * An active LinkedIn GatewayConnection whose externalAccountId is null — which
+ * mirrors the real Composio payload and is the precondition that triggers the
+ * LinkedIn URN-resolve branch (`!externalAccountId && platform === 'linkedin'`).
+ */
+function linkedInConn(id: string, status = 'ACTIVE'): GatewayConnection {
+  return {
+    id,
+    status,
+    statusReason: null,
+    authConfigId: 'auth_cfg_linkedin',
+    toolkitSlug: 'linkedin',
+    externalAccountId: null, // real Composio metadata lacks the member id
+    externalAccountName: null,
+    raw: {},
+  };
+}
+
+/**
+ * Set/restore a subset of process.env keys around an async callback.
+ * Pass `undefined` as the value to delete the key during the callback.
+ */
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prev = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(vars)) {
+    prev.set(k, process.env[k]);
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  return fn().finally(() => {
+    for (const [k, original] of prev) {
+      if (original === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = original;
+      }
+    }
+  });
+}
+
+// ── 1. Flag ON: URN resolved and persisted (direct data shape) ───────────────
+
+test('flag ON + active linkedin conn: LINKEDIN_GET_MY_INFO called + URN persisted', async () => {
+  // FAILS before the fix: no LinkedIn branch → no executeTool call,
+  // external_account_id stays null.
+  await withEnv({ ARIES_LINKEDIN_ENABLED: '1' }, async () => {
+    const gateway = fakeGateway({
+      connections: [linkedInConn('ca_li_1')],
+      executeResult: {
+        successful: true,
+        error: null,
+        data: { id: 'abc123', localizedFirstName: 'Jane', localizedLastName: 'Doe' },
+      },
+    });
+    const db = fakeDb();
+    const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
+    await provider.refreshConnectionStatus(userId, 'linkedin', { tenantId });
+
+    // Exactly one LINKEDIN_GET_MY_INFO call, for the right connectedAccountId
+    const liCalls = gateway.calls.filter((c) => c.slug === 'LINKEDIN_GET_MY_INFO');
+    assert.equal(liCalls.length, 1, 'must call LINKEDIN_GET_MY_INFO exactly once');
+    assert.equal(liCalls[0].options.connectedAccountId, 'ca_li_1');
+
+    // external_account_id is $7 (params[6]) in the INSERT
+    const upsert = db.queries.find((q) => /insert into connected_accounts/i.test(q.text));
+    assert.ok(upsert, 'expected an INSERT upsert query');
+    assert.equal(
+      upsert!.params[6],
+      'urn:li:person:abc123',
+      'external_account_id must be the full urn:li:person:<id>',
+    );
+  });
+});
+
+// ── 2. Wrapper-nested id shape ────────────────────────────────────────────────
+
+test('flag ON + wrapper-nested id shape: URN persisted from results[0].response.data.id', async () => {
+  await withEnv({ ARIES_LINKEDIN_ENABLED: '1' }, async () => {
+    const gateway = fakeGateway({
+      connections: [linkedInConn('ca_li_2')],
+      executeResult: {
+        successful: true,
+        error: null,
+        data: {
+          results: [
+            {
+              response: {
+                successful: true,
+                data: { id: 'xyz789' },
+              },
+            },
+          ],
+        },
+      },
+    });
+    const db = fakeDb();
+    const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
+    await provider.refreshConnectionStatus(userId, 'linkedin', { tenantId });
+
+    const upsert = db.queries.find((q) => /insert into connected_accounts/i.test(q.text));
+    assert.ok(upsert, 'expected an INSERT upsert query');
+    assert.equal(
+      upsert!.params[6],
+      'urn:li:person:xyz789',
+      'external_account_id must be resolved from the wrapper shape',
+    );
+  });
+});
+
+// ── 3. Flag OFF: dormant — no executeTool, external_account_id null ──────────
+
+test('flag OFF (default): no LINKEDIN_GET_MY_INFO call, external_account_id null', async () => {
+  // Pre-fix AND post-fix with flag OFF must be byte-identical: no extra call,
+  // no URN in the row.
+  await withEnv({ ARIES_LINKEDIN_ENABLED: undefined }, async () => {
+    const gateway = fakeGateway({
+      connections: [linkedInConn('ca_li_3')],
+      // This result must never be consumed:
+      executeResult: {
+        successful: true,
+        error: null,
+        data: { id: 'should_not_be_used' },
+      },
+    });
+    const db = fakeDb();
+    const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
+    await provider.refreshConnectionStatus(userId, 'linkedin', { tenantId });
+
+    const liCalls = gateway.calls.filter((c) => c.slug === 'LINKEDIN_GET_MY_INFO');
+    assert.equal(liCalls.length, 0, 'LINKEDIN_GET_MY_INFO must NOT be called when flag is off');
+
+    const upsert = db.queries.find((q) => /insert into connected_accounts/i.test(q.text));
+    assert.ok(upsert, 'expected an INSERT upsert query');
+    assert.equal(
+      upsert!.params[6],
+      null,
+      'external_account_id must be null when ARIES_LINKEDIN_ENABLED is off',
+    );
+  });
+});
+
+test('flag OFF via false string: still dormant', async () => {
+  await withEnv({ ARIES_LINKEDIN_ENABLED: 'false' }, async () => {
+    const gateway = fakeGateway({ connections: [linkedInConn('ca_li_3')] });
+    const db = fakeDb();
+    const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
+    await provider.refreshConnectionStatus(userId, 'linkedin', { tenantId });
+
+    const liCalls = gateway.calls.filter((c) => c.slug === 'LINKEDIN_GET_MY_INFO');
+    assert.equal(liCalls.length, 0, 'LINKEDIN_GET_MY_INFO must NOT be called when flag is false');
+  });
+});
+
+// ── 4. Fail-soft: unsuccessful executeTool → connect still succeeds ──────────
+
+test('flag ON but executeTool unsuccessful: connect succeeds, external_account_id null', async () => {
+  // The best-effort try/catch must never surface the failure to the caller.
+  await withEnv({ ARIES_LINKEDIN_ENABLED: '1' }, async () => {
+    const gateway = fakeGateway({
+      connections: [linkedInConn('ca_li_4')],
+      executeResult: { successful: false, error: 'scope_missing', data: null },
+    });
+    const db = fakeDb();
+    const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
+
+    // Must not throw
+    const result = await provider.refreshConnectionStatus(userId, 'linkedin', { tenantId });
+    assert.ok(result, 'refreshConnectionStatus must return a ConnectedAccount on resolver failure');
+
+    const upsert = db.queries.find((q) => /insert into connected_accounts/i.test(q.text));
+    assert.ok(upsert, 'row must still be upserted (connect must not be blocked)');
+    // The connected_account_id ($5 = params[4]) must be persisted
+    assert.equal(upsert!.params[4], 'ca_li_4', 'connected_account_id must still be stored');
+    // external_account_id ($7 = params[6]) must be null
+    assert.equal(
+      upsert!.params[6],
+      null,
+      'external_account_id must be null when resolver fails',
+    );
+  });
+});
+
+test('flag ON but executeTool throws: connect still succeeds (best-effort catch)', async () => {
+  await withEnv({ ARIES_LINKEDIN_ENABLED: '1' }, async () => {
+    // Override executeTool to throw synchronously
+    const gateway = fakeGateway({ connections: [linkedInConn('ca_li_5')] });
+    // Patch the gateway's executeTool to throw
+    const origExecute = gateway.executeTool.bind(gateway);
+    gateway.executeTool = async (slug, opts) => {
+      if (slug === 'LINKEDIN_GET_MY_INFO') throw new Error('network timeout');
+      return origExecute(slug, opts);
+    };
+
+    const db = fakeDb();
+    const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
+
+    const result = await provider.refreshConnectionStatus(userId, 'linkedin', { tenantId });
+    assert.ok(result, 'connect must not throw when executeTool throws');
+
+    const upsert = db.queries.find((q) => /insert into connected_accounts/i.test(q.text));
+    assert.ok(upsert, 'row must be upserted even when executeTool throws');
+    assert.equal(upsert!.params[6], null, 'external_account_id null on thrown error');
+  });
+});
+
+// ── 5. Platform isolation: LINKEDIN_GET_MY_INFO not called for other platforms ─
+
+test('flag ON: LINKEDIN_GET_MY_INFO NOT called for a facebook connection', async () => {
+  await withEnv({ ARIES_LINKEDIN_ENABLED: '1' }, async () => {
+    const fbConn: GatewayConnection = {
+      id: 'ca_fb_1',
+      status: 'ACTIVE',
+      statusReason: null,
+      authConfigId: 'auth_cfg_fb',
+      toolkitSlug: 'facebook',
+      externalAccountId: null,
+      externalAccountName: null,
+      raw: {},
+    };
+    // executeTool will be called by the FB page-resolver (different slug), not LinkedIn
+    const gateway = fakeGateway({
+      connections: [fbConn],
+      executeResult: {
+        successful: true,
+        error: null,
+        data: { data: [{ id: 'P1', name: 'Test Page' }] },
+      },
+    });
+    const db = fakeDb();
+    const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
+    await provider.refreshConnectionStatus(userId, 'facebook', { tenantId });
+
+    const liCalls = gateway.calls.filter((c) => c.slug === 'LINKEDIN_GET_MY_INFO');
+    assert.equal(
+      liCalls.length,
+      0,
+      'LINKEDIN_GET_MY_INFO must never be called for a facebook connection',
+    );
+  });
+});


### PR DESCRIPTION
Closes #645

## What

On LinkedIn connect, Aries now resolves the authenticated member's person URN via `LINKEDIN_GET_MY_INFO` and persists the COMPLETE `urn:li:person:<id>` string in `connected_accounts.external_account_id` (plus the display name in `external_account_name`). The publisher (#646) reads `conn.externalAccountId` straight into the LINKEDIN_CREATE_LINKED_IN_POST `author` field with no reformatting downstream.

## Root cause

The LinkedIn member person URN is not part of the Composio connection metadata, so connect-time reconciliation left `external_account_id` null — and LinkedIn publish (#646) has no `author` to post as. This is the prerequisite that unblocks #646.

## Design

- New `resolveLinkedInAuthorUrn` helper (`backend/integrations/composio/linkedin-author-resolver.ts`) — a clean sibling of the existing Facebook Page-id resolver. Prefers `data.id`, falls back to the wrapper/batch shape `data.results[0].response.data.id` with the inner `successful` guard, and returns null (never invents a URN) when the id is absent or the call is unsuccessful.
- New `else if (platform === 'linkedin' && isLinkedInEnabled() && ...)` branch in `ComposioAccountProvider.refreshConnectionStatus` — best-effort try/catch (a 429 throttle / empty payload / thrown error leaves the URN null and connect still succeeds, per the resumability rule). Exactly one sequential `executeTool` (no Promise.all / pool fan-out). The Facebook branch is byte-untouched.
- Reuses the existing `external_account_id` column — NO new DB column or migration; the `platform IN (…'linkedin'…)` CHECK already includes linkedin (already a connectable platform).
- LinkedIn `default_scopes` widened to `['openid','profile','email','w_member_social']` (openid/profile are required for LINKEDIN_GET_MY_INFO to return the member id; w_member_social authorizes the member post). This is inert until the human re-connects LinkedIn under a Composio auth-config granting them (external dependency, like the Meta scopes).

## Rollout

Ships DORMANT behind `ARIES_LINKEDIN_ENABLED` (default OFF). When OFF the connect path is byte-identical to today (no `executeTool` call). The scope widening is inert until the human re-connects LinkedIn under a Composio auth-config granting openid/profile/email/w_member_social. v1 resolves the PERSON URN only (org URN is a follow-up). This is the prerequisite that unblocks LinkedIn publish #646.

## Test evidence

- New `tests/composio-linkedin-author-resolver.test.ts` (11) — direct + wrapper shapes, !successful → null, missing/blank id → null, slug override, full `urn:li:person:` prefix always.
- New `tests/composio-linkedin-connect.test.ts` (7) — flag ON persists URN (direct + wrapper), flag OFF dormant (no executeTool, external_account_id null), fail-soft on unsuccessful + thrown executeTool (connect still succeeds), platform isolation (not called for facebook).
- `npm run verify` green (568 tests); composio suite 121/121; the two new files 18/18 confirmed by the reviewer.

## Security

No token or raw Graph/Composio payload is logged (mirrors the Facebook resolver's silence). The connection is loaded/upserted by tenant_id + platform only; the person URN is non-secret identity. The `ON CONFLICT … COALESCE` upsert preserves an existing URN on a flag-off / fail-soft reconnect rather than wiping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)