### PR TITLE
feat(integrations): build YouTube publish via still→video synthesis (#636)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -354,6 +354,19 @@ COMPOSIO_LINKEDIN_ACCOUNT_INFO_ACTION=
 #   COMPOSIO_LINKEDIN_PUBLISH_POST_ACTION=LINKEDIN_CREATE_LINKED_IN_POST
 COMPOSIO_LINKEDIN_PUBLISH_POST_ACTION=
 
+# YouTube publish (#636) — only consulted when ARIES_YOUTUBE_ENABLED=true and
+# PUBLISH_PROVIDER=composio/auto. YouTube's native post is a VIDEO upload, but the
+# Aries pipeline emits a single still; Aries synthesizes a short Ken-Burns MP4
+# (ffmpeg, in the runtime image), stages it via gateway.uploadFile, then uploads.
+# The file arg key (videoFilePath for YOUTUBE_UPLOAD_VIDEO, videoFile for the
+# MULTIPART variant) is derived from the configured slug, so either works.
+#   COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION=YOUTUBE_UPLOAD_VIDEO
+COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION=
+# Optional: YouTube category id (default '22' = People & Blogs) and privacy status
+# (default 'public'; set 'unlisted' or 'private' — recommended for first verify).
+COMPOSIO_YOUTUBE_CATEGORY_ID=
+COMPOSIO_YOUTUBE_PRIVACY_STATUS=
+
 # Facebook analytics + comments sync (#596/#597), read by the insights-sync
 # worker's Facebook adapter (backend/insights/adapters/facebook). The verified
 # slugs below are the CODE DEFAULTS, so analytics works with these left unset;

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN set -eux; \
     ca-certificates \
     chromium \
     curl \
+    ffmpeg \
     ripgrep \
     wget \
   && rm -rf /var/lib/apt/lists/*; \

--- a/app/api/internal/publishing/scheduled-dispatch/route.ts
+++ b/app/api/internal/publishing/scheduled-dispatch/route.ts
@@ -6,7 +6,7 @@ import {
   type MetaPublishFailureKind,
 } from '@/backend/integrations/meta-publishing';
 import { dispatchPublish } from '@/backend/integrations/publish-dispatch';
-import { isLinkedInEnabled, isRedditEnabled, isXEnabled } from '@/backend/integrations/providers/integration-config';
+import { isLinkedInEnabled, isRedditEnabled, isXEnabled, isYouTubeEnabled } from '@/backend/integrations/providers/integration-config';
 import { toSignedPublicUrl } from '@/app/api/publish/dispatch/handler';
 import { resolveSignableBasename } from '@/backend/marketing/signable-basename';
 import { recomputeAndPersistPendingApprovalCount } from '@/backend/marketing/runtime-views';
@@ -260,14 +260,15 @@ export async function POST(req: Request): Promise<Response> {
   let firstPublishedPostId: string | null = null;
 
   for (const platform of platforms) {
-    // X (Twitter), Reddit and LinkedIn are Composio-only publish targets (no
-    // direct-Meta path), so none is an `isMetaProvider`; accept each only when
+    // X (Twitter), Reddit, LinkedIn and YouTube are Composio-only publish targets
+    // (no direct-Meta path), so none is an `isMetaProvider`; accept each only when
     // its rollout flag is on. OFF (default) keeps the exact `unsupported_provider`
     // terminal result as before.
     const isXPublish = platform.trim().toLowerCase() === 'x' && isXEnabled();
     const isRedditPublish = platform.trim().toLowerCase() === 'reddit' && isRedditEnabled();
     const isLinkedInPublish = platform.trim().toLowerCase() === 'linkedin' && isLinkedInEnabled();
-    if (!isMetaProvider(platform) && !isXPublish && !isRedditPublish && !isLinkedInPublish) {
+    const isYouTubePublish = platform.trim().toLowerCase() === 'youtube' && isYouTubeEnabled();
+    if (!isMetaProvider(platform) && !isXPublish && !isRedditPublish && !isLinkedInPublish && !isYouTubePublish) {
       // Unsupported provider can never succeed — terminal, not retryable.
       results.push({ provider: platform, ok: false, error: 'unsupported_provider', retryable: false, kind: 'permanent' });
       continue;

--- a/app/dashboard/calendar/page.tsx
+++ b/app/dashboard/calendar/page.tsx
@@ -4,6 +4,7 @@ import {
   isLinkedInEnabled,
   isRedditEnabled,
   isXEnabled,
+  isYouTubeEnabled,
 } from '@/backend/integrations/providers/integration-config';
 import type { AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
 
@@ -18,6 +19,7 @@ export default function DashboardCalendarPage() {
     ...(isXEnabled() ? (['x'] as const) : []),
     ...(isRedditEnabled() ? (['reddit'] as const) : []),
     ...(isLinkedInEnabled() ? (['linkedin'] as const) : []),
+    ...(isYouTubeEnabled() ? (['youtube'] as const) : []),
   ];
 
   return (

--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -32,6 +32,7 @@ import {
   ComposioToolError,
 } from './errors';
 import { resolveFacebookManagedPage } from './facebook-page-resolver';
+import { synthesizeStillToVideo, type StillToVideoResult } from '../still-to-video';
 import pool from '@/lib/db';
 
 function pickId(data: unknown, keys: string[]): string | null {
@@ -44,7 +45,8 @@ function pickId(data: unknown, keys: string[]): string | null {
   }
   // Some tools nest the payload under data/response/result, and Reddit nests the
   // created object under `json` (data.json.data.name → the t3_ fullname).
-  for (const nestKey of ['data', 'response', 'result', 'json']) {
+  // YouTube nests the created object under `video` (data.video.id → the videoId).
+  for (const nestKey of ['data', 'response', 'result', 'json', 'video']) {
     const nested = obj[nestKey];
     if (nested && typeof nested === 'object') {
       const found = pickId(nested, keys);
@@ -95,6 +97,51 @@ function linkedinCommentary(content: string): string {
   return `${text.slice(0, LINKEDIN_COMMENTARY_MAX - 1)}…`;
 }
 
+const YOUTUBE_TITLE_MAX = 100; // YouTube hard-limits a video title to 100 chars.
+const YOUTUBE_DESCRIPTION_MAX = 5000;
+const YOUTUBE_FALLBACK_TITLE = 'New post';
+const YOUTUBE_DEFAULT_CATEGORY_ID = '22'; // People & Blogs — a safe general default.
+
+/**
+ * YouTube `title` is REQUIRED and ≤ 100 chars. Take the first non-empty line of
+ * the content, collapse internal whitespace, truncate with the shared `…` idiom.
+ * Pure — no I/O — so it is trivially unit-testable.
+ */
+function youtubeTitleFromContent(content: string): string {
+  const firstLine = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  const collapsed = (firstLine ?? '').replace(/\s+/g, ' ').trim();
+  if (!collapsed) return YOUTUBE_FALLBACK_TITLE;
+  if (collapsed.length <= YOUTUBE_TITLE_MAX) return collapsed;
+  return `${collapsed.slice(0, YOUTUBE_TITLE_MAX - 1)}…`;
+}
+
+/** YouTube `description` is REQUIRED and capped at 5000 chars (full body kept). */
+function youtubeDescription(content: string): string {
+  const text = content ?? '';
+  if (text.length <= YOUTUBE_DESCRIPTION_MAX) return text;
+  return `${text.slice(0, YOUTUBE_DESCRIPTION_MAX - 1)}…`;
+}
+
+/** YouTube `categoryId` is REQUIRED — operator-overridable, defaults to '22'. */
+function youtubeCategoryId(env: NodeJS.ProcessEnv = process.env): string {
+  return env.COMPOSIO_YOUTUBE_CATEGORY_ID?.trim() || YOUTUBE_DEFAULT_CATEGORY_ID;
+}
+
+/**
+ * YouTube `privacyStatus` is REQUIRED. Defaults to `public` (parity with how the
+ * other platforms publish live); an operator can set `unlisted`/`private` via
+ * COMPOSIO_YOUTUBE_PRIVACY_STATUS (recommended for first live verification).
+ * Any unrecognized value falls back to `public`.
+ */
+function youtubePrivacyStatus(env: NodeJS.ProcessEnv = process.env): string {
+  const raw = env.COMPOSIO_YOUTUBE_PRIVACY_STATUS?.trim().toLowerCase();
+  if (raw === 'public' || raw === 'private' || raw === 'unlisted') return raw;
+  return 'public';
+}
+
 export class ComposioPublisherProvider implements PublisherProvider {
   readonly kind = 'composio' as const;
 
@@ -102,6 +149,9 @@ export class ComposioPublisherProvider implements PublisherProvider {
     private readonly gateway: ComposioGateway,
     private readonly config: ComposioConfig,
     private readonly db: Queryable = pool,
+    // Still→video synthesis for YouTube publish. Injected (defaults to the real
+    // ffmpeg-backed helper) so unit tests can fake it without a binary on CI.
+    private readonly synthesizeVideo: typeof synthesizeStillToVideo = synthesizeStillToVideo,
   ) {}
 
   supports(platform: IntegrationPlatform): boolean {
@@ -373,6 +423,78 @@ export class ComposioPublisherProvider implements PublisherProvider {
         author,
         commentary: linkedinCommentary(input.content),
         ...(descriptor ? { images: [descriptor] } : {}),
+      };
+    } else if (input.platform === 'youtube') {
+      // YouTube: the native post is a VIDEO upload, but the Aries pipeline emits
+      // a single still image. We synthesize a short Ken-Burns MP4 from the still
+      // (backend/integrations/still-to-video.ts), stage it to Composio's S3 (the
+      // `videoFile`/`videoFilePath` input is a file_uploadable, so a bare path is
+      // rejected unless pre-staged — same as X media / LinkedIn images), then
+      // upload via YOUTUBE_UPLOAD_VIDEO / YOUTUBE_MULTIPART_UPLOAD_VIDEO.
+      //
+      // Synthesis + staging both run BEFORE any video exists on the channel, so
+      // every failure here is a ComposioToolError → definitely-never-posted
+      // (safe rollback + worker re-claim). ONLY the final executeTool below is
+      // the outcome-unknown boundary. YouTube has no native scheduling here, so
+      // `scheduledFor` is ignored and the status resolves to `published`.
+      if (input.mediaUrls.length === 0) {
+        // Nothing to make a video from — refuse rather than upload an empty clip.
+        throw new ComposioCapabilityMissingError(
+          'youtube',
+          'a creative image is required to synthesize the YouTube video',
+        );
+      }
+      slug = this.requireSlug(input.platform, 'publish_post', 'publish videos');
+
+      let synthesized: StillToVideoResult;
+      try {
+        synthesized = await this.synthesizeVideo({ image: input.mediaUrls[0] });
+      } catch (error) {
+        // Synthesis never created a video — definitely-never-posted.
+        throw new ComposioToolError(
+          slug,
+          error instanceof Error ? error.message : 'failed to synthesize video from image',
+        );
+      }
+
+      let descriptor: ComposioFileDescriptor;
+      try {
+        descriptor = await this.gateway.uploadFile({
+          file: synthesized.path,
+          toolSlug: slug,
+          toolkitSlug: this.config.toolkitSlugFor(input.platform),
+        });
+      } catch (error) {
+        // Staging to S3 never created a video — definitely-never-posted.
+        await synthesized.cleanup();
+        throw new ComposioToolError(
+          slug,
+          error instanceof Error ? error.message : 'failed to stage video for upload',
+        );
+      }
+      // Composio holds the bytes in its S3 once staged; drop the local temp file
+      // before the (slower) upload call so a failure there never leaks it.
+      await synthesized.cleanup();
+
+      // The two YouTube upload actions name the file arg differently but take the
+      // same {name,mimetype,s3key} descriptor:
+      //   YOUTUBE_UPLOAD_VIDEO           → videoFilePath
+      //   YOUTUBE_MULTIPART_UPLOAD_VIDEO → videoFile
+      // Key off the configured slug so either works via
+      // COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION.
+      const videoArgKey = slug.toUpperCase().includes('MULTIPART') ? 'videoFile' : 'videoFilePath';
+      // The created videoId comes back nested (commonly data.video.id) — covered
+      // by the `video` nest key added to pickId above.
+      idKeys = ['videoId', 'video_id', 'id'];
+      toolArgs = {
+        [videoArgKey]: descriptor,
+        title: youtubeTitleFromContent(input.content),
+        description: youtubeDescription(input.content),
+        // `tags` is required by YOUTUBE_UPLOAD_VIDEO (optional for multipart); an
+        // empty array satisfies the schema without inventing keywords.
+        tags: [],
+        categoryId: youtubeCategoryId(),
+        privacyStatus: youtubePrivacyStatus(),
       };
     } else if (input.platform === 'instagram') {
       // Instagram: caption + media_urls + placement + media_type (unchanged).

--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -103,24 +103,35 @@ const YOUTUBE_FALLBACK_TITLE = 'New post';
 const YOUTUBE_DEFAULT_CATEGORY_ID = '22'; // People & Blogs — a safe general default.
 
 /**
+ * The YouTube Data API rejects `<`/`>` anywhere in snippet.title/description
+ * (HTTP 400 invalidVideoMetadata). Strip them so a caption like "buy 1 get 1 <3"
+ * cannot turn into a deterministically-failing payload (which would re-fail on
+ * every worker re-claim → a poison-retry loop, since the failure is classified
+ * never-posted). Removed, not escaped — YouTube has no entity decoding here.
+ */
+function stripYouTubeAngleBrackets(text: string): string {
+  return text.replace(/[<>]/g, '');
+}
+
+/**
  * YouTube `title` is REQUIRED and ≤ 100 chars. Take the first non-empty line of
- * the content, collapse internal whitespace, truncate with the shared `…` idiom.
- * Pure — no I/O — so it is trivially unit-testable.
+ * the content, collapse internal whitespace, strip forbidden angle brackets, and
+ * truncate with the shared `…` idiom. Pure — no I/O — so it is unit-testable.
  */
 function youtubeTitleFromContent(content: string): string {
   const firstLine = content
     .split(/\r?\n/)
     .map((line) => line.trim())
     .find((line) => line.length > 0);
-  const collapsed = (firstLine ?? '').replace(/\s+/g, ' ').trim();
+  const collapsed = stripYouTubeAngleBrackets((firstLine ?? '').replace(/\s+/g, ' ')).trim();
   if (!collapsed) return YOUTUBE_FALLBACK_TITLE;
   if (collapsed.length <= YOUTUBE_TITLE_MAX) return collapsed;
   return `${collapsed.slice(0, YOUTUBE_TITLE_MAX - 1)}…`;
 }
 
-/** YouTube `description` is REQUIRED and capped at 5000 chars (full body kept). */
+/** YouTube `description` is REQUIRED, ≤5000 chars, no angle brackets (full body kept). */
 function youtubeDescription(content: string): string {
-  const text = content ?? '';
+  const text = stripYouTubeAngleBrackets(content ?? '');
   if (text.length <= YOUTUBE_DESCRIPTION_MAX) return text;
   return `${text.slice(0, YOUTUBE_DESCRIPTION_MAX - 1)}…`;
 }

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -37,11 +37,14 @@ export function isXEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
- * YouTube insights rollout flag (#637 analytics, #638 comments). Default OFF —
- * ships the Composio-backed YouTube insights adapter dormant. YouTube already
- * *connects* via Composio, so this flag does NOT gate connectability (it is
- * deliberately NOT wired into `connectablePlatforms`); it gates only the
- * insights bridge + adapter. NEW flag — never reuse ARIES_X_ENABLED.
+ * YouTube rollout flag (#637 analytics, #638 comments, #636 publish). Default
+ * OFF — ships the Composio-backed YouTube insights adapter AND the still→video
+ * publish path dormant. YouTube already *connects* via Composio, so this flag
+ * does NOT gate connectability (it is deliberately NOT wired into
+ * `connectablePlatforms`); it gates the insights bridge + adapter, the publish
+ * branch (composio-publisher-provider), and YouTube as a schedulable target
+ * (scheduled-posts allowlist + scheduled-dispatch admit gate). NEW flag — never
+ * reuse ARIES_X_ENABLED.
  */
 export function isYouTubeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return parseFlag(env.ARIES_YOUTUBE_ENABLED);

--- a/backend/integrations/publish-dispatch.ts
+++ b/backend/integrations/publish-dispatch.ts
@@ -34,17 +34,18 @@ import { publishNeverReachedPlatform } from './publish-outcome';
 
 function metaPlatform(provider: string): IntegrationPlatform {
   // Map the dispatch request's provider string to the integration platform the
-  // provider seam services. X (Twitter), Reddit and LinkedIn are each their own
-  // Composio-only platform; Instagram maps to instagram; everything else maps to
-  // facebook (the direct route's two-way split). Without the explicit cases,
-  // 'x'/'reddit'/'linkedin' would fall through to 'facebook' and be sent to a
-  // Facebook Page. None reaches the direct_meta fast path (normalizeMetaProvider
-  // throws a terminal 400), and DirectMetaProvider.supports() is false for them,
-  // so they can never post to FB.
+  // provider seam services. X (Twitter), Reddit, LinkedIn and YouTube are each
+  // their own Composio-only platform; Instagram maps to instagram; everything
+  // else maps to facebook (the direct route's two-way split). Without the
+  // explicit cases, 'x'/'reddit'/'linkedin'/'youtube' would fall through to
+  // 'facebook' and be sent to a Facebook Page. None reaches the direct_meta fast
+  // path (normalizeMetaProvider throws a terminal 400), and
+  // DirectMetaProvider.supports() is false for them, so they can never post to FB.
   const normalized = provider.trim().toLowerCase();
   if (normalized === 'x') return 'x';
   if (normalized === 'reddit') return 'reddit';
   if (normalized === 'linkedin') return 'linkedin';
+  if (normalized === 'youtube') return 'youtube';
   if (normalized === 'instagram') return 'instagram';
   return 'facebook';
 }

--- a/backend/integrations/still-to-video.ts
+++ b/backend/integrations/still-to-video.ts
@@ -1,0 +1,150 @@
+/**
+ * Still-image → short-video synthesis (for YouTube publish, #636).
+ *
+ * YouTube's publish action is a VIDEO upload, but the Aries content pipeline
+ * emits a single still image per post. To satisfy the publish gate we synthesize
+ * a short MP4 from the approved still: a gentle Ken-Burns slow-zoom over a
+ * 1920×1080 frame with a silent audio track (YouTube favors a present audio
+ * stream and universal `yuv420p` pixels).
+ *
+ * The ffmpeg argv builder is pure (no I/O) so it is unit-testable without a
+ * binary on the CI runner — the runtime image installs ffmpeg (see Dockerfile),
+ * the test asserts the argv shape. `synthesizeStillToVideo` does the I/O: it
+ * resolves the image (URL or local path) to a temp file, runs ffmpeg via
+ * `execFile` (argv array — NO shell, so no injection surface), and returns the
+ * output path plus a `cleanup()` the caller invokes once the bytes are staged.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, rm, writeFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+/** ffmpeg binary; overridable for non-standard install paths. */
+const FFMPEG_BIN = process.env.FFMPEG_PATH?.trim() || 'ffmpeg';
+
+/** Default clip length. Short enough to keep encode + upload cheap. */
+export const DEFAULT_VIDEO_DURATION_SEC = 7;
+
+const OUTPUT_FPS = 30;
+const ZOOM_STEP = 0.0008; // per-frame zoom increment
+const ZOOM_MAX = 1.15; // cap so the pan stays subtle, not jarring
+
+export interface StillToVideoResult {
+  /** Absolute path to the synthesized MP4 (inside a private temp dir). */
+  path: string;
+  /** Removes the temp dir + its contents. Call after the bytes are staged. */
+  cleanup: () => Promise<void>;
+}
+
+export interface BuildFfmpegArgsOptions {
+  inputPath: string;
+  outputPath: string;
+  durationSec?: number;
+}
+
+/**
+ * Build the ffmpeg argv for a still → Ken-Burns MP4. Pure — no I/O — so the
+ * shape (looped image input, silent stereo audio, scale/crop/zoompan, libx264,
+ * yuv420p, capped duration) is asserted in `npm run verify` without ffmpeg.
+ */
+export function buildFfmpegArgs(options: BuildFfmpegArgsOptions): string[] {
+  const duration =
+    options.durationSec && options.durationSec > 0
+      ? options.durationSec
+      : DEFAULT_VIDEO_DURATION_SEC;
+  const frames = Math.max(1, Math.round(duration * OUTPUT_FPS));
+  // Scale the still to fully cover 1920×1080, crop the overflow, then apply a
+  // slow centered zoom (zoompan x/y keep the focus centered as it zooms in).
+  const filter =
+    'scale=1920:1080:force_original_aspect_ratio=increase,' +
+    'crop=1920:1080,' +
+    `zoompan=z='min(zoom+${ZOOM_STEP},${ZOOM_MAX})':` +
+    "x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)':" +
+    `d=${frames}:s=1920x1080:fps=${OUTPUT_FPS}`;
+  return [
+    '-y',
+    '-loop',
+    '1',
+    '-i',
+    options.inputPath,
+    '-f',
+    'lavfi',
+    '-i',
+    'anullsrc=channel_layout=stereo:sample_rate=44100',
+    '-t',
+    String(duration),
+    '-filter_complex',
+    `[0:v]${filter}[v]`,
+    '-map',
+    '[v]',
+    '-map',
+    '1:a',
+    '-c:v',
+    'libx264',
+    '-r',
+    String(OUTPUT_FPS),
+    '-pix_fmt',
+    'yuv420p',
+    '-c:a',
+    'aac',
+    '-shortest',
+    options.outputPath,
+  ];
+}
+
+/**
+ * Synthesize a short MP4 from a still image. `image` may be an https URL (it is
+ * fetched to a temp file first — robust against ffmpeg's network quirks) or a
+ * local path. On ANY failure the temp dir is cleaned up and the error is
+ * rethrown so the caller can classify it as definitely-never-posted.
+ */
+export async function synthesizeStillToVideo(input: {
+  image: string;
+  durationSec?: number;
+}): Promise<StillToVideoResult> {
+  const dir = await mkdtemp(join(tmpdir(), 'aries-yt-still-'));
+  const cleanup = async () => {
+    await rm(dir, { recursive: true, force: true });
+  };
+  try {
+    let imagePath: string;
+    if (/^https?:\/\//i.test(input.image)) {
+      const res = await fetch(input.image);
+      if (!res.ok) {
+        throw new Error(`failed to fetch source image (HTTP ${res.status})`);
+      }
+      const bytes = Buffer.from(await res.arrayBuffer());
+      if (bytes.length === 0) {
+        throw new Error('source image fetch returned no bytes');
+      }
+      imagePath = join(dir, 'frame');
+      await writeFile(imagePath, bytes);
+    } else {
+      imagePath = input.image;
+    }
+
+    const outputPath = join(dir, 'video.mp4');
+    const args = buildFfmpegArgs({
+      inputPath: imagePath,
+      outputPath,
+      durationSec: input.durationSec,
+    });
+    await execFileAsync(FFMPEG_BIN, args, {
+      timeout: 120_000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+
+    const out = await stat(outputPath);
+    if (!out.isFile() || out.size === 0) {
+      throw new Error('ffmpeg produced no output');
+    }
+    return { path: outputPath, cleanup };
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+}

--- a/backend/integrations/still-to-video.ts
+++ b/backend/integrations/still-to-video.ts
@@ -29,6 +29,16 @@ const FFMPEG_BIN = process.env.FFMPEG_PATH?.trim() || 'ffmpeg';
 /** Default clip length. Short enough to keep encode + upload cheap. */
 export const DEFAULT_VIDEO_DURATION_SEC = 7;
 
+/**
+ * Cap the source-image fetch. Without it a media host that accepts the
+ * connection but stalls the body would block the publish-dispatch request far
+ * longer than the ffmpeg budget below (the worker gives up at 30s, but its abort
+ * does not cancel this server-side call). On timeout the fetch throws → the
+ * function's catch cleans up + rethrows → the publisher classifies it as
+ * definitely-never-posted (safe rollback + re-claim).
+ */
+const FETCH_TIMEOUT_MS = 30_000;
+
 const OUTPUT_FPS = 30;
 const ZOOM_STEP = 0.0008; // per-frame zoom increment
 const ZOOM_MAX = 1.15; // cap so the pan stays subtle, not jarring
@@ -113,7 +123,7 @@ export async function synthesizeStillToVideo(input: {
   try {
     let imagePath: string;
     if (/^https?:\/\//i.test(input.image)) {
-      const res = await fetch(input.image);
+      const res = await fetch(input.image, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
       if (!res.ok) {
         throw new Error(`failed to fetch source image (HTTP ${res.status})`);
       }

--- a/backend/social-content/scheduled-posts.ts
+++ b/backend/social-content/scheduled-posts.ts
@@ -1,4 +1,4 @@
-import { isLinkedInEnabled, isRedditEnabled, isXEnabled } from '@/backend/integrations/providers/integration-config';
+import { isLinkedInEnabled, isRedditEnabled, isXEnabled, isYouTubeEnabled } from '@/backend/integrations/providers/integration-config';
 
 export type ScheduledPostQueryable = {
   query: (
@@ -107,16 +107,17 @@ export class ScheduledPostTenantMismatchError extends Error {
   }
 }
 
-export const ALLOWED_TARGET_PLATFORMS = ['facebook', 'instagram', 'x', 'reddit', 'linkedin'] as const;
+export const ALLOWED_TARGET_PLATFORMS = ['facebook', 'instagram', 'x', 'reddit', 'linkedin', 'youtube'] as const;
 export type AllowedTargetPlatform = (typeof ALLOWED_TARGET_PLATFORMS)[number];
 
 /**
  * The platforms an operator can schedule a post to RIGHT NOW. `'x'` (Twitter),
- * `'reddit'` and `'linkedin'` are each valid targets only while their rollout
- * flag (`ARIES_X_ENABLED` / `ARIES_REDDIT_ENABLED` / `ARIES_LINKEDIN_ENABLED`) is
- * on; computed at call time so a flag flip takes effect without a restart. When
- * all are OFF (the default) the allowed set is byte-identical to
- * facebook+instagram, so an `x`/`reddit`/`linkedin` schedule request still fails
+ * `'reddit'`, `'linkedin'` and `'youtube'` are each valid targets only while
+ * their rollout flag (`ARIES_X_ENABLED` / `ARIES_REDDIT_ENABLED` /
+ * `ARIES_LINKEDIN_ENABLED` / `ARIES_YOUTUBE_ENABLED`) is on; computed at call
+ * time so a flag flip takes effect without a restart. When all are OFF (the
+ * default) the allowed set is byte-identical to facebook+instagram, so an
+ * `x`/`reddit`/`linkedin`/`youtube` schedule request still fails
  * `invalid_platforms` exactly as before.
  */
 function allowedTargetPlatforms(): ReadonlySet<AllowedTargetPlatform> {
@@ -124,6 +125,7 @@ function allowedTargetPlatforms(): ReadonlySet<AllowedTargetPlatform> {
   if (isXEnabled()) allowed.add('x');
   if (isRedditEnabled()) allowed.add('reddit');
   if (isLinkedInEnabled()) allowed.add('linkedin');
+  if (isYouTubeEnabled()) allowed.add('youtube');
   return allowed;
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,6 +257,16 @@ services:
       # Publish runs in the app process, so this lives here only.
       #   COMPOSIO_LINKEDIN_PUBLISH_POST_ACTION=LINKEDIN_CREATE_LINKED_IN_POST
       COMPOSIO_LINKEDIN_PUBLISH_POST_ACTION: ${COMPOSIO_LINKEDIN_PUBLISH_POST_ACTION:-}
+      # YouTube publish (#636) — only consulted when ARIES_YOUTUBE_ENABLED=true and
+      # PUBLISH_PROVIDER=composio/auto. Aries synthesizes a short MP4 from the still
+      # (ffmpeg), stages it via gateway.uploadFile, and uploads it. The action is a
+      # VIDEO upload; the file arg key (videoFilePath vs videoFile) is derived from
+      # the configured slug. CATEGORY_ID defaults to '22'; PRIVACY_STATUS defaults to
+      # 'public' (set 'unlisted' for first live verification). App-process only.
+      #   COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION=YOUTUBE_UPLOAD_VIDEO
+      COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION: ${COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION:-}
+      COMPOSIO_YOUTUBE_CATEGORY_ID: ${COMPOSIO_YOUTUBE_CATEGORY_ID:-}
+      COMPOSIO_YOUTUBE_PRIVACY_STATUS: ${COMPOSIO_YOUTUBE_PRIVACY_STATUS:-}
       # Facebook analytics + comments sync slugs (#596/#597). Optional — the
       # adapter falls back to the verified code defaults when unset.
       COMPOSIO_FACEBOOK_LIST_POSTS_ACTION: ${COMPOSIO_FACEBOOK_LIST_POSTS_ACTION:-}

--- a/frontend/aries-v1/presenters/calendar-presenter.tsx
+++ b/frontend/aries-v1/presenters/calendar-presenter.tsx
@@ -34,7 +34,7 @@ import type {
 } from '@/frontend/aries-v1/view-models/calendar';
 import { RedditIcon, XIcon } from '@/frontend/components/Icons';
 import RescheduleDrawer from '@/frontend/aries-v1/reschedule-drawer';
-import type { AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
+import { ALLOWED_TARGET_PLATFORMS, type AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
 import {
   formatTimeInTenantZone,
   tenantZoneDateKey,
@@ -567,11 +567,19 @@ function PublishNowButton({
     setErrorMessage(null);
     try {
       const url = `/api/social-content/jobs/${encodeURIComponent(jobId)}/posts/${encodeURIComponent(postId)}/schedule`;
+      // Pass the post's real targets through (filtered to the known set). The
+      // server-side normalizeTargetPlatforms is the flag-aware gate, so a target
+      // whose rollout flag is off (e.g. youtube when ARIES_YOUTUBE_ENABLED is
+      // off) is rejected with invalid_platforms rather than silently rerouted —
+      // previously anything outside fb/ig was coerced to facebook (a wrong-network
+      // mis-publish once x/reddit/linkedin/youtube became selectable targets).
+      const known = new Set<string>(ALLOWED_TARGET_PLATFORMS);
       const filtered = targetPlatforms.filter(
-        (p): p is 'facebook' | 'instagram' => p === 'facebook' || p === 'instagram',
+        (p): p is AllowedTargetPlatform => known.has(p),
       );
-      const fallback: 'facebook' | 'instagram' =
-        platform === 'facebook' || platform === 'instagram' ? platform : 'facebook';
+      const fallback: AllowedTargetPlatform = known.has(platform)
+        ? (platform as AllowedTargetPlatform)
+        : 'facebook';
       const platforms = filtered.length > 0 ? filtered : [fallback];
       const response = await fetch(url, {
         method: 'PATCH',

--- a/frontend/aries-v1/reschedule-drawer.tsx
+++ b/frontend/aries-v1/reschedule-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { type ComponentType, useEffect, useMemo, useRef, useState } from 'react';
 import { CalendarClock, Check, LoaderCircle, X } from 'lucide-react';
-import { FacebookIcon, InstagramIcon, LinkedinIcon } from './brand-icons';
+import { FacebookIcon, InstagramIcon, LinkedinIcon, YoutubeIcon } from './brand-icons';
 import { XIcon, RedditIcon } from '@/frontend/components/Icons';
 import type { AllowedTargetPlatform } from '@/backend/social-content/scheduled-posts';
 
@@ -20,6 +20,7 @@ const PLATFORM_OPTIONS: Array<{ id: AllowedTargetPlatform; label: string; Icon: 
   { id: 'x', label: 'X', Icon: XIcon as PlatformIcon },
   { id: 'reddit', label: 'Reddit', Icon: RedditIcon as PlatformIcon },
   { id: 'linkedin', label: 'LinkedIn', Icon: LinkedinIcon as PlatformIcon },
+  { id: 'youtube', label: 'YouTube', Icon: YoutubeIcon as PlatformIcon },
 ];
 
 export interface ScheduleSavedDetail {

--- a/tests/composio-youtube-publisher.test.ts
+++ b/tests/composio-youtube-publisher.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Regression coverage for #636: YouTube publish dispatched through Composio
+ * YOUTUBE_UPLOAD_VIDEO, gated behind ARIES_YOUTUBE_ENABLED.
+ *
+ * YouTube's native post is a VIDEO upload, but the Aries pipeline emits a single
+ * still. The publisher synthesizes a short MP4 from the still (injected
+ * synthesizer — the real one is ffmpeg-backed; here it is faked so CI needs no
+ * binary), stages it via gateway.uploadFile, then uploads.
+ *
+ * Failure modes locked:
+ *  1. Image post: synthesize once → uploadFile once (toolSlug=YOUTUBE_UPLOAD_VIDEO,
+ *     toolkitSlug='youtube') → EXACTLY ONE executeTool(YOUTUBE_UPLOAD_VIDEO) with
+ *     {videoFilePath: descriptor, title, description, tags, categoryId,
+ *     privacyStatus}; result published; externalPostId from nested data.video.id;
+ *     synthesized temp cleaned up. NEVER the Instagram slug/args.
+ *  2. Multipart slug → the file arg is `videoFile` (not videoFilePath).
+ *  3. No media → ComposioCapabilityMissingError; never-posted; no synth/upload/exec.
+ *  4. Synthesis throw → ComposioToolError (never-posted); no uploadFile, no exec.
+ *  5. uploadFile throw → ComposioToolError (never-posted); temp cleaned up; no exec.
+ *  6. Slug unset → ComposioCapabilityMissingError BEFORE synthesis runs.
+ *     Dry-run → no synth/gateway calls. Not-approved → PublishGuardError.
+ *  7. Title truncation to 100; description truncation to 5000; privacyStatus
+ *     default 'public' + env override; categoryId default '22' + env override.
+ *  8. Dormancy: normalizeTargetPlatforms(['youtube']) → null when flag unset,
+ *     ['youtube'] when =1. isMetaProvider('youtube')===false. Dispatch guard
+ *     predicate 'youtube' && isYouTubeEnabled() false→true.
+ *  9. metaPlatform routing: provider='youtube' reaches the seam with
+ *     platform='youtube', NOT coerced to 'facebook'.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ComposioPublisherProvider } from '@/backend/integrations/composio/composio-publisher-provider';
+import { PublishGuardError } from '@/backend/integrations/providers/errors';
+import {
+  ComposioCapabilityMissingError,
+  ComposioToolError,
+} from '@/backend/integrations/composio/errors';
+import { publishNeverReachedPlatform } from '@/backend/integrations/publish-outcome';
+import { isMetaProvider } from '@/backend/integrations/meta-publishing';
+import { isYouTubeEnabled } from '@/backend/integrations/providers/integration-config';
+import { normalizeTargetPlatforms } from '@/backend/social-content/scheduled-posts';
+import { dispatchPublish } from '@/backend/integrations/publish-dispatch';
+import type {
+  ComposioGateway,
+  ComposioFileDescriptor,
+  ComposioFileUploadInput,
+  GatewayToolResult,
+} from '@/backend/integrations/composio/composio-client';
+import type { StillToVideoResult } from '@/backend/integrations/still-to-video';
+import type { PublisherProvider } from '@/backend/integrations/providers/interfaces';
+import type { PublishPostInput } from '@/backend/integrations/providers/types';
+import type { RecordedExecute } from './composio/helpers';
+import { fakeConfig, fakeDb } from './composio/helpers';
+
+const tenantId = '42';
+
+// ── withEnv helper ──────────────────────────────────────────────────────────
+
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  const prev = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(vars)) {
+    prev.set(k, process.env[k]);
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  return Promise.resolve(fn()).finally(() => {
+    for (const [k, original] of prev) {
+      if (original === undefined) delete process.env[k];
+      else process.env[k] = original;
+    }
+  });
+}
+
+// ── Gateway tracking uploadFile + executeTool separately ────────────────────
+
+function makeYouTubeGateway(opts?: {
+  defaultResult?: GatewayToolResult;
+  uploadFileShouldThrow?: Error;
+}): ComposioGateway & {
+  calls: RecordedExecute[];
+  uploadFileCalls: ComposioFileUploadInput[];
+} {
+  const calls: RecordedExecute[] = [];
+  const uploadFileCalls: ComposioFileUploadInput[] = [];
+  const defaultResult: GatewayToolResult =
+    opts?.defaultResult ?? { data: { video: { id: 'yt_vid_123' } }, successful: true, error: null };
+  return {
+    calls,
+    uploadFileCalls,
+    async findOrCreateManagedAuthConfig(toolkitSlug) {
+      return `ac_${toolkitSlug}`;
+    },
+    async initiateConnection() {
+      return { connectionRequestId: 'cr_1', redirectUrl: null };
+    },
+    async listConnections() {
+      return [];
+    },
+    async getConnection() {
+      return null;
+    },
+    async deleteConnection() {
+      /* no-op */
+    },
+    async executeTool(slug, options) {
+      calls.push({ slug, options });
+      return defaultResult;
+    },
+    async uploadFile(input: ComposioFileUploadInput): Promise<ComposioFileDescriptor> {
+      uploadFileCalls.push(input);
+      if (opts?.uploadFileShouldThrow) throw opts.uploadFileShouldThrow;
+      return { name: 'video.mp4', mimetype: 'video/mp4', s3key: `s3/${input.toolSlug}/video.mp4` };
+    },
+  };
+}
+
+// ── Injected fake video synthesizer (no ffmpeg on CI) ───────────────────────
+
+function makeFakeSynth(opts?: { shouldThrow?: Error }) {
+  const state = { calls: [] as Array<{ image: string }>, cleanupCount: 0 };
+  const fn = async (input: { image: string; durationSec?: number }): Promise<StillToVideoResult> => {
+    state.calls.push({ image: input.image });
+    if (opts?.shouldThrow) throw opts.shouldThrow;
+    return {
+      path: '/tmp/aries-yt-fake/video.mp4',
+      cleanup: async () => {
+        state.cleanupCount += 1;
+      },
+    };
+  };
+  return { fn, state };
+}
+
+const YT_ACTIONS = { publish_post: 'YOUTUBE_UPLOAD_VIDEO' } as const;
+
+function youtubeDb(opts?: { noRow?: boolean }) {
+  return fakeDb({
+    connectionRow: opts?.noRow
+      ? null
+      : {
+          id: 1,
+          tenant_id: 42,
+          external_user_id: 'aries-tenant-42',
+          platform: 'youtube',
+          provider: 'composio',
+          connected_account_id: 'ca_youtube_123',
+          auth_config_id: 'auth_cfg_test',
+          external_account_id: 'UC_channel_1',
+          external_account_name: 'Test Channel',
+          status: 'connected',
+          capabilities_json: null,
+          last_capability_check_at: null,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+        },
+  });
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1. Image post happy path
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 YouTube image post: synthesize once → uploadFile once → EXACTLY ONE executeTool(YOUTUBE_UPLOAD_VIDEO) with {videoFilePath, title, description, tags, categoryId, privacyStatus}; videoId from data.video.id; temp cleaned up', async () => {
+  const gateway = makeYouTubeGateway();
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: YT_ACTIONS }),
+    youtubeDb(),
+    synth.fn,
+  );
+
+  const result = await provider.publishPost({
+    tenantId,
+    platform: 'youtube',
+    content: 'My great post\nsecond line',
+    mediaUrls: ['https://img/1.png'],
+    approved: true,
+  });
+
+  // Synthesis: called once with the first media URL
+  assert.equal(synth.state.calls.length, 1, 'synthesizer called exactly once');
+  assert.equal(synth.state.calls[0].image, 'https://img/1.png', 'synth receives the first mediaUrl');
+  assert.equal(synth.state.cleanupCount, 1, 'synthesized temp must be cleaned up');
+
+  // Staging: called once with the synthesized path + youtube toolkit + publish slug
+  assert.equal(gateway.uploadFileCalls.length, 1, 'uploadFile called exactly once');
+  assert.equal(gateway.uploadFileCalls[0].file, '/tmp/aries-yt-fake/video.mp4', 'stages the synthesized MP4 path');
+  assert.equal(gateway.uploadFileCalls[0].toolSlug, 'YOUTUBE_UPLOAD_VIDEO', 'uploadFile toolSlug is the publish action');
+  assert.equal(gateway.uploadFileCalls[0].toolkitSlug, 'youtube', 'uploadFile toolkitSlug is "youtube"');
+
+  // Upload: EXACTLY ONE executeTool, the publish action — NEVER an Instagram slug
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  const call = gateway.calls[0];
+  assert.equal(call.slug, 'YOUTUBE_UPLOAD_VIDEO', 'the sole executeTool is the YouTube publish action');
+  assert.notEqual(call.slug, 'INSTAGRAM_CREATE_POST', 'must NOT fall through to the Instagram slug');
+
+  const args = call.options.arguments as Record<string, unknown>;
+  const descriptor = args.videoFilePath as ComposioFileDescriptor;
+  assert.ok(descriptor && typeof descriptor === 'object', 'videoFilePath must carry the staged descriptor');
+  assert.equal(descriptor.s3key, 's3/YOUTUBE_UPLOAD_VIDEO/video.mp4', 'descriptor s3key from staging stub');
+  assert.equal(descriptor.mimetype, 'video/mp4', 'descriptor mimetype from staging stub');
+  assert.equal(args.title, 'My great post', 'title is the first non-empty line');
+  assert.equal(args.description, 'My great post\nsecond line', 'description is the full content');
+  assert.deepEqual(args.tags, [], 'tags defaults to an empty array');
+  assert.equal(args.categoryId, '22', 'categoryId defaults to People & Blogs (22)');
+  assert.equal(args.privacyStatus, 'public', 'privacyStatus defaults to public');
+  // Instagram-only args must be absent
+  assert.equal('caption' in args, false, 'must not carry an Instagram caption');
+  assert.equal('media_urls' in args, false, 'must not carry Instagram media_urls');
+
+  assert.equal(result.status, 'published');
+  assert.equal(result.platform, 'youtube');
+  assert.equal(result.provider, 'composio');
+  assert.equal(result.externalPostId, 'yt_vid_123', 'externalPostId extracted from nested data.video.id');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2. Multipart slug → videoFile arg key
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 multipart slug → the file arg is `videoFile` (not videoFilePath)', async () => {
+  const gateway = makeYouTubeGateway();
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: { publish_post: 'YOUTUBE_MULTIPART_UPLOAD_VIDEO' } }),
+    youtubeDb(),
+    synth.fn,
+  );
+
+  await provider.publishPost({
+    tenantId,
+    platform: 'youtube',
+    content: 'hi',
+    mediaUrls: ['https://img/1.png'],
+    approved: true,
+  });
+
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.ok('videoFile' in args, 'multipart action must use the videoFile arg key');
+  assert.equal('videoFilePath' in args, false, 'multipart action must NOT use videoFilePath');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3. No media → capability error, never-posted, nothing called
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 no media → ComposioCapabilityMissingError; never-posted; no synth/upload/executeTool', async () => {
+  const gateway = makeYouTubeGateway();
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: YT_ACTIONS }),
+    youtubeDb(),
+    synth.fn,
+  );
+
+  let caught: unknown;
+  try {
+    await provider.publishPost({ tenantId, platform: 'youtube', content: 'hi', mediaUrls: [], approved: true });
+    assert.fail('expected rejection');
+  } catch (e) {
+    caught = e;
+  }
+  assert.ok(caught instanceof ComposioCapabilityMissingError, 'no media must throw ComposioCapabilityMissingError');
+  assert.equal(publishNeverReachedPlatform(caught), true, 'must be definitely-never-posted');
+  assert.equal(synth.state.calls.length, 0, 'no synthesis without media');
+  assert.equal(gateway.uploadFileCalls.length, 0, 'no uploadFile without media');
+  assert.equal(gateway.calls.length, 0, 'no executeTool without media');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 4. Synthesis throw → ComposioToolError, never-posted
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 synthesis throw → ComposioToolError (never-posted); no uploadFile, no executeTool', async () => {
+  const gateway = makeYouTubeGateway();
+  const synth = makeFakeSynth({ shouldThrow: new Error('ffmpeg failed') });
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: YT_ACTIONS }),
+    youtubeDb(),
+    synth.fn,
+  );
+
+  let caught: unknown;
+  try {
+    await provider.publishPost({ tenantId, platform: 'youtube', content: 'hi', mediaUrls: ['https://img/1.png'], approved: true });
+    assert.fail('expected rejection');
+  } catch (e) {
+    caught = e;
+  }
+  assert.ok(caught instanceof ComposioToolError, 'synthesis failure must throw ComposioToolError');
+  assert.equal(publishNeverReachedPlatform(caught), true, 'synthesis failure is definitely-never-posted');
+  assert.equal(gateway.uploadFileCalls.length, 0, 'no staging after synth failure');
+  assert.equal(gateway.calls.length, 0, 'no executeTool after synth failure');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 5. uploadFile throw → ComposioToolError, temp cleaned up, never-posted
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 uploadFile throw → ComposioToolError (never-posted); synthesized temp cleaned up; no executeTool', async () => {
+  const gateway = makeYouTubeGateway({ uploadFileShouldThrow: new Error('S3 staging failed') });
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(
+    gateway,
+    fakeConfig({ actions: YT_ACTIONS }),
+    youtubeDb(),
+    synth.fn,
+  );
+
+  let caught: unknown;
+  try {
+    await provider.publishPost({ tenantId, platform: 'youtube', content: 'hi', mediaUrls: ['https://img/1.png'], approved: true });
+    assert.fail('expected rejection');
+  } catch (e) {
+    caught = e;
+  }
+  assert.ok(caught instanceof ComposioToolError, 'staging failure must throw ComposioToolError');
+  assert.equal(publishNeverReachedPlatform(caught), true, 'staging failure is definitely-never-posted');
+  assert.equal(synth.state.cleanupCount, 1, 'temp must be cleaned up even when staging fails');
+  assert.equal(gateway.calls.length, 0, 'no executeTool after staging failure');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 6. Capability / dry-run / approval guards
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 publish_post slug unset → ComposioCapabilityMissingError BEFORE synthesis runs', async () => {
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(
+    makeYouTubeGateway(),
+    fakeConfig({ actions: {} }),
+    youtubeDb(),
+    synth.fn,
+  );
+  await assert.rejects(
+    () => provider.publishPost({ tenantId, platform: 'youtube', content: 'hi', mediaUrls: ['https://img/1.png'], approved: true }),
+    ComposioCapabilityMissingError,
+  );
+  assert.equal(synth.state.calls.length, 0, 'synthesis must not run when the slug is unset');
+});
+
+test('#636 dry-run returns preview without synth or gateway calls', async () => {
+  const gateway = makeYouTubeGateway();
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: YT_ACTIONS }), youtubeDb(), synth.fn);
+  const result = await provider.publishPost({
+    tenantId,
+    platform: 'youtube',
+    content: 'hi',
+    mediaUrls: ['https://img/1.png'],
+    dryRun: true,
+  });
+  assert.equal(result.status, 'preview');
+  assert.equal(synth.state.calls.length, 0, 'dry-run must not synthesize');
+  assert.equal(gateway.uploadFileCalls.length, 0, 'dry-run must not stage');
+  assert.equal(gateway.calls.length, 0, 'dry-run must not execute');
+});
+
+test('#636 not-approved throws PublishGuardError (no synth)', async () => {
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(makeYouTubeGateway(), fakeConfig({ actions: YT_ACTIONS }), youtubeDb(), synth.fn);
+  await assert.rejects(
+    () => provider.publishPost({ tenantId, platform: 'youtube', content: 'hi', mediaUrls: ['https://img/1.png'], approved: false }),
+    PublishGuardError,
+  );
+  assert.equal(synth.state.calls.length, 0, 'no synthesis for an unapproved post');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 7. Title / description / category / privacy resolution
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 title truncates to 100 chars with ellipsis; description truncates to 5000', async () => {
+  const gateway = makeYouTubeGateway();
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: YT_ACTIONS }), youtubeDb(), synth.fn);
+  const longLine = 'x'.repeat(250);
+  const longBody = `${longLine}\n${'y'.repeat(6000)}`;
+  await provider.publishPost({ tenantId, platform: 'youtube', content: longBody, mediaUrls: ['https://img/1.png'], approved: true });
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  const title = args.title as string;
+  const description = args.description as string;
+  assert.equal(title.length, 100, 'title must be exactly 100 chars when truncated');
+  assert.ok(title.endsWith('…'), 'truncated title ends with ellipsis');
+  assert.equal(description.length, 5000, 'description must be exactly 5000 chars when truncated');
+  assert.ok(description.endsWith('…'), 'truncated description ends with ellipsis');
+});
+
+test('#636 empty content → fallback title "New post"', async () => {
+  const gateway = makeYouTubeGateway();
+  const synth = makeFakeSynth();
+  const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: YT_ACTIONS }), youtubeDb(), synth.fn);
+  await provider.publishPost({ tenantId, platform: 'youtube', content: '   \n  ', mediaUrls: ['https://img/1.png'], approved: true });
+  const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+  assert.equal(args.title, 'New post', 'empty content yields the fallback title');
+});
+
+test('#636 COMPOSIO_YOUTUBE_PRIVACY_STATUS + CATEGORY_ID env overrides are honored', async () => {
+  await withEnv({ COMPOSIO_YOUTUBE_PRIVACY_STATUS: 'unlisted', COMPOSIO_YOUTUBE_CATEGORY_ID: '27' }, async () => {
+    const gateway = makeYouTubeGateway();
+    const synth = makeFakeSynth();
+    const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: YT_ACTIONS }), youtubeDb(), synth.fn);
+    await provider.publishPost({ tenantId, platform: 'youtube', content: 'hi', mediaUrls: ['https://img/1.png'], approved: true });
+    const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+    assert.equal(args.privacyStatus, 'unlisted', 'privacyStatus honors the env override');
+    assert.equal(args.categoryId, '27', 'categoryId honors the env override');
+  });
+});
+
+test('#636 an unrecognized privacy status falls back to public', async () => {
+  await withEnv({ COMPOSIO_YOUTUBE_PRIVACY_STATUS: 'bogus' }, async () => {
+    const gateway = makeYouTubeGateway();
+    const synth = makeFakeSynth();
+    const provider = new ComposioPublisherProvider(gateway, fakeConfig({ actions: YT_ACTIONS }), youtubeDb(), synth.fn);
+    await provider.publishPost({ tenantId, platform: 'youtube', content: 'hi', mediaUrls: ['https://img/1.png'], approved: true });
+    const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+    assert.equal(args.privacyStatus, 'public', 'unrecognized privacy status falls back to public');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 8. Dormancy: scheduling allowlist + dispatch guard predicates
+// ════════════════════════════════════════════════════════════════════════════
+
+test("#636 normalizeTargetPlatforms: flag OFF → ['youtube'] returns null", async () => {
+  await withEnv({ ARIES_YOUTUBE_ENABLED: undefined }, () => {
+    assert.equal(normalizeTargetPlatforms(['youtube']), null, 'youtube rejected when the flag is off');
+  });
+});
+
+test("#636 normalizeTargetPlatforms: flag OFF → ['facebook','instagram'] still accepted", async () => {
+  await withEnv({ ARIES_YOUTUBE_ENABLED: undefined }, () => {
+    assert.deepEqual(normalizeTargetPlatforms(['facebook', 'instagram']), ['facebook', 'instagram']);
+  });
+});
+
+test("#636 normalizeTargetPlatforms: flag ON → ['youtube'] accepted", async () => {
+  await withEnv({ ARIES_YOUTUBE_ENABLED: '1' }, () => {
+    assert.deepEqual(normalizeTargetPlatforms(['youtube']), ['youtube']);
+  });
+});
+
+test('#636 isMetaProvider(youtube) is false — youtube never routes via the direct-Meta fast path', () => {
+  assert.equal(isMetaProvider('youtube'), false);
+});
+
+test('#636 dispatch guard: youtube rejected when flag off, admitted when on', async () => {
+  await withEnv({ ARIES_YOUTUBE_ENABLED: undefined }, () => {
+    const isYouTubePublish = 'youtube' === 'youtube' && isYouTubeEnabled();
+    assert.equal(!isMetaProvider('youtube') && !isYouTubePublish, true, 'youtube rejected when flag off');
+  });
+  await withEnv({ ARIES_YOUTUBE_ENABLED: '1' }, () => {
+    const isYouTubePublish = 'youtube' === 'youtube' && isYouTubeEnabled();
+    assert.equal(!isMetaProvider('youtube') && !isYouTubePublish, false, 'youtube admitted when flag on');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 9. metaPlatform routing
+// ════════════════════════════════════════════════════════════════════════════
+
+test('#636 metaPlatform routing: provider=youtube reaches the seam with platform=youtube, NOT coerced to facebook', async () => {
+  const calls: PublishPostInput[] = [];
+  const provider: PublisherProvider = {
+    kind: 'composio',
+    supports: () => true,
+    publishPost: async (input: PublishPostInput) => {
+      calls.push(input);
+      return {
+        provider: 'composio',
+        platform: 'youtube' as const,
+        externalPostId: 'yt_vid_routed',
+        externalCampaignId: null,
+        externalAdId: null,
+        status: 'published' as const,
+        url: 'https://youtu.be/yt_vid_routed',
+        rawResponse: {},
+      };
+    },
+    publishAd: async () => {
+      throw new Error('not implemented');
+    },
+    uploadMedia: async () => {
+      throw new Error('not implemented');
+    },
+    getPublishStatus: async () => {
+      throw new Error('not implemented');
+    },
+  } as unknown as PublisherProvider;
+
+  const out = await dispatchPublish(
+    { tenantId: '42', provider: 'youtube', content: 'hello youtube', mediaUrls: [], scheduledFor: null },
+    {
+      selector: () => 'composio',
+      directPublish: async () => {
+        throw new Error('youtube must never reach the direct-Meta path');
+      },
+      publisherProvider: () => provider,
+    },
+  );
+
+  assert.equal(calls.length, 1, 'exactly one publishPost call');
+  assert.equal(calls[0].platform, 'youtube', 'youtube reaches the seam with platform=youtube');
+  assert.notEqual(calls[0].platform, 'facebook', 'youtube must NOT be coerced to facebook');
+  assert.equal(out.platformPostId, 'yt_vid_routed');
+  assert.ok(out.connectionId.includes(':youtube'), `connectionId must reference 'youtube', got: ${out.connectionId}`);
+});

--- a/tests/composio-youtube-publisher.test.ts
+++ b/tests/composio-youtube-publisher.test.ts
@@ -30,7 +30,10 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
+import { resolveProjectRoot } from './helpers/project-root';
 import { ComposioPublisherProvider } from '@/backend/integrations/composio/composio-publisher-provider';
 import { PublishGuardError } from '@/backend/integrations/providers/errors';
 import {
@@ -462,6 +465,17 @@ test('#636 dispatch guard: youtube rejected when flag off, admitted when on', as
     const isYouTubePublish = 'youtube' === 'youtube' && isYouTubeEnabled();
     assert.equal(!isMetaProvider('youtube') && !isYouTubePublish, false, 'youtube admitted when flag on');
   });
+});
+
+test('#636 the scheduled-dispatch route actually wires the flag-gated youtube admit clause', () => {
+  // Guards the REAL gate (the predicate test above only checks the logic in
+  // isolation): if someone drops the youtube clause from the route, this fails.
+  const routeSrc = readFileSync(
+    path.join(resolveProjectRoot(import.meta.url), 'app', 'api', 'internal', 'publishing', 'scheduled-dispatch', 'route.ts'),
+    'utf8',
+  );
+  assert.match(routeSrc, /isYouTubePublish\s*=\s*platform[^\n]*===\s*'youtube'\s*&&\s*isYouTubeEnabled\(\)/, 'route must derive isYouTubePublish behind isYouTubeEnabled()');
+  assert.match(routeSrc, /!isYouTubePublish/, 'route admit gate must include the youtube clause');
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/tests/publish-picker-newplatforms.test.ts
+++ b/tests/publish-picker-newplatforms.test.ts
@@ -102,6 +102,23 @@ test('CalendarPresenter forwards allowedPlatforms prop to RescheduleDrawer insta
   assert.ok(matches && matches.length >= 2, 'allowedPlatforms must be threaded into BOTH RescheduleDrawer usages');
 });
 
+test('handlePublishNow no longer coerces non-fb/ig targets to facebook (#636 mis-publish guard)', () => {
+  // A youtube/x/reddit/linkedin post clicked "Publish now" must pass its real
+  // target through (the server-side normalizeTargetPlatforms is the flag gate),
+  // NOT be silently rerouted to Facebook. Guards against reintroducing the narrow
+  // `p === 'facebook' || p === 'instagram'` filter in handlePublishNow.
+  assert.match(calendarPresenter, /ALLOWED_TARGET_PLATFORMS/);
+  const publishNowBody = calendarPresenter.slice(
+    calendarPresenter.indexOf('async function handlePublishNow'),
+    calendarPresenter.indexOf('async function handlePublishNow') + 1200,
+  );
+  assert.doesNotMatch(
+    publishNowBody,
+    /p === 'facebook' \|\| p === 'instagram'/,
+    'handlePublishNow must not narrow targets to fb/ig (that silently rerouted youtube to facebook)',
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Source-text: RescheduleDrawer structural assertions
 // ---------------------------------------------------------------------------

--- a/tests/publish-picker-newplatforms.test.ts
+++ b/tests/publish-picker-newplatforms.test.ts
@@ -10,8 +10,9 @@
  *   3. RescheduleDrawer with allowedPlatforms=[fb,ig] explicit renders EXACTLY 2 options.
  *   4. CalendarPresenter prop threading: allowedPublishPlatforms flows through to
  *      RescheduleDrawer's allowedPlatforms (source-text assertion).
- *   5. calendar/page.tsx: ARIES_X_ENABLED=1 includes 'x' in allowedPublishPlatforms;
- *      unset flag excludes it; 'youtube' is never a publish target.
+ *   5. calendar/page.tsx: each ARIES_<P>_ENABLED flag includes its platform in
+ *      allowedPublishPlatforms; an unset flag excludes it. 'youtube' is a publish
+ *      target only when ARIES_YOUTUBE_ENABLED is on (#636 still→video publish).
  *
  * Test strategy:
  *   - Source-text assertions for structural/structural-prop-threading tests (3,4,5).
@@ -55,10 +56,11 @@ const rescheduleDrawer = read('frontend', 'aries-v1', 'reschedule-drawer.tsx');
 // Source-text: calendar page flag wiring (test 5)
 // ---------------------------------------------------------------------------
 
-test('calendar page imports the three new platform flag functions', () => {
+test('calendar page imports the four new platform flag functions', () => {
   assert.match(calendarPage, /isXEnabled/);
   assert.match(calendarPage, /isRedditEnabled/);
   assert.match(calendarPage, /isLinkedInEnabled/);
+  assert.match(calendarPage, /isYouTubeEnabled/);
 });
 
 test('calendar page builds allowedPublishPlatforms spreading each flag conditionally', () => {
@@ -67,15 +69,17 @@ test('calendar page builds allowedPublishPlatforms spreading each flag condition
   assert.match(calendarPage, /isXEnabled\(\)/);
   assert.match(calendarPage, /isRedditEnabled\(\)/);
   assert.match(calendarPage, /isLinkedInEnabled\(\)/);
+  assert.match(calendarPage, /isYouTubeEnabled\(\)/);
 });
 
 test('calendar page passes allowedPublishPlatforms down to AriesCalendarScreen', () => {
   assert.match(calendarPage, /allowedPublishPlatforms={allowedPublishPlatforms}/);
 });
 
-test('calendar page never includes youtube as a publish target', () => {
-  // YouTube is insights-only; it must not appear in the allowedPublishPlatforms array
-  assert.doesNotMatch(calendarPage, /['"]youtube['"]/);
+test('calendar page includes youtube as a publish target only behind isYouTubeEnabled() (#636)', () => {
+  // YouTube publish (#636) is flag-gated, mirroring x/reddit/linkedin: its spread
+  // is guarded by isYouTubeEnabled() so it is dormant (absent) when the flag is off.
+  assert.match(calendarPage, /isYouTubeEnabled\(\)\s*\?\s*\(\['youtube'\]\s+as\s+const\)\s*:\s*\[\]/);
 });
 
 // ---------------------------------------------------------------------------
@@ -110,13 +114,15 @@ test('RescheduleDrawer defaults allowedPlatforms to facebook+instagram when abse
   assert.match(rescheduleDrawer, /props\.allowedPlatforms\s*\?\?\s*\['facebook',\s*'instagram'\]/);
 });
 
-test('RescheduleDrawer PLATFORM_OPTIONS includes all five platforms (fb/ig/x/reddit/linkedin)', () => {
-  // All five must be entries in the options table
+test('RescheduleDrawer PLATFORM_OPTIONS includes all six platforms (fb/ig/x/reddit/linkedin/youtube)', () => {
+  // All six must be entries in the options table (visibility is still filtered to
+  // the allowed set, so youtube only renders when ARIES_YOUTUBE_ENABLED is on).
   assert.match(rescheduleDrawer, /id:\s*'instagram'/);
   assert.match(rescheduleDrawer, /id:\s*'facebook'/);
   assert.match(rescheduleDrawer, /id:\s*'x'/);
   assert.match(rescheduleDrawer, /id:\s*'reddit'/);
   assert.match(rescheduleDrawer, /id:\s*'linkedin'/);
+  assert.match(rescheduleDrawer, /id:\s*'youtube'/);
 });
 
 test('RescheduleDrawer renders visibleOptions filtered to the allowed set', () => {
@@ -148,8 +154,8 @@ test('isLinkedInEnabled returns false when ARIES_LINKEDIN_ENABLED is unset', asy
   assert.equal(isLinkedInEnabled(mkEnv({})), false);
 });
 
-test('calendar page allowedPublishPlatforms logic: ARIES_X_ENABLED=1 includes x but never youtube', async () => {
-  const { isXEnabled, isRedditEnabled, isLinkedInEnabled } = await import(
+test('calendar page allowedPublishPlatforms logic: ARIES_X_ENABLED=1 includes x; youtube only with ARIES_YOUTUBE_ENABLED', async () => {
+  const { isXEnabled, isRedditEnabled, isLinkedInEnabled, isYouTubeEnabled } = await import(
     '@/backend/integrations/providers/integration-config'
   );
   const env = mkEnv({ ARIES_X_ENABLED: '1' });
@@ -159,15 +165,33 @@ test('calendar page allowedPublishPlatforms logic: ARIES_X_ENABLED=1 includes x 
     ...(isXEnabled(env) ? ['x'] : []),
     ...(isRedditEnabled(env) ? ['reddit'] : []),
     ...(isLinkedInEnabled(env) ? ['linkedin'] : []),
+    ...(isYouTubeEnabled(env) ? ['youtube'] : []),
   ];
   assert.ok(allowedPublishPlatforms.includes('x'), "x must be included when ARIES_X_ENABLED='1'");
   assert.ok(!allowedPublishPlatforms.includes('reddit'), 'reddit must not be included when flag off');
   assert.ok(!allowedPublishPlatforms.includes('linkedin'), 'linkedin must not be included when flag off');
-  assert.ok(!allowedPublishPlatforms.includes('youtube'), 'youtube must never be a publish target');
+  assert.ok(!allowedPublishPlatforms.includes('youtube'), 'youtube must be absent when ARIES_YOUTUBE_ENABLED is off');
+});
+
+test('calendar page allowedPublishPlatforms logic: ARIES_YOUTUBE_ENABLED=1 includes youtube (#636)', async () => {
+  const { isXEnabled, isRedditEnabled, isLinkedInEnabled, isYouTubeEnabled } = await import(
+    '@/backend/integrations/providers/integration-config'
+  );
+  const env = mkEnv({ ARIES_YOUTUBE_ENABLED: '1' });
+  const allowedPublishPlatforms: string[] = [
+    'facebook',
+    'instagram',
+    ...(isXEnabled(env) ? ['x'] : []),
+    ...(isRedditEnabled(env) ? ['reddit'] : []),
+    ...(isLinkedInEnabled(env) ? ['linkedin'] : []),
+    ...(isYouTubeEnabled(env) ? ['youtube'] : []),
+  ];
+  assert.ok(allowedPublishPlatforms.includes('youtube'), "youtube must be included when ARIES_YOUTUBE_ENABLED='1'");
+  assert.ok(!allowedPublishPlatforms.includes('x'), 'x must not be included when its flag is off');
 });
 
 test('calendar page allowedPublishPlatforms logic: all flags OFF yields facebook+instagram only', async () => {
-  const { isXEnabled, isRedditEnabled, isLinkedInEnabled } = await import(
+  const { isXEnabled, isRedditEnabled, isLinkedInEnabled, isYouTubeEnabled } = await import(
     '@/backend/integrations/providers/integration-config'
   );
   const env = mkEnv({});
@@ -177,6 +201,7 @@ test('calendar page allowedPublishPlatforms logic: all flags OFF yields facebook
     ...(isXEnabled(env) ? ['x'] : []),
     ...(isRedditEnabled(env) ? ['reddit'] : []),
     ...(isLinkedInEnabled(env) ? ['linkedin'] : []),
+    ...(isYouTubeEnabled(env) ? ['youtube'] : []),
   ];
   assert.deepEqual(
     allowedPublishPlatforms,

--- a/tests/still-to-video.test.ts
+++ b/tests/still-to-video.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression coverage for the YouTube still→video synthesis argv (#636).
+ *
+ * `buildFfmpegArgs` is pure (no I/O), so the argv shape is asserted here without
+ * an ffmpeg binary — the CI runner has none; the runtime image installs it. The
+ * actual encode is smoke-tested out-of-band against a real ffmpeg.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildFfmpegArgs, DEFAULT_VIDEO_DURATION_SEC } from '@/backend/integrations/still-to-video';
+
+test('buildFfmpegArgs: loops the still, adds silent stereo audio, scales/crops/zoompans, h264+yuv420p, capped duration', () => {
+  const args = buildFfmpegArgs({ inputPath: '/in/frame.png', outputPath: '/out/video.mp4', durationSec: 7 });
+
+  // Looped single image input
+  const loopIdx = args.indexOf('-loop');
+  assert.ok(loopIdx >= 0, 'must loop the still');
+  assert.equal(args[loopIdx + 1], '1');
+  assert.equal(args[args.indexOf('-i')], '-i');
+  assert.ok(args.includes('/in/frame.png'), 'input image path present');
+
+  // Silent audio source (YouTube favors a present audio stream)
+  assert.ok(args.some((a) => a.startsWith('anullsrc=')), 'silent audio source present');
+
+  // Capped duration
+  const tIdx = args.indexOf('-t');
+  assert.ok(tIdx >= 0, 'duration cap present');
+  assert.equal(args[tIdx + 1], '7');
+
+  // Filter: scale to cover, crop to 1920x1080, zoompan (Ken Burns)
+  const fcIdx = args.indexOf('-filter_complex');
+  assert.ok(fcIdx >= 0, 'filter_complex present');
+  const filter = args[fcIdx + 1];
+  assert.match(filter, /scale=1920:1080:force_original_aspect_ratio=increase/);
+  assert.match(filter, /crop=1920:1080/);
+  assert.match(filter, /zoompan=/);
+
+  // Codecs + universal pixel format
+  assert.equal(args[args.indexOf('-c:v') + 1], 'libx264');
+  assert.equal(args[args.indexOf('-pix_fmt') + 1], 'yuv420p');
+  assert.equal(args[args.indexOf('-c:a') + 1], 'aac');
+  assert.ok(args.includes('-shortest'), 'shortest flag present so the clip ends with the video');
+
+  // Output path is the last arg
+  assert.equal(args[args.length - 1], '/out/video.mp4');
+});
+
+test('buildFfmpegArgs: a non-positive/omitted duration falls back to the default', () => {
+  const a = buildFfmpegArgs({ inputPath: '/in.png', outputPath: '/out.mp4' });
+  assert.equal(a[a.indexOf('-t') + 1], String(DEFAULT_VIDEO_DURATION_SEC));
+
+  const b = buildFfmpegArgs({ inputPath: '/in.png', outputPath: '/out.mp4', durationSec: 0 });
+  assert.equal(b[b.indexOf('-t') + 1], String(DEFAULT_VIDEO_DURATION_SEC));
+
+  const c = buildFfmpegArgs({ inputPath: '/in.png', outputPath: '/out.mp4', durationSec: -5 });
+  assert.equal(c[c.indexOf('-t') + 1], String(DEFAULT_VIDEO_DURATION_SEC));
+});
+
+test('buildFfmpegArgs: argv uses no shell metacharacters around the paths (execFile-safe)', () => {
+  // Paths are passed as discrete argv entries (not interpolated into a shell
+  // string), so even an adversarial path is inert. Assert the input/output are
+  // standalone entries, never concatenated with flags.
+  const weird = '/tmp/a b; rm -rf x/frame.png';
+  const args = buildFfmpegArgs({ inputPath: weird, outputPath: '/out.mp4' });
+  assert.ok(args.includes(weird), 'input path is a single discrete argv entry');
+  assert.equal(args.filter((a) => a === weird).length, 1, 'input path appears exactly once, unsplit');
+});

--- a/tests/still-to-video.test.ts
+++ b/tests/still-to-video.test.ts
@@ -9,7 +9,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildFfmpegArgs, DEFAULT_VIDEO_DURATION_SEC } from '@/backend/integrations/still-to-video';
+import { buildFfmpegArgs, DEFAULT_VIDEO_DURATION_SEC, synthesizeStillToVideo } from '@/backend/integrations/still-to-video';
 
 test('buildFfmpegArgs: loops the still, adds silent stereo audio, scales/crops/zoompans, h264+yuv420p, capped duration', () => {
   const args = buildFfmpegArgs({ inputPath: '/in/frame.png', outputPath: '/out/video.mp4', durationSec: 7 });
@@ -37,6 +37,19 @@ test('buildFfmpegArgs: loops the still, adds silent stereo audio, scales/crops/z
   assert.match(filter, /crop=1920:1080/);
   assert.match(filter, /zoompan=/);
 
+  // The filter output is labeled and BOTH streams are mapped to the output:
+  // the processed video [v] and the silent audio (input 1). Asserting the maps
+  // (not just that anullsrc/aac appear somewhere) proves the audio is actually
+  // wired into the muxed output, not a dangling unused input.
+  assert.match(filter, /\[0:v\].*\[v\]/, 'video filter chain must be labeled [0:v]...[v]');
+  const mapIdxs = args.reduce<number[]>((acc, a, i) => (a === '-map' ? [...acc, i] : acc), []);
+  assert.equal(mapIdxs.length, 2, 'exactly two -map args (video + audio)');
+  assert.deepEqual(
+    mapIdxs.map((i) => args[i + 1]).sort(),
+    ['1:a', '[v]'],
+    'must map the filtered video [v] and the silent audio stream 1:a to the output',
+  );
+
   // Codecs + universal pixel format
   assert.equal(args[args.indexOf('-c:v') + 1], 'libx264');
   assert.equal(args[args.indexOf('-pix_fmt') + 1], 'yuv420p');
@@ -45,6 +58,39 @@ test('buildFfmpegArgs: loops the still, adds silent stereo audio, scales/crops/z
 
   // Output path is the last arg
   assert.equal(args[args.length - 1], '/out/video.mp4');
+});
+
+// ── synthesizeStillToVideo error-classification (fetch leg; no ffmpeg needed) ──
+// These exercise the real I/O wrapper's failure paths, which run BEFORE ffmpeg,
+// so they need no binary. A throw here is what the publisher converts into a
+// ComposioToolError (definitely-never-posted → safe rollback + re-claim).
+
+test('synthesizeStillToVideo: a non-ok image fetch throws (never reaches ffmpeg)', async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(null, { status: 404 })) as typeof fetch;
+  try {
+    await assert.rejects(
+      () => synthesizeStillToVideo({ image: 'https://media.example/missing.png' }),
+      /HTTP 404/,
+      'a non-ok fetch must throw before the encode',
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test('synthesizeStillToVideo: an empty-body image fetch throws (never reaches ffmpeg)', async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(new Uint8Array(0), { status: 200 })) as typeof fetch;
+  try {
+    await assert.rejects(
+      () => synthesizeStillToVideo({ image: 'https://media.example/empty.png' }),
+      /no bytes/,
+      'an empty image body must throw before the encode',
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });
 
 test('buildFfmpegArgs: a non-positive/omitted duration falls back to the default', () => {


### PR DESCRIPTION
## What

Builds the **YouTube publish gate** for the new-platforms golden journey. YouTube's native post is a video upload, but the Aries pipeline emits a single still image — so Aries now **synthesizes a short Ken-Burns MP4 from the approved still** (ffmpeg, added to the runtime image), stages it to Composio's S3, and uploads it via `YOUTUBE_UPLOAD_VIDEO` / `YOUTUBE_MULTIPART_UPLOAD_VIDEO`.

Everything is gated behind the existing **`ARIES_YOUTUBE_ENABLED`** flag (default OFF — ships dormant; behavior byte-identical when off). Mirrors the proven X/Reddit/LinkedIn Composio template. Giving the connected YouTube account a real destination also closes the **#635** dead-end.

`Closes #636`
`Closes #635`

## How it's wired
- **`backend/integrations/still-to-video.ts`** (new) — pure `buildFfmpegArgs` (unit-tested; CI needs no binary) + `synthesizeStillToVideo` (fetch→ffmpeg→temp MP4 with `cleanup()`). The real encode was smoke-tested against ffmpeg 6.1 → valid h264+aac clip.
- **`composio-publisher-provider.ts`** — YouTube branch: synthesize → `uploadFile` → upload. The file-arg key (`videoFilePath` vs `videoFile`) is derived from the configured slug so either Composio action works. videoId is read from the nested `data.video.id`. All pre-upload failures throw `ComposioToolError` (definitely-never-posted → safe rollback + re-claim); only the final `executeTool` is the outcome-unknown boundary.
- Admitted at **`publish-dispatch`** (`metaPlatform`), the **scheduled-dispatch route** admit gate, and the **scheduled-posts** target allowlist — all behind `ARIES_YOUTUBE_ENABLED`.
- **Scheduler picker** entry in `calendar/page.tsx` + `reschedule-drawer.tsx` (flag-gated).
- Env (two-place rule): `COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION` / `CATEGORY_ID` / `PRIVACY_STATUS` in `docker-compose.yml` + `.env.example`.

## Decisions
- **No schema change** — `posts.platform` is plain TEXT; `connected_accounts`/`oauth_connections` CHECKs already list `'youtube'`.
- **Did not touch `synthesize-publish-posts`** — X/Reddit/LinkedIn precedent leaves auto-synthesis fb/ig-only; the new platforms are reached via the manual scheduler picker, not auto-targeted.

## Verification
- `npm run typecheck`, `npm run verify`, `npm run validate:social-content` — all green.
- New regression tests: `composio-youtube-publisher.test.ts` (publish branch, slug/arg derivation, videoId extraction, error classification, dormancy, routing), `still-to-video.test.ts` (argv invariants + fetch error paths), inverted the youtube-exclusion assertions in `publish-picker-newplatforms.test.ts`.
- A 5-dimension adversarial review surfaced 7 minor/nit findings — **all fixed in this PR** (image-fetch timeout, angle-bracket poison-retry guard, Publish-Now wrong-network coercion, plus test-coverage hardening).

## Activation (Brendan, once ready)
Set `COMPOSIO_YOUTUBE_PUBLISH_POST_ACTION=YOUTUBE_UPLOAD_VIDEO`, optionally `COMPOSIO_YOUTUBE_PRIVACY_STATUS=unlisted` for first verify, connect a YouTube account via Composio, then flip `ARIES_YOUTUBE_ENABLED=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)