### PR TITLE
feat(integrations): LinkedIn personal-reactions insights adapter (#647); document #648 comments limitation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -410,7 +410,6 @@ COMPOSIO_YOUTUBE_LIST_POSTS_ACTION=
 COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION=
 COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION=
 
-<<<<<<< HEAD
 # Reddit analytics + comments (#642 analytics, #643 comments), read by the
 # insights-sync worker's Reddit adapter (backend/insights/adapters/reddit). The
 # Reddit insights path turns on ONLY when ARIES_REDDIT_ENABLED=true AND

--- a/.env.example
+++ b/.env.example
@@ -410,6 +410,7 @@ COMPOSIO_YOUTUBE_LIST_POSTS_ACTION=
 COMPOSIO_YOUTUBE_POST_INSIGHTS_ACTION=
 COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION=
 
+<<<<<<< HEAD
 # Reddit analytics + comments (#642 analytics, #643 comments), read by the
 # insights-sync worker's Reddit adapter (backend/insights/adapters/reddit). The
 # Reddit insights path turns on ONLY when ARIES_REDDIT_ENABLED=true AND
@@ -434,6 +435,22 @@ COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION=
 # rawSource.views_available=false). ARIES_REDDIT_ENABLED is declared once near the top.
 COMPOSIO_REDDIT_POST_INSIGHTS_ACTION=
 COMPOSIO_REDDIT_LIST_COMMENTS_ACTION=
+# LinkedIn analytics (#647), read by the insights-sync worker's LinkedIn adapter
+# (backend/insights/adapters/linkedin). The LinkedIn insights path turns on ONLY
+# when ARIES_LINKEDIN_ENABLED=true AND ANALYTICS_PROVIDER=composio; otherwise the
+# bridge no-ops, the adapter never activates, and no Composio tool runs. The
+# verified slug below is the CODE DEFAULT, so analytics works with it unset; set
+# it only to pin a different toolkit version. The adapter authenticates every call
+# with the tenant's Composio connectedAccountId.
+#   post_insights     -> LINKEDIN_LIST_REACTIONS  (entity = the post URN VERBATIM,
+#                        count:100; reaction count -> likes. PERSONAL scope only)
+# Analytics is personal-reactions-only: organisation share stats
+# (LINKEDIN_GET_SHARE_STATS: impressions/reach/clicks/comments/shares) need the
+# rw_organization_admin scope + an org URN, so they are NOT fetched here. There is
+# DELIBERATELY no COMPOSIO_LINKEDIN_LIST_COMMENTS_ACTION: LinkedIn has no Composio
+# list-comments action (#648), so comments cannot be ingested. ARIES_LINKEDIN_ENABLED
+# is declared once near the top.
+COMPOSIO_LINKEDIN_POST_INSIGHTS_ACTION=
 
 # Native comment reply via Composio (#598/gate-5) — posts an operator reply
 # through FACEBOOK_CREATE_COMMENT (object_id = the comment's full graph id), so

--- a/backend/insights/adapters/linkedin/index.ts
+++ b/backend/insights/adapters/linkedin/index.ts
@@ -1,0 +1,339 @@
+/**
+ * backend/insights/adapters/linkedin/index.ts
+ *
+ * LinkedIn insights adapter — backed by Composio (#647 analytics). Mirrors the
+ * Reddit/X adapters (per-post, DB-sourced post list, no Composio "list my posts"
+ * action) behind the EXISTING ARIES_LINKEDIN_ENABLED flag (reused from the LinkedIn
+ * connect/publish path #645/#646 — LinkedIn insights does NOT add a new flag).
+ *
+ * Every platform call goes through the Composio gateway (`executeTool`) so the
+ * adapter depends on a small, mockable surface; tests inject a fake gateway and
+ * never touch the network. The verified Composio action slug is the default,
+ * overridable via `COMPOSIO_LINKEDIN_POST_INSIGHTS_ACTION` (resolved through
+ * `ComposioConfig.actionSlugFor`).
+ *
+ * Method → action:
+ *   fetchPostList     → (DB only — no Composio call) the `posts` table (the
+ *                       LinkedIn posts Aries published). There is NO Composio
+ *                       "list my posts" action, exactly like X/Reddit.
+ *   fetchPostMetrics  → LINKEDIN_LIST_REACTIONS  (per-post; NOT batchable — one
+ *                       call per post, ridden by the dispatcher's bounded
+ *                       SEQUENTIAL per-post loop, no fan-out)
+ *   fetchComments     → [] (LinkedIn has NO Composio list-comments action — an
+ *                       HONEST empty, never a fabricated comment; see #648)
+ *   fetchAccountMetrics → [] (LINKEDIN_GET_SHARE_STATS is organization-admin
+ *                       only; #645 captured the person URN, not an org URN — an
+ *                       org-stats follow-up, never a fabricated account series)
+ *
+ * ── ANALYTICS SCOPE — personal reactions only (#647) ───────────────────────────
+ * For a PERSONAL LinkedIn account the only verified engagement signal is the
+ * reaction list: LINKEDIN_LIST_REACTIONS on the post entity returns the member
+ * reactions, from which we derive a reaction count and map it HONESTLY onto
+ * `likes`. Organisation-level share stats (impressions / reach / clicks /
+ * comments / shares via LINKEDIN_GET_SHARE_STATS) require the
+ * `rw_organization_admin` scope + an org URN Aries does not hold for a personal
+ * connection, so those metrics are NOT fetched and stay 0 placeholders (the FB
+ * `views ?? 0` convention) with the TRUTH recorded in rawSource
+ * (`analytics_scope`, `org_stats_unavailable_reason`, `impressions_available`).
+ * We NEVER invent an impressions/reach/comment/share number.
+ *
+ * ── Reaction-count precedence (load-bearing) ───────────────────────────────────
+ * LINKEDIN_LIST_REACTIONS returns a collection `{ elements:[…], paging:{ total }}`.
+ * We prefer the authoritative `paging.total` (the full reaction count, even when
+ * the page only carries `count` elements); when it is absent we fall back to the
+ * length of `elements` and flag it as a FLOOR (`reaction_count_is_floor=true`)
+ * whenever it equals the page size (100), since the true total may be larger.
+ * When NEITHER is present the count is null → NO row is emitted (a measured 0 is
+ * real signal and IS emitted; an absent count is never fabricated as 0).
+ *
+ * ── Post entity URN (load-bearing) ─────────────────────────────────────────────
+ * `posts.platform_post_id` for LinkedIn is whatever the publish path (#646)
+ * captured from LINKEDIN_CREATE_LINKED_IN_POST. We pass it VERBATIM as the
+ * `entity` arg — we do NOT guess or prepend a `urn:li:share:` / `urn:li:ugcPost:`
+ * prefix, because a bare id is ambiguous (share vs ugcPost vs activity) and
+ * inventing the wrong URN type would silently mis-target the lookup.
+ */
+
+import pool from '@/lib/db';
+import type {
+  InsightsAdapter,
+  InsightsAdapterContext,
+  DateRange,
+  RawAccountMetricsDay,
+  RawPost,
+  RawPostMetricsDay,
+  RawComment,
+} from '../_adapter.types';
+import type { ComposioConfig, ComposioOperation } from '@/backend/integrations/composio/composio-config';
+import type { ComposioGateway } from '@/backend/integrations/composio/composio-client';
+import type { Queryable } from '@/backend/integrations/composio/connection-store';
+import { resolveComposioConfig } from '@/backend/integrations/composio/composio-config';
+import { createComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { num } from '@/backend/integrations/composio/analytics-mappers';
+
+// ── Verified default action slugs (env-overridable) ────────────────────────────
+
+const DEFAULT_SLUGS: Partial<Record<ComposioOperation, string>> = {
+  // Per-post reaction list — the only verified PERSONAL engagement source.
+  post_insights: 'LINKEDIN_LIST_REACTIONS',
+  // NOTE: NO list_comments — LinkedIn has no Composio list-comments action (#648).
+  // NOTE: NO list_posts — LinkedIn has no Composio "list my posts" action; the
+  // post universe is sourced from the `posts` table (like X/Reddit).
+};
+
+/** Page size requested from LINKEDIN_LIST_REACTIONS; doubles as the floor marker. */
+const REACTIONS_PAGE_SIZE = 100;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────────
+
+function asObject(node: unknown): Record<string, unknown> | null {
+  if (node && typeof node === 'object' && !Array.isArray(node)) {
+    return node as Record<string, unknown>;
+  }
+  return null;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+/**
+ * Descend through Composio's `{ data: <toolPayload> }` envelope wrappers to land
+ * on the LinkedIn reactions collection (`{ elements, paging }`). The exact
+ * nesting (one vs two `.data` layers) varies by tool/SDK version, so we peel
+ * object-with-`data` wrappers until the current object IS the collection (carries
+ * `elements`/`paging`) or there is nothing left to peel.
+ */
+function unwrapToCollection(raw: unknown): Record<string, unknown> {
+  let cur: unknown = raw;
+  for (let i = 0; i < 4; i += 1) {
+    const obj = asObject(cur);
+    if (!obj) break;
+    // Stop as soon as we reach the collection carrier itself.
+    if ('elements' in obj || 'paging' in obj) break;
+    if (!('data' in obj)) break;
+    cur = obj.data;
+  }
+  return asObject(cur) ?? {};
+}
+
+interface ReactionCount {
+  count: number | null;
+  source: 'paging_total' | 'elements_length' | null;
+  isFloor: boolean;
+}
+
+/**
+ * Resolve the reaction count from a LINKEDIN_LIST_REACTIONS collection using the
+ * documented precedence: authoritative `paging.total` first; else the length of
+ * `elements` (flagged a FLOOR when it saturates the page size); else null.
+ */
+function extractReactionCount(collection: Record<string, unknown>): ReactionCount {
+  const paging = asObject(collection.paging);
+  const total = paging ? num(paging.total) : null;
+  if (total !== null) {
+    return { count: total, source: 'paging_total', isFloor: false };
+  }
+  const elements = collection.elements;
+  if (Array.isArray(elements)) {
+    const len = elements.length;
+    return { count: len, source: 'elements_length', isFloor: len >= REACTIONS_PAGE_SIZE };
+  }
+  return { count: null, source: null, isFloor: false };
+}
+
+/** Resolve the DB `published_at` (Postgres ISO timestamp) to a Date. */
+function toPublishedAt(value: Date | string | null): Date {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? new Date(0) : value;
+  if (typeof value === 'string' && value.trim()) {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date(0);
+}
+
+// ── Adapter ────────────────────────────────────────────────────────────────────
+
+interface LinkedInPostRow {
+  platform_post_id: string;
+  published_at: Date | string | null;
+  caption: string | null;
+}
+
+export class LinkedInInsightsAdapter implements InsightsAdapter {
+  readonly platform = 'linkedin' as const;
+
+  constructor(
+    private readonly gateway: ComposioGateway,
+    private readonly config: ComposioConfig,
+    private readonly db: Queryable = pool,
+    private readonly ctx: InsightsAdapterContext = {},
+  ) {}
+
+  private slugFor(op: ComposioOperation): string {
+    const override = this.config.actionSlugFor('linkedin', op);
+    const slug = override ?? DEFAULT_SLUGS[op];
+    if (!slug) throw new Error(`No Composio LinkedIn action slug configured for "${op}".`);
+    return slug;
+  }
+
+  private connectedAccountId(): string {
+    const id = this.ctx.connectedAccountId?.trim();
+    if (!id) {
+      throw new Error('LinkedInInsightsAdapter: no Composio connectedAccountId in context.');
+    }
+    return id;
+  }
+
+  private tenantId(): number {
+    const id = this.ctx.tenantId;
+    if (id === null || id === undefined) {
+      throw new Error('LinkedInInsightsAdapter: no tenantId in context.');
+    }
+    return id;
+  }
+
+  /** Execute a tool; throw on a hard (successful=false) failure so the sync run
+   * surfaces the leg error while already-committed rows are preserved (partial
+   * progress is never discarded). */
+  private async exec(op: ComposioOperation, args: Record<string, unknown>): Promise<unknown> {
+    const result = await this.gateway.executeTool(this.slugFor(op), {
+      connectedAccountId: this.connectedAccountId(),
+      arguments: args,
+    });
+    if (!result.successful) {
+      throw new Error(result.error ?? `Composio LinkedIn ${op} call reported unsuccessful.`);
+    }
+    return result.data ?? null;
+  }
+
+  /**
+   * List the LinkedIn posts Aries published for this tenant (from the `posts`
+   * table — LinkedIn has no Composio "list my posts" action, exactly like
+   * X/Reddit). ZERO Composio calls here; per-post engagement is fetched lazily in
+   * fetchPostMetrics (LinkedIn's reaction lookup is per-post, NOT batchable).
+   *
+   * `externalAccountId`/`publishedAfter` are part of the InsightsAdapter contract
+   * but LinkedIn keys the post list on tenant_id (the DB is the source of truth).
+   */
+  async fetchPostList(_externalAccountId: string, _publishedAfter?: Date): Promise<RawPost[]> {
+    const rows = await this.db.query<LinkedInPostRow>(
+      `SELECT platform_post_id, published_at, caption
+         FROM posts
+        WHERE tenant_id = $1
+          AND platform = 'linkedin'
+          AND platform_post_id IS NOT NULL
+          AND published_status = 'published'`,
+      [this.tenantId()],
+    );
+
+    const dbRows = rows.rows.filter((r) => typeof r.platform_post_id === 'string' && r.platform_post_id);
+    if (dbRows.length === 0) return [];
+
+    return dbRows.map((r) => ({
+      // The publish path's captured post URN (share/ugcPost/activity) round-trips
+      // as the stored external_post_id and is passed VERBATIM to Composio.
+      externalPostId: r.platform_post_id,
+      publishedAt: toPublishedAt(r.published_at),
+      // Aries publishes single-image feed posts; LinkedIn exposes no media-type
+      // axis we request here, so the published surface is normalised to 'image'.
+      mediaType: 'image' as const,
+      title: null,
+      caption: str(r.caption),
+      permalink: `https://www.linkedin.com/feed/update/${r.platform_post_id}`,
+      thumbnailUrl: null,
+      durationSeconds: null,
+    }));
+  }
+
+  /**
+   * LinkedIn personal share stats (LINKEDIN_GET_SHARE_STATS) require an
+   * organisation-admin scope + org URN Aries does not hold for a personal
+   * connection — never fabricate an account series. Org-level account metrics are
+   * a documented follow-up, gated on capturing an org URN at connect.
+   */
+  async fetchAccountMetrics(
+    _externalAccountId: string,
+    _range: DateRange,
+  ): Promise<RawAccountMetricsDay[]> {
+    return [];
+  }
+
+  /**
+   * One LINKEDIN_LIST_REACTIONS lookup for a single post (NOT batchable). The
+   * dispatcher calls this inside its bounded SEQUENTIAL per-post loop, so there is
+   * no fan-out. Emits a row only on a measured reaction count (a real 0 included)
+   * — never a fabricated zero row when the count is absent.
+   */
+  async fetchPostMetrics(externalPostId: string, _range?: DateRange): Promise<RawPostMetricsDay[]> {
+    // entity is passed VERBATIM — never prepend/guess a urn:li: prefix.
+    const data = await this.exec('post_insights', {
+      entity: externalPostId,
+      count: REACTIONS_PAGE_SIZE,
+    });
+    const collection = unwrapToCollection(data);
+    const { count: reactionCount, source: reactionCountSource, isFloor } =
+      extractReactionCount(collection);
+
+    // Only emit a row when there is a measured reaction count — never fabricate a
+    // zero row for a post the lookup returned no usable count for (mirror FB/X).
+    // A measured 0 IS a real signal and is emitted.
+    if (reactionCount === null) return [];
+
+    const date = new Date().toISOString().split('T')[0];
+    return [
+      {
+        date,
+        // Personal reactions expose no impressions/reach — 0 is the FB `views ?? 0`
+        // placeholder, NOT a fetched value (the truth lives in rawSource below).
+        views: 0,
+        watchTimeMinutes: 0,
+        avgViewDurationSec: 0,
+        avgViewPercentage: 0,
+        // Reaction count mapped HONESTLY onto likes.
+        likes: reactionCount,
+        // Personal reactions carry no comment/share count — surface 0, not a
+        // fabricated value (the truth lives in rawSource).
+        commentsCount: 0,
+        shares: 0,
+        rawSource: {
+          source: 'LINKEDIN_LIST_REACTIONS',
+          reaction_count: reactionCount,
+          reaction_count_source: reactionCountSource,
+          reaction_count_is_floor: isFloor,
+          analytics_scope: 'personal_reactions_only',
+          org_stats_unavailable_reason: 'requires_org_admin',
+          impressions_available: false,
+        },
+      },
+    ];
+  }
+
+  /**
+   * LinkedIn comments cannot be ingested: there is NO Composio list-comments
+   * action for LinkedIn (LINKEDIN_GET_POST_CONTENT returns a post's content, not a
+   * comments list). We therefore return an HONEST empty array — never a synthesised
+   * or faked comment — and never throw, so the sync run stays 'ok' and the
+   * remaining legs (reactions) still complete. This is a genuine platform
+   * limitation (#648 documents it), reflected by OMITTING the 'comments' capability
+   * for LinkedIn in platforms/capabilities.ts so the product never advertises a
+   * LinkedIn comment feature it cannot back.
+   */
+  async fetchComments(_externalPostId: string, _limit = 100): Promise<RawComment[]> {
+    return [];
+  }
+}
+
+/**
+ * Build a context-bound LinkedIn adapter wired to the live Composio gateway.
+ * Throws (via createComposioGateway) when Composio is enabled but no API key is
+ * configured — the dispatcher catches that and marks the sync run failed.
+ */
+export function createLinkedInInsightsAdapter(
+  ctx: InsightsAdapterContext = {},
+  env: NodeJS.ProcessEnv = process.env,
+): LinkedInInsightsAdapter {
+  const config = resolveComposioConfig(env);
+  const gateway = createComposioGateway(config);
+  return new LinkedInInsightsAdapter(gateway, config!, pool, ctx);
+}

--- a/backend/insights/platforms/capabilities.ts
+++ b/backend/insights/platforms/capabilities.ts
@@ -69,6 +69,18 @@ export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapabil
     'post_daily_metrics',
     'comments',
   ]),
+  // LinkedIn via Composio (#647 analytics): per-post PERSONAL reaction counts
+  // (LINKEDIN_LIST_REACTIONS → likes). Deliberately OMITS 'comments' (#648):
+  // LinkedIn exposes NO Composio list-comments action, so the adapter ingests no
+  // comments and the UI advertises no LinkedIn comment feature — a genuine
+  // platform limitation, not a stub. Also OMITS 'account_daily_metrics'
+  // (LINKEDIN_GET_SHARE_STATS is organization-admin only; #645 captured the
+  // person URN, not an org URN — an org-stats follow-up) and 'reach_impressions'
+  // (personal reactions expose no impressions/reach metric).
+  linkedin: new Set<PlatformCapability>([
+    'post_list',
+    'post_daily_metrics',
+  ]),
 };
 
 /** Returns true if the given platform supports a specific capability. */

--- a/backend/insights/platforms/registry.ts
+++ b/backend/insights/platforms/registry.ts
@@ -8,9 +8,9 @@
  *   2. TypeScript will highlight every spot that needs updating (capabilities.ts, adapter factory, etc.).
  */
 
-export const SUPPORTED_PLATFORMS = ['youtube', 'instagram', 'facebook', 'x', 'reddit'] as const;
+export const SUPPORTED_PLATFORMS = ['youtube', 'instagram', 'facebook', 'x', 'reddit', 'linkedin'] as const;
 
-/** Union type — 'youtube' | 'instagram' | 'facebook' | 'x' | 'reddit' */
+/** Union type — 'youtube' | 'instagram' | 'facebook' | 'x' | 'reddit' | 'linkedin' */
 export type Platform = (typeof SUPPORTED_PLATFORMS)[number];
 
 /** Runtime guard: narrows an unknown string to Platform. */
@@ -25,6 +25,7 @@ export const PLATFORM_LABELS: Record<Platform, string> = {
   facebook: 'Facebook',
   x: 'X',
   reddit: 'Reddit',
+  linkedin: 'LinkedIn',
 };
 
 /** Icon identifiers used by the frontend icon registry (Phase 10). */
@@ -34,4 +35,5 @@ export const PLATFORM_ICON_IDS: Record<Platform, string> = {
   facebook: 'facebook',
   x: 'x',
   reddit: 'reddit',
+  linkedin: 'linkedin',
 };

--- a/backend/insights/sync/adapter-factory.ts
+++ b/backend/insights/sync/adapter-factory.ts
@@ -20,7 +20,8 @@ import { createYouTubeInsightsAdapter } from '../adapters/youtube/index';
 import { createFacebookInsightsAdapter } from '../adapters/facebook/index';
 import { createXInsightsAdapter } from '../adapters/x/index';
 import { createRedditInsightsAdapter } from '../adapters/reddit/index';
-import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled } from '@/backend/integrations/providers/integration-config';
+import { createLinkedInInsightsAdapter } from '../adapters/linkedin/index';
+import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled, isLinkedInEnabled } from '@/backend/integrations/providers/integration-config';
 
 type AdapterBuilder = (ctx: InsightsAdapterContext) => InsightsAdapter;
 
@@ -68,6 +69,17 @@ export function isRedditInsightsEnabled(env: NodeJS.ProcessEnv = process.env): b
   return isRedditEnabled(env) && analyticsProviderSelector(env) === 'composio';
 }
 
+/**
+ * Real off-switch for the Composio-backed LinkedIn insights path (#647): active
+ * only when the LinkedIn rollout flag is ON (ARIES_LINKEDIN_ENABLED) AND analytics
+ * is on Composio (ANALYTICS_PROVIDER=composio). Reuses the existing isLinkedInEnabled
+ * flag — LinkedIn insights does NOT add a new flag. Default OFF on both axes → the
+ * LinkedIn adapter never activates and no Composio tool is ever executed.
+ */
+export function isLinkedInInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isLinkedInEnabled(env) && analyticsProviderSelector(env) === 'composio';
+}
+
 const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
   youtube: (ctx) => {
     if (!isYouTubeInsightsEnabled()) {
@@ -105,6 +117,15 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     }
     return createRedditInsightsAdapter(ctx);
   },
+  linkedin: (ctx) => {
+    if (!isLinkedInInsightsEnabled()) {
+      throw new Error(
+        'LinkedIn insights adapter is disabled: set ARIES_LINKEDIN_ENABLED=1 and ' +
+        'ANALYTICS_PROVIDER=composio to enable Composio-backed LinkedIn analytics.',
+      );
+    }
+    return createLinkedInInsightsAdapter(ctx);
+  },
   // instagram: (ctx) => createInstagramInsightsAdapter(ctx),  ← out of scope (#596/#597 = FB only)
 };
 
@@ -118,6 +139,7 @@ export function hasAdapter(platform: Platform, env: NodeJS.ProcessEnv = process.
   if (platform === 'x') return isXInsightsEnabled(env);
   if (platform === 'youtube') return isYouTubeInsightsEnabled(env);
   if (platform === 'reddit') return isRedditInsightsEnabled(env);
+  if (platform === 'linkedin') return isLinkedInInsightsEnabled(env);
   return platform in REGISTRY && REGISTRY[platform] != null;
 }
 

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -26,7 +26,7 @@
 
 import pool from '@/lib/db';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
-import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled } from '@/backend/integrations/providers/integration-config';
+import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled, isLinkedInEnabled } from '@/backend/integrations/providers/integration-config';
 import { resolveComposioConfig, type ComposioConfig } from '@/backend/integrations/composio/composio-config';
 import { createComposioGateway, type ComposioGateway } from '@/backend/integrations/composio/composio-client';
 import { resolveFacebookManagedPage } from '@/backend/integrations/composio/facebook-page-resolver';
@@ -34,22 +34,24 @@ import { resolveYouTubeChannel } from '@/backend/integrations/composio/youtube-c
 
 /**
  * Platforms whose Composio connections should be projected into insights_accounts.
- * X (Twitter) and YouTube are only bridged when their rollout flag is ON
- * (ARIES_X_ENABLED / ARIES_YOUTUBE_ENABLED), computed dynamically by
- * `bridgedPlatforms` below — the const itself is never mutated, so a flag-OFF
- * environment is byte-identical to the FB-only bridge.
+ * X (Twitter), YouTube, and LinkedIn are only bridged when their rollout flag is
+ * ON (ARIES_X_ENABLED / ARIES_YOUTUBE_ENABLED / ARIES_LINKEDIN_ENABLED), computed
+ * dynamically by `bridgedPlatforms` below — the const itself is never mutated, so
+ * a flag-OFF environment is byte-identical to the FB-only bridge.
  */
 export const BRIDGED_PLATFORMS = ['facebook'] as const;
 
 /**
  * The bridged-platform list for this env: FB always; X only when ARIES_X_ENABLED;
- * YouTube only when ARIES_YOUTUBE_ENABLED; Reddit only when ARIES_REDDIT_ENABLED.
+ * YouTube only when ARIES_YOUTUBE_ENABLED; Reddit only when ARIES_REDDIT_ENABLED;
+ * LinkedIn only when ARIES_LINKEDIN_ENABLED.
  */
 function bridgedPlatforms(env: NodeJS.ProcessEnv): string[] {
   const list: string[] = [...BRIDGED_PLATFORMS];
   if (isXEnabled(env)) list.push('x');
   if (isYouTubeEnabled(env)) list.push('youtube');
   if (isRedditEnabled(env)) list.push('reddit');
+  if (isLinkedInEnabled(env)) list.push('linkedin');
   return list;
 }
 

--- a/backend/integrations/composio/analytics-mappers.ts
+++ b/backend/integrations/composio/analytics-mappers.ts
@@ -119,6 +119,28 @@ function parseLinkedinShareStats(raw: unknown): Partial<NormalizedMetrics> {
   };
 }
 
+/**
+ * Parse a LINKEDIN_LIST_REACTIONS collection (`{ elements, paging:{ total } }`)
+ * into the PERSONAL reaction count, mapped HONESTLY onto `likes`. Precedence:
+ * authoritative `paging.total` first; else the length of `elements`; else absent
+ * (`likes` stays null — never a fabricated zero). This is the only verified
+ * engagement signal for a personal LinkedIn account (org share stats need
+ * organization-admin scope — see parseLinkedinShareStats / linkedin:account_insights).
+ */
+function parseLinkedinReactions(raw: unknown): Partial<NormalizedMetrics> {
+  const p = payload(raw);
+  // The collection may sit at the unwrapped layer or one `.data` deeper.
+  const collection = ('elements' in p || 'paging' in p) ? p : payload(p);
+  const paging = collection.paging && typeof collection.paging === 'object'
+    ? (collection.paging as Record<string, unknown>)
+    : null;
+  const total = paging ? num(paging.total) : null;
+  if (total !== null) return { likes: total };
+  const elements = collection.elements;
+  if (Array.isArray(elements)) return { likes: elements.length };
+  return {};
+}
+
 function parseYoutubeStatistics(raw: unknown): Partial<NormalizedMetrics> {
   const p = payload(raw);
   const items = Array.isArray(p.items) ? (p.items as Array<Record<string, unknown>>) : [];
@@ -256,6 +278,16 @@ const MAPPERS: Partial<Record<string, PlatformAnalyticsMapper>> = {
         shares: num(pm.retweet_count),
       };
     },
+  },
+  // LinkedIn (personal per-post reactions → likes). entity is the post URN
+  // (share/ugcPost/activity) passed VERBATIM — never guess/prepend a urn:li:
+  // prefix. Personal reactions expose no impressions/reach/comment/share, so
+  // those stay null (never a fabricated zero); the org-level metrics need
+  // organization-admin scope (linkedin:account_insights, below).
+  'linkedin:post_insights': {
+    slug: 'LINKEDIN_LIST_REACTIONS',
+    buildArgs: (ctx) => ({ entity: ctx.externalPostId, count: 100 }),
+    parse: parseLinkedinReactions,
   },
   // LinkedIn (organization-level share stats)
   'linkedin:account_insights': {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -543,6 +543,16 @@ services:
       COMPOSIO_REDDIT_AUTH_CONFIG_ID: ${COMPOSIO_REDDIT_AUTH_CONFIG_ID:-}
       COMPOSIO_REDDIT_POST_INSIGHTS_ACTION: ${COMPOSIO_REDDIT_POST_INSIGHTS_ACTION:-}
       COMPOSIO_REDDIT_LIST_COMMENTS_ACTION: ${COMPOSIO_REDDIT_LIST_COMMENTS_ACTION:-}
+      # LinkedIn analytics (#647), read by the insights-sync worker's LinkedIn
+      # adapter (backend/insights/adapters/linkedin). The LinkedIn insights path
+      # (account bridge + adapter) turns on ONLY when ARIES_LINKEDIN_ENABLED=true
+      # AND ANALYTICS_PROVIDER=composio; otherwise dormant. AUTH_CONFIG_ID is the
+      # tenant's Composio auth config; POST_INSIGHTS_ACTION is optional (verified
+      # code default: LINKEDIN_LIST_REACTIONS). Personal-reactions-only — there is
+      # no list-comments slug (LinkedIn has no Composio list-comments action, #648).
+      ARIES_LINKEDIN_ENABLED: ${ARIES_LINKEDIN_ENABLED:-false}
+      COMPOSIO_LINKEDIN_AUTH_CONFIG_ID: ${COMPOSIO_LINKEDIN_AUTH_CONFIG_ID:-}
+      COMPOSIO_LINKEDIN_POST_INSIGHTS_ACTION: ${COMPOSIO_LINKEDIN_POST_INSIGHTS_ACTION:-}
     restart: unless-stopped
     networks:
       - docker_stack

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -289,6 +289,26 @@ test('Reddit bridge: when ARIES_REDDIT_ENABLED=1 the DB query includes "reddit" 
   );
 });
 
+test('LinkedIn bridge: when ARIES_LINKEDIN_ENABLED=1 the DB query includes "linkedin" alongside "facebook"', async () => {
+  const db = recordingDb([]);
+  const liEnv = {
+    ANALYTICS_PROVIDER: 'composio',
+    ARIES_LINKEDIN_ENABLED: '1',
+  } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, liEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'issued a SELECT query');
+  // The bridged-platform list must include 'linkedin' when the rollout flag is on.
+  assert.ok(
+    Array.isArray(select.params) && (select.params as unknown[]).includes('linkedin'),
+    'linkedin is in bridged-platform params when ARIES_LINKEDIN_ENABLED=1',
+  );
+  assert.ok(
+    Array.isArray(select.params) && (select.params as unknown[]).includes('facebook'),
+    'facebook is always included',
+  );
+});
+
 test('Reddit bridge: when ARIES_REDDIT_ENABLED is off, the DB query does NOT include "reddit"', async () => {
   const db = recordingDb([]);
   const fbOnlyEnv = { ANALYTICS_PROVIDER: 'composio' } as unknown as NodeJS.ProcessEnv;
@@ -298,6 +318,18 @@ test('Reddit bridge: when ARIES_REDDIT_ENABLED is off, the DB query does NOT inc
   assert.ok(
     !(select.params as unknown[]).includes('reddit'),
     'reddit is NOT in bridged-platform params when ARIES_REDDIT_ENABLED is off',
+  );
+});
+
+test('LinkedIn bridge: when ARIES_LINKEDIN_ENABLED is off, the DB query does NOT include "linkedin"', async () => {
+  const db = recordingDb([]);
+  const fbOnlyEnv = { ANALYTICS_PROVIDER: 'composio' } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, fbOnlyEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'issued a SELECT query');
+  assert.ok(
+    !(select.params as unknown[]).includes('linkedin'),
+    'linkedin is NOT in bridged-platform params when ARIES_LINKEDIN_ENABLED is off',
   );
 });
 

--- a/tests/insights-linkedin-adapter.test.ts
+++ b/tests/insights-linkedin-adapter.test.ts
@@ -1,0 +1,452 @@
+/**
+ * tests/insights-linkedin-adapter.test.ts
+ *
+ * Regression coverage for the LinkedIn insights adapter (#647 analytics;
+ * #648 documented comments limitation). All tests are self-contained — fake
+ * gateway / fake DB / no real Postgres, no network calls.
+ *
+ * Mirror pattern: tests/insights-x-adapter.test.ts /
+ * tests/insights-youtube-adapter.test.ts.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { LinkedInInsightsAdapter } from '@/backend/insights/adapters/linkedin/index';
+import {
+  hasAdapter,
+  getAdapter,
+  isLinkedInInsightsEnabled,
+} from '@/backend/insights/sync/adapter-factory';
+import { platformSupports } from '@/backend/insights/platforms/capabilities';
+import type {
+  ComposioGateway,
+  GatewayToolResult,
+} from '@/backend/integrations/composio/composio-client';
+import type { Queryable } from '@/backend/integrations/composio/connection-store';
+import { fakeConfig } from './composio/helpers';
+
+// ── Test doubles ──────────────────────────────────────────────────────────────
+
+interface RecordedCall {
+  slug: string;
+  connectedAccountId?: string;
+  arguments?: Record<string, unknown>;
+}
+
+/** Gateway that routes a canned result per action slug and records every call. */
+function routingGateway(
+  results: Record<string, GatewayToolResult>,
+): ComposioGateway & { calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    async findOrCreateManagedAuthConfig(s: string) { return `ac_${s}`; },
+    async initiateConnection() { return { connectionRequestId: 'cr', redirectUrl: null }; },
+    async listConnections() { return []; },
+    async getConnection() { return null; },
+    async deleteConnection() {},
+    async executeTool(slug, options) {
+      calls.push({
+        slug,
+        connectedAccountId: options.connectedAccountId,
+        arguments: options.arguments,
+      });
+      // Default: empty LinkedIn reactions collection.
+      return results[slug] ?? { data: { elements: [], paging: { total: 0 } }, successful: true, error: null };
+    },
+    async uploadFile(input) {
+      return { name: 'staged', mimetype: 'application/octet-stream', s3key: `s3/${input.toolSlug}` };
+    },
+  };
+}
+
+interface LinkedInPostRow {
+  platform_post_id: string;
+  published_at: Date | null;
+  caption: string | null;
+}
+
+interface RecordedDbQuery {
+  text: string;
+  params: unknown[];
+}
+
+/**
+ * Fake Queryable whose SELECT on the `posts` table returns the supplied rows.
+ * All other statements return empty (no real Postgres needed).
+ */
+function fakePostsDb(
+  rows: LinkedInPostRow[],
+): Queryable & { queries: RecordedDbQuery[] } {
+  const queries: RecordedDbQuery[] = [];
+  return {
+    queries,
+    async query<T = Record<string, unknown>>(text: string, params: unknown[] = []) {
+      queries.push({ text, params });
+      if (/^\s*select/i.test(text) && /FROM\s+posts/i.test(text)) {
+        return { rows: rows as unknown as T[], rowCount: rows.length };
+      }
+      return { rows: [] as T[], rowCount: 0 };
+    },
+  };
+}
+
+/** Standard adapter context shared across non-dormancy tests. */
+const ctx = { connectedAccountId: 'ca_li_1', tenantId: 42 };
+
+// ── fetchPostList ─────────────────────────────────────────────────────────────
+
+test('fetchPostList: queries tenant LinkedIn posts from DB, issues ZERO gateway calls, returns RawPost with URN preserved as externalPostId and correct permalink', async () => {
+  const db = fakePostsDb([
+    {
+      platform_post_id: 'urn:li:share:7181111111111111111',
+      published_at: new Date('2026-06-10'),
+      caption: 'Our latest campaign',
+    },
+    {
+      platform_post_id: 'urn:li:ugcPost:7182222222222222222',
+      published_at: new Date('2026-06-11'),
+      caption: null,
+    },
+  ]);
+  const gateway = routingGateway({});
+  const adapter = new LinkedInInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const posts = await adapter.fetchPostList('li_person_1');
+
+  // LinkedIn has no Composio list-posts action — zero gateway calls.
+  assert.equal(gateway.calls.length, 0, 'ZERO gateway calls — DB is the post universe');
+
+  // DB SELECT must be tenant-scoped and platform+status-filtered.
+  const dbQuery = db.queries[0];
+  assert.match(dbQuery.text, /FROM\s+posts/i);
+  assert.match(dbQuery.text, /platform\s*=\s*'linkedin'/i);
+  assert.match(dbQuery.text, /published_status\s*=\s*'published'/i);
+  assert.match(dbQuery.text, /platform_post_id IS NOT NULL/i);
+  assert.deepEqual(dbQuery.params, [42]); // tenant_id=$1
+
+  assert.equal(posts.length, 2);
+
+  // URN is preserved VERBATIM as externalPostId (no prefix stripping/adding).
+  assert.equal(posts[0].externalPostId, 'urn:li:share:7181111111111111111');
+  assert.equal(posts[0].caption, 'Our latest campaign');
+  assert.equal(posts[0].mediaType, 'image', 'LinkedIn feed posts normalised to image');
+  assert.equal(
+    posts[0].permalink,
+    'https://www.linkedin.com/feed/update/urn:li:share:7181111111111111111',
+    'permalink embeds the full URN',
+  );
+
+  assert.equal(posts[1].externalPostId, 'urn:li:ugcPost:7182222222222222222');
+  assert.equal(posts[1].caption, null);
+  assert.equal(
+    posts[1].permalink,
+    'https://www.linkedin.com/feed/update/urn:li:ugcPost:7182222222222222222',
+  );
+});
+
+test('fetchPostList: returns [] when tenant has no published LinkedIn posts (no gateway calls)', async () => {
+  const db = fakePostsDb([]);
+  const gateway = routingGateway({});
+  const adapter = new LinkedInInsightsAdapter(gateway, fakeConfig({ actions: {} }), db, ctx);
+
+  const posts = await adapter.fetchPostList('li_person_1');
+
+  assert.deepEqual(posts, []);
+  assert.equal(gateway.calls.length, 0, 'no gateway calls even when DB is empty');
+  assert.equal(db.queries.length, 1, 'one SELECT issued');
+});
+
+// ── fetchPostMetrics (#647 analytics) ────────────────────────────────────────
+
+test('fetchPostMetrics (#647): LINKEDIN_LIST_REACTIONS call carries entity=post URN VERBATIM (no prefix); paging.total → likes; rawSource correctly documents analytics scope and limitations', async () => {
+  const urn = 'urn:li:share:7181111111111111111';
+  const gateway = routingGateway({
+    LINKEDIN_LIST_REACTIONS: {
+      successful: true,
+      error: null,
+      data: {
+        elements: [
+          { reactionType: 'LIKE' },
+          { reactionType: 'EMPATHY' },
+          { reactionType: 'PRAISE' },
+        ],
+        paging: { total: 42, count: 3, start: 0 },
+      },
+    },
+  });
+  const adapter = new LinkedInInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  const metrics = await adapter.fetchPostMetrics(urn);
+
+  // One LINKEDIN_LIST_REACTIONS call with entity=URN VERBATIM (no prefix added).
+  assert.equal(gateway.calls.length, 1, 'exactly one LINKEDIN_LIST_REACTIONS call');
+  const call = gateway.calls[0];
+  assert.equal(call.slug, 'LINKEDIN_LIST_REACTIONS');
+  assert.equal(call.connectedAccountId, 'ca_li_1');
+  assert.equal(
+    call.arguments?.entity,
+    urn,
+    'entity is the URN VERBATIM — no urn:li: prefix added',
+  );
+  assert.equal(call.arguments?.count, 100, 'requests a page of 100 to detect the floor');
+
+  // paging.total wins (authoritative count, even when elements.length < count).
+  assert.equal(metrics.length, 1);
+  assert.equal(metrics[0].likes, 42, 'paging.total → likes');
+
+  // Personal reactions expose no impressions — 0 is an explicit placeholder, not a fetched value.
+  assert.equal(metrics[0].views, 0, 'views=0 placeholder (no impressions for personal accounts)');
+  assert.equal(metrics[0].commentsCount, 0, 'commentsCount=0 placeholder (no comment count for personal accounts)');
+  assert.equal(metrics[0].shares, 0, 'shares=0 placeholder (no share count for personal accounts)');
+
+  // rawSource documents the analytics scope honestly so consumers can distinguish
+  // "genuinely zero" from "metric unavailable".
+  const rs = metrics[0].rawSource;
+  assert.equal(rs.analytics_scope, 'personal_reactions_only', 'rawSource.analytics_scope must be personal_reactions_only');
+  assert.equal(rs.org_stats_unavailable_reason, 'requires_org_admin', 'rawSource.org_stats_unavailable_reason must be requires_org_admin');
+  assert.equal(rs.impressions_available, false, 'rawSource.impressions_available must be false');
+  assert.equal(rs.reaction_count, 42);
+  assert.equal(rs.reaction_count_source, 'paging_total', 'paging.total path → source=paging_total');
+  assert.equal(rs.reaction_count_is_floor, false, 'paging.total is the exact count — not a floor');
+});
+
+test('fetchPostMetrics: paging.total absent + full page (elements.length=100) → reaction_count_is_floor=true', async () => {
+  const urn = 'urn:li:ugcPost:7182222222222222222';
+  // Saturated page — exactly 100 elements, no paging.total.
+  const elements = Array.from({ length: 100 }, (_, i) => ({ reactionType: i % 2 === 0 ? 'LIKE' : 'EMPATHY' }));
+  const gateway = routingGateway({
+    LINKEDIN_LIST_REACTIONS: {
+      successful: true,
+      error: null,
+      data: {
+        elements,
+        paging: { count: 100, start: 0 }, // total intentionally absent
+      },
+    },
+  });
+  const adapter = new LinkedInInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  const metrics = await adapter.fetchPostMetrics(urn);
+
+  assert.equal(metrics.length, 1, 'a row is emitted even when paging.total is absent');
+  assert.equal(metrics[0].likes, 100, 'falls back to elements.length');
+  assert.equal(
+    metrics[0].rawSource.reaction_count_source,
+    'elements_length',
+    'source is elements_length when paging.total is absent',
+  );
+  assert.equal(
+    metrics[0].rawSource.reaction_count_is_floor,
+    true,
+    'length=100 saturates the page → is_floor must be true',
+  );
+});
+
+test('fetchPostMetrics: paging.total absent + partial page (elements.length < 100) → is_floor=false (exact count)', async () => {
+  const urn = 'urn:li:share:7183333333333333333';
+  const gateway = routingGateway({
+    LINKEDIN_LIST_REACTIONS: {
+      successful: true,
+      error: null,
+      data: {
+        elements: [{ reactionType: 'LIKE' }, { reactionType: 'PRAISE' }],
+        paging: { count: 100, start: 0 },
+      },
+    },
+  });
+  const adapter = new LinkedInInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  const metrics = await adapter.fetchPostMetrics(urn);
+
+  assert.equal(metrics.length, 1);
+  assert.equal(metrics[0].likes, 2);
+  assert.equal(metrics[0].rawSource.reaction_count_is_floor, false, 'partial page is exact, not a floor');
+});
+
+test('fetchPostMetrics: unparseable / completely absent elements and paging → [] (no fabricated zero row)', async () => {
+  const gateway = routingGateway({
+    LINKEDIN_LIST_REACTIONS: {
+      successful: true,
+      error: null,
+      data: {
+        // neither elements nor paging.total present → count is null → no row emitted.
+        someOtherField: 'garbage',
+      },
+    },
+  });
+  const adapter = new LinkedInInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  const metrics = await adapter.fetchPostMetrics('urn:li:share:9999');
+
+  assert.deepEqual(metrics, [], 'no usable count → empty, never a fabricated zero row');
+});
+
+test('fetchPostMetrics: real zero reactions (paging.total=0) emits a row with likes=0 (a measured 0 is real signal)', async () => {
+  const urn = 'urn:li:share:7184444444444444444';
+  const gateway = routingGateway({
+    LINKEDIN_LIST_REACTIONS: {
+      successful: true,
+      error: null,
+      data: {
+        elements: [],
+        paging: { total: 0, count: 100, start: 0 },
+      },
+    },
+  });
+  const adapter = new LinkedInInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  const metrics = await adapter.fetchPostMetrics(urn);
+
+  // A measured 0 is a real signal and IS emitted (mirrors FB/X convention).
+  assert.equal(metrics.length, 1, 'measured zero emits a row');
+  assert.equal(metrics[0].likes, 0, 'likes=0 — the real reaction count');
+  assert.equal(metrics[0].rawSource.reaction_count, 0);
+  assert.equal(metrics[0].rawSource.reaction_count_is_floor, false);
+});
+
+// ── #648 honesty — fetchComments ──────────────────────────────────────────────
+
+test('#648: fetchComments always returns [], issues ZERO gateway calls, never throws — documented platform limitation', async () => {
+  const gateway = routingGateway({});
+  const adapter = new LinkedInInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  let result: unknown[] | undefined;
+  let threw = false;
+  try {
+    result = await adapter.fetchComments('urn:li:share:7181111111111111111', 100);
+  } catch {
+    threw = true;
+  }
+
+  assert.equal(threw, false, 'fetchComments must never throw (sync run stays ok)');
+  assert.deepEqual(result, [], 'fetchComments always returns the honest empty array');
+  assert.equal(gateway.calls.length, 0, 'ZERO gateway calls — LinkedIn has no list-comments action');
+});
+
+// ── fetchAccountMetrics ───────────────────────────────────────────────────────
+
+test('fetchAccountMetrics: always returns [] — org-level share stats require org-admin scope not available for personal accounts', async () => {
+  const gateway = routingGateway({});
+  const adapter = new LinkedInInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: {} }),
+    fakePostsDb([]),
+    ctx,
+  );
+
+  const result = await adapter.fetchAccountMetrics('li_person_1', { from: '2026-06-01', to: '2026-06-18' });
+
+  assert.deepEqual(result, []);
+  assert.equal(gateway.calls.length, 0, 'no gateway calls — never fabricate an account series');
+});
+
+// ── Capabilities (#648 documented limitation) ─────────────────────────────────
+
+test('capabilities: platformSupports("linkedin","comments") is false — documented #648 limitation means no comments capability advertised', () => {
+  assert.equal(
+    platformSupports('linkedin', 'comments'),
+    false,
+    'comments capability must be absent for linkedin (#648)',
+  );
+});
+
+test('capabilities: platformSupports("linkedin","post_daily_metrics") is true — analytics (#647) IS supported', () => {
+  assert.equal(
+    platformSupports('linkedin', 'post_daily_metrics'),
+    true,
+    'post_daily_metrics must be present for linkedin (#647)',
+  );
+});
+
+test('capabilities: platformSupports("linkedin","post_list") is true', () => {
+  assert.equal(platformSupports('linkedin', 'post_list'), true);
+});
+
+test('capabilities: platformSupports("linkedin","account_daily_metrics") is false — org-admin not available for personal accounts', () => {
+  assert.equal(platformSupports('linkedin', 'account_daily_metrics'), false);
+});
+
+// ── Dormancy / off-switch ─────────────────────────────────────────────────────
+
+const LI_COMPOSIO_ENV = {
+  ARIES_LINKEDIN_ENABLED: '1',
+  ANALYTICS_PROVIDER: 'composio',
+} as unknown as NodeJS.ProcessEnv;
+
+const FLAG_OFF_ENV = {
+  ANALYTICS_PROVIDER: 'composio',
+} as unknown as NodeJS.ProcessEnv;
+
+const PROVIDER_OFF_ENV = {
+  ARIES_LINKEDIN_ENABLED: '1',
+} as unknown as NodeJS.ProcessEnv;
+
+test('dormancy: isLinkedInInsightsEnabled requires BOTH ARIES_LINKEDIN_ENABLED=1 AND ANALYTICS_PROVIDER=composio', () => {
+  assert.equal(isLinkedInInsightsEnabled(LI_COMPOSIO_ENV), true, 'both flags on → enabled');
+  assert.equal(isLinkedInInsightsEnabled(FLAG_OFF_ENV), false, 'ARIES_LINKEDIN_ENABLED absent → disabled');
+  assert.equal(isLinkedInInsightsEnabled(PROVIDER_OFF_ENV), false, 'ANALYTICS_PROVIDER!=composio → disabled');
+  assert.equal(
+    isLinkedInInsightsEnabled({} as unknown as NodeJS.ProcessEnv),
+    false,
+    'no flags → disabled (default OFF)',
+  );
+});
+
+test('dormancy: hasAdapter("linkedin") mirrors isLinkedInInsightsEnabled for all flag combinations', () => {
+  assert.equal(hasAdapter('linkedin', LI_COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('linkedin', FLAG_OFF_ENV), false);
+  assert.equal(hasAdapter('linkedin', PROVIDER_OFF_ENV), false);
+  assert.equal(hasAdapter('linkedin', {} as unknown as NodeJS.ProcessEnv), false);
+});
+
+test('dormancy: getAdapter("linkedin") throws a diagnostic error mentioning ARIES_LINKEDIN_ENABLED when disabled', () => {
+  const prevLi = process.env.ARIES_LINKEDIN_ENABLED;
+  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  // Ensure both axes are off so the REGISTRY guard fires.
+  delete process.env.ARIES_LINKEDIN_ENABLED;
+  process.env.ANALYTICS_PROVIDER = 'direct_meta';
+  try {
+    assert.throws(
+      () => getAdapter('linkedin', { connectedAccountId: 'ca_li', tenantId: 1 }),
+      /ARIES_LINKEDIN_ENABLED/,
+      'error message must mention the flag name so operators know what to set',
+    );
+  } finally {
+    if (prevLi === undefined) delete process.env.ARIES_LINKEDIN_ENABLED;
+    else process.env.ARIES_LINKEDIN_ENABLED = prevLi;
+    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
+    else process.env.ANALYTICS_PROVIDER = prevProvider;
+  }
+});


### PR DESCRIPTION
Closes #647

## What

Composio-backed LinkedIn insights adapter (`backend/insights/adapters/linkedin/index.ts`), wired into the insights-sync worker behind the EXISTING `ARIES_LINKEDIN_ENABLED` flag (reused from the LinkedIn connect/publish path #645/#646 — no new flag). Ships **DORMANT**: the path activates only when `ARIES_LINKEDIN_ENABLED=1` AND `ANALYTICS_PROVIDER=composio`; otherwise the bridge excludes linkedin, `hasAdapter('linkedin')` is false, and `getAdapter` throws. FB/IG/X/YouTube/Reddit behavior is unchanged.

## Analytics — personal reactions only (#647)

- `fetchPostMetrics` → one `LINKEDIN_LIST_REACTIONS` call per post (NOT batchable; ridden by the dispatcher's bounded **sequential** per-post loop — no fan-out). Reaction-count precedence: authoritative `paging.total` → `elements.length` (flagged a FLOOR at page size 100) → `null` (no row emitted; a measured 0 IS emitted). Reaction count maps HONESTLY onto `likes`.
- `entity` is passed VERBATIM (no invented `urn:li:share:`/`ugcPost:` prefix).
- views/shares/commentsCount stay 0 placeholders; `rawSource` records `analytics_scope:'personal_reactions_only'`, `org_stats_unavailable_reason:'requires_org_admin'`, `impressions_available:false`. No metric is ever fabricated.
- `fetchPostList` is DB-only (zero Composio calls), tenant-scoped. `fetchAccountMetrics` returns `[]` — org share stats (`LINKEDIN_GET_SHARE_STATS`: impressions/clicks/comments/shares) need an org-admin URN #645 did not capture; that org track is a documented follow-up.

## #648 (LinkedIn comments) is a documented limitation — deliberately NOT closed here

There is **no Composio list-comments action for LinkedIn**, so `fetchComments` returns an honest empty array (never throws, never fabricates a comment), and the `comments` capability is OMITTED from the LinkedIn capability set so the UI advertises no LinkedIn comments. **This PR does NOT `Closes #648`** — #648 stays open as a documented platform limitation for a future org / App-Review / proxy track.

## Notes / residual risk

- Same cross-cutting frontend un-pin dependency as the other new-platform insights units applies.
- Prod activation needs `ARIES_LINKEDIN_ENABLED=1` + `ANALYTICS_PROVIDER=composio` + (optional) `COMPOSIO_LINKEDIN_POST_INSIGHTS_ACTION` (verified code default `LINKEDIN_LIST_REACTIONS`).
- **Open contract risk for live-call confirmation at flag-on:** the `LINKEDIN_LIST_REACTIONS` response shape (`paging.total` / `elements`), and that #646 stores the full post URN as `platform_post_id` — both deserve a live-call check the first time the flag is enabled.

## Test evidence

- New `tests/insights-linkedin-adapter.test.ts` (16) + 2 LinkedIn bridge cases in `tests/insights-ensure-account.test.ts`.
- Rebased onto current master (post Reddit insights #659); 7 shared registry files resolved as a reddit+linkedin union; `npm run typecheck` green (exhaustive `Record<Platform>` maps compile), 62/62 focused tests pass (linkedin + bridge + reddit + the two full-suite mapper invariants), `npm run verify` green, `guardrails:agent` clean (2 ahead, 0 behind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)