### PR TITLE
fix(integrations): refuse unhandled platform in Composio publisher instead of IG fallback

### DIFF
--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -374,7 +374,7 @@ export class ComposioPublisherProvider implements PublisherProvider {
         commentary: linkedinCommentary(input.content),
         ...(descriptor ? { images: [descriptor] } : {}),
       };
-    } else {
+    } else if (input.platform === 'instagram') {
       // Instagram: caption + media_urls + placement + media_type (unchanged).
       slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
       toolArgs = {
@@ -384,6 +384,13 @@ export class ComposioPublisherProvider implements PublisherProvider {
         media_type: input.mediaType ?? 'image',
         ...(input.scheduledFor ? { scheduled_publish_time: input.scheduledFor } : {}),
       };
+    } else {
+      // Unknown / unhandled platform — refuse explicitly rather than silently
+      // falling through to an Instagram payload on the wrong network.
+      throw new ComposioToolError(
+        'publish_post',
+        `${input.platform} is not a supported publish target`,
+      );
     }
 
     const result = await this.gateway.executeTool(slug, {

--- a/tests/composio-publisher.test.ts
+++ b/tests/composio-publisher.test.ts
@@ -6,6 +6,7 @@ import { PublishGuardError } from '@/backend/integrations/providers/errors';
 import {
   ComposioCapabilityMissingError,
   ComposioConnectionMissingError,
+  ComposioToolError,
 } from '@/backend/integrations/composio/errors';
 import { fakeConfig, fakeGateway, fakeDb } from './composio/helpers';
 
@@ -289,4 +290,75 @@ test('#627 FB image post with no upload_media slug throws capability-missing', a
     ComposioCapabilityMissingError,
     'missing upload_media slug must throw capability-missing',
   );
+});
+
+// ── Regression tests for #667: unhandled-platform refusal ─────────────────
+//
+// Before the fix, the publishPost dispatch had a bare `else` that silently
+// built an Instagram `caption`/`media_urls` payload for any platform that
+// wasn't facebook, x, reddit, or linkedin — including tiktok, youtube, and
+// meta_ads. The fix made Instagram an explicit `else if` branch and added a
+// final `else` that throws ComposioToolError immediately.
+//
+// The explicit Instagram branch is already exercised by the '#624 IG
+// publishPost sends `caption`...' test above. These two tests guard the new
+// refusal path.
+
+test('#667 publishPost with an unhandled IntegrationPlatform throws ComposioToolError naming the platform', async () => {
+  // 'tiktok' is a valid IntegrationPlatform but has no dispatch branch in
+  // publishPost. Before the fix it silently built an Instagram payload for the
+  // wrong account; after the fix the final else throws before any gateway call.
+  const provider = new ComposioPublisherProvider(
+    fakeGateway(),
+    fakeConfig({ actions: { publish_post: 'TIKTOK_POST' } }),
+    fakeDb(),
+  );
+  await assert.rejects(
+    () =>
+      provider.publishPost({
+        tenantId,
+        platform: 'tiktok',
+        content: 'hello tiktok',
+        mediaUrls: [],
+        approved: true,
+      }),
+    (err: unknown) => {
+      assert.ok(err instanceof ComposioToolError, `expected ComposioToolError, got ${(err as Error)?.name}`);
+      assert.match(
+        (err as Error).message,
+        /tiktok/,
+        'error message must name the unhandled platform',
+      );
+      assert.match(
+        (err as Error).message,
+        /not a supported publish target/,
+        'error message must include "not a supported publish target"',
+      );
+      return true;
+    },
+  );
+});
+
+test('#667 unhandled-platform publishPost makes zero gateway calls (no silent publish to wrong network)', async () => {
+  // Safety property: the refusal must happen BEFORE any executeTool call.
+  // On the pre-fix code this assertion would also fail because the Instagram
+  // payload would be constructed and the gateway called.
+  const gateway = fakeGateway();
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: { publish_post: 'YOUTUBE_POST' } }),
+    fakeDb(),
+  );
+  await assert.rejects(
+    () =>
+      provider.publishPost({
+        tenantId,
+        platform: 'youtube',
+        content: 'hello youtube',
+        mediaUrls: ['https://aries.example.com/api/public/media/tok/img.png'],
+        approved: true,
+      }),
+    ComposioToolError,
+  );
+  assert.equal(gateway.calls.length, 0, 'no gateway call must be made for an unhandled platform');
 });


### PR DESCRIPTION
Closes #667

## What
The publish dispatch in `backend/integrations/composio/composio-publisher-provider.ts` ended in a bare `else` that built an Instagram `publish_post` payload. Any platform without an explicit branch (`meta_ads`, `tiktok`, `youtube`) therefore fell through and was silently published to the connected **Instagram** account — the wrong network.

## Fix
- Instagram is now an explicit `else if (input.platform === 'instagram')` branch (payload byte-identical to before).
- A new final `else` throws `ComposioToolError('publish_post', \`${input.platform} is not a supported publish target\`)`.

## Why this is safe
- All five handled platforms (facebook / x / reddit / linkedin / instagram) are byte-identical — only the unhandled fall-through changes.
- `ComposioToolError` is enumerated in `publishNeverReachedPlatform` as **definitely-never-posted**, so the refusal rolls the claim back safely (never outcome-unknown, never a silent success, no duplicate post). The throw happens before any `executeTool` call, so no gateway request is made.
- Frontend-safe: the message contains only the closed-union `platform` literal and the op name — no token, SDK internals, or connection id.

## Tests
`tests/composio-publisher.test.ts` adds 2 regression tests (unhandled platform throws `ComposioToolError` naming the platform; and makes zero gateway calls). Verified they **fail** against pre-fix product code and **pass** after the fix. Focused gates green: `validate:execution-provider` 52/0, full composio publisher file 16/16.

## Residual risk
Low. The path is defense-in-depth — the live `dispatchPublish` seam maps unknown providers to `facebook`, so these platforms don't reach this dispatch today; the change hardens against a future direct caller.