### PR TITLE
fix(integrations): provision insights_accounts for X/Reddit via get-me resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -339,6 +339,24 @@ COMPOSIO_REDDIT_PUBLISH_POST_ACTION=
 COMPOSIO_REDDIT_TARGET_SUBREDDIT=
 COMPOSIO_REDDIT_FLAIR_ID=
 
+# X (Twitter) user identity (#670) — only consulted when ARIES_X_ENABLED=true
+# and ANALYTICS_PROVIDER=composio. account_info resolves the authenticated
+# Twitter username (handle) so insights_accounts.external_account_id can be
+# populated. The username is also used by the X insights adapter's fetchComments
+# `-from:<handle>` filter. The verified TWITTER_USER_LOOKUP_ME slug is the code
+# default; set only to pin a different toolkit version.
+#   account_info  -> TWITTER_USER_LOOKUP_ME (username + display name)
+COMPOSIO_X_ACCOUNT_INFO_ACTION=
+
+# Reddit user identity (#670) — only consulted when ARIES_REDDIT_ENABLED=true
+# and ANALYTICS_PROVIDER=composio. account_info resolves the authenticated
+# Reddit username so insights_accounts.external_account_id can be populated.
+# The action REQUIRES the argument { username: 'me' } — this is handled
+# automatically by the resolver. The verified REDDIT_GET_REDDIT_USER_ABOUT slug
+# is the code default; set only to pin a different toolkit version.
+#   account_info  -> REDDIT_GET_REDDIT_USER_ABOUT ({ username: 'me' } required)
+COMPOSIO_REDDIT_ACCOUNT_INFO_ACTION=
+
 # LinkedIn member identity (#645) — only consulted when ARIES_LINKEDIN_ENABLED=true.
 # account_info resolves the authenticated member at connect time so we can persist
 # their urn:li:person:<id> as the author for LinkedIn publish (#646). The verified

--- a/backend/insights/adapters/x/index.ts
+++ b/backend/insights/adapters/x/index.ts
@@ -342,8 +342,10 @@ export class XInsightsAdapter implements InsightsAdapter {
     if (!conversationId) conversationId = externalPostId;
 
     // Exclude our own tweets (the root + any self-replies) from "comments".
-    const ownUserId = this.ctx.pageId?.trim() || null;
-    const query = `conversation_id:${conversationId}` + (ownUserId ? ` -from:${ownUserId}` : '');
+    // pageId stores the X username/handle (e.g. "sugarleather"); the X recent
+    // search `-from:<handle>` operator requires the handle, not the numeric id.
+    const ownUsername = this.ctx.pageId?.trim() || null;
+    const query = `conversation_id:${conversationId}` + (ownUsername ? ` -from:${ownUsername}` : '');
 
     const data = await this.exec('list_comments', {
       query,

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -7,18 +7,25 @@
  * Nothing else inserts into insights_accounts, so without this bridge the sync
  * worker's `SELECT DISTINCT tenant_id FROM insights_accounts` is always empty
  * and the whole analytics pipeline no-ops even though a tenant has a connected
- * Facebook account. This runs once per worker tick and idempotently upserts one
+ * account. This runs once per worker tick and idempotently upserts one
  * insights_accounts row per tenant that has a connected, Composio-backed
- * Facebook connection (mapping connected_accounts.external_account_id → the
- * page id stored in insights_accounts.external_account_id).
+ * connection (mapping connected_accounts.external_account_id → the platform
+ * account id stored in insights_accounts.external_account_id).
  *
- * Page-id back-heal: the Facebook Page id is not part of the Composio connection
- * metadata, so legacy rows can have `external_account_id IS NULL` (the prod
- * 2026-06-04 connection). For such rows the bridge resolves the Page id from
- * Composio (FACEBOOK_LIST_MANAGED_PAGES) using the connection's
- * connected_account_id, persists it back to connected_accounts so it is captured
- * once, then upserts insights_accounts. Resolution is fail-safe: an error or no
- * Page logs + skips that tenant — never throws (the worker tick must not wedge).
+ * External-id back-heal: the external account id is not part of the Composio
+ * connection metadata for several platforms, so legacy rows can have
+ * `external_account_id IS NULL`. For such rows the bridge resolves the id from
+ * Composio using the connection's connected_account_id, persists it back to
+ * connected_accounts so it is captured once, then upserts insights_accounts.
+ * Resolution is fail-safe: an error or no result logs + skips that tenant —
+ * never throws (the worker tick must not wedge).
+ *
+ * Resolver per platform:
+ *   facebook  → FACEBOOK_LIST_MANAGED_PAGES → page id
+ *   youtube   → YOUTUBE_LIST_CHANNELS       → channel id
+ *   x         → TWITTER_USER_LOOKUP_ME      → username/handle (#670)
+ *   reddit    → REDDIT_GET_REDDIT_USER_ABOUT → username (#670)
+ *   linkedin  → no back-heal (URN resolved at connect via ensure-linkedin-urn.ts)
  *
  * Instagram is intentionally out of scope (#596/#597 are Facebook-only); add
  * platforms to BRIDGED_PLATFORMS when their adapter lands.
@@ -31,6 +38,8 @@ import { resolveComposioConfig, type ComposioConfig } from '@/backend/integratio
 import { createComposioGateway, type ComposioGateway } from '@/backend/integrations/composio/composio-client';
 import { resolveFacebookManagedPage } from '@/backend/integrations/composio/facebook-page-resolver';
 import { resolveYouTubeChannel } from '@/backend/integrations/composio/youtube-channel-resolver';
+import { resolveXUser } from '@/backend/integrations/composio/x-user-resolver';
+import { resolveRedditUser } from '@/backend/integrations/composio/reddit-user-resolver';
 
 /**
  * Platforms whose Composio connections should be projected into insights_accounts.
@@ -149,12 +158,11 @@ export async function ensureInsightsAccountsForConnectedPlatforms(
     let pageName = row.external_account_name;
 
     if (!pageId) {
-      // Facebook (FACEBOOK_LIST_MANAGED_PAGES) and YouTube (YOUTUBE_LIST_CHANNELS,
-      // mine:true) have an external-id resolver. X's and Reddit's external
-      // account id (username/id) is captured at connect by pickExternalAccountId,
-      // so a null id is not back-heal-able here — skip this tick (a later
-      // connect/re-auth populates it). Never invent an external account id.
-      if (row.platform !== 'facebook' && row.platform !== 'youtube') {
+      // Back-heal is available for facebook, youtube, x, and reddit. LinkedIn's
+      // URN is resolved at connect time via ensure-linkedin-urn.ts, so a null id
+      // there is not back-heal-able here — skip and let a later connect/re-auth
+      // populate it. Never invent an external account id.
+      if (!['facebook', 'youtube', 'x', 'reddit'].includes(row.platform)) {
         skippedNoPage++;
         log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, platform: row.platform, reason: 'no_external_account_id' });
         continue;
@@ -178,6 +186,25 @@ export async function ensureInsightsAccountsForConnectedPlatforms(
             resolvedId = channel.channelId;
             resolvedName = channel.channelName;
             resolvedManagedCount = channel.managedCount;
+          }
+        } else if (row.platform === 'x') {
+          // Resolve the X username (handle); stored as external_account_id so the
+          // fetchComments `-from:<handle>` filter in the X adapter works correctly.
+          const user = await resolveXUser(r.gateway, r.config, row.connected_account_id);
+          if (user) {
+            resolvedId = user.username;
+            resolvedName = user.name;
+            resolvedManagedCount = 1;
+          }
+        } else if (row.platform === 'reddit') {
+          // Resolve the Reddit username; stored as external_account_id to satisfy
+          // the NOT NULL enrollment column (the Reddit adapter is DB-driven and
+          // never uses pageId, but the column must be non-null to enroll the row).
+          const user = await resolveRedditUser(r.gateway, r.config, row.connected_account_id);
+          if (user) {
+            resolvedId = user.username;
+            resolvedName = user.name;
+            resolvedManagedCount = 1;
           }
         } else {
           const page = await resolveFacebookManagedPage(r.gateway, r.config, row.connected_account_id);

--- a/backend/integrations/composio/reddit-user-resolver.ts
+++ b/backend/integrations/composio/reddit-user-resolver.ts
@@ -1,0 +1,91 @@
+/**
+ * Resolve a tenant's Reddit username from Composio.
+ *
+ * The Reddit username is used as insights_accounts.external_account_id so the
+ * bridge can satisfy the NOT NULL enrollment column. It is NOT part of the
+ * Composio connection metadata, so connect-time reconciliation leaves
+ * connected_accounts.external_account_id null for legacy or first-time connections.
+ * This helper calls the verified REDDIT_GET_REDDIT_USER_ABOUT action (env-overridable
+ * via the `account_info` op) using the connection's connectedAccountId and returns
+ * the authenticated Redditor's username.
+ *
+ * IMPORTANT: REDDIT_GET_REDDIT_USER_ABOUT REQUIRES an argument — `{ username: 'me' }`
+ * — 'me' is the Reddit-convention token for the authenticated user. The call will
+ * fail or return an empty payload without it.
+ *
+ * Fail-safe: returns null on an unsuccessful tool call, a wrapper response that is
+ * not `successful`, or when no username is present. Never invents a username and
+ * never throws — the insights-sync worker tick must not wedge.
+ *
+ * Response shape (Reddit `t2` thing; Composio wraps in one or two `{ data: ... }`
+ * envelopes):
+ *   Two-level: { data: { data: { name, id, ... } }, successful }
+ *   One-level: { data: { name, ... }, successful }
+ * The Reddit username is the `name` field of the `t2` user object.
+ */
+
+import type { ComposioGateway } from './composio-client';
+import type { ComposioConfig } from './composio-config';
+
+export interface ResolvedRedditUser {
+  /** The Reddit username (e.g. "sugarleather") — stored verbatim as external_account_id. */
+  username: string;
+  /** Same as username for Reddit (the `name` field is the display name on t2). */
+  name: string | null;
+}
+
+/** Default verified slug; overridable via COMPOSIO_REDDIT_ACCOUNT_INFO_ACTION. */
+export const DEFAULT_REDDIT_GET_ME_SLUG = 'REDDIT_GET_REDDIT_USER_ABOUT';
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function trimmedString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Pull the Reddit `name` (username) out of Composio's envelope. The `t2` user
+ * object's `name` field is the username. Peels defensive layers:
+ *   data.data.name  (two-level envelope: Composio + Reddit API wrapper)
+ *   data.name       (one-level: tool version that partially unwraps)
+ */
+function extractUsername(rawData: unknown): string | null {
+  const data = asRecord(rawData);
+  if (!data) return null;
+
+  // Two-level: data.data.name (t2 object nested inside Composio + Reddit envelope)
+  const inner = asRecord(data.data);
+  if (inner) {
+    const name = trimmedString(inner.name);
+    if (name) return name;
+  }
+
+  // One-level: data.name
+  return trimmedString(data.name);
+}
+
+export async function resolveRedditUser(
+  gateway: ComposioGateway,
+  config: ComposioConfig,
+  connectedAccountId: string,
+): Promise<ResolvedRedditUser | null> {
+  const slug = config.actionSlugFor('reddit', 'account_info') ?? DEFAULT_REDDIT_GET_ME_SLUG;
+  // 'me' is the Reddit-convention argument required by this action for the
+  // authenticated user. Without it the action errors or returns nothing.
+  const result = await gateway.executeTool(slug, {
+    connectedAccountId,
+    arguments: { username: 'me' },
+  });
+  if (!result.successful) return null;
+
+  const username = extractUsername(result.data);
+  if (!username) return null; // never invent a username
+
+  // Reddit's `name` field is the Redditor's handle (e.g. "sugarleather");
+  // there is no separate display_name on the `t2` object distinct from `name`.
+  return { username, name: username };
+}

--- a/backend/integrations/composio/x-user-resolver.ts
+++ b/backend/integrations/composio/x-user-resolver.ts
@@ -1,0 +1,85 @@
+/**
+ * Resolve a tenant's X (Twitter) username from Composio.
+ *
+ * The X username (Twitter handle) is used as insights_accounts.external_account_id
+ * and by the X insights adapter's fetchComments `-from:<username>` filter. It is
+ * NOT part of the Composio connection metadata, so connect-time reconciliation
+ * leaves connected_accounts.external_account_id null for legacy or first-time
+ * connections. This helper calls the verified TWITTER_USER_LOOKUP_ME action
+ * (env-overridable via the `account_info` op) using the connection's
+ * connectedAccountId and returns the authenticated user's username (handle).
+ *
+ * Storing the USERNAME (not the numeric id) is CORRECT: the X insights adapter's
+ * fetchComments builds a recent-search `-from:<handle>` filter which the X API
+ * expects as a handle, not a numeric id. See backend/insights/adapters/x/index.ts
+ * fetchComments for the usage site.
+ *
+ * Fail-safe: returns null on an unsuccessful tool call, a wrapper response that is
+ * not `successful`, or when no username is present. Never invents a username and
+ * never throws — the insights-sync worker tick must not wedge.
+ *
+ * Response shape (verified via the live Composio catalog 2026-06-18):
+ *   Direct:  { data: { id, name, username, ... }, successful }
+ *   Nested:  { data: { data: { id, name, username, ... } }, successful }
+ * Some toolkit versions wrap the payload one extra level, so we peel defensively.
+ */
+
+import type { ComposioGateway } from './composio-client';
+import type { ComposioConfig } from './composio-config';
+
+export interface ResolvedXUser {
+  /** The Twitter handle (e.g. "sugarleather") — stored verbatim as external_account_id. */
+  username: string;
+  /** Best-effort display name; may be null when the profile is minimal. */
+  name: string | null;
+}
+
+/** Default verified slug; overridable via COMPOSIO_X_ACCOUNT_INFO_ACTION. */
+export const DEFAULT_X_GET_ME_SLUG = 'TWITTER_USER_LOOKUP_ME';
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function trimmedString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Pull the user object out of either the direct shape (`data`) or the nested
+ * shape (`data.data`). Tries the nested shape first since Composio often wraps
+ * the Twitter API response in an extra envelope.
+ */
+function extractUser(rawData: unknown): Record<string, unknown> | null {
+  const data = asRecord(rawData);
+  if (!data) return null;
+
+  // Nested shape: data.data.username (extra Composio envelope around Twitter body)
+  const inner = asRecord(data.data);
+  if (inner && trimmedString(inner.username)) return inner;
+
+  // Direct shape: data.username (tool version that unwraps for us)
+  if (trimmedString(data.username)) return data;
+
+  return null;
+}
+
+export async function resolveXUser(
+  gateway: ComposioGateway,
+  config: ComposioConfig,
+  connectedAccountId: string,
+): Promise<ResolvedXUser | null> {
+  const slug = config.actionSlugFor('x', 'account_info') ?? DEFAULT_X_GET_ME_SLUG;
+  const result = await gateway.executeTool(slug, { connectedAccountId, arguments: {} });
+  if (!result.successful) return null;
+
+  const user = extractUser(result.data);
+  if (!user) return null;
+
+  const username = trimmedString(user.username);
+  if (!username) return null; // never invent a username
+
+  return { username, name: trimmedString(user.name) };
+}

--- a/tests/composio-reddit-user-resolver.test.ts
+++ b/tests/composio-reddit-user-resolver.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for resolveRedditUser (#670).
+ *
+ * Locked behaviors:
+ *  - Two-level shape (data.data.name) → { username, name }
+ *  - One-level shape (data.name)      → { username, name }
+ *  - DEFAULT_REDDIT_GET_ME_SLUG forwarded when no config override
+ *  - connectedAccountId forwarded to executeTool
+ *  - arguments:{username:'me'} always passed (Reddit API requirement)
+ *  - config `account_info` override (COMPOSIO_REDDIT_ACCOUNT_INFO_ACTION) honored
+ *  - successful:false → null  (never invents a username)
+ *  - null / missing-name payload → null
+ *  - Blank-string name → null
+ *
+ * Entirely self-contained: fake gateway + config, no Postgres, no Composio SDK.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveRedditUser,
+  DEFAULT_REDDIT_GET_ME_SLUG,
+} from '@/backend/integrations/composio/reddit-user-resolver';
+import { fakeConfig, fakeGateway } from './composio/helpers';
+
+// ── 1. Two-level shape (data.data.name) ─────────────────────────────────────
+
+test('two-level shape: resolves username from data.data.name', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { name: 'sugarleather', id: 't2_abc' } },
+    },
+  });
+  const result = await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_1');
+  assert.deepEqual(result, { username: 'sugarleather', name: 'sugarleather' });
+});
+
+// ── 2. One-level shape (data.name) ───────────────────────────────────────────
+
+test('one-level shape: resolves username from data.name', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { name: 'aries_redditor' },
+    },
+  });
+  const result = await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_2');
+  assert.deepEqual(result, { username: 'aries_redditor', name: 'aries_redditor' });
+});
+
+// ── 3. Default slug + connectedAccountId forwarding ──────────────────────────
+
+test('uses DEFAULT_REDDIT_GET_ME_SLUG and forwards connectedAccountId', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { name: 'some_redditor' } },
+    },
+  });
+  await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_42');
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  assert.equal(gateway.calls[0].slug, DEFAULT_REDDIT_GET_ME_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_reddit_42');
+});
+
+// ── 4. arguments:{username:'me'} required ────────────────────────────────────
+
+test('always passes arguments:{username:"me"} to satisfy Reddit API requirement', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { name: 'me_user' } },
+    },
+  });
+  await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_1');
+  assert.deepEqual(
+    gateway.calls[0].options.arguments,
+    { username: 'me' },
+    'arguments must contain {username:"me"}',
+  );
+});
+
+// ── 5. account_info slug override ────────────────────────────────────────────
+
+test('honors account_info slug override (COMPOSIO_REDDIT_ACCOUNT_INFO_ACTION)', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { name: 'override_redditor' } },
+    },
+  });
+  await resolveRedditUser(
+    gateway,
+    fakeConfig({ actions: { account_info: 'CUSTOM_REDDIT_USER_ABOUT_V2' } }),
+    'ca_reddit_1',
+  );
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_REDDIT_USER_ABOUT_V2');
+  assert.notEqual(gateway.calls[0].slug, DEFAULT_REDDIT_GET_ME_SLUG, 'override replaces the default');
+});
+
+// ── 6. Fail-safe: must return null, never invent a username ───────────────────
+
+test('unsuccessful top-level result → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: false, error: 'unauthorized', data: null },
+  });
+  const result = await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data is null → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: null },
+  });
+  const result = await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data has no name field → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 't2_abc', link_karma: 500 } },
+  });
+  const result = await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data.data has no name field → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { id: 't2_abc', link_karma: 500 } } },
+  });
+  const result = await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_1');
+  assert.equal(result, null);
+});
+
+test('successful result but name is blank string → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { name: '   ' } } },
+  });
+  const result = await resolveRedditUser(gateway, fakeConfig(), 'ca_reddit_1');
+  assert.equal(result, null);
+});

--- a/tests/composio-x-user-resolver.test.ts
+++ b/tests/composio-x-user-resolver.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for resolveXUser (#670).
+ *
+ * Locked behaviors:
+ *  - Nested shape (data.data.username) → { username, name }
+ *  - Direct shape (data.username)      → { username, name }
+ *  - DEFAULT_X_GET_ME_SLUG forwarded when no config override
+ *  - connectedAccountId forwarded to executeTool
+ *  - config `account_info` override (COMPOSIO_X_ACCOUNT_INFO_ACTION) honored
+ *  - successful:false → null  (never invents a username)
+ *  - null / missing-username payload → null
+ *  - Blank-string username → null
+ *  - name is null when absent from payload
+ *
+ * Entirely self-contained: fake gateway + config, no Postgres, no Composio SDK.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveXUser,
+  DEFAULT_X_GET_ME_SLUG,
+} from '@/backend/integrations/composio/x-user-resolver';
+import { fakeConfig, fakeGateway } from './composio/helpers';
+
+// ── 1. Nested shape (data.data.*) ────────────────────────────────────────────
+
+test('nested shape: resolves username + name from data.data.*', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { id: '123', username: 'sugarleather', name: 'Sugar & Leather' } },
+    },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.deepEqual(result, { username: 'sugarleather', name: 'Sugar & Leather' });
+});
+
+// ── 2. Direct shape (data.*) ─────────────────────────────────────────────────
+
+test('direct shape: resolves username from data.username', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { username: 'aries_direct', name: 'Aries Direct' },
+    },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_2');
+  assert.deepEqual(result, { username: 'aries_direct', name: 'Aries Direct' });
+});
+
+// ── 3. Default slug + connectedAccountId forwarding ──────────────────────────
+
+test('uses DEFAULT_X_GET_ME_SLUG and forwards connectedAccountId', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { username: 'some_user' } },
+    },
+  });
+  await resolveXUser(gateway, fakeConfig(), 'ca_x_99');
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  assert.equal(gateway.calls[0].slug, DEFAULT_X_GET_ME_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_x_99');
+});
+
+// ── 4. account_info slug override ────────────────────────────────────────────
+
+test('honors account_info slug override (COMPOSIO_X_ACCOUNT_INFO_ACTION)', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { username: 'override_user' } },
+    },
+  });
+  await resolveXUser(
+    gateway,
+    fakeConfig({ actions: { account_info: 'CUSTOM_X_LOOKUP_V2' } }),
+    'ca_x_1',
+  );
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_X_LOOKUP_V2');
+  assert.notEqual(gateway.calls[0].slug, DEFAULT_X_GET_ME_SLUG, 'override replaces the default');
+});
+
+// ── 5. Fail-safe: must return null, never invent a username ───────────────────
+
+test('unsuccessful top-level result → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: false, error: 'unauthorized', data: null },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data is null → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: null },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data has no username field → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: '123', name: 'No Handle' } },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.equal(result, null);
+});
+
+test('successful result but data.data has no username field → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { id: '123', name: 'No Handle' } } },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.equal(result, null);
+});
+
+test('successful result but username is blank string → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { username: '   ' } } },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.equal(result, null);
+});
+
+// ── 6. Optional name field ────────────────────────────────────────────────────
+
+test('nested shape with username but no name field → name is null', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { username: 'noname_user' } },
+    },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.equal(result?.username, 'noname_user');
+  assert.equal(result?.name, null);
+});
+
+test('direct shape with username but no name field → name is null', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { username: 'direct_noname' },
+    },
+  });
+  const result = await resolveXUser(gateway, fakeConfig(), 'ca_x_1');
+  assert.equal(result?.username, 'direct_noname');
+  assert.equal(result?.name, null);
+});

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -9,6 +9,8 @@ import type { Queryable } from '@/backend/integrations/composio/connection-store
 import { getAdapter, hasAdapter, isFacebookInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
 import { FacebookInsightsAdapter } from '@/backend/insights/adapters/facebook/index';
 import { DEFAULT_LIST_MANAGED_PAGES_SLUG } from '@/backend/integrations/composio/facebook-page-resolver';
+import { DEFAULT_X_GET_ME_SLUG } from '@/backend/integrations/composio/x-user-resolver';
+import { DEFAULT_REDDIT_GET_ME_SLUG } from '@/backend/integrations/composio/reddit-user-resolver';
 import { fakeConfig, fakeGateway } from './composio/helpers';
 
 interface RecordedQuery {
@@ -331,6 +333,173 @@ test('LinkedIn bridge: when ARIES_LINKEDIN_ENABLED is off, the DB query does NOT
     !(select.params as unknown[]).includes('linkedin'),
     'linkedin is NOT in bridged-platform params when ARIES_LINKEDIN_ENABLED is off',
   );
+});
+
+// ── X back-heal (#670) ────────────────────────────────────────────────────────
+
+test('X bridge back-heals the username and upserts an insights_accounts row', async () => {
+  const db = recordingDb([
+    {
+      id: 20,
+      tenant_id: 15,
+      platform: 'x',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_x',
+    },
+  ]);
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { id: '123', username: 'sugarleather', name: 'Sugar & Leather' } },
+    },
+  });
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(
+    db,
+    { ANALYTICS_PROVIDER: 'composio', ARIES_X_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
+    { gateway, config: fakeConfig({ actions: {} }) },
+  );
+
+  assert.equal(result.resolved, 1);
+  assert.equal(result.upserted, 1);
+  assert.equal(result.skippedNoPage, 0);
+
+  // It called TWITTER_USER_LOOKUP_ME with the connection's connectedAccountId.
+  assert.equal(gateway.calls.length, 1);
+  assert.equal(gateway.calls[0].slug, DEFAULT_X_GET_ME_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_x');
+
+  // It persisted the resolved username back to connected_accounts.
+  const update = db.queries.find((q) => /UPDATE connected_accounts/i.test(q.text));
+  assert.ok(update, 'persists the resolved username back to connected_accounts');
+  assert.equal(update!.params[0], 'sugarleather');
+  assert.equal(update!.params[2], 20); // keyed on the connection row id
+
+  // And upserted insights_accounts with the resolved username + display name.
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.deepEqual(insert!.params, [15, 'x', 'sugarleather', 'Sugar & Leather']);
+});
+
+test('Reddit bridge back-heals the username and upserts an insights_accounts row', async () => {
+  const db = recordingDb([
+    {
+      id: 21,
+      tenant_id: 15,
+      platform: 'reddit',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_reddit',
+    },
+  ]);
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { name: 'sugarleather' } },
+    },
+  });
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(
+    db,
+    { ANALYTICS_PROVIDER: 'composio', ARIES_REDDIT_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
+    { gateway, config: fakeConfig({ actions: {} }) },
+  );
+
+  assert.equal(result.resolved, 1);
+  assert.equal(result.upserted, 1);
+  assert.equal(result.skippedNoPage, 0);
+
+  // It called REDDIT_GET_REDDIT_USER_ABOUT with the right connectedAccountId and
+  // the Reddit-required arguments:{username:'me'}.
+  assert.equal(gateway.calls.length, 1);
+  assert.equal(gateway.calls[0].slug, DEFAULT_REDDIT_GET_ME_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_reddit');
+  assert.deepEqual(gateway.calls[0].options.arguments, { username: 'me' });
+
+  // It persisted the resolved username back to connected_accounts.
+  const update = db.queries.find((q) => /UPDATE connected_accounts/i.test(q.text));
+  assert.ok(update, 'persists the resolved username back to connected_accounts');
+  assert.equal(update!.params[0], 'sugarleather');
+  assert.equal(update!.params[2], 21);
+
+  // And upserted insights_accounts with the resolved username.
+  // For Reddit, username === name (the t2 `name` field is the Redditor handle).
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.deepEqual(insert!.params, [15, 'reddit', 'sugarleather', 'sugarleather']);
+});
+
+// ── Regression guards: existing resolvers unaffected by new dispatch branches ──
+
+test('regression: FB row with external_account_id set still upserts directly when X is also enabled', async () => {
+  const db = recordingDb([
+    {
+      id: 5,
+      tenant_id: 15,
+      platform: 'facebook',
+      external_account_id: 'PAGE456',
+      external_account_name: 'Leather FB Page',
+      connected_account_id: 'ca_fb',
+    },
+  ]);
+  // Proves no resolution happens for FB when external_account_id is already present.
+  const gateway = fakeGateway();
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(
+    db,
+    { ANALYTICS_PROVIDER: 'composio', ARIES_X_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
+    { gateway, config: fakeConfig({ actions: {} }) },
+  );
+
+  assert.equal(result.considered, 1);
+  assert.equal(result.upserted, 1);
+  assert.equal(result.resolved, 0);
+  assert.equal(gateway.calls.length, 0, 'no Composio call for FB row with existing external_account_id');
+
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.deepEqual(insert!.params, [15, 'facebook', 'PAGE456', 'Leather FB Page']);
+});
+
+test('regression: YouTube back-heal still routes to channel resolver when X and Reddit are also enabled', async () => {
+  const db = recordingDb([
+    {
+      id: 30,
+      tenant_id: 15,
+      platform: 'youtube',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_yt',
+    },
+  ]);
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { items: [{ id: 'UCchannel123', snippet: { title: 'Aries YT' } }] },
+    },
+  });
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(
+    db,
+    {
+      ANALYTICS_PROVIDER: 'composio',
+      ARIES_YOUTUBE_ENABLED: '1',
+      ARIES_X_ENABLED: '1',
+      ARIES_REDDIT_ENABLED: '1',
+    } as unknown as NodeJS.ProcessEnv,
+    { gateway, config: fakeConfig({ actions: {} }) },
+  );
+
+  assert.equal(result.resolved, 1);
+  assert.equal(result.upserted, 1);
+  assert.equal(result.skippedNoPage, 0);
+
+  // Verify the YouTube channel resolver was used (not the X or Reddit resolver).
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.equal(insert!.params[1], 'youtube', 'platform column is youtube');
+  assert.equal(insert!.params[2], 'UCchannel123', 'YouTube channel id resolved correctly');
+  assert.equal(insert!.params[3], 'Aries YT', 'YouTube channel name resolved correctly');
 });
 
 test('facebook is registered in the adapter factory and getAdapter binds the connection context', () => {


### PR DESCRIPTION
Closes #670

## Problem
Connecting X or Reddit never provisioned an `insights_accounts` row, so the insights-sync worker's `SELECT DISTINCT tenant_id FROM insights_accounts` stayed empty for those platforms and analytics / comments / native-reply silently no-op'd. The external account id (X handle / Reddit username) is not part of the Composio connection metadata, so connect-time reconciliation left `connected_accounts.external_account_id` null and the back-heal bridge skipped the row.

## Root cause
`backend/insights/sync/ensure-account.ts` only back-healed `facebook` and `youtube`; for any other platform with a null `external_account_id` it incremented `skippedNoPage` and `continue`d, so X/Reddit never enrolled.

## Fix (minimal)
- NEW `backend/integrations/composio/x-user-resolver.ts` — calls `TWITTER_USER_LOOKUP_ME` and peels `data.data.username` / `data.username`, returning `{username,name}|null`. Fail-safe: null on `!successful`, missing/blank username; never invents a value.
- NEW `backend/integrations/composio/reddit-user-resolver.ts` — calls `REDDIT_GET_REDDIT_USER_ABOUT` with the required `arguments:{username:'me'}`, peels `data.data.name` / `data.name`. Same fail-safe contract.
- EDIT `ensure-account.ts` — back-heal skip-guard widened to allow `x`/`reddit` (LinkedIn stays skipped: its URN is resolved at connect via `ensure-linkedin-urn.ts`; FB/YouTube branches unchanged). Two new dispatch branches set the resolved **username** as `external_account_id`, mirroring the FB/YouTube branches. Each resolver call stays inside the existing per-row try/catch backstop so a single tenant can never wedge the worker tick.
- Cosmetic X adapter rename `ownUserId`→`ownUsername` (the `-from:<handle>` recent-search operator needs the handle, not a numeric id) + `.env.example` docs for `COMPOSIO_X_ACCOUNT_INFO_ACTION` / `COMPOSIO_REDDIT_ACCOUNT_INFO_ACTION`.

### Why username (not numeric id) is correct
Audited both adapters: `adapters/x/index.ts` keys `fetchPostList`/`fetchPostMetrics` on `tenant_id`, returns `[]` for account metrics, and uses `ctx.pageId` only as the `-from:<handle>` filter in `fetchComments` (needs the handle). `adapters/reddit/index.ts` never reads `pageId` at all (DB-driven on `tenant_id`); the username only satisfies the NOT NULL enrollment column. The numeric user id is never used on either path.

## Test evidence
- 2 new resolver unit-test files (nested/direct shape, slug + connectedAccountId forwarding, env-override, fail-safe on `!successful`/null/missing/blank, optional name).
- `insights-ensure-account.test.ts`: X + Reddit back-heal upsert tests (resolve → persist back to `connected_accounts` → upsert `insights_accounts`), plus FB/YouTube regression guards proving the new dispatch branches don't re-route existing platforms, plus flag-gating (x/reddit/youtube/linkedin only in the SELECT when their rollout flag is on).
- Focused gate: 63 pass / 0 fail. `npm run verify`: 17/17 green. Banned patterns clean. No merge conflict vs the latest master (#673 is independent — connect-time auth-config, never touched by these resolvers).

## Residual risk / activation gate
Dormant by default. Gates 3/4/5 for X/Reddit only activate when `ANALYTICS_PROVIDER=composio` **and** the platform rollout flag (`ARIES_X_ENABLED` / `ARIES_REDDIT_ENABLED`) is on — a human env gate. With either off the bridge is byte-identical to the FB-only path. Tenant-isolated (rows carry `tenant_id` end to end), no `Promise.all`/DB fan-out (sequential per-row, one gateway call per unresolved row), no secrets read or logged.