### PR TITLE
fix(integrations): graceful not-configured connect error for custom-auth toolkits (X, Reddit)

### DIFF
--- a/backend/integrations/composio/composio-account-provider.ts
+++ b/backend/integrations/composio/composio-account-provider.ts
@@ -63,7 +63,18 @@ export class ComposioAccountProvider implements AccountConnectionProvider {
     // dashboard setup (just the API key).
     let authConfigId = this.config.authConfigIdFor(platform);
     if (!authConfigId) {
-      authConfigId = await this.gateway.findOrCreateManagedAuthConfig(this.config.toolkitSlugFor(platform));
+      try {
+        authConfigId = await this.gateway.findOrCreateManagedAuthConfig(this.config.toolkitSlugFor(platform));
+      } catch {
+        // Custom-OAuth toolkits (e.g. twitter/X, reddit) have no Composio-managed
+        // shared credentials. Throw a frontend-safe, actionable error that names
+        // the env var the operator must set — never leak the raw SDK error text.
+        const envKey = `COMPOSIO_${platform.toUpperCase()}_AUTH_CONFIG_ID`;
+        throw new ComposioConfigError(
+          `${platform} requires a custom OAuth app and is not configured for Composio-managed credentials. ` +
+            `Set ${envKey} to the Composio auth-config id for this platform.`,
+        );
+      }
     }
 
     const initiated = await this.gateway.initiateConnection(externalUserId, authConfigId, options?.callbackUrl);

--- a/tests/composio-connect-hardening.test.ts
+++ b/tests/composio-connect-hardening.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression coverage for #655 (X connect 500s with raw Composio error) and
+ * #640 (Reddit connect falls back to wrong default).
+ *
+ * Root cause: when no per-platform auth-config id is configured, the account
+ * provider falls back to findOrCreateManagedAuthConfig. For custom-OAuth
+ * toolkits (twitter/X, reddit) that have NO Composio-managed shared
+ * credentials, the SDK throws a raw error. That raw error escaped as HTTP 500
+ * with reason:'composio_error' and the raw SDK message visible to operators.
+ *
+ * Fix: wrap findOrCreateManagedAuthConfig in a try/catch; on failure raise
+ * ComposioConfigError (503, composio_not_configured) with a frontend-safe
+ * message that names COMPOSIO_<PLATFORM>_AUTH_CONFIG_ID so the operator knows
+ * exactly what env var to set. Managed toolkits (facebook/instagram/etc.) are
+ * byte-identical — their findOrCreateManagedAuthConfig succeeds so the catch
+ * never fires.
+ *
+ * Failure modes locked:
+ *  a. X (twitter) connect with rejecting gateway → ComposioConfigError,
+ *     message names COMPOSIO_X_AUTH_CONFIG_ID, does not include raw SDK text.
+ *  b. Reddit connect with rejecting gateway → ComposioConfigError,
+ *     message names COMPOSIO_REDDIT_AUTH_CONFIG_ID, does not include raw SDK text.
+ *  c. Regression: facebook with resolving gateway → connect succeeds,
+ *     initiateConnection is called, no throw.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ComposioAccountProvider } from '@/backend/integrations/composio/composio-account-provider';
+import { ComposioConfigError } from '@/backend/integrations/composio/errors';
+import type {
+  ComposioGateway,
+  GatewayConnection,
+  GatewayInitiateResult,
+  GatewayToolResult,
+} from '@/backend/integrations/composio/composio-client';
+import { fakeConfig, fakeDb } from './composio/helpers';
+
+// ── Fake gateway helpers ──────────────────────────────────────────────────────
+
+/**
+ * A gateway whose findOrCreateManagedAuthConfig REJECTS with the given error.
+ * All other gateway methods are no-ops so the failure path can be tested
+ * without any DB or network interaction.
+ */
+function rejectingGateway(err: Error): ComposioGateway {
+  return {
+    async findOrCreateManagedAuthConfig(): Promise<string> {
+      throw err;
+    },
+    async initiateConnection(): Promise<GatewayInitiateResult> {
+      return { connectionRequestId: 'cr_1', redirectUrl: 'https://composio.dev/connect/abc' };
+    },
+    async listConnections(): Promise<GatewayConnection[]> {
+      return [];
+    },
+    async getConnection(): Promise<GatewayConnection | null> {
+      return null;
+    },
+    async deleteConnection(): Promise<void> {
+      /* no-op */
+    },
+    async executeTool(): Promise<GatewayToolResult> {
+      return { data: {}, successful: true, error: null };
+    },
+    async uploadFile() {
+      return { name: 'staged.jpg', mimetype: 'image/jpeg', s3key: 's3/test/staged.jpg' };
+    },
+  };
+}
+
+/**
+ * A gateway whose findOrCreateManagedAuthConfig RESOLVES. Tracks whether
+ * initiateConnection was invoked (the managed-path regression guard).
+ */
+function resolvingGateway() {
+  const state = { initiateConnectionCalled: false };
+  const gw: ComposioGateway = {
+    async findOrCreateManagedAuthConfig(): Promise<string> {
+      return 'ac_managed_facebook';
+    },
+    async initiateConnection(): Promise<GatewayInitiateResult> {
+      state.initiateConnectionCalled = true;
+      return { connectionRequestId: 'cr_1', redirectUrl: 'https://composio.dev/connect/abc' };
+    },
+    async listConnections(): Promise<GatewayConnection[]> {
+      return [];
+    },
+    async getConnection(): Promise<GatewayConnection | null> {
+      return null;
+    },
+    async deleteConnection(): Promise<void> {
+      /* no-op */
+    },
+    async executeTool(): Promise<GatewayToolResult> {
+      return { data: {}, successful: true, error: null };
+    },
+    async uploadFile() {
+      return { name: 'staged.jpg', mimetype: 'image/jpeg', s3key: 's3/test/staged.jpg' };
+    },
+  };
+  return { gw, state };
+}
+
+// Raw SDK error text that must never appear in the frontend-visible message.
+const RAW_SDK_ERROR = 'Internal Composio SDK error: no managed credentials for this toolkit';
+
+const tenantId = '99';
+const userId = 'aries-tenant-99';
+
+// ── a. X (#655): raw SDK error → ComposioConfigError naming COMPOSIO_X_AUTH_CONFIG_ID ──
+
+test('#655 X connect: findOrCreateManagedAuthConfig failure raises ComposioConfigError, not raw SDK error', async () => {
+  const provider = new ComposioAccountProvider(
+    rejectingGateway(new Error(RAW_SDK_ERROR)),
+    fakeConfig({ authConfigId: null }),
+    fakeDb(),
+  );
+
+  await assert.rejects(
+    () => provider.createConnectLink(userId, 'x', 'full', { tenantId }),
+    (err: unknown) => {
+      assert.ok(err instanceof ComposioConfigError, `expected ComposioConfigError, got ${String(err)}`);
+      assert.ok(
+        err.message.includes('COMPOSIO_X_AUTH_CONFIG_ID'),
+        `message must name COMPOSIO_X_AUTH_CONFIG_ID; got: ${err.message}`,
+      );
+      assert.ok(
+        !err.message.includes(RAW_SDK_ERROR),
+        `message must NOT include raw SDK error text; got: ${err.message}`,
+      );
+      assert.equal(err.code, 'composio_not_configured');
+      assert.equal(err.status, 503);
+      return true;
+    },
+  );
+});
+
+// ── b. Reddit (#640): raw SDK error → ComposioConfigError naming COMPOSIO_REDDIT_AUTH_CONFIG_ID ──
+
+test('#640 Reddit connect: findOrCreateManagedAuthConfig failure raises ComposioConfigError, not raw SDK error', async () => {
+  const provider = new ComposioAccountProvider(
+    rejectingGateway(new Error(RAW_SDK_ERROR)),
+    fakeConfig({ authConfigId: null }),
+    fakeDb(),
+  );
+
+  await assert.rejects(
+    () => provider.createConnectLink(userId, 'reddit', 'full', { tenantId }),
+    (err: unknown) => {
+      assert.ok(err instanceof ComposioConfigError, `expected ComposioConfigError, got ${String(err)}`);
+      assert.ok(
+        err.message.includes('COMPOSIO_REDDIT_AUTH_CONFIG_ID'),
+        `message must name COMPOSIO_REDDIT_AUTH_CONFIG_ID; got: ${err.message}`,
+      );
+      assert.ok(
+        !err.message.includes(RAW_SDK_ERROR),
+        `message must NOT include raw SDK error text; got: ${err.message}`,
+      );
+      assert.equal(err.code, 'composio_not_configured');
+      assert.equal(err.status, 503);
+      return true;
+    },
+  );
+});
+
+// ── c. Regression guard: managed toolkit (facebook) is byte-identical ─────────
+
+test('managed toolkit (facebook): findOrCreateManagedAuthConfig resolves → connect succeeds, initiateConnection called', async () => {
+  const { gw, state } = resolvingGateway();
+  const provider = new ComposioAccountProvider(
+    gw,
+    fakeConfig({ authConfigId: null }), // no configured id → falls through to findOrCreate
+    fakeDb(),
+  );
+
+  // Must not throw; must proceed to initiateConnection and return a connectUrl.
+  const result = await provider.createConnectLink(userId, 'facebook', 'full', { tenantId });
+
+  assert.equal(result.connectUrl, 'https://composio.dev/connect/abc');
+  assert.ok(
+    state.initiateConnectionCalled,
+    'initiateConnection must be called when findOrCreateManagedAuthConfig resolves',
+  );
+  assert.equal(result.platform, 'facebook');
+  assert.equal(result.provider, 'composio');
+});


### PR DESCRIPTION
Closes #655
Closes #640

## Problem
When an operator clicks Connect for **X** or **Reddit**, the Composio account provider has no per-platform `COMPOSIO_<P>_AUTH_CONFIG_ID` configured, so it falls back to `findOrCreateManagedAuthConfig`. Custom-OAuth toolkits (twitter/X, reddit) have **no** Composio-managed shared credentials, so the SDK throws a raw error. That raw error escaped the handler as an HTTP **500** with `reason: 'composio_error'` and the **raw SDK message** rendered verbatim in the operator UI.

## Fix
Wrap the `findOrCreateManagedAuthConfig` fallback in `try/catch` (`backend/integrations/composio/composio-account-provider.ts`). On failure, throw a `ComposioConfigError` — an `IntegrationError` mapped to **503 / `composio_not_configured`** — whose message is **fully synthetic** (built from the platform name + the derived env key) and names exactly which env var to set:

> `<platform> requires a custom OAuth app and is not configured for Composio-managed credentials. Set COMPOSIO_<PLATFORM>_AUTH_CONFIG_ID to the Composio auth-config id for this platform.`

The raw SDK error text is never included, so nothing leaks to the operator-facing surface. The throw happens **before** `initiateConnection`/`upsertConnection`, so there is no DB write on the failure path and no new query fan-out.

## Managed toolkits are byte-identical
The `catch` fires only when `findOrCreateManagedAuthConfig` actually throws. Managed toolkits (Facebook, Instagram, YouTube, LinkedIn) resolve that call, so the catch never fires and their connect flow is unchanged. A regression test (facebook, resolving gateway) locks this: connect still proceeds to `initiateConnection` and returns a `connectUrl`.

## Tests
`tests/composio-connect-hardening.test.ts` (new):
- **#655 X**: rejecting gateway -> `ComposioConfigError`, message names `COMPOSIO_X_AUTH_CONFIG_ID`, does **not** contain the raw SDK text, `code='composio_not_configured'`, `status=503`.
- **#640 Reddit**: same, naming `COMPOSIO_REDDIT_AUTH_CONFIG_ID`.
- **Regression**: facebook (managed) connect succeeds, `initiateConnection` invoked, no throw.

Fails pre-fix (raw `Error`, not `ComposioConfigError`), passes post-fix. Focused gate green 3/3; full green-gate verified (typecheck clean, `npm run verify` all suites, banned-patterns clean).

## Provisioning note
This change only makes the **unprovisioned** state fail cleanly. Actually enabling X / Reddit connect in prod still requires provisioning the auth configs + platform credentials in the prod `.env`:
- X: `COMPOSIO_X_AUTH_CONFIG_ID` + X (twitter) OAuth app credentials
- Reddit: `COMPOSIO_REDDIT_AUTH_CONFIG_ID` + Reddit OAuth app credentials

## Residual risk
Low. Failure-path-only behavioral change for custom-auth toolkits; managed-toolkit connect is byte-identical. The original SDK error is not preserved as a `cause` (the `IntegrationError` base accepts no cause and the route never logs it) — a possible future observability follow-up, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)