### PR TITLE
feat(integrations): implement YouTube insights adapter (analytics + comments) behind ARIES_YOUTUBE_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,6 +273,13 @@ ARIES_REDDIT_ENABLED=false
 # `author`). Flip to true once a LinkedIn auth-config granting openid/profile is
 # provisioned (COMPOSIO_LINKEDIN_AUTH_CONFIG_ID) and the user re-connects.
 ARIES_LINKEDIN_ENABLED=false
+# YouTube insights rollout flag (#637 analytics, #638 comments). Default OFF —
+# ships the Composio-backed YouTube insights adapter dormant. YouTube already
+# CONNECTS via Composio; this flag gates only the insights bridge + adapter (NOT
+# connectability). The YouTube insights path turns on ONLY when
+# ARIES_YOUTUBE_ENABLED=true AND ANALYTICS_PROVIDER=composio. Flip to true once
+# the YouTube auth-config below is provisioned in Composio.
+ARIES_YOUTUBE_ENABLED=false
 # Toolkit version for manual (by-slug) Composio tool execution — publishing,
 # analytics, AND comments all go through tools.execute, which the @composio/core
 # SDK rejects without a toolkit version. Default 'latest' (the gateway pairs it
@@ -381,6 +388,27 @@ COMPOSIO_FACEBOOK_LIST_COMMENTS_ACTION=
 COMPOSIO_X_LIST_POSTS_ACTION=
 COMPOSIO_X_POST_INSIGHTS_ACTION=
 COMPOSIO_X_LIST_COMMENTS_ACTION=
+
+# YouTube analytics + comments (#637/#638), read by the insights-sync worker's
+# YouTube adapter (backend/insights/adapters/youtube). The YouTube insights path
+# turns on ONLY when ARIES_YOUTUBE_ENABLED=true AND ANALYTICS_PROVIDER=composio;
+# otherwise the bridge no-ops, the adapter never activates, and no Composio tool
+# runs. The verified slugs below are the CODE DEFAULTS, so analytics works with
+# them unset; set them only to pin a different toolkit version. The adapter
+# authenticates every call with the tenant's Composio connectedAccountId.
+# YouTube responses nest rows at `.items` (NOT Graph's `.data[]`).
+#   list_posts        -> YOUTUBE_LIST_CHANNEL_VIDEOS      (mine:true uploads;
+#                        video id at items[].snippet.resourceId.videoId)
+#   post_insights     -> YOUTUBE_GET_VIDEO_DETAILS_BATCH  (id:[videoIds],
+#                        parts:['statistics']; one batch call, no per-video fan-out)
+#   list_comments     -> YOUTUBE_LIST_COMMENT_THREADS2    (videoId; top-level
+#                        threads at items[].snippet.topLevelComment)
+# Channel-id back-heal for enrollment uses YOUTUBE_LIST_CHANNELS (mine:true),
+# overridable via COMPOSIO_YOUTUBE_LIST_PAGES_ACTION. ARIES_YOUTUBE_ENABLED is
+# declared once near the top.
+COMPOSIO_YOUTUBE_LIST_POSTS_ACTION=
+COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION=
+COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION=
 
 # Native comment reply via Composio (#598/gate-5) — posts an operator reply
 # through FACEBOOK_CREATE_COMMENT (object_id = the comment's full graph id), so

--- a/backend/insights/adapters/youtube/index.ts
+++ b/backend/insights/adapters/youtube/index.ts
@@ -1,81 +1,313 @@
 /**
  * backend/insights/adapters/youtube/index.ts
  *
- * YouTube Analytics adapter — Phase 2 skeleton.
+ * YouTube insights adapter — backed by Composio (#637 analytics, #638 comments).
+ * Mirrors the verified Facebook adapter (backend/insights/adapters/facebook/
+ * index.ts) and the X adapter one platform over, behind the new
+ * ARIES_YOUTUBE_ENABLED flag.
  *
- * This file satisfies the InsightsAdapter interface so the rest of the
- * codebase compiles. The actual YouTube API calls will be added in Phase 3.
+ * Every platform call goes through the Composio gateway (`executeTool`) so the
+ * adapter depends on a small, mockable surface; tests inject a fake gateway and
+ * never touch the network. The verified Composio action slugs are the defaults,
+ * each overridable via `COMPOSIO_YOUTUBE_<OP>_ACTION` (resolved through
+ * `ComposioConfig.actionSlugFor`).
  *
- * Phase 3 will add:
- *   - YouTube Data API v3  — fetchPostList (search.list / playlistItems.list)
- *   - YouTube Data API v3  — fetchComments (commentThreads.list)
- *   - YouTube Analytics v2 — fetchAccountMetrics (reports.query)
- *   - YouTube Analytics v2 — fetchPostMetrics  (reports.query with video filter)
+ * Method → action:
+ *   fetchPostList     → YOUTUBE_LIST_CHANNEL_VIDEOS    (the authenticated
+ *                       channel's uploads via mine:true) then ONE
+ *                       YOUTUBE_GET_VIDEO_DETAILS_BATCH (statistics for every
+ *                       listed video, cached on the instance)
+ *   fetchPostMetrics  → (cache only — no call; reads fetchPostList's cache)
+ *   fetchComments     → YOUTUBE_LIST_COMMENT_THREADS2  (top-level threads)
+ *   fetchAccountMetrics → [] (no verified per-day account series — never
+ *                       fabricate a channel time series)
  *
- * Required env vars (Phase 3):
- *   YOUTUBE_CLIENT_ID
- *   YOUTUBE_CLIENT_SECRET
- *   YOUTUBE_REFRESH_TOKEN   ← service-account-style offline token per tenant
+ * YouTube list responses nest as `{ data: { items: [...] } }` — the row array is
+ * at `.items`, NOT Graph's `.data[]`. The dedicated `unwrapToItems` helper below
+ * resolves that shape; it must not be confused with the FB/X `.data[]` unwrap.
+ *
+ * Engagement model: YouTube exposes per-video statistics (viewCount/likeCount/
+ * commentCount) only through GET_VIDEO_DETAILS_BATCH, so fetchPostList captures
+ * them once for the whole listing in a single batch call and caches them on the
+ * adapter instance (the dispatcher reuses one adapter per sync and calls
+ * fetchPostList before fetchPostMetrics). There is NO per-video fan-out.
  */
 
 import type {
   InsightsAdapter,
+  InsightsAdapterContext,
   DateRange,
   RawAccountMetricsDay,
   RawPost,
   RawPostMetricsDay,
   RawComment,
 } from '../_adapter.types';
+import type { ComposioConfig, ComposioOperation } from '@/backend/integrations/composio/composio-config';
+import type { ComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { resolveComposioConfig } from '@/backend/integrations/composio/composio-config';
+import { createComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { num } from '@/backend/integrations/composio/analytics-mappers';
+
+// ── Verified default action slugs (env-overridable) ────────────────────────────
+
+const DEFAULT_SLUGS: Partial<Record<ComposioOperation, string>> = {
+  // List the authenticated channel's uploads (playlistItems via mine:true).
+  list_posts: 'YOUTUBE_LIST_CHANNEL_VIDEOS',
+  // Batch video statistics (videos.list?part=statistics&id=…) — engagement source.
+  post_insights: 'YOUTUBE_GET_VIDEO_DETAILS_BATCH',
+  // Top-level comment threads for one video.
+  list_comments: 'YOUTUBE_LIST_COMMENT_THREADS2',
+};
+
+// ── Response unwrapping helpers (YouTube nests rows at `.items`) ─────────────────
+
+/**
+ * Descend through Composio's `{ data: <toolPayload> }` envelope wrappers until we
+ * reach the object that carries YouTube's `items` array (or a leaf). The exact
+ * nesting (one vs two `.data` layers) varies by tool/SDK version, so we peel
+ * object-with-`data` wrappers, stopping as soon as we hit an `items` carrier.
+ */
+function unwrap(raw: unknown): unknown {
+  let cur = raw;
+  for (let i = 0; i < 3; i += 1) {
+    if (!cur || typeof cur !== 'object' || Array.isArray(cur)) break;
+    const obj = cur as Record<string, unknown>;
+    if (Array.isArray(obj.items)) break; // found the YouTube container
+    if (!('data' in obj)) break;
+    cur = obj.data;
+  }
+  return cur;
+}
+
+/**
+ * Resolve a YouTube list response into its row array. Unlike Graph's `.data[]`,
+ * YouTube returns `{ items: [...] }`; this reads `.items` after peeling the
+ * Composio envelope, and tolerates a bare array if a tool version returns one.
+ */
+function unwrapToItems(raw: unknown): Array<Record<string, unknown>> {
+  const peeled = unwrap(raw);
+  if (Array.isArray(peeled)) return peeled as Array<Record<string, unknown>>;
+  if (peeled && typeof peeled === 'object') {
+    const items = (peeled as Record<string, unknown>).items;
+    if (Array.isArray(items)) return items as Array<Record<string, unknown>>;
+  }
+  return [];
+}
+
+function asObject(node: unknown): Record<string, unknown> | null {
+  if (node && typeof node === 'object' && !Array.isArray(node)) {
+    return node as Record<string, unknown>;
+  }
+  return null;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function toDate(value: unknown): Date {
+  if (typeof value === 'string' && value.trim()) {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date(0);
+}
+
+/** Pull the videoId out of a playlistItem snippet (`snippet.resourceId.videoId`). */
+function videoIdOf(snippet: Record<string, unknown> | null): string | null {
+  const resourceId = asObject(snippet?.resourceId);
+  return str(resourceId?.videoId);
+}
+
+/** Pull the best available thumbnail url (`snippet.thumbnails.high.url`). */
+function thumbnailUrlOf(snippet: Record<string, unknown> | null): string | null {
+  const thumbnails = asObject(snippet?.thumbnails);
+  const high = asObject(thumbnails?.high);
+  return str(high?.url);
+}
+
+// ── Adapter ────────────────────────────────────────────────────────────────────
+
+interface CachedStats {
+  views: number | null;
+  likes: number | null;
+  comments: number | null;
+  /** The raw statistics object, preserved for rawSource provenance. */
+  statistics: Record<string, unknown> | null;
+}
 
 export class YouTubeInsightsAdapter implements InsightsAdapter {
   readonly platform = 'youtube' as const;
 
+  /** Per-video statistics captured in fetchPostList, read in fetchPostMetrics. */
+  private readonly engagementCache = new Map<string, CachedStats>();
+
+  constructor(
+    private readonly gateway: ComposioGateway,
+    private readonly config: ComposioConfig,
+    private readonly ctx: InsightsAdapterContext = {},
+  ) {}
+
+  private slugFor(op: ComposioOperation): string {
+    const override = this.config.actionSlugFor('youtube', op);
+    const slug = override ?? DEFAULT_SLUGS[op];
+    if (!slug) throw new Error(`No Composio YouTube action slug configured for "${op}".`);
+    return slug;
+  }
+
+  private connectedAccountId(): string {
+    const id = this.ctx.connectedAccountId?.trim();
+    if (!id) {
+      throw new Error('YouTubeInsightsAdapter: no Composio connectedAccountId in context.');
+    }
+    return id;
+  }
+
+  /** Execute a tool; throw on a hard (successful=false) failure so the sync run
+   * surfaces the leg error while already-committed rows are preserved. */
+  private async exec(op: ComposioOperation, args: Record<string, unknown>): Promise<unknown> {
+    const result = await this.gateway.executeTool(this.slugFor(op), {
+      connectedAccountId: this.connectedAccountId(),
+      arguments: args,
+    });
+    if (!result.successful) {
+      throw new Error(result.error ?? `Composio YouTube ${op} call reported unsuccessful.`);
+    }
+    return result.data ?? null;
+  }
+
+  /**
+   * List the authenticated channel's uploads (mine:true — no channelId needed)
+   * and enrich every listed video with live statistics via ONE batch call. The
+   * batch response populates the engagementCache; the returned RawPost list is
+   * sourced from the listing so a video is tracked even if the batch transiently
+   * omits its statistics.
+   *
+   * `externalAccountId`/`publishedAfter` are part of the InsightsAdapter contract
+   * but YouTube keys the listing on the authenticated channel (mine:true).
+   */
+  async fetchPostList(_externalAccountId: string, _publishedAfter?: Date): Promise<RawPost[]> {
+    const listData = await this.exec('list_posts', {
+      mine: true,
+      part: 'snippet',
+      maxResults: 50,
+    });
+
+    const posts: RawPost[] = [];
+    const videoIds: string[] = [];
+    for (const item of unwrapToItems(listData)) {
+      const snippet = asObject(item.snippet);
+      const videoId = videoIdOf(snippet);
+      if (!videoId) continue;
+      videoIds.push(videoId);
+      posts.push({
+        externalPostId: videoId,
+        publishedAt: toDate(snippet?.publishedAt),
+        // YouTube uploads are videos.
+        mediaType: 'video',
+        title: str(snippet?.title),
+        caption: str(snippet?.description),
+        permalink: `https://youtube.com/watch?v=${videoId}`,
+        thumbnailUrl: thumbnailUrlOf(snippet),
+        durationSeconds: null,
+      });
+    }
+
+    // ONE batch statistics call for every listed video (no per-video fan-out).
+    // YouTube caps id at 50/request; the action auto-splits if needed.
+    if (videoIds.length > 0) {
+      const detailsData = await this.exec('post_insights', {
+        id: videoIds,
+        parts: ['statistics'],
+      });
+      for (const item of unwrapToItems(detailsData)) {
+        const id = str(item.id);
+        if (!id) continue;
+        const statistics = asObject(item.statistics);
+        this.engagementCache.set(id, {
+          views: num(statistics?.viewCount),
+          likes: num(statistics?.likeCount),
+          comments: num(statistics?.commentCount),
+          statistics,
+        });
+      }
+    }
+
+    return posts;
+  }
+
+  /** YouTube exposes no verified per-day account series — never fabricate one. */
   async fetchAccountMetrics(
     _externalAccountId: string,
     _range: DateRange,
   ): Promise<RawAccountMetricsDay[]> {
-    // Phase 3: GET https://youtubeanalytics.googleapis.com/v2/reports
-    //   ?ids=channel==<channelId>&startDate=<from>&endDate=<to>
-    //   &metrics=views,estimatedMinutesWatched,subscribersGained,subscribersLost,likes,comments,shares
-    throw new Error(
-      'YouTubeInsightsAdapter.fetchAccountMetrics: not implemented — Phase 3',
-    );
+    return [];
   }
 
-  async fetchPostList(
-    _externalAccountId: string,
-    _publishedAfter?: Date,
-  ): Promise<RawPost[]> {
-    // Phase 3: GET https://www.googleapis.com/youtube/v3/search
-    //   ?channelId=<channelId>&type=video&order=date&publishedAfter=<ISO>
-    throw new Error(
-      'YouTubeInsightsAdapter.fetchPostList: not implemented — Phase 3',
-    );
+  async fetchPostMetrics(externalPostId: string, _range?: DateRange): Promise<RawPostMetricsDay[]> {
+    const cached = this.engagementCache.get(externalPostId) ?? null;
+
+    // Only emit a row when there is a real cached signal — never fabricate a zero
+    // row for a video whose statistics we never fetched (mirror FB/X).
+    if (!cached) return [];
+
+    const date = new Date().toISOString().split('T')[0];
+    return [
+      {
+        date,
+        views: cached.views ?? 0,
+        watchTimeMinutes: 0,
+        avgViewDurationSec: 0,
+        avgViewPercentage: 0,
+        likes: cached.likes ?? 0,
+        commentsCount: cached.comments ?? 0,
+        // YouTube statistics expose no share count — surface 0, not a fabricated
+        // value (the truth lives in rawSource.statistics).
+        shares: 0,
+        rawSource: {
+          source: 'YOUTUBE_GET_VIDEO_DETAILS_BATCH',
+          statistics: cached.statistics,
+        },
+      },
+    ];
   }
 
-  async fetchPostMetrics(
-    _externalPostId: string,
-    _range?: DateRange,
-  ): Promise<RawPostMetricsDay[]> {
-    // Phase 3: GET https://youtubeanalytics.googleapis.com/v2/reports
-    //   ?filters=video==<videoId>&metrics=views,estimatedMinutesWatched,
-    //     averageViewDuration,averageViewPercentage,likes,comments,shares
-    throw new Error(
-      'YouTubeInsightsAdapter.fetchPostMetrics: not implemented — Phase 3',
-    );
-  }
+  async fetchComments(externalPostId: string, limit = 100): Promise<RawComment[]> {
+    const data = await this.exec('list_comments', {
+      videoId: externalPostId,
+      // YouTube commentThreads caps maxResults at [1, 100].
+      maxResults: Math.min(Math.max(limit, 1), 100),
+    });
 
-  async fetchComments(
-    _externalPostId: string,
-    _limit?: number,
-  ): Promise<RawComment[]> {
-    // Phase 3: GET https://www.googleapis.com/youtube/v3/commentThreads
-    //   ?videoId=<videoId>&part=snippet&maxResults=<limit>
-    throw new Error(
-      'YouTubeInsightsAdapter.fetchComments: not implemented — Phase 3',
-    );
+    const out: RawComment[] = [];
+    for (const thread of unwrapToItems(data)) {
+      const threadSnippet = asObject(thread.snippet);
+      const topLevel = asObject(threadSnippet?.topLevelComment);
+      if (!topLevel) continue;
+      const externalCommentId = str(topLevel.id);
+      if (!externalCommentId) continue;
+      const commentSnippet = asObject(topLevel.snippet);
+      out.push({
+        externalCommentId,
+        receivedAt: toDate(commentSnippet?.publishedAt),
+        authorHandle: str(commentSnippet?.authorDisplayName),
+        bodyText: str(commentSnippet?.textOriginal) ?? str(commentSnippet?.textDisplay) ?? '',
+      });
+    }
+    return out;
   }
 }
 
-/** Singleton instance — import this in the adapter factory (Phase 3). */
-export const youTubeInsightsAdapter = new YouTubeInsightsAdapter();
+/**
+ * Build a context-bound YouTube adapter wired to the live Composio gateway.
+ * Throws (via createComposioGateway) when Composio is enabled but no API key is
+ * configured — the dispatcher catches that and marks the sync run failed.
+ */
+export function createYouTubeInsightsAdapter(
+  ctx: InsightsAdapterContext = {},
+  env: NodeJS.ProcessEnv = process.env,
+): YouTubeInsightsAdapter {
+  const config = resolveComposioConfig(env);
+  const gateway = createComposioGateway(config);
+  return new YouTubeInsightsAdapter(gateway, config!, ctx);
+}

--- a/backend/insights/platforms/capabilities.ts
+++ b/backend/insights/platforms/capabilities.ts
@@ -24,14 +24,15 @@ export type PlatformCapability =
   | 'saves';                  // saves / bookmarks (Instagram, Facebook)
 
 export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapability>> = {
+  // YouTube via Composio: per-video statistics (views/likes/comments) +
+  // top-level comment threads. Deliberately OMITS 'account_daily_metrics'
+  // (no verified per-day channel series), 'watch_time'/'avg_view_duration'
+  // (not delivered by GET_VIDEO_DETAILS_BATCH), and 'audience_demographics'
+  // (not fetched) — the adapter only delivers these three.
   youtube: new Set<PlatformCapability>([
-    'account_daily_metrics',
     'post_list',
     'post_daily_metrics',
     'comments',
-    'audience_demographics',
-    'watch_time',
-    'avg_view_duration',
   ]),
   instagram: new Set<PlatformCapability>([
     'account_daily_metrics',

--- a/backend/insights/sync/adapter-factory.ts
+++ b/backend/insights/sync/adapter-factory.ts
@@ -4,9 +4,9 @@
  * Maps a platform string to its InsightsAdapter instance.
  *
  * Adapters are produced by per-platform builder functions so a platform that
- * needs per-tenant connection context (e.g. Facebook via Composio, which needs
- * the Composio `connectedAccountId`) can be constructed bound to that context,
- * while context-free adapters (YouTube) return a shared singleton.
+ * needs per-tenant connection context (e.g. Facebook, X, and YouTube via
+ * Composio, which need the Composio `connectedAccountId`) can be constructed
+ * bound to that context.
  *
  * To add a new platform:
  *   1. Create backend/insights/adapters/<platform>/index.ts
@@ -16,10 +16,10 @@
 
 import type { Platform } from '../platforms/registry';
 import type { InsightsAdapter, InsightsAdapterContext } from '../adapters/_adapter.types';
-import { youTubeInsightsAdapter } from '../adapters/youtube/index';
+import { createYouTubeInsightsAdapter } from '../adapters/youtube/index';
 import { createFacebookInsightsAdapter } from '../adapters/facebook/index';
 import { createXInsightsAdapter } from '../adapters/x/index';
-import { analyticsProviderSelector, isXEnabled } from '@/backend/integrations/providers/integration-config';
+import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled } from '@/backend/integrations/providers/integration-config';
 
 type AdapterBuilder = (ctx: InsightsAdapterContext) => InsightsAdapter;
 
@@ -44,8 +44,27 @@ export function isXInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolea
   return isXEnabled(env) && analyticsProviderSelector(env) === 'composio';
 }
 
+/**
+ * Real off-switch for the Composio-backed YouTube insights path: active only when
+ * the YouTube rollout flag is ON (ARIES_YOUTUBE_ENABLED) AND analytics is on
+ * Composio (ANALYTICS_PROVIDER=composio). NEW flag (not ARIES_X_ENABLED). Default
+ * OFF on both axes → the YouTube adapter never activates and no Composio tool is
+ * ever executed; the previously registered throwing skeleton is gone.
+ */
+export function isYouTubeInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isYouTubeEnabled(env) && analyticsProviderSelector(env) === 'composio';
+}
+
 const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
-  youtube: () => youTubeInsightsAdapter,
+  youtube: (ctx) => {
+    if (!isYouTubeInsightsEnabled()) {
+      throw new Error(
+        'YouTube insights adapter is disabled: set ARIES_YOUTUBE_ENABLED=1 and ' +
+        'ANALYTICS_PROVIDER=composio to enable Composio-backed YouTube analytics.',
+      );
+    }
+    return createYouTubeInsightsAdapter(ctx);
+  },
   facebook: (ctx) => {
     if (!isFacebookInsightsEnabled()) {
       throw new Error(
@@ -75,6 +94,7 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
 export function hasAdapter(platform: Platform, env: NodeJS.ProcessEnv = process.env): boolean {
   if (platform === 'facebook') return isFacebookInsightsEnabled(env);
   if (platform === 'x') return isXInsightsEnabled(env);
+  if (platform === 'youtube') return isYouTubeInsightsEnabled(env);
   return platform in REGISTRY && REGISTRY[platform] != null;
 }
 

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -26,23 +26,29 @@
 
 import pool from '@/lib/db';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
-import { analyticsProviderSelector, isXEnabled } from '@/backend/integrations/providers/integration-config';
+import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled } from '@/backend/integrations/providers/integration-config';
 import { resolveComposioConfig, type ComposioConfig } from '@/backend/integrations/composio/composio-config';
 import { createComposioGateway, type ComposioGateway } from '@/backend/integrations/composio/composio-client';
 import { resolveFacebookManagedPage } from '@/backend/integrations/composio/facebook-page-resolver';
+import { resolveYouTubeChannel } from '@/backend/integrations/composio/youtube-channel-resolver';
 
 /**
  * Platforms whose Composio connections should be projected into insights_accounts.
- * X (Twitter) is only bridged when ARIES_X_ENABLED is ON (computed dynamically by
+ * X (Twitter) and YouTube are only bridged when their rollout flag is ON
+ * (ARIES_X_ENABLED / ARIES_YOUTUBE_ENABLED), computed dynamically by
  * `bridgedPlatforms` below — the const itself is never mutated, so a flag-OFF
- * environment is byte-identical to the FB-only bridge).
+ * environment is byte-identical to the FB-only bridge.
  */
 export const BRIDGED_PLATFORMS = ['facebook'] as const;
 
-/** The bridged-platform list for this env: FB always; X only when ARIES_X_ENABLED. */
+/**
+ * The bridged-platform list for this env: FB always; X only when ARIES_X_ENABLED;
+ * YouTube only when ARIES_YOUTUBE_ENABLED.
+ */
 function bridgedPlatforms(env: NodeJS.ProcessEnv): string[] {
   const list: string[] = [...BRIDGED_PLATFORMS];
   if (isXEnabled(env)) list.push('x');
+  if (isYouTubeEnabled(env)) list.push('youtube');
   return list;
 }
 
@@ -140,47 +146,66 @@ export async function ensureInsightsAccountsForConnectedPlatforms(
     let pageName = row.external_account_name;
 
     if (!pageId) {
-      // Only Facebook has a Page-id resolver (FACEBOOK_LIST_MANAGED_PAGES). X's
-      // external account id is captured at connect by pickExternalAccountId, so a
-      // null id is not back-heal-able here — skip this tick (a later connect/
-      // re-auth populates it). Never invent an X account id.
-      if (row.platform !== 'facebook') {
+      // Facebook (FACEBOOK_LIST_MANAGED_PAGES) and YouTube (YOUTUBE_LIST_CHANNELS,
+      // mine:true) have an external-id resolver. X's external account id is
+      // captured at connect by pickExternalAccountId, so a null id is not
+      // back-heal-able here — skip this tick (a later connect/re-auth populates
+      // it). Never invent an external account id.
+      if (row.platform !== 'facebook' && row.platform !== 'youtube') {
         skippedNoPage++;
         log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, platform: row.platform, reason: 'no_external_account_id' });
         continue;
       }
-      // Back-heal: resolve the Page id from Composio and persist it once.
+      // Back-heal: resolve the external id from Composio and persist it once.
       const r = getResolver();
       if (!r || !row.connected_account_id) {
         skippedNoPage++;
-        log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, reason: r ? 'no_connected_account' : 'composio_unavailable' });
+        log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, platform: row.platform, reason: r ? 'no_connected_account' : 'composio_unavailable' });
         continue;
       }
-      let page: Awaited<ReturnType<typeof resolveFacebookManagedPage>> = null;
+      // Each resolver is fail-safe (returns null, never throws); the catch is a
+      // belt-and-braces guard so a single tenant can never wedge the worker tick.
+      let resolvedId: string | null = null;
+      let resolvedName: string | null = null;
+      let resolvedManagedCount = 0;
       try {
-        page = await resolveFacebookManagedPage(r.gateway, r.config, row.connected_account_id);
+        if (row.platform === 'youtube') {
+          const channel = await resolveYouTubeChannel(r.gateway, r.config, row.connected_account_id);
+          if (channel) {
+            resolvedId = channel.channelId;
+            resolvedName = channel.channelName;
+            resolvedManagedCount = channel.managedCount;
+          }
+        } else {
+          const page = await resolveFacebookManagedPage(r.gateway, r.config, row.connected_account_id);
+          if (page) {
+            resolvedId = page.pageId;
+            resolvedName = page.pageName;
+            resolvedManagedCount = page.managedCount;
+          }
+        }
       } catch (err) {
-        page = null;
-        log({ event: 'insights_bridge_page_resolve_error', tenantId: row.tenant_id, error: err instanceof Error ? err.message : String(err) });
+        resolvedId = null;
+        log({ event: 'insights_bridge_page_resolve_error', tenantId: row.tenant_id, platform: row.platform, error: err instanceof Error ? err.message : String(err) });
       }
-      if (!page) {
+      if (!resolvedId) {
         skippedNoPage++;
-        log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, reason: 'no_managed_page' });
+        log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, platform: row.platform, reason: 'no_managed_account' });
         continue;
       }
-      pageId = page.pageId;
-      pageName = pageName ?? page.pageName;
-      // Persist back so the Page id is captured once (future ticks skip resolution).
+      pageId = resolvedId;
+      pageName = pageName ?? resolvedName;
+      // Persist back so the external id is captured once (future ticks skip resolution).
       await db.query(
         `UPDATE connected_accounts
            SET external_account_id = $1,
                external_account_name = COALESCE($2, external_account_name),
                updated_at = now()
          WHERE id = $3`,
-        [pageId, page.pageName, row.id],
+        [pageId, resolvedName, row.id],
       );
       resolved++;
-      log({ event: 'insights_bridge_page_resolved', tenantId: row.tenant_id, pageId, managedCount: page.managedCount });
+      log({ event: 'insights_bridge_page_resolved', tenantId: row.tenant_id, platform: row.platform, pageId, managedCount: resolvedManagedCount });
     }
 
     const res = await db.query(

--- a/backend/integrations/composio/youtube-channel-resolver.ts
+++ b/backend/integrations/composio/youtube-channel-resolver.ts
@@ -1,0 +1,88 @@
+/**
+ * Resolve a tenant's YouTube channel id from Composio.
+ *
+ * The YouTube channel id (needed as insights_accounts.external_account_id, which
+ * is NOT NULL) is not part of the Composio connection metadata, so connect-time
+ * reconciliation can leave connected_accounts.external_account_id null. This
+ * helper calls a channel-listing action with `mine:true` using the connection's
+ * connectedAccountId and returns the authenticated channel.
+ *
+ * The list/insight fetch path itself does NOT need the channel id (fetchPostList
+ * uses mine:true) — the id is required only so the bridge can satisfy the NOT
+ * NULL enrollment column, exactly mirroring the Facebook Page-id back-heal.
+ *
+ * Single-channel SMB case = the one channel. When several are returned we pick
+ * the first deterministically and report the full count so the caller can log it.
+ *
+ * Fail-safe: returns null on an unsuccessful tool call or when no channel is
+ * returned (e.g. missing scope). Throwing is the caller's call to make — this
+ * never invents a channel id and never wedges the worker tick.
+ *
+ * Response shape (YouTube): { data: { items: [ { id, snippet: { title } } ] } }
+ * — the row array is at `.items`, NOT Graph's `.data[]`.
+ *
+ * OPEN CONTRACT RISK: the exact verified action for "list my channel" was not
+ * pinned in the Composio catalog; `YOUTUBE_LIST_CHANNELS` is the default and is
+ * env-overridable via COMPOSIO_YOUTUBE_LIST_PAGES_ACTION so an operator can point
+ * it at the confirmed slug without a code change.
+ */
+
+import type { ComposioGateway } from './composio-client';
+import type { ComposioConfig } from './composio-config';
+
+export interface ResolvedYouTubeChannel {
+  channelId: string;
+  channelName: string | null;
+  /** Total channels returned (>1 means we picked the first). */
+  managedCount: number;
+}
+
+/** Default slug; overridable via COMPOSIO_YOUTUBE_LIST_PAGES_ACTION. */
+export const DEFAULT_LIST_CHANNELS_SLUG = 'YOUTUBE_LIST_CHANNELS';
+
+/**
+ * Peel Composio's `{ data: <toolPayload> }` wrappers until we reach the YouTube
+ * container, then read its `.items` array. Tolerates a bare array if a tool
+ * version returns one directly.
+ */
+function unwrapToItems(raw: unknown): Array<Record<string, unknown>> {
+  let cur = raw;
+  for (let i = 0; i < 3; i += 1) {
+    if (Array.isArray(cur)) return cur as Array<Record<string, unknown>>;
+    if (!cur || typeof cur !== 'object') break;
+    const obj = cur as Record<string, unknown>;
+    if (Array.isArray(obj.items)) return obj.items as Array<Record<string, unknown>>;
+    if (!('data' in obj)) break;
+    cur = obj.data;
+  }
+  return Array.isArray(cur) ? (cur as Array<Record<string, unknown>>) : [];
+}
+
+export async function resolveYouTubeChannel(
+  gateway: ComposioGateway,
+  config: ComposioConfig,
+  connectedAccountId: string,
+): Promise<ResolvedYouTubeChannel | null> {
+  const slug = config.actionSlugFor('youtube', 'list_pages') ?? DEFAULT_LIST_CHANNELS_SLUG;
+  const result = await gateway.executeTool(slug, {
+    connectedAccountId,
+    arguments: { mine: true, part: 'snippet', maxResults: 25 },
+  });
+  if (!result.successful) return null;
+
+  const channels = unwrapToItems(result.data);
+  for (const channel of channels) {
+    const id = typeof channel.id === 'string' && channel.id.trim() ? channel.id.trim() : null;
+    if (!id) continue;
+    const snippet =
+      channel.snippet && typeof channel.snippet === 'object'
+        ? (channel.snippet as Record<string, unknown>)
+        : null;
+    const name =
+      snippet && typeof snippet.title === 'string' && snippet.title.trim()
+        ? snippet.title.trim()
+        : null;
+    return { channelId: id, channelName: name, managedCount: channels.length };
+  }
+  return null;
+}

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -37,6 +37,17 @@ export function isXEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
+ * YouTube insights rollout flag (#637 analytics, #638 comments). Default OFF —
+ * ships the Composio-backed YouTube insights adapter dormant. YouTube already
+ * *connects* via Composio, so this flag does NOT gate connectability (it is
+ * deliberately NOT wired into `connectablePlatforms`); it gates only the
+ * insights bridge + adapter. NEW flag — never reuse ARIES_X_ENABLED.
+ */
+export function isYouTubeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseFlag(env.ARIES_YOUTUBE_ENABLED);
+}
+
+/**
  * Reddit publish rollout flag. Default OFF — ships the publish path dormant
  * (Reddit already *connects* via Composio; this flag gates publish only, so it
  * is deliberately NOT wired into `connectablePlatforms`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,6 +205,10 @@ services:
       # LinkedIn rollout flag — default OFF ships the connect-time person-URN
       # lookup dormant (no LINKEDIN_GET_MY_INFO call; connect byte-identical).
       ARIES_LINKEDIN_ENABLED: ${ARIES_LINKEDIN_ENABLED:-false}
+      # YouTube insights rollout flag (#637/#638) — default OFF ships the
+      # Composio-backed YouTube insights adapter dormant (no bridge row, no
+      # adapter, no Composio tool). Gates insights only, not connectability.
+      ARIES_YOUTUBE_ENABLED: ${ARIES_YOUTUBE_ENABLED:-false}
       # Toolkit version for manual Composio tool execution (publish/analytics/
       # comments). The SDK rejects by-slug execution without one; default 'latest'
       # (gateway pairs it with a skip-check). Pin a concrete version to avoid drift.
@@ -512,6 +516,18 @@ services:
       COMPOSIO_X_POST_INSIGHTS_ACTION: ${COMPOSIO_X_POST_INSIGHTS_ACTION:-}
       COMPOSIO_X_LIST_COMMENTS_ACTION: ${COMPOSIO_X_LIST_COMMENTS_ACTION:-}
       COMPOSIO_X_LIST_POSTS_ACTION: ${COMPOSIO_X_LIST_POSTS_ACTION:-}
+      # YouTube analytics + comments (#637/#638), read by the insights-sync
+      # worker's YouTube adapter (backend/insights/adapters/youtube). The YouTube
+      # insights path (account bridge + adapter) turns on ONLY when
+      # ARIES_YOUTUBE_ENABLED=true AND ANALYTICS_PROVIDER=composio; otherwise
+      # dormant. AUTH_CONFIG_ID is the tenant's Composio auth config; the *_ACTION
+      # slugs are optional (verified code defaults: YOUTUBE_LIST_CHANNEL_VIDEOS,
+      # YOUTUBE_GET_VIDEO_DETAILS_BATCH, YOUTUBE_LIST_COMMENT_THREADS2).
+      ARIES_YOUTUBE_ENABLED: ${ARIES_YOUTUBE_ENABLED:-false}
+      COMPOSIO_YOUTUBE_AUTH_CONFIG_ID: ${COMPOSIO_YOUTUBE_AUTH_CONFIG_ID:-}
+      COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION: ${COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION:-}
+      COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION: ${COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION:-}
+      COMPOSIO_YOUTUBE_LIST_POSTS_ACTION: ${COMPOSIO_YOUTUBE_LIST_POSTS_ACTION:-}
     restart: unless-stopped
     networks:
       - docker_stack

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -237,6 +237,38 @@ test('X bridge: when ARIES_X_ENABLED is off, the DB query only includes "faceboo
   assert.deepEqual(select.params, ['facebook'], 'only facebook when ARIES_X_ENABLED is off');
 });
 
+test('YouTube bridge: when ARIES_YOUTUBE_ENABLED=1 the DB query includes "youtube" alongside "facebook"', async () => {
+  const db = recordingDb([]);
+  const ytEnv = {
+    ANALYTICS_PROVIDER: 'composio',
+    ARIES_YOUTUBE_ENABLED: '1',
+  } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, ytEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'issued a SELECT query');
+  // The bridged-platform list must include 'youtube' when the rollout flag is on.
+  assert.ok(
+    Array.isArray(select.params) && (select.params as unknown[]).includes('youtube'),
+    'youtube is in bridged-platform params when ARIES_YOUTUBE_ENABLED=1',
+  );
+  assert.ok(
+    Array.isArray(select.params) && (select.params as unknown[]).includes('facebook'),
+    'facebook is always included',
+  );
+});
+
+test('YouTube bridge: when ARIES_YOUTUBE_ENABLED is off, the DB query does NOT include "youtube"', async () => {
+  const db = recordingDb([]);
+  const fbOnlyEnv = { ANALYTICS_PROVIDER: 'composio' } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, fbOnlyEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'issued a SELECT query');
+  assert.ok(
+    !(select.params as unknown[]).includes('youtube'),
+    'youtube is NOT in bridged-platform params when ARIES_YOUTUBE_ENABLED is off',
+  );
+});
+
 test('facebook is registered in the adapter factory and getAdapter binds the connection context', () => {
   // getAdapter builds a real Composio gateway (needs an API key) AND requires
   // the ANALYTICS_PROVIDER=composio off-switch to be on.

--- a/tests/insights-youtube-adapter.test.ts
+++ b/tests/insights-youtube-adapter.test.ts
@@ -1,0 +1,435 @@
+/**
+ * tests/insights-youtube-adapter.test.ts
+ *
+ * Regression coverage for the YouTube insights adapter (#637 analytics,
+ * #638 comments). All tests are self-contained — fake gateway / no DB / no
+ * real Postgres, no network calls.
+ *
+ * Mirror pattern: tests/insights-x-adapter.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { YouTubeInsightsAdapter } from '@/backend/insights/adapters/youtube/index';
+import {
+  hasAdapter,
+  getAdapter,
+  isYouTubeInsightsEnabled,
+} from '@/backend/insights/sync/adapter-factory';
+import type {
+  ComposioGateway,
+  GatewayToolResult,
+} from '@/backend/integrations/composio/composio-client';
+import { fakeConfig } from './composio/helpers';
+
+// ── Test doubles ──────────────────────────────────────────────────────────────
+
+interface RecordedCall {
+  slug: string;
+  connectedAccountId?: string;
+  arguments?: Record<string, unknown>;
+}
+
+/** Gateway that routes a canned result per action slug and records every call. */
+function routingGateway(
+  results: Record<string, GatewayToolResult>,
+): ComposioGateway & { calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    async findOrCreateManagedAuthConfig(s: string) { return `ac_${s}`; },
+    async initiateConnection() { return { connectionRequestId: 'cr', redirectUrl: null }; },
+    async listConnections() { return []; },
+    async getConnection() { return null; },
+    async deleteConnection() {},
+    async executeTool(slug, options) {
+      calls.push({
+        slug,
+        connectedAccountId: options.connectedAccountId,
+        arguments: options.arguments,
+      });
+      // Default: YouTube-shaped empty list (not Graph's .data[] shape).
+      return results[slug] ?? { data: { items: [] }, successful: true, error: null };
+    },
+    async uploadFile(input) {
+      return { name: 'staged', mimetype: 'application/octet-stream', s3key: `s3/${input.toolSlug}` };
+    },
+  };
+}
+
+/** Standard adapter context shared across non-dormancy tests. */
+const ctx = { connectedAccountId: 'ca_yt_1', tenantId: 42 };
+
+// ── fetchPostList ─────────────────────────────────────────────────────────────
+
+test('fetchPostList: issues YOUTUBE_LIST_CHANNEL_VIDEOS with mine:true, maps items[].snippet.resourceId.videoId → RawPost, then ONE batch call for statistics', async () => {
+  const gateway = routingGateway({
+    YOUTUBE_LIST_CHANNEL_VIDEOS: {
+      successful: true,
+      error: null,
+      data: {
+        items: [
+          {
+            snippet: {
+              resourceId: { videoId: 'vid1' },
+              title: 'First Video',
+              description: 'A description',
+              publishedAt: '2026-06-10T12:00:00Z',
+              thumbnails: { high: { url: 'https://img/thumb1.jpg' } },
+            },
+          },
+          {
+            snippet: {
+              resourceId: { videoId: 'vid2' },
+              title: 'Second Video',
+              description: 'Another description',
+              publishedAt: '2026-06-11T14:00:00Z',
+              thumbnails: { high: { url: 'https://img/thumb2.jpg' } },
+            },
+          },
+        ],
+      },
+    },
+    YOUTUBE_GET_VIDEO_DETAILS_BATCH: {
+      successful: true,
+      error: null,
+      data: {
+        items: [
+          { id: 'vid1', statistics: { viewCount: '1000', likeCount: '50', commentCount: '10' } },
+          { id: 'vid2', statistics: { viewCount: '500', likeCount: '20', commentCount: '5' } },
+        ],
+      },
+    },
+  });
+
+  const adapter = new YouTubeInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  const posts = await adapter.fetchPostList('yt_channel_1');
+
+  // 2 calls: list + ONE batch stats — not N per-video fan-out calls.
+  assert.equal(gateway.calls.length, 2, 'list call + ONE batch stats call, no per-video fan-out');
+
+  const listCall = gateway.calls[0];
+  assert.equal(listCall.slug, 'YOUTUBE_LIST_CHANNEL_VIDEOS');
+  assert.equal(listCall.connectedAccountId, 'ca_yt_1');
+  assert.equal(listCall.arguments?.mine, true, 'mine:true — authenticated channel listing, no channelId needed');
+  assert.equal(listCall.arguments?.part, 'snippet');
+  assert.equal(listCall.arguments?.maxResults, 50);
+
+  const batchCall = gateway.calls[1];
+  assert.equal(batchCall.slug, 'YOUTUBE_GET_VIDEO_DETAILS_BATCH');
+  // id is the full array of video ids from the listing.
+  assert.deepEqual(batchCall.arguments?.id, ['vid1', 'vid2'], 'batch call carries all listed video ids');
+  assert.deepEqual(batchCall.arguments?.parts, ['statistics']);
+
+  // RawPost field mapping.
+  assert.equal(posts.length, 2);
+  assert.equal(posts[0].externalPostId, 'vid1');
+  assert.equal(posts[0].mediaType, 'video', 'YouTube uploads are videos');
+  assert.equal(posts[0].title, 'First Video');
+  assert.equal(posts[0].caption, 'A description');
+  assert.match(String(posts[0].permalink), /vid1/, 'permalink embeds the video id');
+  assert.equal(posts[0].thumbnailUrl, 'https://img/thumb1.jpg');
+  assert.equal(posts[1].externalPostId, 'vid2');
+});
+
+test('fetchPostList: empty channel → returns [] and issues NO batch stats call', async () => {
+  const gateway = routingGateway({
+    YOUTUBE_LIST_CHANNEL_VIDEOS: {
+      successful: true,
+      error: null,
+      data: { items: [] },
+    },
+  });
+
+  const adapter = new YouTubeInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  const posts = await adapter.fetchPostList('yt_channel_1');
+
+  assert.deepEqual(posts, []);
+  // Only the list call — no batch stats call when there are no video ids.
+  assert.equal(gateway.calls.length, 1, 'only list call; no batch call for empty channel');
+  assert.equal(gateway.calls[0].slug, 'YOUTUBE_LIST_CHANNEL_VIDEOS');
+});
+
+// ── fetchPostMetrics ──────────────────────────────────────────────────────────
+
+test('fetchPostMetrics: reads from cache (no extra gateway call), maps viewCount/likeCount/commentCount strings to numbers', async () => {
+  const gateway = routingGateway({
+    YOUTUBE_LIST_CHANNEL_VIDEOS: {
+      successful: true,
+      error: null,
+      data: {
+        items: [
+          {
+            snippet: {
+              resourceId: { videoId: 'vid1' },
+              title: 'My Video',
+              description: null,
+              publishedAt: '2026-06-10T00:00:00Z',
+              thumbnails: {},
+            },
+          },
+        ],
+      },
+    },
+    YOUTUBE_GET_VIDEO_DETAILS_BATCH: {
+      successful: true,
+      error: null,
+      data: {
+        items: [
+          {
+            id: 'vid1',
+            statistics: {
+              viewCount: '12345',
+              likeCount: '678',
+              commentCount: '90',
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  const adapter = new YouTubeInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  // Prime the cache (dispatcher always calls fetchPostList before fetchPostMetrics).
+  await adapter.fetchPostList('yt_channel_1');
+  const callsBefore = gateway.calls.length; // 2 (list + batch)
+
+  const metrics = await adapter.fetchPostMetrics('vid1');
+
+  // No additional gateway call — reads from the engagementCache.
+  assert.equal(gateway.calls.length, callsBefore, 'no extra gateway call; metrics read from cache');
+
+  assert.equal(metrics.length, 1);
+  assert.equal(metrics[0].views, 12345, 'viewCount string coerced to number');
+  assert.equal(metrics[0].likes, 678, 'likeCount string coerced to number');
+  assert.equal(metrics[0].commentsCount, 90, 'commentCount string coerced to number');
+  assert.equal(metrics[0].shares, 0, 'YouTube has no share count — always 0, not fabricated');
+
+  // rawSource must identify the batch action for provenance.
+  assert.equal(metrics[0].rawSource.source, 'YOUTUBE_GET_VIDEO_DETAILS_BATCH');
+});
+
+test('fetchPostMetrics: empty cache → returns [] (no fabricated zero row for unknown video)', async () => {
+  const adapter = new YouTubeInsightsAdapter(
+    routingGateway({}),
+    fakeConfig({ actions: {} }),
+    ctx,
+  );
+  // Cache was never populated — simulates a video whose stats were never fetched.
+  const metrics = await adapter.fetchPostMetrics('vid_unknown');
+  assert.deepEqual(metrics, [], 'no cached stats → empty, never a fabricated zero row');
+});
+
+// ── fetchComments ─────────────────────────────────────────────────────────────
+
+test('fetchComments: issues YOUTUBE_LIST_COMMENT_THREADS2 keyed on videoId, maps topLevelComment id/authorDisplayName/textOriginal/publishedAt → RawComment', async () => {
+  const gateway = routingGateway({
+    YOUTUBE_LIST_COMMENT_THREADS2: {
+      successful: true,
+      error: null,
+      data: {
+        items: [
+          {
+            snippet: {
+              topLevelComment: {
+                id: 'comment1',
+                snippet: {
+                  authorDisplayName: 'Jane Doe',
+                  textOriginal: 'Great video!',
+                  publishedAt: '2026-06-11T08:00:00Z',
+                },
+              },
+            },
+          },
+          {
+            snippet: {
+              topLevelComment: {
+                id: 'comment2',
+                snippet: {
+                  authorDisplayName: 'John Smith',
+                  textOriginal: 'Very informative.',
+                  publishedAt: '2026-06-11T09:00:00Z',
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  const adapter = new YouTubeInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  const comments = await adapter.fetchComments('vid1', 50);
+
+  const commentCall = gateway.calls[0];
+  assert.equal(commentCall.slug, 'YOUTUBE_LIST_COMMENT_THREADS2');
+  assert.equal(commentCall.connectedAccountId, 'ca_yt_1');
+  assert.equal(commentCall.arguments?.videoId, 'vid1', 'call is keyed on the video id');
+  assert.equal(commentCall.arguments?.maxResults, 50);
+
+  assert.equal(comments.length, 2);
+  assert.equal(comments[0].externalCommentId, 'comment1');
+  assert.equal(comments[0].authorHandle, 'Jane Doe', 'authorHandle from authorDisplayName');
+  assert.equal(comments[0].bodyText, 'Great video!', 'bodyText from textOriginal');
+  assert.ok(comments[0].receivedAt instanceof Date, 'receivedAt is a Date');
+  assert.equal(comments[0].receivedAt.getFullYear(), 2026);
+
+  assert.equal(comments[1].externalCommentId, 'comment2');
+  assert.equal(comments[1].authorHandle, 'John Smith');
+  assert.equal(comments[1].bodyText, 'Very informative.');
+});
+
+test('fetchComments: falls back to textDisplay when textOriginal is absent', async () => {
+  const gateway = routingGateway({
+    YOUTUBE_LIST_COMMENT_THREADS2: {
+      successful: true,
+      error: null,
+      data: {
+        items: [
+          {
+            snippet: {
+              topLevelComment: {
+                id: 'comment_display',
+                snippet: {
+                  authorDisplayName: 'Anonymous',
+                  // textOriginal absent — should fall back to textDisplay.
+                  textDisplay: 'Hello from display text',
+                  publishedAt: '2026-06-12T00:00:00Z',
+                },
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  const adapter = new YouTubeInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  const comments = await adapter.fetchComments('vid1');
+
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0].bodyText, 'Hello from display text', 'textDisplay fallback when textOriginal is absent');
+});
+
+// ── fetchAccountMetrics ───────────────────────────────────────────────────────
+
+test('fetchAccountMetrics: always returns [] — no verified per-day YouTube channel series', async () => {
+  const gateway = routingGateway({});
+  const adapter = new YouTubeInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const result = await adapter.fetchAccountMetrics('yt_channel_1', { from: '2026-06-01', to: '2026-06-18' });
+
+  assert.deepEqual(result, []);
+  assert.equal(gateway.calls.length, 0, 'no gateway calls — never fabricate an account series');
+});
+
+// ── .items unwrap (YouTube nesting vs Graph .data[]) ─────────────────────────
+
+test('.items unwrap: adapter reads row array from {data:{items:[...]}} (YouTube double-envelope nesting), not .data[]', async () => {
+  // Composio wraps the YouTube response in { data: <toolPayload> }.
+  // YouTube's toolPayload is itself { items: [...] }.
+  // Together the executeTool result.data is { data: { items: [...] } }
+  // so exec() receives { data: { items: [...] } } and unwrapToItems must peel
+  // the inner .data layer before reading .items.
+  // If the adapter mistakenly used Graph's .data[] it would return 0 posts.
+  const gateway = routingGateway({
+    YOUTUBE_LIST_CHANNEL_VIDEOS: {
+      successful: true,
+      error: null,
+      data: {
+        // Inner data layer (Composio envelope) wrapping YouTube's items payload.
+        data: {
+          items: [
+            {
+              snippet: {
+                resourceId: { videoId: 'vid_double_wrapped' },
+                title: 'Double-Wrapped Video',
+                description: 'desc',
+                publishedAt: '2026-06-10T00:00:00Z',
+                thumbnails: {},
+              },
+            },
+          ],
+        },
+      },
+    },
+    YOUTUBE_GET_VIDEO_DETAILS_BATCH: {
+      successful: true,
+      error: null,
+      data: {
+        data: {
+          items: [
+            { id: 'vid_double_wrapped', statistics: { viewCount: '100', likeCount: '10', commentCount: '1' } },
+          ],
+        },
+      },
+    },
+  });
+
+  const adapter = new YouTubeInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  const posts = await adapter.fetchPostList('yt_channel_1');
+
+  // The adapter must correctly unwrap through the double envelope to .items.
+  assert.equal(posts.length, 1, 'reads one video from double-envelope {data:{items:[...]}} nesting');
+  assert.equal(posts[0].externalPostId, 'vid_double_wrapped');
+
+  // Cache was also populated from the double-envelope batch response.
+  const metrics = await adapter.fetchPostMetrics('vid_double_wrapped');
+  assert.equal(metrics.length, 1, 'batch stats double-envelope also unwrapped correctly');
+  assert.equal(metrics[0].views, 100);
+});
+
+// ── Dormancy / off-switch ─────────────────────────────────────────────────────
+
+const YT_COMPOSIO_ENV = {
+  ARIES_YOUTUBE_ENABLED: '1',
+  ANALYTICS_PROVIDER: 'composio',
+} as unknown as NodeJS.ProcessEnv;
+
+const FLAG_OFF_ENV = {
+  ANALYTICS_PROVIDER: 'composio',
+} as unknown as NodeJS.ProcessEnv;
+
+const PROVIDER_OFF_ENV = {
+  ARIES_YOUTUBE_ENABLED: '1',
+} as unknown as NodeJS.ProcessEnv;
+
+test('dormancy: isYouTubeInsightsEnabled requires BOTH ARIES_YOUTUBE_ENABLED=1 AND ANALYTICS_PROVIDER=composio', () => {
+  assert.equal(isYouTubeInsightsEnabled(YT_COMPOSIO_ENV), true, 'both flags on → enabled');
+  assert.equal(isYouTubeInsightsEnabled(FLAG_OFF_ENV), false, 'ARIES_YOUTUBE_ENABLED absent → disabled');
+  assert.equal(isYouTubeInsightsEnabled(PROVIDER_OFF_ENV), false, 'ANALYTICS_PROVIDER!=composio → disabled');
+  assert.equal(
+    isYouTubeInsightsEnabled({} as unknown as NodeJS.ProcessEnv),
+    false,
+    'no flags → disabled (default OFF)',
+  );
+});
+
+test('dormancy: hasAdapter("youtube") mirrors isYouTubeInsightsEnabled for all flag combinations', () => {
+  assert.equal(hasAdapter('youtube', YT_COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('youtube', FLAG_OFF_ENV), false);
+  assert.equal(hasAdapter('youtube', PROVIDER_OFF_ENV), false);
+  assert.equal(hasAdapter('youtube', {} as unknown as NodeJS.ProcessEnv), false);
+});
+
+test('dormancy: getAdapter("youtube") throws a diagnostic error mentioning ARIES_YOUTUBE_ENABLED when disabled', () => {
+  const prevYt = process.env.ARIES_YOUTUBE_ENABLED;
+  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  // Ensure both axes are off so the REGISTRY guard fires.
+  delete process.env.ARIES_YOUTUBE_ENABLED;
+  process.env.ANALYTICS_PROVIDER = 'direct_meta';
+  try {
+    assert.throws(
+      () => getAdapter('youtube', { connectedAccountId: 'ca_yt', tenantId: 1 }),
+      /ARIES_YOUTUBE_ENABLED/,
+      'error message must mention the flag name so operators know what to set',
+    );
+  } finally {
+    if (prevYt === undefined) delete process.env.ARIES_YOUTUBE_ENABLED;
+    else process.env.ARIES_YOUTUBE_ENABLED = prevYt;
+    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
+    else process.env.ANALYTICS_PROVIDER = prevProvider;
+  }
+});


### PR DESCRIPTION
Closes #637
Closes #638

## What changed
Replaces the throwing YouTube Phase-3 skeleton (every method `throw new Error('not implemented — Phase 3')`, plus dead direct-YouTube-Data-API references) with a real Composio-backed insights adapter, mirroring the verified Facebook and X adapters one platform over.

- `backend/insights/adapters/youtube/index.ts` — real adapter + `createYouTubeInsightsAdapter` factory (mirrors X/FB). `fetchPostList` → `YOUTUBE_LIST_CHANNEL_VIDEOS {mine:true, part:'snippet', maxResults:50}` (videoId at `snippet.resourceId.videoId`) then ONE `YOUTUBE_GET_VIDEO_DETAILS_BATCH {id:[ids], parts:['statistics']}` whose per-video statistics are cached on the instance (no per-video fan-out); `fetchPostMetrics` reads that cache (views/likes/commentsCount from statistics strings — no fabricated zero row for an unfetched video); `fetchComments` → `YOUTUBE_LIST_COMMENT_THREADS2 {videoId, maxResults}` → top-level thread id/author/text/publishedAt; `fetchAccountMetrics` returns `[]` (no verified per-day channel series — never fabricated). A dedicated `unwrapToItems` helper reads YouTube's `.items` nesting (NOT Graph's `.data[]`).
- `backend/insights/sync/adapter-factory.ts` — new `isYouTubeInsightsEnabled` off-switch (`ARIES_YOUTUBE_ENABLED` AND `ANALYTICS_PROVIDER=composio`); `hasAdapter('youtube')`/`getAdapter('youtube')` now honor it. FB/IG/X are byte-identical (additive checks only).
- `backend/insights/sync/ensure-account.ts` + new `backend/integrations/composio/youtube-channel-resolver.ts` — bridges `youtube` into `insights_accounts` only when the flag is on; the fail-safe-null resolver back-heals the channel id to satisfy the NOT NULL `external_account_id` enrollment column (mirrors the Facebook Page-id back-heal). Never throws (cannot wedge the worker tick), never logs a token.
- `capabilities.ts` trimmed to the honest set (`post_list`, `post_daily_metrics`, `comments`) — no over-claimed `watch_time`/`avg_view_duration`/`audience_demographics`.
- New `ARIES_YOUTUBE_ENABLED` flag wired into `integration-config.ts`, `.env.example`, and the `aries-app` + `aries-insights-sync-worker` service blocks in `docker-compose.yml` (default OFF).

## Ships DORMANT
Gated behind the NEW `ARIES_YOUTUBE_ENABLED` (default OFF, never reuses `ARIES_X_ENABLED`). With the flag off and the default `ANALYTICS_PROVIDER=direct_meta`: the bridge excludes youtube → no enrollment row → the dispatcher never builds the adapter; `getAdapter('youtube')` throws a diagnostic that names the flag. The previously-registered throwing skeleton is gone. The on-demand sync consumer (`hasAdapter('youtube')` flipping from unconditionally-true to false-by-default) is benign: youtube was never bridged into `insights_accounts`, so nothing was ever synced via the old path.

## Test evidence
New `tests/insights-youtube-adapter.test.ts` (11) covers the contract (list+batch call shape, no fan-out, cache reads, no fabricated zero/account rows, `.items` double-envelope unwrap, comment mapping + textDisplay fallback) and dormancy (both-flags matrix, `hasAdapter`, `getAdapter` diagnostic throw). 2 new `insights-ensure-account.test.ts` bridge tests assert youtube is in/out of the bridged-platform SELECT params by flag. Focused run: 23/23 green. `npm run verify` green (17/17); `npm run guardrails:agent` clean (2 ahead, 0 behind, unique diff); banned-patterns ok. No regression across FB/X/ensure-account.

## Residual risk / follow-ups
- Comments are top-level threads only (nested replies via `YOUTUBE_LIST_COMMENTS` are a follow-up).
- Account-level / watch-time metrics are a follow-up (YouTube Analytics v2).
- The channel-id back-heal default slug `YOUTUBE_LIST_CHANNELS` was not pinned in the Composio catalog; it is env-overridable via `COMPOSIO_YOUTUBE_LIST_PAGES_ACTION` and fail-safe-null, so this is dormant-safe.
- Same cross-cutting frontend un-pin dependency as X applies (analytics/comments screens are pinned to `'facebook'`); the orchestrator handles it once for all platforms.

## Prod activation (when ready)
`ARIES_YOUTUBE_ENABLED=1` + `ANALYTICS_PROVIDER=composio` on the insights-sync-worker; the `COMPOSIO_YOUTUBE_{POST_INSIGHTS,LIST_COMMENTS,LIST_POSTS}_ACTION` slugs have verified code defaults (`YOUTUBE_GET_VIDEO_DETAILS_BATCH`, `YOUTUBE_LIST_COMMENT_THREADS2`, `YOUTUBE_LIST_CHANNEL_VIDEOS`) so they work unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)