### PR TITLE
fix(integrations): resolve reddit as managed + drop DEFAULT auth-config fallback for reddit/x

### DIFF
--- a/backend/integrations/composio/composio-account-provider.ts
+++ b/backend/integrations/composio/composio-account-provider.ts
@@ -35,6 +35,10 @@ import { resolveLinkedInAuthorUrn } from './linkedin-author-resolver';
 import { isLinkedInEnabled } from '../providers/integration-config';
 import pool from '@/lib/db';
 
+// Genuinely no Composio-managed shared credentials → operator must register a
+// custom OAuth app. Today only X/twitter. (Reddit HAS managed auth.)
+const CUSTOM_OAUTH_PLATFORMS: ReadonlySet<IntegrationPlatform> = new Set(['x']);
+
 export class ComposioAccountProvider implements AccountConnectionProvider {
   readonly kind = 'composio' as const;
 
@@ -66,13 +70,22 @@ export class ComposioAccountProvider implements AccountConnectionProvider {
       try {
         authConfigId = await this.gateway.findOrCreateManagedAuthConfig(this.config.toolkitSlugFor(platform));
       } catch {
-        // Custom-OAuth toolkits (e.g. twitter/X, reddit) have no Composio-managed
-        // shared credentials. Throw a frontend-safe, actionable error that names
-        // the env var the operator must set — never leak the raw SDK error text.
+        // Throw a frontend-safe, actionable error — never leak the raw SDK error text.
         const envKey = `COMPOSIO_${platform.toUpperCase()}_AUTH_CONFIG_ID`;
+        if (CUSTOM_OAUTH_PLATFORMS.has(platform)) {
+          // X/twitter has no Composio-managed shared credentials; operator must
+          // register a custom OAuth app and supply the auth-config id.
+          throw new ComposioConfigError(
+            `${platform} requires a custom OAuth app and is not configured for Composio-managed credentials. ` +
+              `Set ${envKey} to the Composio auth-config id for this platform.`,
+          );
+        }
+        // Reddit and other platforms with Composio-managed auth: provisioning
+        // failed transiently. Signal a retryable error; name the env var only as
+        // an explicit override, not as a required step.
         throw new ComposioConfigError(
-          `${platform} requires a custom OAuth app and is not configured for Composio-managed credentials. ` +
-            `Set ${envKey} to the Composio auth-config id for this platform.`,
+          `Could not provision Composio-managed auth for ${platform}. ` +
+            `Please retry; if this persists, set ${envKey} to an explicit Composio auth-config id.`,
         );
       }
     }

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -114,6 +114,11 @@ export function composioAuthConfigId(
   };
   const specific = perPlatform[platform]?.trim();
   if (specific) return specific;
+  // reddit + x are toolkit-specific (reddit provisions Composio-managed auth;
+  // x needs its own custom OAuth app). Neither may inherit
+  // COMPOSIO_DEFAULT_AUTH_CONFIG_ID (typically a Meta-family config) or connect
+  // would target the wrong toolkit (#669).
+  if (platform === 'reddit' || platform === 'x') return null;
   const fallback = env.COMPOSIO_DEFAULT_AUTH_CONFIG_ID?.trim();
   return fallback || null;
 }

--- a/tests/composio-connect-hardening.test.ts
+++ b/tests/composio-connect-hardening.test.ts
@@ -158,11 +158,39 @@ test('#640 Reddit connect: findOrCreateManagedAuthConfig failure raises Composio
         !err.message.includes(RAW_SDK_ERROR),
         `message must NOT include raw SDK error text; got: ${err.message}`,
       );
+      assert.ok(
+        !err.message.toLowerCase().includes('custom oauth app'),
+        `message must NOT include 'custom oauth app' for reddit (reddit has Composio-managed auth, #668); got: ${err.message}`,
+      );
       assert.equal(err.code, 'composio_not_configured');
       assert.equal(err.status, 503);
       return true;
     },
   );
+});
+
+// ── b2. Reddit managed connect: resolving gateway → succeeds (#668) ───────────
+
+test('#668 reddit managed connect: findOrCreateManagedAuthConfig resolves → connect succeeds, initiateConnection called', async () => {
+  // Proves that when Composio-managed auth provisioning succeeds for reddit
+  // (the happy path), createConnectLink completes normally — no ComposioConfigError,
+  // no "custom OAuth app" message. Reddit HAS managed credentials.
+  const { gw, state } = resolvingGateway();
+  const provider = new ComposioAccountProvider(
+    gw,
+    fakeConfig({ authConfigId: null }), // no explicit id → falls through to findOrCreate
+    fakeDb(),
+  );
+
+  const result = await provider.createConnectLink(userId, 'reddit', 'full', { tenantId });
+
+  assert.equal(result.connectUrl, 'https://composio.dev/connect/abc');
+  assert.ok(
+    state.initiateConnectionCalled,
+    'initiateConnection must be called when findOrCreateManagedAuthConfig resolves for reddit',
+  );
+  assert.equal(result.platform, 'reddit');
+  assert.equal(result.provider, 'composio');
 });
 
 // ── c. Regression guard: managed toolkit (facebook) is byte-identical ─────────

--- a/tests/composio-x-connect.test.ts
+++ b/tests/composio-x-connect.test.ts
@@ -217,11 +217,47 @@ test('composioAuthConfigId x: returns null when neither x-specific nor default k
   assert.equal(composioAuthConfigId('facebook', mkEnv({})), null);
 });
 
-test('composioAuthConfigId x: falls back to COMPOSIO_DEFAULT_AUTH_CONFIG_ID when x-specific key absent', () => {
+test('composioAuthConfigId x: returns null when only COMPOSIO_DEFAULT_AUTH_CONFIG_ID is set (no default fallback for x, #669)', () => {
+  // x must NOT inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID — that is typically a
+  // Meta-family config and would route the X connection through the wrong toolkit
+  // (#669). Only the platform-specific COMPOSIO_X_AUTH_CONFIG_ID is accepted.
   assert.equal(
     composioAuthConfigId('x', mkEnv({ COMPOSIO_DEFAULT_AUTH_CONFIG_ID: 'ac_default' })),
-    'ac_default',
+    null,
   );
+});
+
+test('composioAuthConfigId reddit: returns null when only COMPOSIO_DEFAULT_AUTH_CONFIG_ID is set (no default fallback for reddit, #669)', () => {
+  // reddit provisions Composio-managed auth but must NOT inherit
+  // COMPOSIO_DEFAULT_AUTH_CONFIG_ID either — that config targets a different
+  // toolkit and would break the connection. Set COMPOSIO_REDDIT_AUTH_CONFIG_ID
+  // to pin an explicit one when Composio-managed provisioning fails.
+  assert.equal(
+    composioAuthConfigId('reddit', mkEnv({ COMPOSIO_DEFAULT_AUTH_CONFIG_ID: 'ac_default' })),
+    null,
+  );
+});
+
+test('composioAuthConfigId regression: managed platforms still fall back to COMPOSIO_DEFAULT_AUTH_CONFIG_ID (#669)', () => {
+  // The exclusion is narrow — only reddit + x are excluded from the DEFAULT
+  // fallback. All other platforms (facebook, instagram, meta_ads, youtube,
+  // linkedin, tiktok) must still inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID.
+  const env = mkEnv({ COMPOSIO_DEFAULT_AUTH_CONFIG_ID: 'ac_default' });
+  const managed = [
+    'facebook',
+    'instagram',
+    'meta_ads',
+    'youtube',
+    'linkedin',
+    'tiktok',
+  ] as const;
+  for (const platform of managed) {
+    assert.equal(
+      composioAuthConfigId(platform, env),
+      'ac_default',
+      `${platform} must still fall back to COMPOSIO_DEFAULT_AUTH_CONFIG_ID`,
+    );
+  }
 });
 
 // ── 4. Regression guard: the other 7 platforms remain byte-identical ─────────


### PR DESCRIPTION
Closes #668
Closes #669

## What
- `composioAuthConfigId` (#669): reddit + x now return `null` instead of inheriting `COMPOSIO_DEFAULT_AUTH_CONFIG_ID`. That default is typically a Meta-family config; letting reddit/x inherit it would route the connection through the wrong toolkit. All other platforms (facebook/instagram/meta_ads/youtube/linkedin/tiktok) keep the DEFAULT fallback unchanged.
- `createConnectLink` catch (#668): new `CUSTOM_OAUTH_PLATFORMS = {'x'}` set. Only x gets the "requires a custom OAuth app" error (byte-identical to before). reddit/others now get a transient, retryable "could not provision Composio-managed auth, please retry" message — reddit HAS Composio-managed auth, so the old "custom OAuth app" copy was wrong for it. X custom-OAuth fallback path preserved.

## Why
Reddit has Composio managed auth (verified live via MCP); X does not. Treating reddit like X (no managed auth + DEFAULT fallback) both blocked reddit connect with a misleading error and risked targeting the wrong toolkit.

## Safety
- Both call sites (`createConnectLink`, `refreshConnectionStatus`) safe with `null`: refresh passes `authConfigIds: undefined` then narrows by toolkit slug, so cross-platform contamination is already guarded.
- Reddit error message is frontend-safe — names only the env var, never the raw SDK error or any secret.
- No behavior change for the 6 managed platforms in `composioAuthConfigId`; their catch-path error type/code/503 status are unchanged.

## Tests
- `tests/composio-x-connect.test.ts`: x/reddit → null; 6 managed platforms still → DEFAULT.
- `tests/composio-connect-hardening.test.ts`: reddit message no longer says "custom oauth app"; positive reddit-managed connect succeeds.
- Focused gate 23/23 green; `npm run verify` all 17 gates green.