### PR TITLE
fix(integrations): admit X/YouTube/Reddit/LinkedIn to the native-reply Composio seam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -459,6 +459,21 @@ COMPOSIO_LINKEDIN_POST_INSIGHTS_ACTION=
 #   reply_comment     -> FACEBOOK_CREATE_COMMENT     (object_id = comment id)
 COMPOSIO_FACEBOOK_REPLY_COMMENT_ACTION=
 
+# New-platform native reply via Composio (#634/gate-5) — X / YouTube / Reddit /
+# LinkedIn. Each is admitted to the reply endpoint ONLY when its own rollout flag
+# (ARIES_X_ENABLED / ARIES_YOUTUBE_ENABLED / ARIES_REDDIT_ENABLED /
+# ARIES_LINKEDIN_ENABLED) AND the master ARIES_NATIVE_REPLY_ENABLED are on. These
+# overrides are OPTIONAL — the verified-default action slug (in the comment) is the
+# code default; set only to pin a different toolkit-version slug.
+#   x        -> TWITTER_CREATION_OF_A_POST   (reply = create-post + reply_in_reply_to_tweet_id)
+#   youtube  -> YOUTUBE_CREATE_COMMENT_REPLY (parentId + textOriginal)
+#   reddit   -> REDDIT_POST_REDDIT_COMMENT   (thing_id t1_<id> + text; rate-limited)
+#   linkedin -> LINKEDIN_CREATE_COMMENT_ON_POST (actor + object + message.text; comments not yet ingested #648)
+COMPOSIO_X_REPLY_COMMENT_ACTION=
+COMPOSIO_YOUTUBE_REPLY_COMMENT_ACTION=
+COMPOSIO_REDDIT_REPLY_COMMENT_ACTION=
+COMPOSIO_LINKEDIN_REPLY_COMMENT_ACTION=
+
 # Transactional email (password reset flow) — Resend https://resend.com
 # Free tier: 100 emails/day, 3000/month. The Resend Node SDK reads
 # RESEND_API_KEY directly from process.env — don't rename it.

--- a/app/api/insights/comments/[commentId]/reply/handler.ts
+++ b/app/api/insights/comments/[commentId]/reply/handler.ts
@@ -4,7 +4,12 @@ import pool from '@/lib/db';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 import { isNativeReplyEnabled } from '@/backend/integrations/meta-reply-env';
 import { replyToComment, type MetaReplyRequest, type MetaReplySuccess } from '@/backend/integrations/meta-reply';
-import { replyToCommentViaComposio, shouldUseComposioReply } from '@/backend/integrations/composio/composio-reply';
+import {
+  replyToCommentViaComposio,
+  replyToCommentViaComposioForPlatform,
+  shouldUseComposioReply,
+  isComposioReplyPlatform,
+} from '@/backend/integrations/composio/composio-reply';
 import {
   classifyMetaPublishFailure,
   classifyMetaPublishFailureKind,
@@ -110,11 +115,17 @@ export async function handleReplyToComment(
     id: string | number;
     platform: string;
     external_comment_id: string;
+    external_post_id: string;
     is_replied: boolean;
   }>(
-    `SELECT id, platform, external_comment_id, is_replied
-     FROM insights_comments
-     WHERE id = $1 AND tenant_id = $2`,
+    // INNER JOIN insights_posts to also pull the parent post's external id. Every
+    // comment has a NOT NULL post_id -> insights_posts(id), so the join never
+    // drops a row. external_post_id is the LinkedIn reply `object` (share/ugcPost
+    // URN); harmless/ignored for FB/IG/X/YouTube/Reddit.
+    `SELECT c.id, c.platform, c.external_comment_id, c.is_replied, p.external_post_id
+     FROM insights_comments c
+     INNER JOIN insights_posts p ON p.id = c.post_id
+     WHERE c.id = $1 AND c.tenant_id = $2`,
     [commentId, tenantId],
   );
   const comment = loaded.rows[0];
@@ -126,13 +137,17 @@ export async function handleReplyToComment(
     return json({ status: 'already_replied', comment_id: commentId }, 200);
   }
 
-  // (e) Provider guard — only Meta (IG/FB) is reply-capable on this path.
-  if (!isMetaProvider(comment.platform)) {
+  // (e) Provider guard — Meta (IG/FB) on the direct/Composio-FB path, or one of
+  // the new Composio-only platforms (X/YouTube/Reddit/LinkedIn) when ITS rollout
+  // flag is on. Each new platform stays invisible (422 reply_not_supported,
+  // byte-identical to a Meta-platform reject) until its ARIES_<P>_ENABLED flips.
+  const platform = comment.platform;
+  if (!isMetaProvider(platform) && !isComposioReplyPlatform(platform, deps.env)) {
     return json(
       {
         status: 'error',
         reason: 'reply_not_supported',
-        message: `Replies are not supported for platform '${comment.platform}'.`,
+        message: `Replies are not supported for platform '${platform}'.`,
       },
       422,
     );
@@ -168,19 +183,26 @@ export async function handleReplyToComment(
   // outcome-unknown handling below is identical.
   const replyRequest: MetaReplyRequest = {
     tenantId: String(tenantId),
-    provider: comment.platform,
+    provider: platform,
     externalCommentId: comment.external_comment_id,
+    externalPostId: comment.external_post_id,
     message,
   };
-  const useComposioReply = shouldUseComposioReply(comment.platform, deps.env);
+  const useComposioReply = shouldUseComposioReply(platform, deps.env);
 
   let replySucceeded = false;
   try {
-    const published = useComposioReply
-      ? await (deps.composioReply
-          ? deps.composioReply(replyRequest)
-          : replyToCommentViaComposio(replyRequest, deps.env, { db: deps.db }))
-      : await replyToComment({ ...replyRequest, fetchImpl: deps.fetchImpl });
+    // New Composio-only platforms (X/YouTube/Reddit/LinkedIn) route through the
+    // per-platform Composio reply; the FB/IG branch below is UNCHANGED. Every
+    // path returns a { platformReplyId } and throws the same MetaPublishError
+    // taxonomy, so the claim/rollback/outcome-unknown handling is identical.
+    const published = isComposioReplyPlatform(platform, deps.env)
+      ? await replyToCommentViaComposioForPlatform(replyRequest, platform, deps.env, { db: deps.db })
+      : useComposioReply
+        ? await (deps.composioReply
+            ? deps.composioReply(replyRequest)
+            : replyToCommentViaComposio(replyRequest, deps.env, { db: deps.db }))
+        : await replyToComment({ ...replyRequest, fetchImpl: deps.fetchImpl });
     replySucceeded = true;
 
     // (h) Confirmed success — record the platform reply id + delivery stamp.

--- a/backend/integrations/composio/composio-reply.ts
+++ b/backend/integrations/composio/composio-reply.ts
@@ -26,6 +26,13 @@
 import { MetaPublishError, normalizeMetaProvider } from '../meta-publishing';
 import type { MetaReplyRequest, MetaReplySuccess } from '../meta-reply';
 import { effectivePublishProvider } from '../providers/provider-factory';
+import {
+  isXEnabled,
+  isYouTubeEnabled,
+  isRedditEnabled,
+  isLinkedInEnabled,
+} from '../providers/integration-config';
+import type { IntegrationPlatform } from '../providers/types';
 import { resolveComposioConfig, type ComposioConfig } from './composio-config';
 import { createComposioGateway, type ComposioGateway } from './composio-client';
 import { getConnectionRow, type Queryable } from './connection-store';
@@ -173,4 +180,291 @@ export async function replyToCommentViaComposio(
   }
 
   return { provider, platformReplyId, connectionId: conn.connectedAccountId };
+}
+
+// ---------------------------------------------------------------------------
+// New-platform native reply (#634: X / YouTube / Reddit / LinkedIn).
+//
+// These platforms have NO direct-Graph reply path — Composio is the only reply
+// transport — so admission is gated solely by the platform's own rollout flag
+// (ARIES_<P>_ENABLED) PLUS the master ARIES_NATIVE_REPLY_ENABLED gate in the
+// route handler. They deliberately do NOT route through isMetaProvider /
+// normalizeMetaProvider (those stay Facebook/Instagram-only); the connection is
+// loaded by the RAW Aries platform key (e.g. 'x', whose Composio toolkit is
+// 'twitter'). Every failure throws the SAME MetaPublishError taxonomy as the FB
+// reply above so the route handler's claim/rollback/outcome-unknown logic is
+// reused verbatim — see module header.
+// ---------------------------------------------------------------------------
+
+/** Result of a new-platform Composio reply. No `provider` field — the handler
+ *  reads only `.platformReplyId` (and stamps `.connectionId` is unused here). */
+export type ComposioPlatformReplyResult = {
+  platformReplyId: string;
+  connectionId: string;
+};
+
+/**
+ * Verified-default reply action slug per non-Meta platform. Overridable via
+ * COMPOSIO_<PLATFORM>_REPLY_COMMENT_ACTION (the generic actionEnvKey). Sourced
+ * from the verified Composio catalog (2026-06-18):
+ *   x        -> TWITTER_CREATION_OF_A_POST   (reply = create-post + in-reply-to)
+ *   youtube  -> YOUTUBE_CREATE_COMMENT_REPLY (parentId + textOriginal)
+ *   reddit   -> REDDIT_POST_REDDIT_COMMENT   (thing_id t1_<id> + text)
+ *   linkedin -> LINKEDIN_CREATE_COMMENT_ON_POST (actor + object + message.text)
+ */
+export const DEFAULT_COMPOSIO_REPLY_SLUG: Readonly<Record<string, string>> = {
+  x: 'TWITTER_CREATION_OF_A_POST',
+  youtube: 'YOUTUBE_CREATE_COMMENT_REPLY',
+  reddit: 'REDDIT_POST_REDDIT_COMMENT',
+  linkedin: 'LINKEDIN_CREATE_COMMENT_ON_POST',
+};
+
+/** LinkedIn comment `message.text` cap (1250). Mirrors linkedinCommentary's
+ *  ellipsis idiom (single `…` glyph counted within the cap). */
+const LINKEDIN_COMMENT_MAX = 1250;
+function clampLinkedIn(text: string, max: number = LINKEDIN_COMMENT_MAX): string {
+  const t = text ?? '';
+  if (t.length <= max) return t;
+  return `${t.slice(0, max - 1)}…`;
+}
+
+/**
+ * Reddit's reply target `thing_id` must be a `t1_<base36>` comment fullname. The
+ * adapter stores the fullname (`comment.name`, already `t1_<id>`) and falls back
+ * to the bare base36 id only when `name` is absent — so prefix the bare form but
+ * NEVER double-prefix an already-`t1_` id.
+ */
+function redditThingId(id: string): string {
+  const trimmed = id.trim();
+  return trimmed.startsWith('t1_') ? trimmed : `t1_${trimmed}`;
+}
+
+/** A transport error that means Reddit rate-limited/cooled-down the write — the
+ *  comment was DEFINITELY never created, so it is safe to roll back + re-attempt
+ *  (unlike a generic transport drop, which is outcome-unknown). */
+function isRedditRateLimit(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    /\b429\b/.test(msg) ||
+    msg.includes('rate limit') ||
+    msg.includes('ratelimit') ||
+    msg.includes('rate-limit') ||
+    msg.includes('too many requests') ||
+    msg.includes('cooldown') ||
+    msg.includes('try again later')
+  );
+}
+
+/**
+ * Pull a created-reply id from a loosely-typed tool result, trying each candidate
+ * key in order and looking one `data` wrap deep (Composio sometimes nests the
+ * payload under `data`). Shared shape — the per-platform `idKeys` differ.
+ */
+function pickId(data: unknown, keys: readonly string[]): string | null {
+  if (!data || typeof data !== 'object') return null;
+  const obj = data as Record<string, unknown>;
+  for (const key of keys) {
+    const v = obj[key];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  const nested = obj.data;
+  if (nested && typeof nested === 'object') {
+    const n = nested as Record<string, unknown>;
+    for (const key of keys) {
+      const v = n[key];
+      if (typeof v === 'string' && v.trim()) return v.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * True when an operator reply for one of the new (non-Meta) platforms should be
+ * routed through Composio. Admission is the platform's OWN rollout flag only —
+ * there is no direct path to fall back to, and the master ARIES_NATIVE_REPLY_ENABLED
+ * gate is enforced earlier in the route handler. NOT a provider-selector check
+ * (unlike shouldUseComposioReply for FB) — these platforms have no PUBLISH_PROVIDER
+ * axis.
+ */
+export function isComposioReplyPlatform(platform: string, env: Env = process.env): boolean {
+  const p = platform.trim().toLowerCase();
+  const e = env as NodeJS.ProcessEnv;
+  switch (p) {
+    case 'x':
+      return isXEnabled(e);
+    case 'youtube':
+      return isYouTubeEnabled(e);
+    case 'reddit':
+      return isRedditEnabled(e);
+    case 'linkedin':
+      return isLinkedInEnabled(e);
+    default:
+      return false;
+  }
+}
+
+/**
+ * Post a public reply to a stored comment on X / YouTube / Reddit / LinkedIn via
+ * Composio. Mirrors replyToCommentViaComposio's dispatch structure (config →
+ * connection → slug → executeTool, classified into the MetaPublishError taxonomy)
+ * but with per-platform args + id-extraction keys. Resolves only on a confirmed
+ * reply id; every other path throws — see module header for how each maps to the
+ * handler's claim/rollback/outcome-unknown decision.
+ */
+export async function replyToCommentViaComposioForPlatform(
+  req: MetaReplyRequest,
+  platform: string,
+  env: Env = process.env,
+  deps: ComposioReplyDeps = {},
+): Promise<ComposioPlatformReplyResult> {
+  const p = platform.trim().toLowerCase();
+
+  const message = req.message.trim();
+  if (message.length === 0) {
+    throw new MetaPublishError('missing_reply_text', '`reply_text` is required.', { status: 400 });
+  }
+
+  const config = deps.config !== undefined ? deps.config : resolveComposioConfig(env as NodeJS.ProcessEnv);
+  if (!config) {
+    throw new MetaPublishError('oauth_token_missing', 'Composio is not configured (no API key).', { status: 409 });
+  }
+
+  const db = deps.db ?? pool;
+  // RAW Aries platform key — NO normalizeMetaProvider (these are non-Meta
+  // toolkits; e.g. 'x' maps to the Composio 'twitter' toolkit internally).
+  const conn = await getConnectionRow(req.tenantId, p as IntegrationPlatform, db);
+  if (!conn || conn.status !== 'connected' || !conn.connectedAccountId) {
+    // Definite never-created (auth) -> handler rolls back + surfaces reconnect.
+    throw new MetaPublishError(
+      'oauth_token_missing',
+      `No connected ${p} account is available for this tenant.`,
+      { status: 409 },
+    );
+  }
+
+  // Env override wins; else the verified-default slug. Null => not configured.
+  const slug =
+    config.actionSlugFor(p as IntegrationPlatform, 'reply_comment') ??
+    (DEFAULT_COMPOSIO_REPLY_SLUG[p] ?? null);
+  if (!slug) {
+    throw new MetaPublishError(
+      'reply_not_supported',
+      `Composio reply is not configured for ${p}.`,
+      { status: 422 },
+    );
+  }
+
+  const externalCommentId = req.externalCommentId;
+  let args: Record<string, unknown>;
+  let idKeys: readonly string[];
+  switch (p) {
+    case 'x':
+      // Reply = create-post with in-reply-to (no separate reply action).
+      args = { text: message, reply_in_reply_to_tweet_id: externalCommentId };
+      idKeys = ['id'];
+      break;
+    case 'youtube':
+      args = { parentId: externalCommentId, textOriginal: message };
+      idKeys = ['id'];
+      break;
+    case 'reddit':
+      // thing_id must be the t1_<id> comment fullname (never double-prefixed).
+      args = { thing_id: redditThingId(externalCommentId), text: message };
+      idKeys = ['name', 'id'];
+      break;
+    case 'linkedin': {
+      // actor = the resolved author URN persisted at connect into
+      // connected_accounts.external_account_id (#645). Missing => reconnect
+      // (definitely-never-posted -> rollback), mirroring the publish path.
+      const actor = conn.externalAccountId?.trim() || null;
+      if (!actor) {
+        throw new MetaPublishError(
+          'oauth_token_missing',
+          'No LinkedIn author URN is available for this tenant; reconnect LinkedIn.',
+          { status: 409 },
+        );
+      }
+      // object = the parent post's share/ugcPost URN (insights_posts.external_post_id,
+      // threaded through req.externalPostId from the handler JOIN). Without it the
+      // reply has no target -> reply_not_supported (definitely-never-posted).
+      const object = req.externalPostId?.trim() || null;
+      if (!object) {
+        throw new MetaPublishError(
+          'reply_not_supported',
+          'No LinkedIn post URN is available for this comment.',
+          { status: 422 },
+        );
+      }
+      // parentComment nests the reply under the comment being replied to (its
+      // URN = the stored external_comment_id). LinkedIn comments are not yet
+      // ingested (#648), so in practice this path is dormant until they are.
+      const commentUrn = externalCommentId?.trim() || null;
+      args = {
+        actor,
+        object,
+        message: { text: clampLinkedIn(message) },
+        ...(commentUrn ? { parentComment: commentUrn } : {}),
+      };
+      idKeys = ['commentUrn', 'id', 'urn'];
+      break;
+    }
+    default:
+      // isComposioReplyPlatform admitted only x/youtube/reddit/linkedin; any
+      // other value is a programming error, surfaced as not-supported.
+      throw new MetaPublishError(
+        'reply_not_supported',
+        `Composio reply is not supported for ${p}.`,
+        { status: 422 },
+      );
+  }
+
+  const gateway = deps.gateway ?? createComposioGateway(config);
+
+  let result;
+  try {
+    result = await gateway.executeTool(slug, {
+      connectedAccountId: conn.connectedAccountId,
+      arguments: args,
+    });
+  } catch (err) {
+    // Reddit divergence: a rate-limit/cooldown/429 is the API REJECTING the write
+    // — the comment was definitely never created, so roll back and allow a safe
+    // re-attempt (retryable, NOT outcome-unknown). A successful:false rate-limit
+    // is already handled as never-created below.
+    if (p === 'reddit' && isRedditRateLimit(err)) {
+      throw new MetaPublishError(
+        'composio_reply_rate_limited',
+        `Composio Reddit reply rate-limited: ${err instanceof Error ? err.message : String(err)}`,
+        { status: 429, retryable: true },
+      );
+    }
+    // Any other transport drop: the reply MAY have reached the platform — treat
+    // as outcome unknown so the handler keeps the claim and never auto-retries.
+    throw new MetaPublishError(
+      'composio_reply_unconfirmed',
+      `Composio reply transport error: ${err instanceof Error ? err.message : String(err)}`,
+      { status: 502, outcomeUnknown: true },
+    );
+  }
+
+  if (!result.successful) {
+    // Explicit tool failure -> the reply was not created -> safe to roll back.
+    throw new MetaPublishError(
+      'composio_reply_failed',
+      result.error ?? 'Composio reply tool reported unsuccessful.',
+      { status: 502, retryable: false },
+    );
+  }
+
+  const platformReplyId = pickId(result.data, idKeys);
+  if (!platformReplyId) {
+    // 2xx with no id -> unconfirmed, never auto-retry.
+    throw new MetaPublishError(
+      'composio_reply_missing_id',
+      'Composio accepted the reply but returned no reply id.',
+      { status: 502, outcomeUnknown: true },
+    );
+  }
+
+  return { platformReplyId, connectionId: conn.connectedAccountId };
 }

--- a/backend/integrations/meta-reply.ts
+++ b/backend/integrations/meta-reply.ts
@@ -30,6 +30,14 @@ export type MetaReplyRequest = {
   tenantId: string;
   provider: string;
   externalCommentId: string;
+  /**
+   * The parent post's external id (insights_posts.external_post_id). Used ONLY by
+   * the Composio LinkedIn reply path as the `object` (share/ugcPost URN) the reply
+   * is attached to. The direct-Graph Meta reply (this module) and the other
+   * Composio reply platforms ignore it. Optional + nullable so existing callers
+   * are unaffected.
+   */
+  externalPostId?: string | null;
   message: string;
   fetchImpl?: typeof fetch;
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,6 +267,14 @@ services:
       # Optional; defaults to the verified FACEBOOK_CREATE_COMMENT slug. Consumed
       # only by the app (the reply endpoint), routed when PUBLISH_PROVIDER=composio.
       COMPOSIO_FACEBOOK_REPLY_COMMENT_ACTION: ${COMPOSIO_FACEBOOK_REPLY_COMMENT_ACTION:-}
+      # New-platform native reply via Composio (#634/gate-5) — X/YouTube/Reddit/
+      # LinkedIn. Optional slug overrides; default to the verified catalog slugs.
+      # Consumed only by the app (the reply endpoint runs in aries-app), each
+      # admitted behind its own ARIES_<P>_ENABLED + master ARIES_NATIVE_REPLY_ENABLED.
+      COMPOSIO_X_REPLY_COMMENT_ACTION: ${COMPOSIO_X_REPLY_COMMENT_ACTION:-}
+      COMPOSIO_YOUTUBE_REPLY_COMMENT_ACTION: ${COMPOSIO_YOUTUBE_REPLY_COMMENT_ACTION:-}
+      COMPOSIO_REDDIT_REPLY_COMMENT_ACTION: ${COMPOSIO_REDDIT_REPLY_COMMENT_ACTION:-}
+      COMPOSIO_LINKEDIN_REPLY_COMMENT_ACTION: ${COMPOSIO_LINKEDIN_REPLY_COMMENT_ACTION:-}
       PUBLISH_PROVIDER: ${PUBLISH_PROVIDER:-direct_meta}
       ANALYTICS_PROVIDER: ${ANALYTICS_PROVIDER:-direct_meta}
       AUTH_URL: ${AUTH_URL}

--- a/tests/composio-reply-newplatforms.test.ts
+++ b/tests/composio-reply-newplatforms.test.ts
@@ -1,0 +1,763 @@
+/**
+ * Unit-level regression coverage for the new-platform (X / YouTube / Reddit /
+ * LinkedIn) Composio reply dispatch added in #634 / #639 / #644 / #649.
+ *
+ * Covers:
+ *   1. isComposioReplyPlatform flag routing.
+ *   2. Per-platform correct slug + argument construction + id extraction.
+ *   3. Idempotency classification: definitely_never_posted vs outcome_unknown.
+ *   4. Reddit rate-limit divergence (transport 429 → rollback-safe, NOT outcome-unknown).
+ *   5. Reddit t1_ no-double-prefix invariant (load-bearing #634).
+ *   6. LinkedIn actor/object guard (missing URNs → typed rollback errors).
+ *
+ * Self-contained: uses fakeGateway + fakeConfig + fakeDb from tests/composio/helpers.
+ * No real Postgres, no real Composio SDK.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isComposioReplyPlatform,
+  replyToCommentViaComposioForPlatform,
+  DEFAULT_COMPOSIO_REPLY_SLUG,
+} from '@/backend/integrations/composio/composio-reply';
+import { MetaPublishError, classifyMetaPublishFailure } from '@/backend/integrations/meta-publishing';
+import { fakeConfig, fakeGateway, fakeDb } from './composio/helpers';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Full connected_accounts row shape that fakeDb can return. */
+function connectionRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    tenant_id: 42,
+    external_user_id: 'u42',
+    platform: 'linkedin',
+    provider: 'composio',
+    connected_account_id: 'ca_main',
+    auth_config_id: 'ac_main',
+    external_account_id: 'ext_1', // LinkedIn actor URN by default
+    external_account_name: 'Test User',
+    status: 'connected',
+    capabilities_json: null,
+    last_capability_check_at: null,
+    created_at: new Date(0),
+    updated_at: new Date(0),
+    ...overrides,
+  };
+}
+
+/** No platform flags in env — config is injected via deps so env is irrelevant. */
+const ENV = {} as Record<string, string>;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 1. isComposioReplyPlatform — per-platform flag routing
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('isComposioReplyPlatform: X enabled (ARIES_X_ENABLED=1) → true', () => {
+  assert.equal(isComposioReplyPlatform('x', { ARIES_X_ENABLED: '1' }), true);
+});
+test('isComposioReplyPlatform: X off (no flag) → false', () => {
+  assert.equal(isComposioReplyPlatform('x', {}), false);
+});
+test('isComposioReplyPlatform: YouTube enabled (ARIES_YOUTUBE_ENABLED=1) → true', () => {
+  assert.equal(isComposioReplyPlatform('youtube', { ARIES_YOUTUBE_ENABLED: '1' }), true);
+});
+test('isComposioReplyPlatform: YouTube off → false', () => {
+  assert.equal(isComposioReplyPlatform('youtube', {}), false);
+});
+test('isComposioReplyPlatform: Reddit enabled (ARIES_REDDIT_ENABLED=1) → true', () => {
+  assert.equal(isComposioReplyPlatform('reddit', { ARIES_REDDIT_ENABLED: '1' }), true);
+});
+test('isComposioReplyPlatform: Reddit off → false', () => {
+  assert.equal(isComposioReplyPlatform('reddit', {}), false);
+});
+test('isComposioReplyPlatform: LinkedIn enabled (ARIES_LINKEDIN_ENABLED=1) → true', () => {
+  assert.equal(isComposioReplyPlatform('linkedin', { ARIES_LINKEDIN_ENABLED: '1' }), true);
+});
+test('isComposioReplyPlatform: LinkedIn off → false', () => {
+  assert.equal(isComposioReplyPlatform('linkedin', {}), false);
+});
+test('isComposioReplyPlatform: facebook → always false (handled by shouldUseComposioReply)', () => {
+  // Facebook is not in the new-platform set — its routing lives in shouldUseComposioReply.
+  assert.equal(
+    isComposioReplyPlatform('facebook', {
+      COMPOSIO_ENABLED: 'true',
+      PUBLISH_PROVIDER: 'composio',
+    }),
+    false,
+  );
+});
+test('isComposioReplyPlatform: unknown platform → false', () => {
+  assert.equal(isComposioReplyPlatform('snapchat', { ARIES_X_ENABLED: '1' }), false);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 2. X dispatch
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const xReq = {
+  tenantId: '42',
+  provider: 'x',
+  externalCommentId: 'tweet_id_123',
+  message: 'Great tweet!',
+};
+
+test('X: correct slug (TWITTER_CREATION_OF_A_POST) and args {text, reply_in_reply_to_tweet_id}', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: { id: 'x_reply_1' } } });
+  const out = await replyToCommentViaComposioForPlatform(xReq, 'x', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+
+  assert.equal(out.platformReplyId, 'x_reply_1');
+  assert.equal(out.connectionId, 'ca_123');
+  assert.equal(gateway.calls.length, 1);
+  assert.equal(gateway.calls[0].slug, DEFAULT_COMPOSIO_REPLY_SLUG.x);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_123');
+  assert.deepEqual(gateway.calls[0].options.arguments, {
+    text: 'Great tweet!',
+    reply_in_reply_to_tweet_id: 'tweet_id_123',
+  });
+});
+
+test('X: successful:false → definitely_never_posted (safe rollback)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: false, error: 'not authorized', data: null } });
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(xReq, 'x', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_failed');
+      assert.equal(err.outcomeUnknown, false);
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+});
+
+test('X: transport throw → outcomeUnknown (claim left, never auto-retry)', async () => {
+  const gateway = { ...fakeGateway(), async executeTool() { throw new Error('ECONNRESET'); } };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(xReq, 'x', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_unconfirmed');
+      assert.equal(err.outcomeUnknown, true);
+      assert.equal(classifyMetaPublishFailure(err), 'outcome_unknown');
+      return true;
+    },
+  );
+});
+
+test('X: success + no reply id → outcomeUnknown', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: {} } });
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(xReq, 'x', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_missing_id');
+      assert.equal(err.outcomeUnknown, true);
+      return true;
+    },
+  );
+});
+
+test('X: no active connection → oauth_token_missing (never-posted, rollback safe)', async () => {
+  const gateway = fakeGateway();
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(xReq, 'x', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb({ connectionRow: null }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'oauth_token_missing');
+      assert.equal(err.outcomeUnknown, false);
+      return true;
+    },
+  );
+  assert.equal(gateway.calls.length, 0, 'no tool call without a connection');
+});
+
+test('X: empty reply text is rejected before any tool call', async () => {
+  const gateway = fakeGateway();
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform({ ...xReq, message: '   ' }, 'x', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => err instanceof MetaPublishError && err.code === 'missing_reply_text',
+  );
+  assert.equal(gateway.calls.length, 0);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 3. YouTube dispatch
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const ytReq = {
+  tenantId: '42',
+  provider: 'youtube',
+  externalCommentId: 'UgxYT_comment_id',
+  message: 'Nice video!',
+};
+
+test('YouTube: correct slug (YOUTUBE_CREATE_COMMENT_REPLY) and args {parentId, textOriginal}', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: { id: 'yt_reply_1' } } });
+  const out = await replyToCommentViaComposioForPlatform(ytReq, 'youtube', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+
+  assert.equal(out.platformReplyId, 'yt_reply_1');
+  assert.equal(gateway.calls[0].slug, DEFAULT_COMPOSIO_REPLY_SLUG.youtube);
+  assert.deepEqual(gateway.calls[0].options.arguments, {
+    parentId: 'UgxYT_comment_id',
+    textOriginal: 'Nice video!',
+  });
+});
+
+test('YouTube: success with nested data.id wrapper → extracted', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { id: 'yt_nested_reply' } } },
+  });
+  const out = await replyToCommentViaComposioForPlatform(ytReq, 'youtube', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  assert.equal(out.platformReplyId, 'yt_nested_reply');
+});
+
+test('YouTube: successful:false → definitely_never_posted', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: false, error: 'forbidden', data: null } });
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(ytReq, 'youtube', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.outcomeUnknown, false);
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+});
+
+test('YouTube: transport throw → outcomeUnknown', async () => {
+  const gateway = { ...fakeGateway(), async executeTool() { throw new Error('timeout'); } };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(ytReq, 'youtube', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.outcomeUnknown, true);
+      return true;
+    },
+  );
+});
+
+test('YouTube: success + no id → outcomeUnknown', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: {} } });
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(ytReq, 'youtube', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.outcomeUnknown, true);
+      return true;
+    },
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 4. Reddit dispatch — t1_ no-double-prefix + rate-limit divergence (load-bearing)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test('Reddit: pre-prefixed t1_ id is NOT double-prefixed (load-bearing #634)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: { name: 't1_abcdef' } } });
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abcdef', message: 'Great!' };
+  await replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.thing_id, 't1_abcdef', 'pre-prefixed id must NOT be double-prefixed');
+});
+
+test('Reddit: bare base36 id gets t1_ prefix (load-bearing #634)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: { name: 't1_xyz789' } } });
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 'xyz789', message: 'ok' };
+  await replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.thing_id, 't1_xyz789', 'bare id must be prefixed with t1_');
+});
+
+test('Reddit: correct slug (REDDIT_POST_REDDIT_COMMENT) and text arg', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: { name: 't1_abc' } } });
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'Hello Reddit!' };
+  await replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  assert.equal(gateway.calls[0].slug, DEFAULT_COMPOSIO_REPLY_SLUG.reddit);
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.text, 'Hello Reddit!');
+});
+
+test('Reddit: idKey order — data.name is preferred over data.id', async () => {
+  // Both `name` and `id` are present; `name` must win (listed first in idKeys).
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { name: 't1_name_wins', id: 'fallback_id' } },
+  });
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  const out = await replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  assert.equal(out.platformReplyId, 't1_name_wins');
+});
+
+test('Reddit: fallback to data.id when data.name absent', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'fallback_id_only' } },
+  });
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  const out = await replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  assert.equal(out.platformReplyId, 'fallback_id_only');
+});
+
+test('Reddit: successful:false → definitely_never_posted (rollback safe)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: false, error: 'forbidden', data: null } });
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_failed');
+      assert.equal(err.outcomeUnknown, false);
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+});
+
+test('Reddit: non-rate-limit transport throw → outcomeUnknown (NOT rollback) — divergent assertion', async () => {
+  // A generic transport drop (no 429/rate-limit keyword) is outcome-unknown for
+  // Reddit too — the comment MAY have reached the API. This is the same as other
+  // platforms; the divergence only applies to rate-limit errors (see next test).
+  const gateway = { ...fakeGateway(), async executeTool() { throw new Error('ECONNRESET'); } };
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_unconfirmed');
+      assert.equal(
+        err.outcomeUnknown,
+        true,
+        'non-rate-limit transport error must be outcome_unknown for Reddit too',
+      );
+      assert.equal(classifyMetaPublishFailure(err), 'outcome_unknown');
+      return true;
+    },
+  );
+});
+
+test('Reddit: rate-limit transport throw (429 in message) → definitely_never_posted + retryable (load-bearing #634)', async () => {
+  // A 429 means the API REJECTED the write — the comment was DEFINITELY never
+  // created. This is rollback-safe and retryable, NOT outcome-unknown. This is
+  // the key divergence from the generic transport-drop path.
+  const gateway = {
+    ...fakeGateway(),
+    async executeTool() { throw new Error('Request failed with status 429 Too Many Requests'); },
+  };
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_rate_limited');
+      assert.equal(err.outcomeUnknown, false, 'rate-limit must NOT be outcome-unknown');
+      assert.equal(err.retryable, true, 'rate-limit is retryable after backoff');
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+});
+
+test('Reddit: "cooldown" in message → definitely_never_posted (load-bearing #634)', async () => {
+  const gateway = {
+    ...fakeGateway(),
+    async executeTool() {
+      throw new Error('you are doing that too much. try again in 8 minutes. (cooldown)');
+    },
+  };
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_rate_limited');
+      assert.equal(err.outcomeUnknown, false);
+      return true;
+    },
+  );
+});
+
+test('Reddit: "rate limit" text in message → definitely_never_posted', async () => {
+  const gateway = {
+    ...fakeGateway(),
+    async executeTool() { throw new Error('rate limit exceeded, please back off'); },
+  };
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_rate_limited');
+      assert.equal(err.outcomeUnknown, false);
+      return true;
+    },
+  );
+});
+
+test('Reddit: success + no id → outcomeUnknown', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: {} } });
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.outcomeUnknown, true);
+      return true;
+    },
+  );
+});
+
+test('Reddit: no active connection → oauth_token_missing', async () => {
+  const gateway = fakeGateway();
+  const req = { tenantId: '42', provider: 'reddit', externalCommentId: 't1_abc', message: 'ok' };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'reddit', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb({ connectionRow: null }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'oauth_token_missing');
+      assert.equal(err.outcomeUnknown, false);
+      return true;
+    },
+  );
+  assert.equal(gateway.calls.length, 0, 'no tool call without a connection');
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 5. LinkedIn dispatch — actor/object guards + idKey order + clamp
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const liReq = {
+  tenantId: '42',
+  provider: 'linkedin',
+  externalCommentId: 'urn:li:comment:789',
+  externalPostId: 'urn:li:share:456',
+  message: 'Insightful post!',
+};
+
+// Default fakeDb has external_account_id: 'ext_1' (actor URN).
+test('LinkedIn: correct slug (LINKEDIN_CREATE_COMMENT_ON_POST) + args (actor/object/message.text + parentComment)', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { commentUrn: 'urn:li:comment:new_1' } },
+  });
+  const out = await replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+
+  assert.equal(out.platformReplyId, 'urn:li:comment:new_1');
+  assert.equal(gateway.calls[0].slug, DEFAULT_COMPOSIO_REPLY_SLUG.linkedin);
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.actor, 'ext_1', 'actor must come from conn.externalAccountId');
+  assert.equal(args.object, 'urn:li:share:456', 'object must be the post URN (externalPostId)');
+  assert.deepEqual(args.message, { text: 'Insightful post!' });
+  assert.equal(args.parentComment, 'urn:li:comment:789', 'parentComment = the stored comment URN');
+});
+
+test('LinkedIn: empty externalCommentId → parentComment omitted (top-level comment reply)', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { commentUrn: 'urn:li:comment:top' } },
+  });
+  const req = { ...liReq, externalCommentId: '' };
+  await replyToCommentViaComposioForPlatform(req, 'linkedin', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal('parentComment' in args, false, 'parentComment must be absent when no comment URN');
+});
+
+test('LinkedIn: long message is clamped at 1250 chars with ellipsis', async () => {
+  const longMsg = 'x'.repeat(1300);
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { commentUrn: 'urn:li:comment:clamped' } },
+  });
+  const req = { ...liReq, message: longMsg };
+  await replyToCommentViaComposioForPlatform(req, 'linkedin', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  const sent = (args.message as { text: string }).text;
+  assert.equal(sent.length, 1250, 'clamped to exactly 1250 chars');
+  assert.ok(sent.endsWith('…'), 'clamped message must end with ellipsis glyph');
+});
+
+test('LinkedIn: message at exactly 1250 chars is not clamped', async () => {
+  const exactMsg = 'y'.repeat(1250);
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { commentUrn: 'urn:li:comment:exact' } },
+  });
+  const req = { ...liReq, message: exactMsg };
+  await replyToCommentViaComposioForPlatform(req, 'linkedin', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  const sent = (args.message as { text: string }).text;
+  assert.equal(sent.length, 1250);
+  assert.ok(!sent.endsWith('…'), '1250-char message must NOT be truncated');
+});
+
+test('LinkedIn: missing externalPostId (no JOIN row) → reply_not_supported (never-posted, rollback safe)', async () => {
+  const req = { ...liReq, externalPostId: null as string | null };
+  const gateway = fakeGateway();
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(req, 'linkedin', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'reply_not_supported');
+      assert.equal(err.outcomeUnknown, false);
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+  assert.equal(gateway.calls.length, 0, 'no gateway call when object (post URN) is missing');
+});
+
+test('LinkedIn: missing actor (null externalAccountId) → oauth_token_missing (rollback safe)', async () => {
+  const gateway = fakeGateway();
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb({ connectionRow: connectionRow({ external_account_id: null }) }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'oauth_token_missing');
+      assert.equal(err.outcomeUnknown, false);
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+  assert.equal(gateway.calls.length, 0, 'no gateway call when actor URN is missing');
+});
+
+test('LinkedIn: idKey order — commentUrn wins over id wins over urn', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { commentUrn: 'urn:li:comment:winner', id: 'li_id', urn: 'urn:li:comment:third' },
+    },
+  });
+  const out = await replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  assert.equal(out.platformReplyId, 'urn:li:comment:winner');
+});
+
+test('LinkedIn: fallback to id when commentUrn absent', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'li_id_fallback' } },
+  });
+  const out = await replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  assert.equal(out.platformReplyId, 'li_id_fallback');
+});
+
+test('LinkedIn: fallback to urn when commentUrn + id absent', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { urn: 'urn:li:comment:urn_only' } },
+  });
+  const out = await replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+  assert.equal(out.platformReplyId, 'urn:li:comment:urn_only');
+});
+
+test('LinkedIn: successful:false → definitely_never_posted', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: false, error: 'access denied', data: null } });
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.outcomeUnknown, false);
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+});
+
+test('LinkedIn: transport throw → outcomeUnknown', async () => {
+  const gateway = { ...fakeGateway(), async executeTool() { throw new Error('network error'); } };
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.outcomeUnknown, true);
+      return true;
+    },
+  );
+});
+
+test('LinkedIn: success + no id → outcomeUnknown', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: {} } });
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb(),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.outcomeUnknown, true);
+      return true;
+    },
+  );
+});
+
+test('LinkedIn: no active connection → oauth_token_missing', async () => {
+  const gateway = fakeGateway();
+  await assert.rejects(
+    () =>
+      replyToCommentViaComposioForPlatform(liReq, 'linkedin', ENV, {
+        gateway,
+        config: fakeConfig({ actions: {} }),
+        db: fakeDb({ connectionRow: null }),
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'oauth_token_missing');
+      assert.equal(err.outcomeUnknown, false);
+      return true;
+    },
+  );
+  assert.equal(gateway.calls.length, 0, 'no tool call without a connection');
+});

--- a/tests/insights-comment-reply-composio-route.test.ts
+++ b/tests/insights-comment-reply-composio-route.test.ts
@@ -144,3 +144,107 @@ test('Composio explicit failure rolls the claim back so a retry can re-attempt',
   assert.equal(state.is_replied, false, 'claim rolled back on a definite failure');
   assert.equal(state.platform_reply_id, null);
 });
+
+// ── New-platform dormancy (per-platform ARIES_<P>_ENABLED OFF → 422) ─────────
+//
+// When a platform's rollout flag is off, a stored comment of that platform → the
+// route returns 422 reply_not_supported and never reaches the Composio dispatch
+// (no pre-claim UPDATE is issued). The master ARIES_NATIVE_REPLY_ENABLED OFF
+// case → 404 is also guarded here for new-platform context.
+
+const BASE_ENV_NO_PLATFORM = {
+  ARIES_NATIVE_REPLY_ENABLED: '1',
+  COMPOSIO_ENABLED: 'true',
+  // Intentionally NO ARIES_X_ENABLED / ARIES_YOUTUBE_ENABLED / ARIES_REDDIT_ENABLED / ARIES_LINKEDIN_ENABLED.
+} as const;
+
+function newPlatformComment(platform: string): CommentRow {
+  return {
+    id: 5,
+    tenant_id: 12,
+    platform,
+    external_comment_id: `${platform}_ext_1`,
+    is_replied: false,
+    platform_reply_id: null,
+  };
+}
+
+test('X: ARIES_X_ENABLED OFF → 422 reply_not_supported, no pre-claim UPDATE issued', async () => {
+  const { db, calls } = makeFakeCommentDb(newPlatformComment('x'));
+
+  const res = await handleReplyToComment(replyRequest('Hello!'), '5', {
+    env: BASE_ENV_NO_PLATFORM,
+    db,
+    tenantContextLoader: tenantLoader(12),
+  });
+
+  assert.equal(res.status, 422);
+  assert.equal((await res.json()).reason, 'reply_not_supported');
+  const updateCalls = calls.filter(c => c.sql.includes('SET is_replied'));
+  assert.equal(updateCalls.length, 0, 'no claim UPDATE when X platform is dormant');
+});
+
+test('YouTube: ARIES_YOUTUBE_ENABLED OFF → 422 reply_not_supported, no pre-claim UPDATE issued', async () => {
+  const { db, calls } = makeFakeCommentDb(newPlatformComment('youtube'));
+
+  const res = await handleReplyToComment(replyRequest('Hello!'), '5', {
+    env: BASE_ENV_NO_PLATFORM,
+    db,
+    tenantContextLoader: tenantLoader(12),
+  });
+
+  assert.equal(res.status, 422);
+  assert.equal((await res.json()).reason, 'reply_not_supported');
+  const updateCalls = calls.filter(c => c.sql.includes('SET is_replied'));
+  assert.equal(updateCalls.length, 0, 'no claim UPDATE when YouTube platform is dormant');
+});
+
+test('Reddit: ARIES_REDDIT_ENABLED OFF → 422 reply_not_supported, no pre-claim UPDATE issued', async () => {
+  const { db, calls } = makeFakeCommentDb(newPlatformComment('reddit'));
+
+  const res = await handleReplyToComment(replyRequest('Hello!'), '5', {
+    env: BASE_ENV_NO_PLATFORM,
+    db,
+    tenantContextLoader: tenantLoader(12),
+  });
+
+  assert.equal(res.status, 422);
+  assert.equal((await res.json()).reason, 'reply_not_supported');
+  const updateCalls = calls.filter(c => c.sql.includes('SET is_replied'));
+  assert.equal(updateCalls.length, 0, 'no claim UPDATE when Reddit platform is dormant');
+});
+
+test('LinkedIn: ARIES_LINKEDIN_ENABLED OFF → 422 reply_not_supported, no pre-claim UPDATE issued', async () => {
+  const { db, calls } = makeFakeCommentDb(newPlatformComment('linkedin'));
+
+  const res = await handleReplyToComment(replyRequest('Hello!'), '5', {
+    env: BASE_ENV_NO_PLATFORM,
+    db,
+    tenantContextLoader: tenantLoader(12),
+  });
+
+  assert.equal(res.status, 422);
+  assert.equal((await res.json()).reason, 'reply_not_supported');
+  const updateCalls = calls.filter(c => c.sql.includes('SET is_replied'));
+  assert.equal(updateCalls.length, 0, 'no claim UPDATE when LinkedIn platform is dormant');
+});
+
+test('ARIES_NATIVE_REPLY_ENABLED OFF with an X comment → 404 (route is invisible)', async () => {
+  let dbCalls = 0;
+  const db = {
+    query: async () => {
+      dbCalls += 1;
+      return { rows: [], rowCount: 0 };
+    },
+  } as unknown as Pool;
+
+  const res = await handleReplyToComment(replyRequest('Hello!'), '5', {
+    env: {}, // master switch OFF
+    db,
+    tenantContextLoader: tenantLoader(12),
+  });
+
+  assert.equal(res.status, 404);
+  assert.equal((await res.json()).reason, 'not_found');
+  assert.equal(dbCalls, 0, 'no DB access when master flag is OFF');
+});


### PR DESCRIPTION
Closes #634
Closes #639
Closes #644
Closes #649

Admits X, YouTube, Reddit, and LinkedIn to the existing native-reply Composio seam (`POST /api/insights/comments/[commentId]/reply`). FB/IG behavior is byte-identical.

## What changed
- New sibling `replyToCommentViaComposioForPlatform` in `backend/integrations/composio/composio-reply.ts` posts a reply per platform via Composio's verified actions: X `TWITTER_CREATION_OF_A_POST {text, reply_in_reply_to_tweet_id}`, YouTube `YOUTUBE_CREATE_COMMENT_REPLY {parentId, textOriginal}`, Reddit `REDDIT_POST_REDDIT_COMMENT {thing_id (t1_ normalized, never double-prefixed), text}`, LinkedIn `LINKEDIN_CREATE_COMMENT_ON_POST {actor=connection URN, object=parent post URN, message.text ≤1250}`. Slugs resolve via `actionSlugFor(platform,'reply_comment')` with verified-catalog defaults; capability-missing (422) when a slug is unset — never guessed.
- Handler touched lines are ONLY the load JOIN (pulls the parent post's `external_post_id` for LinkedIn's `object`), the admission guard (`isComposioReplyPlatform`), the request literal (`externalPostId`), and the dispatch branch. The claim / rollback / classify path is UNCHANGED.
- `MetaReplyRequest` gains an optional nullable `externalPostId` (LinkedIn-only; FB/IG/X/YouTube/Reddit ignore it).

## Idempotency preserved per platform
Every new-platform dispatch throws the SAME `MetaPublishError` taxonomy so the untouched handler drives it: pre-call failures (no config/connection/slug; LinkedIn missing actor/object) → definitely-never-posted → rollback (safe retry); transport drop → outcomeUnknown → claim LEFT, `needs_manual_reconciliation`, never auto-retried; `successful:false` → never-created → rollback; success-with-no-id → outcomeUnknown. Reddit rate-limit (429/cooldown) → definitely-never-posted → rollback (the comment is rejected before creation, so re-attempt is safe — NOT outcome-unknown). The pre-claim `is_replied false→true` UPDATE remains the single concurrency guard.

## Ships DORMANT
Each platform is admitted only behind its own `ARIES_<PLATFORM>_ENABLED` (default OFF) AND the master `ARIES_NATIVE_REPLY_ENABLED` (default OFF). With a platform flag OFF → 422 `reply_not_supported` (byte-identical to a Meta reject, no Composio traffic); master flag OFF → 404. Prod activation needs the master flag + the platform flag + (optionally) `COMPOSIO_<PLATFORM>_REPLY_COMMENT_ACTION` — verified-default slugs exist, so the env override is only to pin a different slug. New env vars wired in both `.env.example` and the `aries-app` service block in `docker-compose.yml` (two-place rule).

## Test evidence
New `tests/composio-reply-newplatforms.test.ts` (46) + 5 route dormancy/admission tests in `tests/insights-comment-reply-composio-route.test.ts`. Focused reply suite green: 84/84 across composio-reply-newplatforms, composio-reply, both insights-comment-reply route files, and meta-reply (no FB regression). `npm run verify` green; banned-patterns clean; `guardrails:agent` clean (2 ahead of master, unique diff).

## Known limitations / residual risk
- The comments-tray UI is FB-only — the reply endpoint has no rendered surface yet for these platforms (an aries-frontend follow-up).
- LinkedIn comments aren't ingested (#648), so #649's reply is code-complete but has no live comments to reply to until #648 lands.
- Open contract risk: the YouTube/Reddit/LinkedIn reply response id nesting deserves a live-call confirmation at flag-on. The id extraction (`pickId`) looks one `data` wrap deep across the candidate keys and fails SAFE to outcome-unknown if a key is missed (never mis-stamps), so a missed nesting strands the reply for manual reconciliation rather than double-posting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
