### PR TITLE
feat(integrations): add Reddit insights (analytics + comments) behind ARIES_REDDIT_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -410,6 +410,31 @@ COMPOSIO_YOUTUBE_LIST_POSTS_ACTION=
 COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION=
 COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION=
 
+# Reddit analytics + comments (#642 analytics, #643 comments), read by the
+# insights-sync worker's Reddit adapter (backend/insights/adapters/reddit). The
+# Reddit insights path turns on ONLY when ARIES_REDDIT_ENABLED=true AND
+# ANALYTICS_PROVIDER=composio; otherwise the bridge no-ops, the adapter never
+# activates, and no Composio tool runs. REUSES ARIES_REDDIT_ENABLED from the #641
+# publish path (no new flag). The verified slugs below are the CODE DEFAULTS, so
+# analytics works with them unset; set them only to pin a different toolkit
+# version. The adapter authenticates every call with the tenant's Composio
+# connectedAccountId.
+#   post_insights     -> REDDIT_RETRIEVE_REDDIT_POST   (per-post {article:<bare
+#                        base36>}; score / num_comments / upvote_ratio. PER-POST,
+#                        NOT batchable — one sequential call per post)
+#   list_comments     -> REDDIT_RETRIEVE_POST_COMMENTS ({article:<bare base36>};
+#                        top-level comments at the comments Listing's children)
+# NO list_posts action — Reddit's post universe is sourced from Aries' `posts`
+# table (no Composio "list my posts" action), exactly like X. posts.platform_post_id
+# is the t3_<base36> fullname; BOTH actions take the BARE base36 (the `t3_` prefix
+# is stripped at the call boundary).
+# DOCUMENTED LIMITATION: Reddit exposes NO impressions/reach/views metric — only
+# score (CAN be negative → mapped honestly onto likes, never clamped), num_comments,
+# and upvote_ratio. views fails soft to 0 (placeholder; the truth lives in
+# rawSource.views_available=false). ARIES_REDDIT_ENABLED is declared once near the top.
+COMPOSIO_REDDIT_POST_INSIGHTS_ACTION=
+COMPOSIO_REDDIT_LIST_COMMENTS_ACTION=
+
 # Native comment reply via Composio (#598/gate-5) — posts an operator reply
 # through FACEBOOK_CREATE_COMMENT (object_id = the comment's full graph id), so
 # it needs NO Meta App Review (unlike the direct-Graph pages_manage_engagement

--- a/backend/insights/adapters/reddit/index.ts
+++ b/backend/insights/adapters/reddit/index.ts
@@ -1,0 +1,380 @@
+/**
+ * backend/insights/adapters/reddit/index.ts
+ *
+ * Reddit insights adapter — backed by Composio (#642 analytics, #643 comments).
+ * Mirrors the X adapter (backend/insights/adapters/x/index.ts) one platform over,
+ * behind the EXISTING ARIES_REDDIT_ENABLED flag (reused from the #641 Reddit
+ * publish path — Reddit insights does NOT add a new flag).
+ *
+ * Every platform call goes through the Composio gateway (`executeTool`) so the
+ * adapter depends on a small, mockable surface; tests inject a fake gateway and
+ * never touch the network. The verified Composio action slugs are the defaults,
+ * each overridable via `COMPOSIO_REDDIT_<OP>_ACTION` (resolved through
+ * `ComposioConfig.actionSlugFor`).
+ *
+ * Method → action:
+ *   fetchPostList     → (DB only — no Composio call) the `posts` table (the
+ *                       Reddit posts Aries published). There is NO Composio
+ *                       "list my posts" action, exactly like X.
+ *   fetchPostMetrics  → REDDIT_RETRIEVE_REDDIT_POST  (per-post; NOT batchable —
+ *                       one call per post, ridden by the dispatcher's bounded
+ *                       SEQUENTIAL per-post loop, no fan-out)
+ *   fetchComments     → REDDIT_RETRIEVE_POST_COMMENTS (top-level post comments)
+ *   fetchAccountMetrics → [] (no verified Reddit account-insights action — never
+ *                       fabricate an account series)
+ *
+ * ── t3_ prefix stripping (load-bearing) ────────────────────────────────────────
+ * `posts.platform_post_id` for Reddit is the `t3_<base36>` fullname; BOTH Composio
+ * actions take the BARE base36 id in their `article` arg. We strip the `t3_`
+ * prefix once at the call boundary (`stripFullname`, no-op if already bare) but
+ * keep the full `t3_<base36>` as the stored `external_post_id` so it round-trips
+ * with the publish path.
+ *
+ * ── created_utc is epoch SECONDS (load-bearing) ────────────────────────────────
+ * Reddit timestamps (`created_utc` on a post or comment) are a Unix epoch in
+ * SECONDS, not an ISO string. We use a dedicated `epochToDate(seconds)` helper —
+ * the X adapter's `toDate` expects ISO and would mis-date Reddit values, so it is
+ * deliberately NOT reused here.
+ *
+ * ── DOCUMENTED LIMITATION — no impressions/reach ───────────────────────────────
+ * REDDIT_RETRIEVE_REDDIT_POST returns `score`, `num_comments`, `upvote_ratio`
+ * only — Reddit exposes NO impressions/reach/views metric at all. `score` CAN be
+ * negative (net up/downvotes) and is mapped HONESTLY onto `likes` (never clamped).
+ * `views` is the FB `views ?? 0` placeholder convention (0 here is a placeholder,
+ * NOT a fetched value); the TRUTH (`views_available:false` +
+ * `views_unavailable_reason`) lives in rawSource. We NEVER invent a views number.
+ */
+
+import pool from '@/lib/db';
+import type {
+  InsightsAdapter,
+  InsightsAdapterContext,
+  DateRange,
+  RawAccountMetricsDay,
+  RawPost,
+  RawPostMetricsDay,
+  RawComment,
+} from '../_adapter.types';
+import type { ComposioConfig, ComposioOperation } from '@/backend/integrations/composio/composio-config';
+import type { ComposioGateway } from '@/backend/integrations/composio/composio-client';
+import type { Queryable } from '@/backend/integrations/composio/connection-store';
+import { resolveComposioConfig } from '@/backend/integrations/composio/composio-config';
+import { createComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { num } from '@/backend/integrations/composio/analytics-mappers';
+
+// ── Verified default action slugs (env-overridable) ────────────────────────────
+
+const DEFAULT_SLUGS: Partial<Record<ComposioOperation, string>> = {
+  // Single-post lookup (score / num_comments / upvote_ratio) — engagement source.
+  post_insights: 'REDDIT_RETRIEVE_REDDIT_POST',
+  // Threaded comments for one post.
+  list_comments: 'REDDIT_RETRIEVE_POST_COMMENTS',
+  // NOTE: NO list_posts — Reddit has no Composio "list my posts" action; the
+  // post universe is sourced from the `posts` table (like X).
+};
+
+// ── Reddit-specific helpers ─────────────────────────────────────────────────────
+
+/**
+ * Strip Reddit's `t3_` fullname prefix to the BARE base36 id both Composio
+ * actions expect in their `article` arg. No-op if the id is already bare.
+ */
+function stripFullname(id: string): string {
+  return id.replace(/^t3_/, '');
+}
+
+/**
+ * Reddit `created_utc` is a Unix epoch in SECONDS (not ISO). Convert to a Date;
+ * fall back to the epoch (new Date(0)) when the value is missing/garbage. Do NOT
+ * reuse the X adapter's `toDate` here — it parses ISO strings and would mis-date.
+ */
+function epochToDate(value: unknown): Date {
+  const seconds = num(value);
+  if (seconds === null) return new Date(0);
+  const d = new Date(seconds * 1000);
+  return Number.isNaN(d.getTime()) ? new Date(0) : d;
+}
+
+function asObject(node: unknown): Record<string, unknown> | null {
+  if (node && typeof node === 'object' && !Array.isArray(node)) {
+    return node as Record<string, unknown>;
+  }
+  return null;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+// ── Response unwrapping helpers ─────────────────────────────────────────────────
+
+/**
+ * Descend through Composio's `{ data: <toolPayload> }` envelope wrappers to land
+ * on the post-lookup leaf object. The exact nesting (one vs two `.data` layers)
+ * varies by tool/SDK version, so we peel object-with-`data` wrappers until we hit
+ * an array or a leaf object.
+ */
+function unwrap(raw: unknown): unknown {
+  let cur = raw;
+  for (let i = 0; i < 3; i += 1) {
+    if (!cur || typeof cur !== 'object' || Array.isArray(cur)) break;
+    const obj = cur as Record<string, unknown>;
+    if (!('data' in obj)) break;
+    cur = obj.data;
+  }
+  return cur;
+}
+
+/** Resolve a single-post lookup response into its leaf object, however nested. */
+function unwrapToObject(raw: unknown): Record<string, unknown> {
+  const peeled = unwrap(raw);
+  return asObject(peeled) ?? {};
+}
+
+/**
+ * Resolve the TOP-LEVEL comment array out of a REDDIT_RETRIEVE_POST_COMMENTS
+ * response. Reddit's native listing for a post is a TWO-element array
+ * `[postListing, commentsListing]`; each Listing is `{ kind:'Listing', data:{
+ * children: [ { kind:'t1', data: <comment> }, ... ] } }`. Composio may wrap that
+ * in one or more `{ data: ... }` envelopes and/or hand back the comments listing
+ * directly. This unwrap is deliberately tolerant: it peels envelopes, picks the
+ * comments listing (the 2nd element of a `[post, comments]` pair, else the lone
+ * listing), and returns its `data.children` array. Nested replies
+ * (`comment.replies.data.children`) are intentionally LEFT for a follow-up — v1
+ * surfaces top-level comments only.
+ */
+function unwrapToCommentChildren(raw: unknown): Array<Record<string, unknown>> {
+  // Peel pure `{ data: ... }` envelope wrappers, but STOP as soon as we reach an
+  // array (the [post, comments] pair) or a Listing carrier (`{ data: { children }}`).
+  let cur: unknown = raw;
+  for (let i = 0; i < 4; i += 1) {
+    if (Array.isArray(cur)) break;
+    const obj = asObject(cur);
+    if (!obj) break;
+    // A Listing object carries its rows at `.data.children`; don't peel past it.
+    const inner = asObject(obj.data);
+    if (inner && Array.isArray(inner.children)) break;
+    if (!('data' in obj)) break;
+    cur = obj.data;
+  }
+
+  // Reddit returns `[postListing, commentsListing]`; the comments are the LAST
+  // listing. Some tool versions return just the comments listing object.
+  let listing: Record<string, unknown> | null = null;
+  if (Array.isArray(cur)) {
+    const arr = cur as unknown[];
+    listing = asObject(arr[arr.length - 1]) ?? null;
+  } else {
+    listing = asObject(cur);
+  }
+  if (!listing) return [];
+
+  const listingData = asObject(listing.data);
+  const children = listingData?.children;
+  if (Array.isArray(children)) return children as Array<Record<string, unknown>>;
+  return [];
+}
+
+// ── Adapter ────────────────────────────────────────────────────────────────────
+
+interface RedditPostRow {
+  platform_post_id: string;
+  published_at: Date | string | null;
+  caption: string | null;
+}
+
+export class RedditInsightsAdapter implements InsightsAdapter {
+  readonly platform = 'reddit' as const;
+
+  constructor(
+    private readonly gateway: ComposioGateway,
+    private readonly config: ComposioConfig,
+    private readonly db: Queryable = pool,
+    private readonly ctx: InsightsAdapterContext = {},
+  ) {}
+
+  private slugFor(op: ComposioOperation): string {
+    const override = this.config.actionSlugFor('reddit', op);
+    const slug = override ?? DEFAULT_SLUGS[op];
+    if (!slug) throw new Error(`No Composio Reddit action slug configured for "${op}".`);
+    return slug;
+  }
+
+  private connectedAccountId(): string {
+    const id = this.ctx.connectedAccountId?.trim();
+    if (!id) {
+      throw new Error('RedditInsightsAdapter: no Composio connectedAccountId in context.');
+    }
+    return id;
+  }
+
+  private tenantId(): number {
+    const id = this.ctx.tenantId;
+    if (id === null || id === undefined) {
+      throw new Error('RedditInsightsAdapter: no tenantId in context.');
+    }
+    return id;
+  }
+
+  /** Execute a tool; throw on a hard (successful=false) failure so the sync run
+   * surfaces the leg error while already-committed rows are preserved (partial
+   * progress is never discarded). */
+  private async exec(op: ComposioOperation, args: Record<string, unknown>): Promise<unknown> {
+    const result = await this.gateway.executeTool(this.slugFor(op), {
+      connectedAccountId: this.connectedAccountId(),
+      arguments: args,
+    });
+    if (!result.successful) {
+      throw new Error(result.error ?? `Composio Reddit ${op} call reported unsuccessful.`);
+    }
+    return result.data ?? null;
+  }
+
+  /**
+   * List the Reddit posts Aries published for this tenant (from the `posts`
+   * table — Reddit has no Composio "list my posts" action, exactly like X). ZERO
+   * Composio calls here; per-post engagement is fetched lazily in fetchPostMetrics
+   * (Reddit's post lookup is per-post, NOT batchable, so there is no cache to
+   * populate up front).
+   *
+   * `externalAccountId`/`publishedAfter` are part of the InsightsAdapter contract
+   * but Reddit keys the post list on tenant_id (the DB is the source of truth).
+   */
+  async fetchPostList(_externalAccountId: string, _publishedAfter?: Date): Promise<RawPost[]> {
+    const rows = await this.db.query<RedditPostRow>(
+      `SELECT platform_post_id, published_at, caption
+         FROM posts
+        WHERE tenant_id = $1
+          AND platform = 'reddit'
+          AND platform_post_id IS NOT NULL
+          AND published_status = 'published'`,
+      [this.tenantId()],
+    );
+
+    const dbRows = rows.rows.filter((r) => typeof r.platform_post_id === 'string' && r.platform_post_id);
+    if (dbRows.length === 0) return [];
+
+    return dbRows.map((r) => ({
+      // Keep the full t3_<base36> fullname as the stored external_post_id so it
+      // round-trips with the publish path; only the Composio `article` arg is
+      // stripped to bare base36 (in fetchPostMetrics / fetchComments).
+      externalPostId: r.platform_post_id,
+      // `published_at` is a Postgres timestamp (ISO), NOT Reddit epoch_utc — parse
+      // it as ISO (epochToDate is only for Reddit's created_utc on posts/comments).
+      publishedAt: toPublishedAt(r.published_at),
+      // Aries publishes single-image feed posts; Reddit exposes no media-type axis
+      // we request here, so the published surface is normalised to 'image'.
+      mediaType: 'image' as const,
+      title: null,
+      caption: str(r.caption),
+      permalink: `https://www.reddit.com/comments/${stripFullname(r.platform_post_id)}`,
+      thumbnailUrl: null,
+      durationSeconds: null,
+    }));
+  }
+
+  /** Reddit exposes no verified account-insights action — never fabricate a series. */
+  async fetchAccountMetrics(
+    _externalAccountId: string,
+    _range: DateRange,
+  ): Promise<RawAccountMetricsDay[]> {
+    return [];
+  }
+
+  /**
+   * One REDDIT_RETRIEVE_REDDIT_POST lookup for a single post (NOT batchable). The
+   * dispatcher calls this inside its bounded SEQUENTIAL per-post loop, so there is
+   * no fan-out. Emits a row only on a real signal — never a fabricated zero row.
+   */
+  async fetchPostMetrics(externalPostId: string, _range?: DateRange): Promise<RawPostMetricsDay[]> {
+    const data = await this.exec('post_insights', { article: stripFullname(externalPostId) });
+    const post = unwrapToObject(data);
+
+    // score / num_comments / upvote_ratio are the only signals Reddit exposes.
+    const score = num(post.score);
+    const numComments = num(post.num_comments);
+    const upvoteRatio = num(post.upvote_ratio);
+
+    // Only emit a row when there is a real signal — never fabricate a zero row for
+    // a post the lookup returned nothing useful for (mirror FB/X).
+    if (score === null && numComments === null && upvoteRatio === null) return [];
+
+    const date = new Date().toISOString().split('T')[0];
+    return [
+      {
+        date,
+        // Reddit has NO impressions/reach/views metric — 0 is the FB `views ?? 0`
+        // placeholder, NOT a fetched value (the truth lives in rawSource below).
+        views: 0,
+        watchTimeMinutes: 0,
+        avgViewDurationSec: 0,
+        avgViewPercentage: 0,
+        // score CAN be negative (net up/downvotes); map it HONESTLY, never clamp.
+        likes: score ?? 0,
+        commentsCount: numComments ?? 0,
+        // Reddit posts expose no share count — surface 0, not a fabricated value.
+        shares: 0,
+        rawSource: {
+          source: 'REDDIT_RETRIEVE_REDDIT_POST',
+          score,
+          num_comments: numComments,
+          upvote_ratio: upvoteRatio,
+          views_available: false,
+          views_unavailable_reason: 'reddit_no_impressions_metric',
+        },
+      },
+    ];
+  }
+
+  /**
+   * One REDDIT_RETRIEVE_POST_COMMENTS call for a single post → TOP-LEVEL comments
+   * only (nested `replies.data.children` are intentionally a follow-up). Author /
+   * body / timestamp come straight off each `t1` comment; the stable comment id is
+   * the `name` fullname (`t1_<base36>`), falling back to the bare `id`.
+   */
+  async fetchComments(externalPostId: string, limit = 100): Promise<RawComment[]> {
+    const data = await this.exec('list_comments', { article: stripFullname(externalPostId) });
+
+    const out: RawComment[] = [];
+    for (const child of unwrapToCommentChildren(data)) {
+      // Each child is `{ kind:'t1', data: <comment> }`; tolerate a bare comment.
+      const comment = asObject(child.data) ?? child;
+      const externalCommentId = str(comment.name) ?? str(comment.id);
+      if (!externalCommentId) continue;
+      // Skip the synthetic "load more comments" stub Reddit appends (kind 'more').
+      if (str(child.kind) === 'more') continue;
+      out.push({
+        externalCommentId,
+        receivedAt: epochToDate(comment.created_utc),
+        authorHandle: str(comment.author),
+        bodyText: str(comment.body) ?? '',
+      });
+      if (out.length >= limit) break;
+    }
+    return out;
+  }
+}
+
+/** Resolve the DB `published_at` (Postgres ISO timestamp) to a Date. */
+function toPublishedAt(value: Date | string | null): Date {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? new Date(0) : value;
+  if (typeof value === 'string' && value.trim()) {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date(0);
+}
+
+/**
+ * Build a context-bound Reddit adapter wired to the live Composio gateway. Throws
+ * (via createComposioGateway) when Composio is enabled but no API key is
+ * configured — the dispatcher catches that and marks the sync run failed.
+ */
+export function createRedditInsightsAdapter(
+  ctx: InsightsAdapterContext = {},
+  env: NodeJS.ProcessEnv = process.env,
+): RedditInsightsAdapter {
+  const config = resolveComposioConfig(env);
+  const gateway = createComposioGateway(config);
+  return new RedditInsightsAdapter(gateway, config!, pool, ctx);
+}

--- a/backend/insights/platforms/capabilities.ts
+++ b/backend/insights/platforms/capabilities.ts
@@ -59,6 +59,16 @@ export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapabil
     'post_daily_metrics',
     'comments',
   ]),
+  // Reddit: per-post engagement (score/num_comments/upvote_ratio via
+  // REDDIT_RETRIEVE_REDDIT_POST) + top-level post comments. Deliberately OMITS
+  // 'account_daily_metrics' (no verified Reddit account-insights action) and
+  // 'reach_impressions' — Reddit exposes NO impressions/reach metric at all
+  // (the absent reach cap IS the documented Reddit analytics limitation).
+  reddit: new Set<PlatformCapability>([
+    'post_list',
+    'post_daily_metrics',
+    'comments',
+  ]),
 };
 
 /** Returns true if the given platform supports a specific capability. */

--- a/backend/insights/platforms/registry.ts
+++ b/backend/insights/platforms/registry.ts
@@ -8,9 +8,9 @@
  *   2. TypeScript will highlight every spot that needs updating (capabilities.ts, adapter factory, etc.).
  */
 
-export const SUPPORTED_PLATFORMS = ['youtube', 'instagram', 'facebook', 'x'] as const;
+export const SUPPORTED_PLATFORMS = ['youtube', 'instagram', 'facebook', 'x', 'reddit'] as const;
 
-/** Union type — 'youtube' | 'instagram' | 'facebook' | 'x' */
+/** Union type — 'youtube' | 'instagram' | 'facebook' | 'x' | 'reddit' */
 export type Platform = (typeof SUPPORTED_PLATFORMS)[number];
 
 /** Runtime guard: narrows an unknown string to Platform. */
@@ -24,6 +24,7 @@ export const PLATFORM_LABELS: Record<Platform, string> = {
   instagram: 'Instagram',
   facebook: 'Facebook',
   x: 'X',
+  reddit: 'Reddit',
 };
 
 /** Icon identifiers used by the frontend icon registry (Phase 10). */
@@ -32,4 +33,5 @@ export const PLATFORM_ICON_IDS: Record<Platform, string> = {
   instagram: 'instagram',
   facebook: 'facebook',
   x: 'x',
+  reddit: 'reddit',
 };

--- a/backend/insights/sync/adapter-factory.ts
+++ b/backend/insights/sync/adapter-factory.ts
@@ -19,7 +19,8 @@ import type { InsightsAdapter, InsightsAdapterContext } from '../adapters/_adapt
 import { createYouTubeInsightsAdapter } from '../adapters/youtube/index';
 import { createFacebookInsightsAdapter } from '../adapters/facebook/index';
 import { createXInsightsAdapter } from '../adapters/x/index';
-import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled } from '@/backend/integrations/providers/integration-config';
+import { createRedditInsightsAdapter } from '../adapters/reddit/index';
+import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled } from '@/backend/integrations/providers/integration-config';
 
 type AdapterBuilder = (ctx: InsightsAdapterContext) => InsightsAdapter;
 
@@ -55,6 +56,18 @@ export function isYouTubeInsightsEnabled(env: NodeJS.ProcessEnv = process.env): 
   return isYouTubeEnabled(env) && analyticsProviderSelector(env) === 'composio';
 }
 
+/**
+ * Real off-switch for the Composio-backed Reddit insights path: active only when
+ * the Reddit rollout flag is ON (ARIES_REDDIT_ENABLED) AND analytics is on
+ * Composio (ANALYTICS_PROVIDER=composio). REUSES the existing isRedditEnabled
+ * flag from the Reddit publish path (#641) — Reddit insights does NOT add a new
+ * flag. Default OFF on both axes → the Reddit adapter never activates and no
+ * Composio tool is ever executed.
+ */
+export function isRedditInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isRedditEnabled(env) && analyticsProviderSelector(env) === 'composio';
+}
+
 const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
   youtube: (ctx) => {
     if (!isYouTubeInsightsEnabled()) {
@@ -83,6 +96,15 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     }
     return createXInsightsAdapter(ctx);
   },
+  reddit: (ctx) => {
+    if (!isRedditInsightsEnabled()) {
+      throw new Error(
+        'Reddit insights adapter is disabled: set ARIES_REDDIT_ENABLED=1 and ' +
+        'ANALYTICS_PROVIDER=composio to enable Composio-backed Reddit analytics.',
+      );
+    }
+    return createRedditInsightsAdapter(ctx);
+  },
   // instagram: (ctx) => createInstagramInsightsAdapter(ctx),  ← out of scope (#596/#597 = FB only)
 };
 
@@ -95,6 +117,7 @@ export function hasAdapter(platform: Platform, env: NodeJS.ProcessEnv = process.
   if (platform === 'facebook') return isFacebookInsightsEnabled(env);
   if (platform === 'x') return isXInsightsEnabled(env);
   if (platform === 'youtube') return isYouTubeInsightsEnabled(env);
+  if (platform === 'reddit') return isRedditInsightsEnabled(env);
   return platform in REGISTRY && REGISTRY[platform] != null;
 }
 

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -26,7 +26,7 @@
 
 import pool from '@/lib/db';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
-import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled } from '@/backend/integrations/providers/integration-config';
+import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled } from '@/backend/integrations/providers/integration-config';
 import { resolveComposioConfig, type ComposioConfig } from '@/backend/integrations/composio/composio-config';
 import { createComposioGateway, type ComposioGateway } from '@/backend/integrations/composio/composio-client';
 import { resolveFacebookManagedPage } from '@/backend/integrations/composio/facebook-page-resolver';
@@ -43,12 +43,13 @@ export const BRIDGED_PLATFORMS = ['facebook'] as const;
 
 /**
  * The bridged-platform list for this env: FB always; X only when ARIES_X_ENABLED;
- * YouTube only when ARIES_YOUTUBE_ENABLED.
+ * YouTube only when ARIES_YOUTUBE_ENABLED; Reddit only when ARIES_REDDIT_ENABLED.
  */
 function bridgedPlatforms(env: NodeJS.ProcessEnv): string[] {
   const list: string[] = [...BRIDGED_PLATFORMS];
   if (isXEnabled(env)) list.push('x');
   if (isYouTubeEnabled(env)) list.push('youtube');
+  if (isRedditEnabled(env)) list.push('reddit');
   return list;
 }
 
@@ -147,10 +148,10 @@ export async function ensureInsightsAccountsForConnectedPlatforms(
 
     if (!pageId) {
       // Facebook (FACEBOOK_LIST_MANAGED_PAGES) and YouTube (YOUTUBE_LIST_CHANNELS,
-      // mine:true) have an external-id resolver. X's external account id is
-      // captured at connect by pickExternalAccountId, so a null id is not
-      // back-heal-able here — skip this tick (a later connect/re-auth populates
-      // it). Never invent an external account id.
+      // mine:true) have an external-id resolver. X's and Reddit's external
+      // account id (username/id) is captured at connect by pickExternalAccountId,
+      // so a null id is not back-heal-able here — skip this tick (a later
+      // connect/re-auth populates it). Never invent an external account id.
       if (row.platform !== 'facebook' && row.platform !== 'youtube') {
         skippedNoPage++;
         log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, platform: row.platform, reason: 'no_external_account_id' });

--- a/backend/integrations/composio/analytics-mappers.ts
+++ b/backend/integrations/composio/analytics-mappers.ts
@@ -257,6 +257,23 @@ const MAPPERS: Partial<Record<string, PlatformAnalyticsMapper>> = {
       };
     },
   },
+  // Reddit — single-post lookup; score / num_comments / upvote_ratio only.
+  // Reddit exposes NO impressions/reach/views metric, so impressions/views stay
+  // null (never a fabricated zero). `article` is the BARE base36 id (the stored
+  // platform_post_id is the `t3_<base36>` fullname → strip the prefix here).
+  // upvote_ratio has no NormalizedMetrics field, so it is intentionally omitted.
+  'reddit:post_insights': {
+    slug: 'REDDIT_RETRIEVE_REDDIT_POST',
+    buildArgs: (ctx) => ({ article: (ctx.externalPostId ?? '').replace(/^t3_/, '') }),
+    parse: (raw) => {
+      const p = payload(raw);
+      // score CAN be negative (net up/downvotes) — keep it honest, never clamp.
+      return {
+        likes: num(p.score),
+        comments: num(p.num_comments),
+      };
+    },
+  },
   // LinkedIn (organization-level share stats)
   'linkedin:account_insights': {
     slug: 'LINKEDIN_GET_SHARE_STATS',

--- a/backend/integrations/composio/analytics-mappers.ts
+++ b/backend/integrations/composio/analytics-mappers.ts
@@ -257,23 +257,6 @@ const MAPPERS: Partial<Record<string, PlatformAnalyticsMapper>> = {
       };
     },
   },
-  // Reddit — single-post lookup; score / num_comments / upvote_ratio only.
-  // Reddit exposes NO impressions/reach/views metric, so impressions/views stay
-  // null (never a fabricated zero). `article` is the BARE base36 id (the stored
-  // platform_post_id is the `t3_<base36>` fullname → strip the prefix here).
-  // upvote_ratio has no NormalizedMetrics field, so it is intentionally omitted.
-  'reddit:post_insights': {
-    slug: 'REDDIT_RETRIEVE_REDDIT_POST',
-    buildArgs: (ctx) => ({ article: (ctx.externalPostId ?? '').replace(/^t3_/, '') }),
-    parse: (raw) => {
-      const p = payload(raw);
-      // score CAN be negative (net up/downvotes) — keep it honest, never clamp.
-      return {
-        likes: num(p.score),
-        comments: num(p.num_comments),
-      };
-    },
-  },
   // LinkedIn (organization-level share stats)
   'linkedin:account_insights': {
     slug: 'LINKEDIN_GET_SHARE_STATS',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -528,6 +528,21 @@ services:
       COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION: ${COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION:-}
       COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION: ${COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION:-}
       COMPOSIO_YOUTUBE_LIST_POSTS_ACTION: ${COMPOSIO_YOUTUBE_LIST_POSTS_ACTION:-}
+      # Reddit analytics + comments (#642/#643), read by the insights-sync worker's
+      # Reddit adapter (backend/insights/adapters/reddit). The Reddit insights path
+      # (account bridge + adapter) turns on ONLY when ARIES_REDDIT_ENABLED=true AND
+      # ANALYTICS_PROVIDER=composio; otherwise dormant. REUSES ARIES_REDDIT_ENABLED
+      # from the #641 publish path (no new flag). This flag MUST be set on the
+      # worker (not just aries-app): the worker process runs the insights sync, so
+      # without it here the sidecar reads it false and Reddit insights stay dormant
+      # even when enabled. AUTH_CONFIG_ID is the tenant's Composio auth config; the
+      # *_ACTION slugs are optional (verified code defaults: REDDIT_RETRIEVE_REDDIT_POST,
+      # REDDIT_RETRIEVE_POST_COMMENTS). NO LIST_POSTS — Reddit's post universe is
+      # the `posts` table (no Composio "list my posts" action), like X.
+      ARIES_REDDIT_ENABLED: ${ARIES_REDDIT_ENABLED:-false}
+      COMPOSIO_REDDIT_AUTH_CONFIG_ID: ${COMPOSIO_REDDIT_AUTH_CONFIG_ID:-}
+      COMPOSIO_REDDIT_POST_INSIGHTS_ACTION: ${COMPOSIO_REDDIT_POST_INSIGHTS_ACTION:-}
+      COMPOSIO_REDDIT_LIST_COMMENTS_ACTION: ${COMPOSIO_REDDIT_LIST_COMMENTS_ACTION:-}
     restart: unless-stopped
     networks:
       - docker_stack

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -269,6 +269,38 @@ test('YouTube bridge: when ARIES_YOUTUBE_ENABLED is off, the DB query does NOT i
   );
 });
 
+test('Reddit bridge: when ARIES_REDDIT_ENABLED=1 the DB query includes "reddit" alongside "facebook"', async () => {
+  const db = recordingDb([]);
+  const redditEnv = {
+    ANALYTICS_PROVIDER: 'composio',
+    ARIES_REDDIT_ENABLED: '1',
+  } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, redditEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'issued a SELECT query');
+  // The bridged-platform list must include 'reddit' when the rollout flag is on.
+  assert.ok(
+    Array.isArray(select.params) && (select.params as unknown[]).includes('reddit'),
+    'reddit is in bridged-platform params when ARIES_REDDIT_ENABLED=1',
+  );
+  assert.ok(
+    Array.isArray(select.params) && (select.params as unknown[]).includes('facebook'),
+    'facebook is always included',
+  );
+});
+
+test('Reddit bridge: when ARIES_REDDIT_ENABLED is off, the DB query does NOT include "reddit"', async () => {
+  const db = recordingDb([]);
+  const fbOnlyEnv = { ANALYTICS_PROVIDER: 'composio' } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, fbOnlyEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'issued a SELECT query');
+  assert.ok(
+    !(select.params as unknown[]).includes('reddit'),
+    'reddit is NOT in bridged-platform params when ARIES_REDDIT_ENABLED is off',
+  );
+});
+
 test('facebook is registered in the adapter factory and getAdapter binds the connection context', () => {
   // getAdapter builds a real Composio gateway (needs an API key) AND requires
   // the ANALYTICS_PROVIDER=composio off-switch to be on.

--- a/tests/insights-reddit-adapter.test.ts
+++ b/tests/insights-reddit-adapter.test.ts
@@ -1,0 +1,469 @@
+/**
+ * tests/insights-reddit-adapter.test.ts
+ *
+ * Regression coverage for the Reddit insights adapter (#642 analytics,
+ * #643 comments).  All tests are self-contained — fake gateway / fake DB /
+ * no real Postgres, no network calls.
+ *
+ * Mirror pattern: tests/insights-x-adapter.test.ts
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RedditInsightsAdapter } from '@/backend/insights/adapters/reddit/index';
+import {
+  hasAdapter,
+  getAdapter,
+  isRedditInsightsEnabled,
+} from '@/backend/insights/sync/adapter-factory';
+import type {
+  ComposioGateway,
+  GatewayToolResult,
+} from '@/backend/integrations/composio/composio-client';
+import type { Queryable } from '@/backend/integrations/composio/connection-store';
+import { fakeConfig } from './composio/helpers';
+
+// ── Test doubles ──────────────────────────────────────────────────────────────
+
+interface RecordedCall {
+  slug: string;
+  connectedAccountId?: string;
+  arguments?: Record<string, unknown>;
+}
+
+/** Gateway that routes a canned result per action slug and records every call. */
+function routingGateway(
+  results: Record<string, GatewayToolResult>,
+): ComposioGateway & { calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    async findOrCreateManagedAuthConfig(s: string) { return `ac_${s}`; },
+    async initiateConnection() { return { connectionRequestId: 'cr', redirectUrl: null }; },
+    async listConnections() { return []; },
+    async getConnection() { return null; },
+    async deleteConnection() {},
+    async executeTool(slug, options) {
+      calls.push({
+        slug,
+        connectedAccountId: options.connectedAccountId,
+        arguments: options.arguments,
+      });
+      return results[slug] ?? { data: { data: [] }, successful: true, error: null };
+    },
+    async uploadFile(input) {
+      return { name: 'staged', mimetype: 'application/octet-stream', s3key: `s3/${input.toolSlug}` };
+    },
+  };
+}
+
+interface RedditPostRow {
+  platform_post_id: string;
+  published_at: Date | null;
+  caption: string | null;
+}
+
+interface RecordedDbQuery {
+  text: string;
+  params: unknown[];
+}
+
+/**
+ * Fake Queryable whose SELECT on the `posts` table returns the supplied rows.
+ * All other statements return empty (no real Postgres needed).
+ */
+function fakePostsDb(
+  rows: RedditPostRow[],
+): Queryable & { queries: RecordedDbQuery[] } {
+  const queries: RecordedDbQuery[] = [];
+  return {
+    queries,
+    async query<T = Record<string, unknown>>(text: string, params: unknown[] = []) {
+      queries.push({ text, params });
+      if (/^\s*select/i.test(text) && /FROM\s+posts/i.test(text)) {
+        return { rows: rows as unknown as T[], rowCount: rows.length };
+      }
+      return { rows: [] as T[], rowCount: 0 };
+    },
+  };
+}
+
+/** Standard adapter context shared across non-dormancy tests. */
+const ctx = { connectedAccountId: 'ca_reddit_1', tenantId: 42 };
+
+// ── fetchPostList ─────────────────────────────────────────────────────────────
+
+test('fetchPostList: queries tenant Reddit posts from DB, issues ZERO Composio gateway calls, returns correct RawPost shape', async () => {
+  const db = fakePostsDb([
+    { platform_post_id: 't3_abc123', published_at: new Date('2026-06-10'), caption: 'My Reddit Post' },
+    { platform_post_id: 't3_xyz789', published_at: new Date('2026-06-11'), caption: null },
+  ]);
+  const gateway = routingGateway({});
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const posts = await adapter.fetchPostList('reddit_user');
+
+  // Reddit has no Composio list-posts action — zero gateway calls.
+  assert.equal(gateway.calls.length, 0, 'fetchPostList must issue ZERO Composio gateway calls (DB-only)');
+
+  // DB SELECT must be tenant-scoped and platform-filtered.
+  const dbQuery = db.queries[0];
+  assert.ok(dbQuery, 'a DB query must have been issued');
+  assert.match(dbQuery.text, /FROM\s+posts/i);
+  assert.match(dbQuery.text, /platform\s*=\s*'reddit'/i, "SELECT must filter platform='reddit'");
+  assert.match(dbQuery.text, /published_status\s*=\s*'published'/i, "SELECT must filter published_status='published'");
+  assert.deepEqual(dbQuery.params, [42], 'tenant_id=$1 must be the only query parameter');
+
+  assert.equal(posts.length, 2);
+
+  // externalPostId keeps the full t3_ fullname — only the Composio `article` arg is stripped.
+  assert.equal(posts[0].externalPostId, 't3_abc123', 'externalPostId preserves the full t3_ fullname');
+  assert.equal(posts[0].caption, 'My Reddit Post');
+  assert.equal(posts[0].mediaType, 'image', 'Reddit posts normalised to image mediaType');
+  // Permalink uses the STRIPPED (bare base36) id, not the t3_ fullname.
+  assert.match(String(posts[0].permalink), /reddit\.com\/comments\/abc123/, 'permalink must use bare base36 id (t3_ stripped)');
+  assert.equal(posts[0].title, null);
+  assert.equal(posts[0].thumbnailUrl, null);
+  assert.equal(posts[0].durationSeconds, null);
+
+  assert.equal(posts[1].externalPostId, 't3_xyz789');
+  assert.equal(posts[1].caption, null);
+  assert.match(String(posts[1].permalink), /reddit\.com\/comments\/xyz789/);
+});
+
+test('fetchPostList: returns [] when no published Reddit posts exist for the tenant', async () => {
+  const db = fakePostsDb([]);
+  const gateway = routingGateway({});
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const posts = await adapter.fetchPostList('reddit_user');
+
+  assert.deepEqual(posts, []);
+  assert.equal(gateway.calls.length, 0, 'still no Composio calls for an empty post list');
+});
+
+// ── fetchPostMetrics (analytics #642) ─────────────────────────────────────────
+
+test('fetchPostMetrics: issues REDDIT_RETRIEVE_REDDIT_POST with article stripped of t3_, maps score→likes/num_comments→commentsCount; views=0 placeholder; rawSource documents no-impressions', async () => {
+  const db = fakePostsDb([]);
+  const gateway = routingGateway({
+    REDDIT_RETRIEVE_REDDIT_POST: {
+      successful: true,
+      error: null,
+      data: { score: 128, num_comments: 14, upvote_ratio: 0.92 },
+    },
+  });
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const metrics = await adapter.fetchPostMetrics('t3_abc123');
+
+  // One Composio call issued.
+  assert.equal(gateway.calls.length, 1, 'exactly one Composio call for fetchPostMetrics');
+  const call = gateway.calls[0];
+  assert.equal(call.slug, 'REDDIT_RETRIEVE_REDDIT_POST');
+  assert.equal(call.connectedAccountId, 'ca_reddit_1');
+  // The t3_ prefix must be stripped before the call.
+  assert.equal(call.arguments?.article, 'abc123', 'article must be the bare base36 id (t3_ stripped)');
+
+  assert.equal(metrics.length, 1);
+
+  // score→likes (positive).
+  assert.equal(metrics[0].likes, 128);
+  // num_comments→commentsCount.
+  assert.equal(metrics[0].commentsCount, 14);
+  // shares is always 0 — Reddit exposes no share count.
+  assert.equal(metrics[0].shares, 0);
+  // views=0 is the FB `views ?? 0` placeholder — NOT a fetched value.
+  assert.equal(metrics[0].views, 0, 'views must be the 0 placeholder (Reddit has no impressions metric)');
+
+  // rawSource documents the no-impressions limitation.
+  assert.equal(
+    metrics[0].rawSource.views_available,
+    false,
+    'rawSource.views_available must be false — Reddit has no impressions metric',
+  );
+  assert.ok(
+    metrics[0].rawSource.views_unavailable_reason !== null &&
+      metrics[0].rawSource.views_unavailable_reason !== undefined,
+    'rawSource.views_unavailable_reason must be populated',
+  );
+  assert.equal(metrics[0].rawSource.views_unavailable_reason, 'reddit_no_impressions_metric');
+
+  // rawSource preserves the raw signal values for provenance.
+  assert.equal(metrics[0].rawSource.score, 128);
+  assert.equal(metrics[0].rawSource.num_comments, 14);
+  assert.equal(metrics[0].rawSource.upvote_ratio, 0.92);
+});
+
+test('fetchPostMetrics: NEGATIVE score is passed through un-clamped (honest downvoted-post mapping)', async () => {
+  const db = fakePostsDb([]);
+  const gateway = routingGateway({
+    REDDIT_RETRIEVE_REDDIT_POST: {
+      successful: true,
+      error: null,
+      data: { score: -15, num_comments: 3, upvote_ratio: 0.2 },
+    },
+  });
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const metrics = await adapter.fetchPostMetrics('t3_neg1');
+
+  assert.equal(metrics.length, 1, 'a row is emitted even for a net-negative post');
+  // Must NOT clamp to 0 — score CAN be negative (net downvotes); map it honestly.
+  assert.equal(metrics[0].likes, -15, 'negative score must be mapped to likes without clamping');
+  assert.equal(metrics[0].commentsCount, 3);
+  assert.equal(metrics[0].rawSource.score, -15);
+});
+
+test('fetchPostMetrics: no usable data in response → empty array (never fabricate a zero row)', async () => {
+  const db = fakePostsDb([]);
+  const gateway = routingGateway({
+    REDDIT_RETRIEVE_REDDIT_POST: {
+      successful: true,
+      error: null,
+      // No score / num_comments / upvote_ratio — all null after num().
+      data: { title: 'some post', url: 'https://reddit.com/r/test' },
+    },
+  });
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const metrics = await adapter.fetchPostMetrics('t3_nodata');
+
+  assert.deepEqual(metrics, [], 'no usable signal → empty array, never a fabricated zero row');
+});
+
+test('fetchPostMetrics: strips t3_ even when the stored id has no prefix (bare id is a no-op)', async () => {
+  const db = fakePostsDb([]);
+  const gateway = routingGateway({
+    REDDIT_RETRIEVE_REDDIT_POST: {
+      successful: true,
+      error: null,
+      data: { score: 5, num_comments: 1, upvote_ratio: 0.8 },
+    },
+  });
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  await adapter.fetchPostMetrics('bare123'); // no t3_ prefix
+
+  // stripFullname on an already-bare id is a no-op.
+  assert.equal(gateway.calls[0].arguments?.article, 'bare123', 'bare id passes through unchanged');
+});
+
+// ── fetchComments (comments #643) ─────────────────────────────────────────────
+
+test('fetchComments: issues REDDIT_RETRIEVE_POST_COMMENTS with article stripped, maps name/author/body/created_utc (epoch seconds→Date); skips kind:more', async () => {
+  const db = fakePostsDb([]);
+  // Reddit native response: [postListing, commentsListing].
+  // The comments listing carries t1 comment children + a 'more' stub.
+  const gateway = routingGateway({
+    REDDIT_RETRIEVE_POST_COMMENTS: {
+      successful: true,
+      error: null,
+      data: [
+        // First element: post listing (ignored by unwrapToCommentChildren).
+        { kind: 'Listing', data: { children: [] } },
+        // Second element: comments listing — the adapter takes the LAST element.
+        {
+          kind: 'Listing',
+          data: {
+            children: [
+              {
+                kind: 't1',
+                data: {
+                  name: 't1_comment1',
+                  author: 'redditor_jane',
+                  body: 'Great post!',
+                  created_utc: 1700000000, // epoch SECONDS — Nov 14/15 2023
+                },
+              },
+              {
+                kind: 't1',
+                data: {
+                  name: 't1_comment2',
+                  author: 'redditor_bob',
+                  body: 'Agreed, very useful.',
+                  created_utc: 1700100000,
+                },
+              },
+              // kind:'more' synthetic stub — must be skipped.
+              {
+                kind: 'more',
+                data: {
+                  id: '_',
+                  name: 'more_stub_abc',
+                  children: [],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const comments = await adapter.fetchComments('t3_abc123', 100);
+
+  // One Composio call.
+  assert.equal(gateway.calls.length, 1, 'exactly one Composio call for fetchComments');
+  const call = gateway.calls[0];
+  assert.equal(call.slug, 'REDDIT_RETRIEVE_POST_COMMENTS');
+  assert.equal(call.connectedAccountId, 'ca_reddit_1');
+  // t3_ prefix must be stripped from the article argument.
+  assert.equal(call.arguments?.article, 'abc123', 'article must be the bare base36 id (t3_ stripped)');
+
+  // kind:'more' is excluded; only 2 real comments returned.
+  assert.equal(comments.length, 2, 'kind:more stub must be skipped; only 2 real comments returned');
+
+  assert.equal(comments[0].externalCommentId, 't1_comment1', 'externalCommentId comes from the name fullname (t1_)');
+  assert.equal(comments[0].authorHandle, 'redditor_jane');
+  assert.equal(comments[0].bodyText, 'Great post!');
+
+  // created_utc=1700000000 epoch SECONDS → Date (NOT milliseconds).
+  assert.ok(comments[0].receivedAt instanceof Date, 'receivedAt must be a Date');
+  // 1700000000s = 2023-11-14T22:13:20.000Z → year 2023, month November (index 10).
+  assert.equal(comments[0].receivedAt.getFullYear(), 2023, 'epoch seconds correctly converted (not ms)');
+  assert.equal(comments[0].receivedAt.getMonth(), 10, 'month is November (index 10)');
+  assert.equal(comments[0].receivedAt.getDate(), 14, 'day is 14 for epoch 1700000000');
+
+  assert.equal(comments[1].externalCommentId, 't1_comment2');
+  assert.equal(comments[1].authorHandle, 'redditor_bob');
+  assert.equal(comments[1].bodyText, 'Agreed, very useful.');
+  assert.ok(comments[1].receivedAt instanceof Date);
+});
+
+test('fetchComments: respects the limit parameter and returns at most limit comments', async () => {
+  const db = fakePostsDb([]);
+  // Supply 5 comments; limit to 3.
+  const children = Array.from({ length: 5 }, (_, i) => ({
+    kind: 't1',
+    data: {
+      name: `t1_cmt${i}`,
+      author: `user${i}`,
+      body: `Comment ${i}`,
+      created_utc: 1700000000 + i * 100,
+    },
+  }));
+  const gateway = routingGateway({
+    REDDIT_RETRIEVE_POST_COMMENTS: {
+      successful: true,
+      error: null,
+      data: [
+        { kind: 'Listing', data: { children: [] } },
+        { kind: 'Listing', data: { children } },
+      ],
+    },
+  });
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const comments = await adapter.fetchComments('t3_limitme', 3);
+
+  assert.equal(comments.length, 3, 'fetchComments must honour the limit parameter');
+});
+
+test('fetchComments: falls back to comment.id when name is absent', async () => {
+  const db = fakePostsDb([]);
+  const gateway = routingGateway({
+    REDDIT_RETRIEVE_POST_COMMENTS: {
+      successful: true,
+      error: null,
+      data: [
+        { kind: 'Listing', data: { children: [] } },
+        {
+          kind: 'Listing',
+          data: {
+            children: [
+              {
+                kind: 't1',
+                data: {
+                  // name is absent — adapter falls back to id.
+                  id: 'fallback_id',
+                  author: 'anon',
+                  body: 'Hello',
+                  created_utc: 1700000000,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+  const adapter = new RedditInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const comments = await adapter.fetchComments('t3_fallback');
+
+  assert.equal(comments.length, 1);
+  assert.equal(comments[0].externalCommentId, 'fallback_id', 'falls back to id when name is absent');
+});
+
+// ── fetchAccountMetrics ───────────────────────────────────────────────────────
+
+test('fetchAccountMetrics: always returns [] — Reddit has no verified account-insights action', async () => {
+  const gateway = routingGateway({});
+  const adapter = new RedditInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  const result = await adapter.fetchAccountMetrics('reddit_user', { from: '2026-06-01', to: '2026-06-18' });
+
+  assert.deepEqual(result, []);
+  assert.equal(gateway.calls.length, 0, 'no gateway calls — never fabricate a Reddit account series');
+});
+
+// ── Dormancy / off-switch ─────────────────────────────────────────────────────
+
+const REDDIT_COMPOSIO_ENV = {
+  ARIES_REDDIT_ENABLED: '1',
+  ANALYTICS_PROVIDER: 'composio',
+} as unknown as NodeJS.ProcessEnv;
+
+const FLAG_OFF_ENV = {
+  ANALYTICS_PROVIDER: 'composio',
+} as unknown as NodeJS.ProcessEnv;
+
+const PROVIDER_OFF_ENV = {
+  ARIES_REDDIT_ENABLED: '1',
+} as unknown as NodeJS.ProcessEnv;
+
+test('dormancy: isRedditInsightsEnabled requires BOTH ARIES_REDDIT_ENABLED=1 AND ANALYTICS_PROVIDER=composio', () => {
+  assert.equal(isRedditInsightsEnabled(REDDIT_COMPOSIO_ENV), true, 'both flags on → enabled');
+  assert.equal(isRedditInsightsEnabled(FLAG_OFF_ENV), false, 'ARIES_REDDIT_ENABLED absent → disabled');
+  assert.equal(isRedditInsightsEnabled(PROVIDER_OFF_ENV), false, 'ANALYTICS_PROVIDER!=composio → disabled');
+  assert.equal(
+    isRedditInsightsEnabled({} as unknown as NodeJS.ProcessEnv),
+    false,
+    'no flags → disabled (default OFF)',
+  );
+});
+
+test('dormancy: hasAdapter("reddit") mirrors isRedditInsightsEnabled for all flag combinations', () => {
+  assert.equal(hasAdapter('reddit', REDDIT_COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('reddit', FLAG_OFF_ENV), false);
+  assert.equal(hasAdapter('reddit', PROVIDER_OFF_ENV), false);
+  assert.equal(hasAdapter('reddit', {} as unknown as NodeJS.ProcessEnv), false);
+});
+
+test('dormancy: getAdapter("reddit") throws a diagnostic error mentioning ARIES_REDDIT_ENABLED when disabled', () => {
+  const prevReddit = process.env.ARIES_REDDIT_ENABLED;
+  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  // Ensure both axes are off so the REGISTRY guard fires.
+  delete process.env.ARIES_REDDIT_ENABLED;
+  process.env.ANALYTICS_PROVIDER = 'direct_meta';
+  try {
+    assert.throws(
+      () => getAdapter('reddit', { connectedAccountId: 'ca_reddit', tenantId: 1 }),
+      /ARIES_REDDIT_ENABLED/,
+      'error message must mention the flag name so operators know what to set',
+    );
+  } finally {
+    if (prevReddit === undefined) delete process.env.ARIES_REDDIT_ENABLED;
+    else process.env.ARIES_REDDIT_ENABLED = prevReddit;
+    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
+    else process.env.ANALYTICS_PROVIDER = prevProvider;
+  }
+});


### PR DESCRIPTION
Closes #642
Closes #643

## What

Adds a Reddit insights adapter (analytics #642 sev:medium + comments #643 sev:high), mirroring the X adapter one platform over. Ships **DORMANT** behind the existing `ARIES_REDDIT_ENABLED` flag (reused from the #641 publish path — no new flag). With the flag OFF (default), the insights bridge excludes reddit, `hasAdapter('reddit')` is false, and `getAdapter('reddit')` throws — FB/IG/X/YouTube are byte-identical.

## How

- `backend/insights/adapters/reddit/index.ts` — new adapter:
  - `fetchPostList` is **DB-only** (zero Composio calls): `posts WHERE platform='reddit'`, tenant-scoped. The full `t3_<base36>` fullname is kept as the stored `external_post_id`; only the Composio `article` arg is stripped to bare base36 at the call boundary.
  - `fetchPostMetrics` → ONE `REDDIT_RETRIEVE_REDDIT_POST {article}` per post (not batchable), ridden by the dispatcher's existing bounded **sequential** per-post loop (no `Promise.all`, no fan-out).
  - `fetchComments` → ONE `REDDIT_RETRIEVE_POST_COMMENTS {article}` per post, top-level comments only, skips `kind:'more'` stubs. `created_utc` is parsed as epoch **seconds** via a dedicated `epochToDate` helper (X's ISO `toDate` is deliberately not reused).
  - `fetchAccountMetrics` returns `[]` — no verified Reddit account-insights action; never fabricate a series.
  - Adapter throws on `successful===false`, so a leg error surfaces while already-committed rows are preserved (resumability honored).
- Union-widening: `'reddit'` added to the insights `Platform` union; TS-forced `Record<Platform>` maps (capabilities, labels, icons) updated. Reddit falls through to the generic narrative branch (`posts`/`post`), never YouTube's `videos`/`viewers`.
- `ARIES_REDDIT_ENABLED` + `COMPOSIO_REDDIT_{POST_INSIGHTS,LIST_COMMENTS}_ACTION` wired into **both** `aries-app` and the `aries-insights-sync-worker` compose block (the worker runs the sync — without it on the worker, Reddit insights stay dormant even when enabled).

## DOCUMENTED LIMITATION (load-bearing)

Reddit exposes **NO impressions/reach/views metric** — only `score`, `num_comments`, `upvote_ratio`. Mapping is honest:
- `score → likes`, and **`likes` CAN be negative** for downvoted posts (never clamped — an honest value the dashboard may want to special-case).
- `num_comments → commentsCount`.
- `views = 0` is a placeholder, NOT a fetched value; the truth lives in `rawSource.views_available=false` / `views_unavailable_reason`. No impressions/reach is ever fabricated (mirrors X's impressions fail-soft).
- Comments are **top-level only**; nested replies (`replies.data.children`) are a deliberate follow-up.

## Tests

`tests/insights-reddit-adapter.test.ts` (13: post-list DB-only/zero-calls, t3_ strip, score→likes incl. negative un-clamped, no-signal→no row, comments mapping/epoch-seconds/kind:more skip/limit/id-fallback, account-metrics `[]`, dormancy on both axes) + 2 bridge tests in `tests/insights-ensure-account.test.ts`. `npm run verify` green (no regression); `guardrails:agent` clean (2 ahead of master, unique diff).

## Activation + residual risk

Prod activation needs `ARIES_REDDIT_ENABLED=1` + `ANALYTICS_PROVIDER=composio` (the `COMPOSIO_REDDIT_{POST_INSIGHTS,LIST_COMMENTS}_ACTION` slugs have verified code defaults, so they work unset). The same cross-cutting frontend un-pin dependency as X/YouTube applies (orchestrator handles it once). **Open contract risk:** the Reddit comments response nesting (`[postListing, commentsListing]` envelope depth) is handled tolerantly but needs a single live-call confirmation when first enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
