### PR TITLE
feat(insights): add platform selector to analytics + comments screens

### DIFF
--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,14 +1,33 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import AriesAnalyticsScreen from '@/frontend/aries-v1/analytics-screen';
+import {
+  isXEnabled,
+  isYouTubeEnabled,
+  isRedditEnabled,
+  isLinkedInEnabled,
+} from '@/backend/integrations/providers/integration-config';
+import type { Platform } from '@/backend/insights/platforms/registry';
 
 export const metadata = {
   title: 'Analytics — Aries AI',
 };
 
 export default function DashboardAnalyticsPage() {
+  // Build the ordered enabled-platforms list server-side from env flags.
+  // Facebook is always first. All other platforms are gated by their rollout
+  // flags; when all flags are OFF this collapses to ['facebook'] and the
+  // client-side selector is never rendered (length === 1 guard in the screen).
+  const enabledPlatforms: Platform[] = [
+    'facebook',
+    ...(isXEnabled() ? (['x'] as const) : []),
+    ...(isYouTubeEnabled() ? (['youtube'] as const) : []),
+    ...(isRedditEnabled() ? (['reddit'] as const) : []),
+    ...(isLinkedInEnabled() ? (['linkedin'] as const) : []),
+  ];
+
   return (
     <AppShellLayout currentRouteId="analytics" loginRedirectPath="/dashboard/analytics">
-      <AriesAnalyticsScreen />
+      <AriesAnalyticsScreen enabledPlatforms={enabledPlatforms} />
     </AppShellLayout>
   );
 }

--- a/app/dashboard/comments/page.tsx
+++ b/app/dashboard/comments/page.tsx
@@ -1,14 +1,33 @@
 import AppShellLayout from '@/frontend/app-shell/layout';
 import AriesCommentsScreen from '@/frontend/aries-v1/comments-screen';
+import {
+  isXEnabled,
+  isYouTubeEnabled,
+  isRedditEnabled,
+  isLinkedInEnabled,
+} from '@/backend/integrations/providers/integration-config';
+import type { Platform } from '@/backend/insights/platforms/registry';
 
 export const metadata = {
   title: 'Comments — Aries AI',
 };
 
 export default function DashboardCommentsPage() {
+  // Build the ordered enabled-platforms list server-side from env flags.
+  // Facebook is always first. All other platforms are gated by their rollout
+  // flags; when all flags are OFF this collapses to ['facebook'] and the
+  // client-side selector is never rendered (length === 1 guard in the screen).
+  const enabledPlatforms: Platform[] = [
+    'facebook',
+    ...(isXEnabled() ? (['x'] as const) : []),
+    ...(isYouTubeEnabled() ? (['youtube'] as const) : []),
+    ...(isRedditEnabled() ? (['reddit'] as const) : []),
+    ...(isLinkedInEnabled() ? (['linkedin'] as const) : []),
+  ];
+
   return (
     <AppShellLayout currentRouteId="comments" loginRedirectPath="/dashboard/comments">
-      <AriesCommentsScreen />
+      <AriesCommentsScreen enabledPlatforms={enabledPlatforms} />
     </AppShellLayout>
   );
 }

--- a/frontend/aries-v1/analytics-screen.tsx
+++ b/frontend/aries-v1/analytics-screen.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import {
   CartesianGrid,
   Line,
@@ -12,9 +13,12 @@ import {
 
 import type { InsightsAccountMetricPoint, InsightsPostItem } from '@/lib/api/aries-v1';
 import { useInsightsAnalytics } from '@/hooks/use-insights-analytics';
+import type { Platform } from '@/backend/insights/platforms/registry';
+import { PLATFORM_LABELS } from '@/backend/insights/platforms/registry';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { EmptyStatePanel, LoadingStateGrid, MetricCard, ShellPanel } from './components';
+import { PlatformSelector } from './platform-selector';
 
 function formatNumber(value: number): string {
   if (!Number.isFinite(value)) return '0';
@@ -28,8 +32,14 @@ function formatDay(value: string): string {
   return value.slice(0, 10) || '—';
 }
 
-export default function AriesAnalyticsScreen() {
-  const analytics = useInsightsAnalytics({ autoLoad: true, platform: 'facebook' });
+export default function AriesAnalyticsScreen({
+  enabledPlatforms = ['facebook'],
+}: {
+  enabledPlatforms?: Platform[];
+}) {
+  const [platform, setPlatform] = useState<Platform>('facebook');
+
+  const analytics = useInsightsAnalytics({ autoLoad: true, platform });
   const data = analytics.data;
 
   const summary = data?.summary;
@@ -49,13 +59,34 @@ export default function AriesAnalyticsScreen() {
         posts.length > 0),
   );
 
+  const label = PLATFORM_LABELS[platform];
+
   return (
     <div className="space-y-5">
-      <ShellPanel eyebrow="Analytics" title="Facebook performance">
-        <p className="max-w-3xl text-sm leading-7 text-white/65">
-          Views, followers, and engagement from your connected Facebook Page, plus per-post results.
-          Numbers populate here after Aries syncs analytics from Meta.
-        </p>
+      <ShellPanel
+        eyebrow="Analytics"
+        title={`${label} performance`}
+        action={
+          enabledPlatforms.length > 1 ? (
+            <PlatformSelector
+              platforms={enabledPlatforms}
+              value={platform}
+              onChange={setPlatform}
+            />
+          ) : null
+        }
+      >
+        {platform === 'facebook' ? (
+          <p className="max-w-3xl text-sm leading-7 text-white/65">
+            Views, followers, and engagement from your connected Facebook Page, plus per-post results.
+            Numbers populate here after Aries syncs analytics from Meta.
+          </p>
+        ) : (
+          <p className="max-w-3xl text-sm leading-7 text-white/65">
+            Views, followers, and engagement from your connected {label} account, plus per-post results.
+            Numbers populate here after Aries syncs analytics.
+          </p>
+        )}
       </ShellPanel>
 
       {analytics.isLoading ? (
@@ -74,7 +105,11 @@ export default function AriesAnalyticsScreen() {
       ) : !hasData || !summary ? (
         <EmptyStatePanel
           title="No analytics yet"
-          description="Once your Facebook posts are live and Aries has synced performance data from Meta, your views, followers, and per-post results will appear here."
+          description={
+            platform === 'facebook'
+              ? 'Once your Facebook posts are live and Aries has synced performance data from Meta, your views, followers, and per-post results will appear here.'
+              : `Once your ${label} posts are live and Aries has synced performance data, your views, followers, and per-post results will appear here.`
+          }
         />
       ) : (
         <>

--- a/frontend/aries-v1/comments-screen.tsx
+++ b/frontend/aries-v1/comments-screen.tsx
@@ -173,7 +173,7 @@ export default function AriesCommentsScreen({
                       {isReplied ? null : outcome?.kind === 'not_enabled' ? (
                         <p className="mt-3 text-xs text-white/45">
                           {platform === 'facebook' ? (
-                            <>Native reply isn&apos;t enabled for your account yet. You can still reply from
+                            <>Native reply isn’t enabled for your account yet. You can still reply from
                             Facebook directly.</>
                           ) : (
                             <>Native reply isn&apos;t enabled for your account yet. You can still reply from{' '}

--- a/frontend/aries-v1/comments-screen.tsx
+++ b/frontend/aries-v1/comments-screen.tsx
@@ -4,9 +4,12 @@ import { useMemo, useState } from 'react';
 
 import type { InsightsCommentItem } from '@/lib/api/aries-v1';
 import { useInsightsComments, type CommentReplyOutcome } from '@/hooks/use-insights-comments';
+import type { Platform } from '@/backend/insights/platforms/registry';
+import { PLATFORM_LABELS } from '@/backend/insights/platforms/registry';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { EmptyStatePanel, LoadingStateGrid, ShellPanel } from './components';
+import { PlatformSelector } from './platform-selector';
 
 function formatDay(value: string): string {
   if (typeof value !== 'string') return '';
@@ -40,8 +43,19 @@ function groupByPost(comments: InsightsCommentItem[]): PostGroup[] {
   return order.map((id) => groups.get(id)!);
 }
 
-export default function AriesCommentsScreen() {
-  const inbox = useInsightsComments({ autoLoad: true, platform: 'facebook' });
+export default function AriesCommentsScreen({
+  enabledPlatforms = ['facebook'],
+}: {
+  enabledPlatforms?: Platform[];
+}) {
+  const [platform, setPlatform] = useState<Platform>('facebook');
+
+  // LinkedIn has no Composio list-comments action (#648); skip the fetch and
+  // show an honest unavailable panel instead of an error or empty-state.
+  const inbox = useInsightsComments({
+    autoLoad: platform !== 'linkedin',
+    platform,
+  });
   const comments = inbox.data?.comments ?? [];
   const groups = useMemo(() => groupByPost(comments), [comments]);
 
@@ -64,16 +78,43 @@ export default function AriesCommentsScreen() {
     setSubmittingId(null);
   }
 
+  const label = PLATFORM_LABELS[platform];
+
   return (
     <div className="space-y-5">
-      <ShellPanel eyebrow="Comments" title="Facebook comment inbox">
-        <p className="max-w-3xl text-sm leading-7 text-white/65">
-          Comments on your Facebook posts, grouped by the post they belong to. Reply directly from
-          Aries when native reply is enabled for your account.
-        </p>
+      <ShellPanel
+        eyebrow="Comments"
+        title={`${label} comment inbox`}
+        action={
+          enabledPlatforms.length > 1 ? (
+            <PlatformSelector
+              platforms={enabledPlatforms}
+              value={platform}
+              onChange={setPlatform}
+            />
+          ) : null
+        }
+      >
+        {platform === 'facebook' ? (
+          <p className="max-w-3xl text-sm leading-7 text-white/65">
+            Comments on your Facebook posts, grouped by the post they belong to. Reply directly from
+            Aries when native reply is enabled for your account.
+          </p>
+        ) : (
+          <p className="max-w-3xl text-sm leading-7 text-white/65">
+            Comments on your {label} posts, grouped by the post they belong to. Reply directly from
+            Aries when native reply is enabled for your account.
+          </p>
+        )}
       </ShellPanel>
 
-      {inbox.isLoading ? (
+      {/* LinkedIn short-circuit: no Composio list-comments action for LinkedIn. */}
+      {platform === 'linkedin' ? (
+        <EmptyStatePanel
+          title="Comments aren't available for LinkedIn."
+          description="LinkedIn doesn't support listing post comments via the integration used here. Visit LinkedIn directly to read and respond to comments."
+        />
+      ) : inbox.isLoading ? (
         <LoadingStateGrid />
       ) : inbox.error ? (
         <div className="rounded-[1.5rem] border border-red-500/20 bg-red-500/10 p-5 text-red-100">
@@ -89,7 +130,11 @@ export default function AriesCommentsScreen() {
       ) : groups.length === 0 ? (
         <EmptyStatePanel
           title="No comments yet"
-          description="When people comment on your live Facebook posts, their messages will appear here so you can read and reply."
+          description={
+            platform === 'facebook'
+              ? 'When people comment on your live Facebook posts, their messages will appear here so you can read and reply.'
+              : `When people comment on your live ${label} posts, their messages will appear here so you can read and reply.`
+          }
         />
       ) : (
         <div className="space-y-5">
@@ -111,7 +156,8 @@ export default function AriesCommentsScreen() {
                     >
                       <div className="flex flex-wrap items-center justify-between gap-2">
                         <p className="text-sm font-medium text-white">
-                          {comment.authorHandle?.trim() || 'Facebook user'}
+                          {comment.authorHandle?.trim() ||
+                            (platform === 'facebook' ? 'Facebook user' : `${label} user`)}
                         </p>
                         <div className="flex items-center gap-3">
                           <span className="text-xs text-white/45">{formatDay(comment.receivedAt)}</span>
@@ -126,8 +172,13 @@ export default function AriesCommentsScreen() {
 
                       {isReplied ? null : outcome?.kind === 'not_enabled' ? (
                         <p className="mt-3 text-xs text-white/45">
-                          Native reply isn’t enabled for your account yet. You can still reply from
-                          Facebook directly.
+                          {platform === 'facebook' ? (
+                            <>Native reply isn&apos;t enabled for your account yet. You can still reply from
+                            Facebook directly.</>
+                          ) : (
+                            <>Native reply isn&apos;t enabled for your account yet. You can still reply from{' '}
+                            {label} directly.</>
+                          )}
                         </p>
                       ) : (
                         <div className="mt-3 space-y-2">

--- a/frontend/aries-v1/platform-icon.tsx
+++ b/frontend/aries-v1/platform-icon.tsx
@@ -1,0 +1,39 @@
+/**
+ * PlatformIcon — maps a Platform value to the correct icon component.
+ *
+ * Brand icons (Facebook/Instagram/LinkedIn/YouTube) come from brand-icons.tsx
+ * (inline SVGs added when lucide-react v1 dropped brand glyphs).
+ * X and Reddit come from frontend/components/Icons.tsx.
+ *
+ * The `size` prop is passed as the `size` attribute to BrandIcon components
+ * and as `width`/`height` to the SVGProps-based X and Reddit icons.
+ */
+
+import type { Platform } from '@/backend/insights/platforms/registry';
+import { FacebookIcon, InstagramIcon, LinkedinIcon, YoutubeIcon } from './brand-icons';
+import { RedditIcon, XIcon } from '@/frontend/components/Icons';
+
+export function PlatformIcon({
+  platform,
+  size = 16,
+  className,
+}: {
+  platform: Platform;
+  size?: number;
+  className?: string;
+}) {
+  switch (platform) {
+    case 'facebook':
+      return <FacebookIcon size={size} className={className} />;
+    case 'instagram':
+      return <InstagramIcon size={size} className={className} />;
+    case 'linkedin':
+      return <LinkedinIcon size={size} className={className} />;
+    case 'youtube':
+      return <YoutubeIcon size={size} className={className} />;
+    case 'reddit':
+      return <RedditIcon width={size} height={size} className={className} />;
+    case 'x':
+      return <XIcon width={size} height={size} className={className} />;
+  }
+}

--- a/frontend/aries-v1/platform-selector.tsx
+++ b/frontend/aries-v1/platform-selector.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+/**
+ * PlatformSelector — segmented control for picking the active analytics/comments
+ * platform.  Reuses the visual idiom from calendar-presenter.tsx's week/month
+ * toggle (rounded-xl border border-white/5 bg-[#111] wrapper, rounded-lg
+ * bg-[#222] active pill) so it matches the existing design system without
+ * adding a dependency.
+ *
+ * Props:
+ *   platforms  — ordered list of platforms to show (Facebook always first).
+ *   value      — the currently selected platform.
+ *   onChange   — called when the user clicks a different segment.
+ *
+ * Rendered only when `platforms.length > 1`; the parent components gate on that
+ * condition so this component is never mounted in the single-platform (flags-off)
+ * default, keeping the flags-off screen pixel-identical to today.
+ */
+
+import type { Platform } from '@/backend/insights/platforms/registry';
+import { PLATFORM_LABELS } from '@/backend/insights/platforms/registry';
+import { PlatformIcon } from './platform-icon';
+
+export function PlatformSelector({
+  platforms,
+  value,
+  onChange,
+}: {
+  platforms: Platform[];
+  value: Platform;
+  onChange: (p: Platform) => void;
+}) {
+  return (
+    <div className="flex rounded-xl border border-white/5 bg-[#111] p-1">
+      {platforms.map((p) => (
+        <button
+          key={p}
+          type="button"
+          onClick={() => onChange(p)}
+          className={`flex items-center gap-1.5 px-3 py-2 text-sm font-medium transition-all ${
+            value === p
+              ? 'rounded-lg bg-[#222] text-white shadow-lg'
+              : 'text-zinc-400 hover:text-zinc-300'
+          }`}
+        >
+          <span className="flex h-4 w-4 items-center justify-center">
+            <PlatformIcon platform={p} size={12} />
+          </span>
+          {PLATFORM_LABELS[p]}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/tests/insights-dashboard-ui.test.ts
+++ b/tests/insights-dashboard-ui.test.ts
@@ -50,14 +50,22 @@ test('analytics page renders the analytics screen inside the app shell', () => {
   assert.match(analyticsPage, /import AppShellLayout from '@\/frontend\/app-shell\/layout'/);
   assert.match(analyticsPage, /import AriesAnalyticsScreen from '@\/frontend\/aries-v1\/analytics-screen'/);
   assert.match(analyticsPage, /currentRouteId="analytics"/);
-  assert.match(analyticsPage, /<AriesAnalyticsScreen \/>/);
+  // enabledPlatforms is passed as a prop (not hard-pinned).
+  assert.match(analyticsPage, /<AriesAnalyticsScreen enabledPlatforms=\{enabledPlatforms\} \/>/);
+  // Facebook is always the first entry — dormancy default preserved.
+  assert.match(analyticsPage, /const enabledPlatforms/);
+  assert.match(analyticsPage, /'facebook'/);
 });
 
 test('comments page renders the comments screen inside the app shell', () => {
   assert.match(commentsPage, /import AppShellLayout from '@\/frontend\/app-shell\/layout'/);
   assert.match(commentsPage, /import AriesCommentsScreen from '@\/frontend\/aries-v1\/comments-screen'/);
   assert.match(commentsPage, /currentRouteId="comments"/);
-  assert.match(commentsPage, /<AriesCommentsScreen \/>/);
+  // enabledPlatforms is passed as a prop (not hard-pinned).
+  assert.match(commentsPage, /<AriesCommentsScreen enabledPlatforms=\{enabledPlatforms\} \/>/);
+  // Facebook is always the first entry — dormancy default preserved.
+  assert.match(commentsPage, /const enabledPlatforms/);
+  assert.match(commentsPage, /'facebook'/);
 });
 
 test('api client targets the real /api/insights/* endpoints (Facebook scoped by the screens)', () => {
@@ -70,7 +78,14 @@ test('api client targets the real /api/insights/* endpoints (Facebook scoped by 
 
 test('analytics screen consumes the analytics hook, charts the series, and keeps the empty state', () => {
   assert.match(analyticsScreen, /useInsightsAnalytics/);
-  assert.match(analyticsScreen, /platform:\s*'facebook'/);
+  // Platform state defaults to 'facebook' — dormancy: flags-off renders FB-only, no selector.
+  assert.match(analyticsScreen, /useState<Platform>\('facebook'\)/);
+  // The hook receives the platform STATE variable, not a hard-coded literal.
+  assert.match(analyticsScreen, /useInsightsAnalytics\(\{ autoLoad: true, platform \}\)/);
+  // Prop default of ['facebook'] preserves the single-platform dormant state.
+  assert.match(analyticsScreen, /enabledPlatforms\s*=\s*\['facebook'\]/);
+  // Selector is only rendered when more than one platform is enabled.
+  assert.match(analyticsScreen, /enabledPlatforms\.length > 1/);
   // Headline tiles for the real summary fields.
   assert.match(analyticsScreen, /summary\.totalViews/);
   assert.match(analyticsScreen, /summary\.currentFollowers/);
@@ -95,7 +110,18 @@ test('analytics hook reads summary, account-metrics, and posts and defaults to F
 
 test('comments screen groups by post, shows replied state, and surfaces a reply box', () => {
   assert.match(commentsScreen, /useInsightsComments/);
-  assert.match(commentsScreen, /platform:\s*'facebook'/);
+  // Platform state defaults to 'facebook' — dormancy: flags-off renders FB-only, no selector.
+  assert.match(commentsScreen, /useState<Platform>\('facebook'\)/);
+  // The hook receives the platform STATE variable, not a hard-coded literal.
+  assert.match(commentsScreen, /platform,/);
+  // Prop default of ['facebook'] preserves the single-platform dormant state.
+  assert.match(commentsScreen, /enabledPlatforms\s*=\s*\['facebook'\]/);
+  // Selector is only rendered when more than one platform is enabled.
+  assert.match(commentsScreen, /enabledPlatforms\.length > 1/);
+  // LinkedIn short-circuit: no autoLoad for LinkedIn (no Composio list-comments action).
+  assert.match(commentsScreen, /autoLoad: platform !== 'linkedin'/);
+  // LinkedIn renders an honest unavailable EmptyStatePanel rather than an error.
+  assert.match(commentsScreen, /platform === 'linkedin'[\s\S]*?EmptyStatePanel/);
   assert.match(commentsScreen, /groupByPost/);
   assert.match(commentsScreen, /comment\.authorHandle/);
   assert.match(commentsScreen, /comment\.bodyText/);


### PR DESCRIPTION
FRONTEND completeness PR — makes the already-merged X/Reddit/LinkedIn/YouTube analytics + comments work user-visible via an additive platform selector on the analytics and comments screens (un-pins them from the hard-coded `platform: 'facebook'`).

## What changed
- 2 server pages (`app/dashboard/{analytics,comments}/page.tsx`) compute an ordered `enabledPlatforms` list server-side from the rollout flags (`isXEnabled`/`isYouTubeEnabled`/`isRedditEnabled`/`isLinkedInEnabled`), Facebook always first, and pass it down as a plain prop.
- 2 screens (`analytics-screen.tsx`, `comments-screen.tsx`) hold `platform` state (default `'facebook'`), thread it into `useInsightsAnalytics`/`useInsightsComments`, and render `<PlatformSelector>` ONLY when `enabledPlatforms.length > 1`.
- 2 new small client components: `platform-selector.tsx` (segmented control, reuses the existing calendar-toggle idiom) and `platform-icon.tsx` (maps `Platform` to a brand icon).
- Reuses `PLATFORM_LABELS` from the platforms registry (no duplicated labels). No backend / route / read-api change; no new endpoint.

## Dormant by default (zero live-FB regression)
With all rollout flags OFF (current prod), `enabledPlatforms` collapses to `['facebook']`, the selector never mounts (`length > 1` guard), `platform` stays `'facebook'`, and every Facebook string is byte-identical to today — pixel-identical to the current screens. The selector only appears once a platform flag is flipped on.

## LinkedIn comments
LinkedIn has no list-comments action in the integration used here (#648), so the comments tab short-circuits to an honest "comments aren't available for LinkedIn" panel and does not fetch (`autoLoad: platform !== 'linkedin'`) — no fake data, no error.

## Tests
Updated `tests/insights-dashboard-ui.test.ts` for the prop wiring, the `'facebook'` default, the `length > 1` selector guard, and the LinkedIn short-circuit. Full test glob green (2837 pass / 0 fail); typecheck + lint clean.

No `Closes` — the analytics/comments qa-defects are already closed; this is the "rendered-UI = done" completeness pass. QA/Brendan should screenshot-verify with a platform flag on post-deploy (the real done-signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)