### PR TITLE
fix(integrations): allow 'x' in connected_accounts.platform CHECK (X connect DB blocker)

### DIFF
--- a/migrations/20260618000000_connected_accounts_allow_x.sql
+++ b/migrations/20260618000000_connected_accounts_allow_x.sql
@@ -1,0 +1,22 @@
+-- X (Twitter) connect: allow platform='x' on connected_accounts.
+--
+-- #650 added 'x' to the IntegrationPlatform enum (backend/integrations/providers/
+-- types.ts) but never widened this CHECK, so the Composio connect callback's
+-- upsertConnection(... platform='x') is rejected at the DB layer in prod — no
+-- platform='x' row can ever persist, DB-blocking X connect/publish/insights
+-- end-to-end. Its tests passed because they mock the DB.
+--
+-- The original CHECK is an unnamed inline column constraint, so Postgres
+-- auto-named it connected_accounts_platform_check.
+--
+-- Additive + idempotent; mirrored in scripts/init-db.js (applied on container
+-- start). No 'x' rows can pre-exist (the old CHECK blocked them), so re-adding
+-- the constraint never fails on existing data. Purely allows a new value —
+-- safe on existing rows and independent of any feature flag.
+
+ALTER TABLE connected_accounts
+  DROP CONSTRAINT IF EXISTS connected_accounts_platform_check;
+
+ALTER TABLE connected_accounts
+  ADD CONSTRAINT connected_accounts_platform_check
+  CHECK (platform IN ('facebook','instagram','meta_ads','tiktok','youtube','linkedin','reddit','x'));

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -155,7 +155,7 @@ async function initDb() {
         id BIGSERIAL PRIMARY KEY,
         tenant_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
         external_user_id TEXT NOT NULL,
-        platform TEXT NOT NULL CHECK (platform IN ('facebook','instagram','meta_ads','tiktok','youtube','linkedin','reddit')),
+        platform TEXT NOT NULL CHECK (platform IN ('facebook','instagram','meta_ads','tiktok','youtube','linkedin','reddit','x')),
         provider TEXT NOT NULL DEFAULT 'composio' CHECK (provider IN ('composio','direct_meta','none')),
         connected_account_id TEXT,
         auth_config_id TEXT,
@@ -171,6 +171,19 @@ async function initDb() {
 
       CREATE INDEX IF NOT EXISTS idx_connected_accounts_tenant ON connected_accounts (tenant_id);
       CREATE INDEX IF NOT EXISTS idx_connected_accounts_tenant_platform ON connected_accounts (tenant_id, platform);
+
+      -- X (Twitter) connect (#650 added 'x' to IntegrationPlatform but not this
+      -- CHECK), applied to EXISTING databases: widen the platform CHECK to allow
+      -- 'x' so the Composio connect callback's upsertConnection(platform='x') is
+      -- not rejected at the DB layer. Idempotent: DROP IF EXISTS + re-ADD. No 'x'
+      -- rows can pre-exist (the old CHECK blocked them), so re-adding the
+      -- constraint never fails on existing data. Mirrored in
+      -- migrations/20260618000000_connected_accounts_allow_x.sql.
+      ALTER TABLE connected_accounts
+        DROP CONSTRAINT IF EXISTS connected_accounts_platform_check;
+      ALTER TABLE connected_accounts
+        ADD CONSTRAINT connected_accounts_platform_check
+        CHECK (platform IN ('facebook','instagram','meta_ads','tiktok','youtube','linkedin','reddit','x'));
     `);
 
     await client.query(`

--- a/tests/connected-accounts-platform-check.test.ts
+++ b/tests/connected-accounts-platform-check.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression guard for #650 / fix/connected-accounts-x-platform-check.
+ *
+ * The connected_accounts.platform CHECK constraint was missing 'x', which
+ * DB-blocked X connect in prod. This test locks:
+ *
+ *   1. The inline CREATE TABLE CHECK in scripts/init-db.js includes all 8
+ *      IntegrationPlatform values (facebook, instagram, meta_ads, tiktok,
+ *      youtube, linkedin, reddit, x).
+ *   2. The idempotent self-heal ALTER TABLE … ADD CONSTRAINT block in
+ *      scripts/init-db.js also includes all 8 values.
+ *   3. migrations/20260618000000_connected_accounts_allow_x.sql exists and
+ *      its ADD CONSTRAINT includes all 8 values.
+ *   4. (Invariant) Every value in INTEGRATION_PLATFORMS (the TS union) is
+ *      present in the init-db connected_accounts CHECK — so a future platform
+ *      addition that forgets the CHECK is caught here.
+ *
+ * Self-contained: reads source files as text, no DB required.
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+import { INTEGRATION_PLATFORMS } from '@/backend/integrations/providers/types';
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const INIT_DB = fs.readFileSync(path.join(PROJECT_ROOT, 'scripts', 'init-db.js'), 'utf8');
+const MIGRATION_FILE = path.join(
+  PROJECT_ROOT,
+  'migrations',
+  '20260618000000_connected_accounts_allow_x.sql',
+);
+const MIGRATION = fs.readFileSync(MIGRATION_FILE, 'utf8');
+
+// Full set of platforms the CHECK must cover — matches INTEGRATION_PLATFORMS.
+const ALL_PLATFORMS: readonly string[] = [
+  'facebook',
+  'instagram',
+  'meta_ads',
+  'tiktok',
+  'youtube',
+  'linkedin',
+  'reddit',
+  'x',
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the comma-separated content inside
+ *   CHECK (platform IN (<content>))
+ * from a larger source string.  Returns `null` if the pattern is not found.
+ * The regex is deliberately anchored on `platform IN (` so it does not match
+ * the `provider IN (` or `status IN (` siblings.
+ */
+function extractPlatformCheckContent(src: string): string | null {
+  const m = /platform\s+IN\s*\(([^)]+)\)/.exec(src);
+  return m ? m[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — inline CREATE TABLE constraint
+// ---------------------------------------------------------------------------
+
+test('init-db.js: connected_accounts inline CREATE TABLE platform CHECK includes all 8 platforms', () => {
+  // Isolate the connected_accounts CREATE TABLE block so we are not accidentally
+  // matching a CHECK in a different table.
+  const createBlockMatch =
+    /CREATE TABLE IF NOT EXISTS connected_accounts\s*\(([\s\S]*?)\);/.exec(INIT_DB);
+  assert.ok(
+    createBlockMatch,
+    'init-db.js must contain a CREATE TABLE IF NOT EXISTS connected_accounts block',
+  );
+  const createBlock = createBlockMatch[1];
+
+  const content = extractPlatformCheckContent(createBlock);
+  assert.ok(
+    content,
+    'connected_accounts CREATE TABLE must have a CHECK (platform IN (...)) constraint',
+  );
+
+  for (const platform of ALL_PLATFORMS) {
+    assert.ok(
+      content.includes(`'${platform}'`),
+      `init-db.js connected_accounts CREATE TABLE CHECK must include platform '${platform}'; got: ${content}`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — idempotent self-heal ADD CONSTRAINT block
+// ---------------------------------------------------------------------------
+
+test('init-db.js: connected_accounts self-heal ADD CONSTRAINT platform CHECK includes all 8 platforms', () => {
+  // Match the ADD CONSTRAINT … CHECK block that follows the CREATE TABLE.
+  const alterBlockMatch =
+    /ADD CONSTRAINT connected_accounts_platform_check([\s\S]*?)CHECK\s*\(\s*platform\s+IN\s*\(([^)]+)\)\s*\)/.exec(
+      INIT_DB,
+    );
+  assert.ok(
+    alterBlockMatch,
+    'init-db.js must have the idempotent ADD CONSTRAINT connected_accounts_platform_check … CHECK block',
+  );
+  const content = alterBlockMatch[2];
+
+  for (const platform of ALL_PLATFORMS) {
+    assert.ok(
+      content.includes(`'${platform}'`),
+      `init-db.js ADD CONSTRAINT self-heal CHECK must include platform '${platform}'; got: ${content}`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — migration file exists and ADD CONSTRAINT includes all 8 platforms
+// ---------------------------------------------------------------------------
+
+test('migrations/20260618000000_connected_accounts_allow_x.sql: ADD CONSTRAINT includes all 8 platforms', () => {
+  const alterBlockMatch =
+    /ADD CONSTRAINT connected_accounts_platform_check([\s\S]*?)CHECK\s*\(\s*platform\s+IN\s*\(([^)]+)\)\s*\)/.exec(
+      MIGRATION,
+    );
+  assert.ok(
+    alterBlockMatch,
+    'migration must have an ADD CONSTRAINT connected_accounts_platform_check … CHECK block',
+  );
+  const content = alterBlockMatch[2];
+
+  for (const platform of ALL_PLATFORMS) {
+    assert.ok(
+      content.includes(`'${platform}'`),
+      `migration ADD CONSTRAINT CHECK must include platform '${platform}'; got: ${content}`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 4 — INTEGRATION_PLATFORMS superset invariant
+// ---------------------------------------------------------------------------
+
+test('connected_accounts.platform CHECK is a superset of INTEGRATION_PLATFORMS (invariant: future platform additions are caught)', () => {
+  // Re-extract the inline CREATE TABLE CHECK as the canonical gate for this
+  // invariant — it is the source of truth for what a freshly provisioned DB allows.
+  const createBlockMatch =
+    /CREATE TABLE IF NOT EXISTS connected_accounts\s*\(([\s\S]*?)\);/.exec(INIT_DB);
+  assert.ok(createBlockMatch, 'connected_accounts CREATE TABLE block must exist in init-db.js');
+  const createBlock = createBlockMatch[1];
+
+  const content = extractPlatformCheckContent(createBlock);
+  assert.ok(content, 'connected_accounts CREATE TABLE must have a platform CHECK clause');
+
+  for (const platform of INTEGRATION_PLATFORMS) {
+    assert.ok(
+      content.includes(`'${platform}'`),
+      `INTEGRATION_PLATFORMS includes '${platform}' but the connected_accounts.platform CHECK in ` +
+        `init-db.js does not — add '${platform}' to the CHECK (this is the #650 oversight pattern)`,
+    );
+  }
+
+  // Symmetry check: every value in ALL_PLATFORMS (this test's hardcoded list)
+  // must also appear in INTEGRATION_PLATFORMS, so this test stays in sync when
+  // a platform is removed from the enum.
+  for (const platform of ALL_PLATFORMS) {
+    assert.ok(
+      (INTEGRATION_PLATFORMS as readonly string[]).includes(platform),
+      `ALL_PLATFORMS in this test includes '${platform}' but INTEGRATION_PLATFORMS does not — update this test's ALL_PLATFORMS list`,
+    );
+  }
+});


### PR DESCRIPTION
Latent **production blocker** from #650 (X / Twitter connect). #650 added `'x'` to the `IntegrationPlatform` enum (`backend/integrations/providers/types.ts`) but never widened the `connected_accounts.platform` CHECK constraint. As a result the Composio connect callback's `upsertConnection(... platform='x')` is rejected at the DB layer (Postgres 23514) — **no `platform='x'` row can ever persist**, DB-blocking X connect / publish / insights end-to-end. The #650 / #630 X work compiled and its tests passed only because they mock the DB, so the gap was masked.

**Verified live:** querying the running prod DB, the constraint is named `connected_accounts_platform_check` and currently lists exactly the 7 pre-X platforms (no `'x'`), confirming both the blocker and that the self-heal targets the right constraint name.

### Fix (additive + idempotent)
- `scripts/init-db.js` — widen the inline CREATE-TABLE CHECK to include `'x'` (fresh DBs) **and** add an idempotent self-heal `DROP CONSTRAINT IF EXISTS connected_accounts_platform_check` + `ADD CONSTRAINT … CHECK (… 'x')` block that runs on every container start (existing DBs). DROP-IF-EXISTS + re-ADD is safe to re-run; no `'x'` rows can pre-exist (the old CHECK blocked them), so re-adding never fails on existing data.
- `migrations/20260618000000_connected_accounts_allow_x.sql` — additive migration for record / manual apply (timestamp after the latest existing migration).

Adding a value to a CHECK is additive: it never rejects existing rows and is cheap on this small table. Scope is tight — only the `connected_accounts.platform` CHECK changes; the sibling `provider`/`status` CHECKs and the `oauth_connections`/`oauth_providers.provider` CHECK (which already allows `'x'`) are untouched, and `insights_accounts.platform` has no CHECK (no gap). `'x'` was the only value missing vs `INTEGRATION_PLATFORMS`.

### Test
`tests/connected-accounts-platform-check.test.ts` (4 tests) locks the inline CHECK, the self-heal block, and the migration to all 8 platforms, plus a **superset invariant** — every `INTEGRATION_PLATFORMS` value must appear in the init-db CHECK — so a future platform addition that forgets the CHECK is caught (the #650 oversight class). `npm run verify` green; `guardrails:agent` clean.

Unblocks X connect / publish / insights end-to-end. Does not `Closes` an issue — this is a follow-up fix to already-merged #650 (see also #630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)