### PR TITLE
chore(agents): correct branch-protection docs (only full-suite CI, no approval gate)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -72,9 +72,11 @@ groomer (queue → ordered)
   label is needed. The team does **not** add **`agent:auto-merge`** — that label triggers the cloud
   `pr-agent-autofix-automerge.yml`, which spawns an autonomous cloud Claude agent that
   commits/pushes/merges the branch, racing this local team (the same reason it avoids `agent:fix`).
-- **Branch-protection heads-up:** `master` also requires **1 approving review** (no bypass), so
-  `--auto` waits for an approval *and* CI; until that requirement is lowered, a green PR queues
-  awaiting a human/second-identity approval (see the setup PR description for the toggle).
+- **Branch-protection reality:** `master` requires **only the `full-suite` CI check** — there is
+  **no required approving review** (`enforce_admins` is off). So `gh pr merge --squash --auto` merges
+  every green PR automatically with zero human approval; there is no "awaiting approval" state. A
+  green PR that doesn't merge is a CI/branch issue (red or pending `full-suite`, behind `master`, or a
+  conflict), never an approval one.
 - Fixes auto-close their issue via `Closes #<n>`; **no agent closes a `qa-defect` issue by hand** —
   the QA session verifies in prod.
 

--- a/.claude/agents/aries-reviewer.md
+++ b/.claude/agents/aries-reviewer.md
@@ -68,15 +68,17 @@ Produce a verdict: **APPROVE** or **REQUEST CHANGES** with a numbered list of mu
    The body **must** contain `Closes #<issue>` so the issue auto-closes on merge. Do not close the
    `qa-defect` issue by hand — the QA session verifies in prod.
 3. **Enable squash auto-merge:** `gh pr merge <pr> --squash --auto`. Auto-merge is enabled on the
-   repo and `full-suite` is a required status check on `master`, so `--auto` waits for CI.
-   **Branch-protection reality:** `master` *also* currently requires **1 approving review** with no
-   bypass, and the bot cannot approve its own PR — so a green PR will sit **queued awaiting an
-   approval**; it does not merge on CI alone until that requirement is lowered (the setup PR
-   describes the toggle).
-4. **If auto-merge can't complete** (queued on the required approval, the repo setting flipped off,
-   or required checks unset): do **not** force it with an admin merge — that bypasses the
-   `full-suite` CI gate. Surface it to the orchestrator once; a green, review-passed PR awaiting only
-   a GitHub approval is the expected hand-off point under the current branch protection.
+   repo and `full-suite` is the **only** required status check on `master`, so `--auto` merges the PR
+   automatically the moment CI is green.
+   **Branch-protection reality:** `master` requires **only the `full-suite` CI check** — there is
+   **no required approving review** and `enforce_admins` is off. So a green PR **lands itself** with
+   zero human approval; "awaiting approval" is not a state that exists in this loop. The bot does not
+   need to approve anything.
+4. **If auto-merge can't complete** (e.g. `full-suite` is red or still running, the branch is behind
+   `master`, or there's a merge conflict): do **not** force it with an admin merge — that bypasses the
+   `full-suite` CI gate. Fix the cause (rebase onto `master` / fix the failing test) so CI goes green;
+   the PR then auto-merges on its own. A green PR that doesn't merge is a CI/branch problem, never an
+   approval one.
 5. **Deploy note (so the fix reaches prod):** your PAT-attributed `gh pr merge --auto` completes the
    merge as the authenticated user, so the push to `master` triggers `deploy.yml`'s push trigger
    directly — no extra label is needed. **Do NOT add `agent:auto-merge`:** it triggers the cloud


### PR DESCRIPTION
The `aries-reviewer` agent def + the team `README.md` claimed master requires 1 approving review and that green PRs queue 'awaiting approval'. That is stale: master's branch protection requires ONLY the `full-suite` CI check (no required reviews, `enforce_admins` off), so `gh pr merge --squash --auto` lands every green PR with zero human approval. The stale text caused reviewers to treat a non-existent approval gate as a blocker all session.

Doc-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)