### PR TITLE
feat(social-content): add X/Reddit/LinkedIn publish targets to the scheduler picker

### DIFF
--- a/app/dashboard/calendar/page.tsx
+++ b/app/dashboard/calendar/page.tsx
@@ -1,14 +1,28 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import AriesCalendarScreen from '@/frontend/aries-v1/calendar-screen';
+import {
+  isLinkedInEnabled,
+  isRedditEnabled,
+  isXEnabled,
+} from '@/backend/integrations/providers/integration-config';
+import type { AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
 
 export const metadata = {
   title: 'Calendar — Aries AI',
 };
 
 export default function DashboardCalendarPage() {
+  const allowedPublishPlatforms: AllowedTargetPlatform[] = [
+    'facebook',
+    'instagram',
+    ...(isXEnabled() ? (['x'] as const) : []),
+    ...(isRedditEnabled() ? (['reddit'] as const) : []),
+    ...(isLinkedInEnabled() ? (['linkedin'] as const) : []),
+  ];
+
   return (
     <AppShellLayout currentRouteId="calendar" loginRedirectPath="/dashboard/calendar">
-      <AriesCalendarScreen />
+      <AriesCalendarScreen allowedPublishPlatforms={allowedPublishPlatforms} />
     </AppShellLayout>
   );
 }

--- a/frontend/aries-v1/calendar-screen.tsx
+++ b/frontend/aries-v1/calendar-screen.tsx
@@ -12,6 +12,7 @@ import {
   type UnscheduledPost,
 } from '@/frontend/aries-v1/view-models/calendar';
 import { useCalendarScheduling } from '@/frontend/aries-v1/hooks/useCalendarScheduling';
+import type { AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { LoadingStateGrid } from './components';
@@ -29,7 +30,16 @@ function defaultRange(): { from: string; to: string } {
   return { from: from.toISOString(), to: to.toISOString() };
 }
 
-export default function AriesCalendarScreen() {
+export interface AriesCalendarScreenProps {
+  /**
+   * Server-computed list of platforms the operator can schedule to right now.
+   * Omit (or leave undefined) to get the default facebook+instagram picker —
+   * byte-identical to the old behaviour when all rollout flags are OFF.
+   */
+  allowedPublishPlatforms?: AllowedTargetPlatform[];
+}
+
+export default function AriesCalendarScreen({ allowedPublishPlatforms }: AriesCalendarScreenProps = {}) {
   const api = useMemo(() => createAriesV1Api({}), []);
   const range = useMemo(() => defaultRange(), []);
 
@@ -151,6 +161,7 @@ export default function AriesCalendarScreen() {
       onRescheduled={() => {
         void loadSchedule();
       }}
+      allowedPublishPlatforms={allowedPublishPlatforms}
     />
   );
 }

--- a/frontend/aries-v1/presenters/calendar-presenter.tsx
+++ b/frontend/aries-v1/presenters/calendar-presenter.tsx
@@ -34,6 +34,7 @@ import type {
 } from '@/frontend/aries-v1/view-models/calendar';
 import { RedditIcon, XIcon } from '@/frontend/components/Icons';
 import RescheduleDrawer from '@/frontend/aries-v1/reschedule-drawer';
+import type { AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
 import {
   formatTimeInTenantZone,
   tenantZoneDateKey,
@@ -96,6 +97,13 @@ export interface CalendarPresenterProps {
   campaignsLoading?: boolean;
   /** Called after the RescheduleDrawer saves — lets the screen refetch the queue. */
   onRescheduled?: () => void;
+  /**
+   * Platforms the operator is allowed to schedule to right now. Computed
+   * server-side from rollout flags and passed down. Defaults to
+   * `['facebook','instagram']` when absent (byte-identical to previous behaviour
+   * when all flags are OFF).
+   */
+  allowedPublishPlatforms?: AllowedTargetPlatform[];
 }
 
 export default function CalendarPresenter({
@@ -105,6 +113,7 @@ export default function CalendarPresenter({
   schedulingError,
   campaignsLoading,
   onRescheduled,
+  allowedPublishPlatforms,
 }: CalendarPresenterProps) {
   const timeZone = model.timeZone;
   const [view, setView] = useState<CalendarMode>('month');
@@ -482,9 +491,12 @@ export default function CalendarPresenter({
             postId={rescheduleTarget.postId}
             defaultScheduledAt={rescheduleTarget.scheduledForIso}
             defaultPlatforms={rescheduleTarget.targetPlatforms.filter(
-              (platform): platform is 'facebook' | 'instagram' =>
-                platform === 'facebook' || platform === 'instagram',
+              (platform): platform is AllowedTargetPlatform =>
+                (allowedPublishPlatforms ?? (['facebook', 'instagram'] as AllowedTargetPlatform[])).includes(
+                  platform as AllowedTargetPlatform,
+                ),
             )}
+            allowedPlatforms={allowedPublishPlatforms}
             timeZone={timeZone}
             onClose={() => setRescheduleEventId(null)}
             onSaved={() => {
@@ -500,10 +512,14 @@ export default function CalendarPresenter({
             jobId={scheduleTrayPost.jobId}
             postId={scheduleTrayPost.postId}
             defaultPlatforms={
-              scheduleTrayPost.platform === 'facebook' || scheduleTrayPost.platform === 'instagram'
-                ? [scheduleTrayPost.platform]
+              scheduleTrayPost.platform !== null &&
+              (allowedPublishPlatforms ?? (['facebook', 'instagram'] as AllowedTargetPlatform[])).includes(
+                scheduleTrayPost.platform as AllowedTargetPlatform,
+              )
+                ? [scheduleTrayPost.platform as AllowedTargetPlatform]
                 : undefined
             }
+            allowedPlatforms={allowedPublishPlatforms}
             timeZone={timeZone}
             onClose={() => setScheduleTrayPost(null)}
             onSaved={() => {

--- a/frontend/aries-v1/reschedule-drawer.tsx
+++ b/frontend/aries-v1/reschedule-drawer.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type ComponentType, useEffect, useMemo, useRef, useState } from 'react';
 import { CalendarClock, Check, LoaderCircle, X } from 'lucide-react';
-import { FacebookIcon, InstagramIcon } from './brand-icons';
+import { FacebookIcon, InstagramIcon, LinkedinIcon } from './brand-icons';
+import { XIcon, RedditIcon } from '@/frontend/components/Icons';
+import type { AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
 
 import {
   DEFAULT_TENANT_TIMEZONE,
@@ -10,18 +12,21 @@ import {
   wallTimeToUtc,
 } from '@/lib/format-timestamp';
 
-const PLATFORM_OPTIONS = [
-  { id: 'instagram' as const, label: 'Instagram', Icon: InstagramIcon },
-  { id: 'facebook' as const, label: 'Facebook', Icon: FacebookIcon },
-];
+type PlatformIcon = ComponentType<{ className?: string; 'aria-hidden'?: boolean | 'true' | 'false' }>;
 
-type PlatformId = (typeof PLATFORM_OPTIONS)[number]['id'];
+const PLATFORM_OPTIONS: Array<{ id: AllowedTargetPlatform; label: string; Icon: PlatformIcon }> = [
+  { id: 'instagram', label: 'Instagram', Icon: InstagramIcon as PlatformIcon },
+  { id: 'facebook', label: 'Facebook', Icon: FacebookIcon as PlatformIcon },
+  { id: 'x', label: 'X', Icon: XIcon as PlatformIcon },
+  { id: 'reddit', label: 'Reddit', Icon: RedditIcon as PlatformIcon },
+  { id: 'linkedin', label: 'LinkedIn', Icon: LinkedinIcon as PlatformIcon },
+];
 
 export interface ScheduleSavedDetail {
   jobId: string;
   postId: string;
   scheduledAt: string;
-  platforms: PlatformId[];
+  platforms: AllowedTargetPlatform[];
   updatedAt: string;
 }
 
@@ -29,7 +34,14 @@ export interface RescheduleDrawerProps {
   jobId: string;
   postId: string;
   defaultScheduledAt?: string | null;
-  defaultPlatforms?: PlatformId[];
+  defaultPlatforms?: AllowedTargetPlatform[];
+  /**
+   * Which platforms to show as selectable options. Defaults to
+   * `['facebook', 'instagram']` (byte-identical to previous behaviour when all
+   * rollout flags are OFF). Pass the server-computed `allowedPublishPlatforms`
+   * to surface X / Reddit / LinkedIn when their flags are ON.
+   */
+  allowedPlatforms?: AllowedTargetPlatform[];
   /** Tenant business timezone — the datetime-local wall time is read in it. */
   timeZone?: string;
   timezoneLabel?: string;
@@ -54,16 +66,25 @@ function toLocalInputValue(iso: string | null | undefined, timeZone: string): st
 
 export default function RescheduleDrawer(props: RescheduleDrawerProps) {
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
-  const initialPlatforms = useMemo<Set<PlatformId>>(
+  const initialPlatforms = useMemo<Set<AllowedTargetPlatform>>(
     () => new Set(props.defaultPlatforms?.length ? props.defaultPlatforms : ['instagram', 'facebook']),
     [props.defaultPlatforms],
   );
+
+  // Platforms visible in the picker. Defaults to facebook+instagram so the
+  // rendered output is byte-identical to the old behaviour when all flags are OFF.
+  const visibleOptions = useMemo(() => {
+    const allowed = new Set<AllowedTargetPlatform>(
+      props.allowedPlatforms ?? ['facebook', 'instagram'],
+    );
+    return PLATFORM_OPTIONS.filter((o) => allowed.has(o.id));
+  }, [props.allowedPlatforms]);
 
   const timeZone = props.timeZone ?? DEFAULT_TENANT_TIMEZONE;
   const [scheduledAtLocal, setScheduledAtLocal] = useState(() =>
     toLocalInputValue(props.defaultScheduledAt, timeZone),
   );
-  const [platforms, setPlatforms] = useState<Set<PlatformId>>(initialPlatforms);
+  const [platforms, setPlatforms] = useState<Set<AllowedTargetPlatform>>(initialPlatforms);
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [confirmation, setConfirmation] = useState<string | null>(null);
@@ -82,7 +103,7 @@ export default function RescheduleDrawer(props: RescheduleDrawerProps) {
     return () => window.removeEventListener('keydown', onKey);
   }, [props, submitting]);
 
-  function togglePlatform(id: PlatformId) {
+  function togglePlatform(id: AllowedTargetPlatform) {
     setErrorMessage(null);
     setPlatforms((current) => {
       const next = new Set(current);
@@ -110,7 +131,7 @@ export default function RescheduleDrawer(props: RescheduleDrawerProps) {
       setErrorMessage('That date and time could not be read. Try again.');
       return;
     }
-    const orderedPlatforms: PlatformId[] = PLATFORM_OPTIONS
+    const orderedPlatforms: AllowedTargetPlatform[] = PLATFORM_OPTIONS
       .map((option) => option.id)
       .filter((id) => platforms.has(id));
     if (orderedPlatforms.length === 0) {
@@ -149,7 +170,7 @@ export default function RescheduleDrawer(props: RescheduleDrawerProps) {
   }
 
   const tzLabel = props.timezoneLabel ?? timeZone;
-  const orderedPlatformChips: PlatformId[] = PLATFORM_OPTIONS
+  const orderedPlatformChips: AllowedTargetPlatform[] = PLATFORM_OPTIONS
     .map((option) => option.id)
     .filter((id) => platforms.has(id));
 
@@ -216,7 +237,7 @@ export default function RescheduleDrawer(props: RescheduleDrawerProps) {
           <fieldset className="space-y-3">
             <legend className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/70">Publish to</legend>
             <div className="grid gap-2 sm:grid-cols-2">
-              {PLATFORM_OPTIONS.map((option) => {
+              {visibleOptions.map((option) => {
                 const checked = platforms.has(option.id);
                 const Icon = option.Icon;
                 return (

--- a/tests/publish-picker-newplatforms.test.ts
+++ b/tests/publish-picker-newplatforms.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Regression coverage for the publish-target picker new-platforms expansion
+ * (PR feat/publish-picker-newplatforms).
+ *
+ * Covers:
+ *   1. RescheduleDrawer with allowedPlatforms=[fb,ig,x] renders exactly 3 platform
+ *      options — the new option appears when the allowed set widens.
+ *   2. RescheduleDrawer with allowedPlatforms absent renders EXACTLY 2 options (dormancy
+ *      regression guard — byte-identical to today when all flags are OFF).
+ *   3. RescheduleDrawer with allowedPlatforms=[fb,ig] explicit renders EXACTLY 2 options.
+ *   4. CalendarPresenter prop threading: allowedPublishPlatforms flows through to
+ *      RescheduleDrawer's allowedPlatforms (source-text assertion).
+ *   5. calendar/page.tsx: ARIES_X_ENABLED=1 includes 'x' in allowedPublishPlatforms;
+ *      unset flag excludes it; 'youtube' is never a publish target.
+ *
+ * Test strategy:
+ *   - Source-text assertions for structural/structural-prop-threading tests (3,4,5).
+ *   - Pure-function tests for flag-logic (isXEnabled / allowedPublishPlatforms logic).
+ *   - jsdom component tests for the load-bearing option-count assertions (1,2,3).
+ *
+ * Self-contained: no DB, no real Meta API.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { installJsdom } from './helpers/jsdom-env';
+import { resolveProjectRoot } from './helpers/project-root';
+
+// DOM must exist before React and @testing-library load.
+installJsdom();
+
+import React from 'react';
+
+/** Cast a plain string-keyed object to NodeJS.ProcessEnv without the required readonly fields. */
+const mkEnv = (o: Record<string, string>): NodeJS.ProcessEnv => o as unknown as NodeJS.ProcessEnv;
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+function read(...segments: string[]): string {
+  return readFileSync(path.join(PROJECT_ROOT, ...segments), 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Source text: the files we assert structure over
+// ---------------------------------------------------------------------------
+
+const calendarPage = read('app', 'dashboard', 'calendar', 'page.tsx');
+const calendarPresenter = read('frontend', 'aries-v1', 'presenters', 'calendar-presenter.tsx');
+const calendarScreen = read('frontend', 'aries-v1', 'calendar-screen.tsx');
+const rescheduleDrawer = read('frontend', 'aries-v1', 'reschedule-drawer.tsx');
+
+// ---------------------------------------------------------------------------
+// Source-text: calendar page flag wiring (test 5)
+// ---------------------------------------------------------------------------
+
+test('calendar page imports the three new platform flag functions', () => {
+  assert.match(calendarPage, /isXEnabled/);
+  assert.match(calendarPage, /isRedditEnabled/);
+  assert.match(calendarPage, /isLinkedInEnabled/);
+});
+
+test('calendar page builds allowedPublishPlatforms spreading each flag conditionally', () => {
+  assert.match(calendarPage, /allowedPublishPlatforms/);
+  // Each flag guards its own spread into the array
+  assert.match(calendarPage, /isXEnabled\(\)/);
+  assert.match(calendarPage, /isRedditEnabled\(\)/);
+  assert.match(calendarPage, /isLinkedInEnabled\(\)/);
+});
+
+test('calendar page passes allowedPublishPlatforms down to AriesCalendarScreen', () => {
+  assert.match(calendarPage, /allowedPublishPlatforms={allowedPublishPlatforms}/);
+});
+
+test('calendar page never includes youtube as a publish target', () => {
+  // YouTube is insights-only; it must not appear in the allowedPublishPlatforms array
+  assert.doesNotMatch(calendarPage, /['"]youtube['"]/);
+});
+
+// ---------------------------------------------------------------------------
+// Source-text: prop threading through screen + presenter (test 4)
+// ---------------------------------------------------------------------------
+
+test('AriesCalendarScreen accepts and threads allowedPublishPlatforms prop', () => {
+  assert.match(calendarScreen, /allowedPublishPlatforms/);
+  // The prop must be passed into CalendarPresenter
+  assert.match(calendarScreen, /allowedPublishPlatforms={allowedPublishPlatforms}/);
+});
+
+test('CalendarPresenter declares allowedPublishPlatforms in its props interface', () => {
+  assert.match(calendarPresenter, /allowedPublishPlatforms\?/);
+});
+
+test('CalendarPresenter forwards allowedPlatforms prop to RescheduleDrawer instances', () => {
+  // Must appear for both the reschedule (event) and schedule (tray) drawer invocations
+  const matches = calendarPresenter.match(/allowedPlatforms=\{allowedPublishPlatforms\}/g);
+  assert.ok(matches && matches.length >= 2, 'allowedPlatforms must be threaded into BOTH RescheduleDrawer usages');
+});
+
+// ---------------------------------------------------------------------------
+// Source-text: RescheduleDrawer structural assertions
+// ---------------------------------------------------------------------------
+
+test('RescheduleDrawer declares allowedPlatforms optional prop', () => {
+  assert.match(rescheduleDrawer, /allowedPlatforms\?\s*:\s*AllowedTargetPlatform\[\]/);
+});
+
+test('RescheduleDrawer defaults allowedPlatforms to facebook+instagram when absent', () => {
+  assert.match(rescheduleDrawer, /props\.allowedPlatforms\s*\?\?\s*\['facebook',\s*'instagram'\]/);
+});
+
+test('RescheduleDrawer PLATFORM_OPTIONS includes all five platforms (fb/ig/x/reddit/linkedin)', () => {
+  // All five must be entries in the options table
+  assert.match(rescheduleDrawer, /id:\s*'instagram'/);
+  assert.match(rescheduleDrawer, /id:\s*'facebook'/);
+  assert.match(rescheduleDrawer, /id:\s*'x'/);
+  assert.match(rescheduleDrawer, /id:\s*'reddit'/);
+  assert.match(rescheduleDrawer, /id:\s*'linkedin'/);
+});
+
+test('RescheduleDrawer renders visibleOptions filtered to the allowed set', () => {
+  // The map target must be visibleOptions (the filtered list), not PLATFORM_OPTIONS
+  assert.match(rescheduleDrawer, /visibleOptions\.map/);
+});
+
+// ---------------------------------------------------------------------------
+// Pure-function flag tests (test 5: flag logic without React)
+// ---------------------------------------------------------------------------
+
+test('isXEnabled returns false when ARIES_X_ENABLED is unset', async () => {
+  const { isXEnabled } = await import('@/backend/integrations/providers/integration-config');
+  assert.equal(isXEnabled(mkEnv({})), false);
+});
+
+test('isXEnabled returns true when ARIES_X_ENABLED=1', async () => {
+  const { isXEnabled } = await import('@/backend/integrations/providers/integration-config');
+  assert.equal(isXEnabled(mkEnv({ ARIES_X_ENABLED: '1' })), true);
+});
+
+test('isRedditEnabled returns false when ARIES_REDDIT_ENABLED is unset', async () => {
+  const { isRedditEnabled } = await import('@/backend/integrations/providers/integration-config');
+  assert.equal(isRedditEnabled(mkEnv({})), false);
+});
+
+test('isLinkedInEnabled returns false when ARIES_LINKEDIN_ENABLED is unset', async () => {
+  const { isLinkedInEnabled } = await import('@/backend/integrations/providers/integration-config');
+  assert.equal(isLinkedInEnabled(mkEnv({})), false);
+});
+
+test('calendar page allowedPublishPlatforms logic: ARIES_X_ENABLED=1 includes x but never youtube', async () => {
+  const { isXEnabled, isRedditEnabled, isLinkedInEnabled } = await import(
+    '@/backend/integrations/providers/integration-config'
+  );
+  const env = mkEnv({ ARIES_X_ENABLED: '1' });
+  const allowedPublishPlatforms: string[] = [
+    'facebook',
+    'instagram',
+    ...(isXEnabled(env) ? ['x'] : []),
+    ...(isRedditEnabled(env) ? ['reddit'] : []),
+    ...(isLinkedInEnabled(env) ? ['linkedin'] : []),
+  ];
+  assert.ok(allowedPublishPlatforms.includes('x'), "x must be included when ARIES_X_ENABLED='1'");
+  assert.ok(!allowedPublishPlatforms.includes('reddit'), 'reddit must not be included when flag off');
+  assert.ok(!allowedPublishPlatforms.includes('linkedin'), 'linkedin must not be included when flag off');
+  assert.ok(!allowedPublishPlatforms.includes('youtube'), 'youtube must never be a publish target');
+});
+
+test('calendar page allowedPublishPlatforms logic: all flags OFF yields facebook+instagram only', async () => {
+  const { isXEnabled, isRedditEnabled, isLinkedInEnabled } = await import(
+    '@/backend/integrations/providers/integration-config'
+  );
+  const env = mkEnv({});
+  const allowedPublishPlatforms: string[] = [
+    'facebook',
+    'instagram',
+    ...(isXEnabled(env) ? ['x'] : []),
+    ...(isRedditEnabled(env) ? ['reddit'] : []),
+    ...(isLinkedInEnabled(env) ? ['linkedin'] : []),
+  ];
+  assert.deepEqual(
+    allowedPublishPlatforms,
+    ['facebook', 'instagram'],
+    'all flags off must produce the legacy 2-platform array',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// jsdom component tests: RescheduleDrawer option count (tests 1,2,3)
+// ---------------------------------------------------------------------------
+
+test('RescheduleDrawer with allowedPlatforms=[fb,ig,x] renders 3 platform options', async () => {
+  const { render, cleanup } = await import('@testing-library/react');
+  const { default: RescheduleDrawer } = await import('../frontend/aries-v1/reschedule-drawer');
+
+  const { container } = render(
+    React.createElement(RescheduleDrawer, {
+      jobId: 'test-job',
+      postId: '42',
+      allowedPlatforms: ['facebook', 'instagram', 'x'] as const,
+      onClose: () => {},
+    }),
+  );
+
+  try {
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    assert.equal(
+      checkboxes.length,
+      3,
+      `Expected 3 platform option checkboxes, got ${checkboxes.length}`,
+    );
+
+    // Each expected option renders by testid
+    assert.ok(
+      container.querySelector('[data-testid="reschedule-platform-facebook"]'),
+      'Facebook option must render',
+    );
+    assert.ok(
+      container.querySelector('[data-testid="reschedule-platform-instagram"]'),
+      'Instagram option must render',
+    );
+    assert.ok(
+      container.querySelector('[data-testid="reschedule-platform-x"]'),
+      'X option must render when in allowedPlatforms',
+    );
+
+    // Dormant platforms must NOT render
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-reddit"]'),
+      null,
+      'Reddit must not render when not in allowedPlatforms',
+    );
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-linkedin"]'),
+      null,
+      'LinkedIn must not render when not in allowedPlatforms',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('RescheduleDrawer with allowedPlatforms absent renders exactly 2 options (dormancy regression guard)', async () => {
+  const { render, cleanup } = await import('@testing-library/react');
+  const { default: RescheduleDrawer } = await import('../frontend/aries-v1/reschedule-drawer');
+
+  const { container } = render(
+    React.createElement(RescheduleDrawer, {
+      jobId: 'test-job',
+      postId: '42',
+      // allowedPlatforms intentionally absent — must default to facebook+instagram
+      onClose: () => {},
+    }),
+  );
+
+  try {
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    assert.equal(
+      checkboxes.length,
+      2,
+      `Dormancy guard: expected exactly 2 platform checkboxes (fb+ig), got ${checkboxes.length}`,
+    );
+    assert.ok(
+      container.querySelector('[data-testid="reschedule-platform-facebook"]'),
+      'Facebook must render by default',
+    );
+    assert.ok(
+      container.querySelector('[data-testid="reschedule-platform-instagram"]'),
+      'Instagram must render by default',
+    );
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-x"]'),
+      null,
+      'X must not render when allowedPlatforms is absent',
+    );
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-reddit"]'),
+      null,
+      'Reddit must not render when allowedPlatforms is absent',
+    );
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-linkedin"]'),
+      null,
+      'LinkedIn must not render when allowedPlatforms is absent',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('RescheduleDrawer with allowedPlatforms=[fb,ig] explicit renders exactly 2 options', async () => {
+  const { render, cleanup } = await import('@testing-library/react');
+  const { default: RescheduleDrawer } = await import('../frontend/aries-v1/reschedule-drawer');
+
+  const { container } = render(
+    React.createElement(RescheduleDrawer, {
+      jobId: 'test-job',
+      postId: '42',
+      allowedPlatforms: ['facebook', 'instagram'] as const,
+      onClose: () => {},
+    }),
+  );
+
+  try {
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    assert.equal(
+      checkboxes.length,
+      2,
+      `Expected exactly 2 platform checkboxes when allowedPlatforms=[fb,ig], got ${checkboxes.length}`,
+    );
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-x"]'),
+      null,
+      'X must not render when explicitly excluded from allowedPlatforms',
+    );
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-reddit"]'),
+      null,
+      'Reddit must not render when explicitly excluded',
+    );
+    assert.equal(
+      container.querySelector('[data-testid="reschedule-platform-linkedin"]'),
+      null,
+      'LinkedIn must not render when explicitly excluded',
+    );
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## What & why

Frontend completeness for the already-merged, dormant X / Reddit / LinkedIn publish gates: makes those platforms **selectable as publish targets** in the calendar scheduler picker (RescheduleDrawer) when their `ARIES_<PLATFORM>_ENABLED` rollout flag is ON. The backend (`normalizeTargetPlatforms` in `backend/social-content/scheduled-posts.ts`) already accepts these platforms when flagged; until now there was no UI to choose them.

## Shape of the change (4 frontend files + 1 test file)

- `app/dashboard/calendar/page.tsx` (server component) computes `allowedPublishPlatforms` from the flag helpers (`isXEnabled` / `isRedditEnabled` / `isLinkedInEnabled`) at request time and passes it down.
- `calendar-screen.tsx` → `calendar-presenter.tsx` → `reschedule-drawer.tsx` thread the prop; the drawer renders `visibleOptions` filtered to the allowed set (Set membership, not literal `=== 'facebook'` ladders).
- `PlatformId` → `AllowedTargetPlatform` (the existing 5-platform union already defined backend-side; no new widening); the two presenter `defaultPlatforms` filters use the same allowed set.

## Why this is safe

- **ADDITIVE + default-Facebook+Instagram + DORMANT.** With all `ARIES_*_ENABLED` flags OFF (current prod), `allowedPublishPlatforms = ['facebook','instagram']` and `RescheduleDrawer`'s `allowedPlatforms` prop defaults to `['facebook','instagram']`, so the rendered picker is **byte-identical to today** (exactly 2 options) → zero live-Facebook/Instagram regression. A jsdom render test locks this 2-option dormancy property.
- **NOT YouTube** — publish to YouTube is a documented limitation (insights-only); a test asserts `'youtube'` never appears as a publish target.
- Reddit subreddit selection stays **env-only** (`ARIES_REDDIT_TARGET_SUBREDDIT`) — a noted follow-up, not part of this picker.
- `PublishNowButton`'s separate FB/IG narrowing is intentionally left as-is (a noted follow-up) — unchanged by this PR, so not a regression.
- Pure type-only imports of `AllowedTargetPlatform` into the client components (erased at compile) — no server-only/backend runtime leaks across the client boundary.

## Tests

New `tests/publish-picker-newplatforms.test.ts` (20 tests incl. jsdom render tests for the option-count + dormancy guards). Full test glob green (2837 pass / 0 fail); typecheck + lint clean.

## QA note

This does NOT `Closes` an issue — the X/Reddit/LinkedIn publish qa-defects are already closed; this is frontend completeness. The **rendered UI** is the real done-signal: QA/Brendan should screenshot-verify the picker with one of the `ARIES_<PLATFORM>_ENABLED` flags ON post-deploy (a flag-OFF deploy is a no-op by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)