### PR TITLE
fix(integrations): route x/reddit/linkedin publish through Composio regardless of the direct_meta selector

### DIFF
--- a/backend/integrations/providers/provider-factory.ts
+++ b/backend/integrations/providers/provider-factory.ts
@@ -45,6 +45,7 @@ import {
   createComposioAnalyticsProvider,
   createComposioCapabilityProvider,
 } from '../composio';
+import type { IntegrationPlatform } from './types';
 
 /**
  * The effective publish selector after applying the master switch. Exposed so
@@ -98,4 +99,37 @@ export function getCapabilityProvider(
 ): CapabilityProvider {
   if (!isComposioEnabled(env)) return new DirectMetaProvider();
   return createComposioCapabilityProvider(env);
+}
+
+/**
+ * Platforms that must ALWAYS route through Composio for publishing, regardless
+ * of the global PUBLISH_PROVIDER selector. Facebook and Instagram keep the
+ * selector-driven path (direct_meta by default) — no change to their behavior.
+ *
+ * YouTube and TikTok are intentionally excluded here: their publisher branches
+ * do not exist yet (tracked in #636 / #647). They join this set only when a
+ * Composio publisher branch is implemented and tested for them.
+ */
+const COMPOSIO_ONLY_PUBLISH_PLATFORMS = new Set<IntegrationPlatform>(['x', 'reddit', 'linkedin']);
+
+/** True when the platform can only publish through Composio (not direct Meta). */
+export function isComposioOnlyPublishPlatform(platform: IntegrationPlatform): boolean {
+  return COMPOSIO_ONLY_PUBLISH_PLATFORMS.has(platform);
+}
+
+/**
+ * Platform-aware publisher factory. Composio-only platforms (x, reddit,
+ * linkedin) always return the Composio publisher, regardless of the global
+ * PUBLISH_PROVIDER selector. All other platforms (facebook, instagram, …)
+ * delegate to the existing selector-driven getPublisherProvider so their
+ * behavior is byte-identical to before this change.
+ */
+export function getPublisherProviderForPlatform(
+  platform: IntegrationPlatform,
+  env: NodeJS.ProcessEnv = process.env,
+): PublisherProvider {
+  if (isComposioOnlyPublishPlatform(platform)) {
+    return createComposioPublisherProvider(env);
+  }
+  return getPublisherProvider(env);
 }

--- a/backend/integrations/publish-dispatch.ts
+++ b/backend/integrations/publish-dispatch.ts
@@ -26,9 +26,14 @@ import {
   type MetaPublishRequest,
   type MetaPublishSuccess,
 } from './meta-publishing';
-import { effectivePublishProvider, getPublisherProvider } from './providers/provider-factory';
+import {
+  effectivePublishProvider,
+  getPublisherProvider,
+  getPublisherProviderForPlatform,
+  isComposioOnlyPublishPlatform,
+} from './providers/provider-factory';
 import type { PublisherProvider } from './providers/interfaces';
-import type { ProviderSelector } from './providers/integration-config';
+import { isComposioEnabled, type ProviderSelector } from './providers/integration-config';
 import type { IntegrationPlatform, PublishResult } from './providers/types';
 import { publishNeverReachedPlatform } from './publish-outcome';
 
@@ -54,8 +59,10 @@ export interface DispatchPublishDeps {
   selector?: () => ProviderSelector;
   /** Direct-Meta publish. Defaults to the real `publishToMetaGraph`. */
   directPublish?: (request: MetaPublishRequest) => Promise<MetaPublishSuccess>;
-  /** Provider seam factory. Defaults to the real `getPublisherProvider`. */
+  /** Provider seam factory. Defaults to the platform-aware `getPublisherProviderForPlatform`. */
   publisherProvider?: () => PublisherProvider;
+  /** Reports whether Composio is enabled. Defaults to env-based `isComposioEnabled`. */
+  composioEnabled?: () => boolean;
 }
 
 export async function dispatchPublish(
@@ -64,15 +71,36 @@ export async function dispatchPublish(
 ): Promise<MetaPublishSuccess> {
   const selector = deps.selector ?? effectivePublishProvider;
   const directPublish = deps.directPublish ?? publishToMetaGraph;
+  const composioEnabled = deps.composioEnabled ?? isComposioEnabled;
 
-  // Fast path: the shipped default. Identical to the pre-seam call the handlers
-  // made, so nothing about direct-Meta publishing changes.
-  if (selector() === 'direct_meta') {
+  // Resolve the platform early so the routing decision is made in one place.
+  const platform = metaPlatform(request.provider);
+  const composioOnly = isComposioOnlyPublishPlatform(platform);
+
+  // Composio-only platforms (x, reddit, linkedin) require Composio to be enabled.
+  // Reject with a terminal 400 before any provider is contacted so the handlers
+  // classify this as definitely-never-posted (safe to surface, never auto-retry,
+  // and the direct-Meta path is NEVER a fallback for these platforms).
+  if (composioOnly && !composioEnabled()) {
+    throw new MetaPublishError(
+      'provider_not_configured',
+      `Publishing to ${platform} requires Composio to be enabled (COMPOSIO_ENABLED=true).`,
+      { status: 400, retryable: false },
+    );
+  }
+
+  // Fast path for non-composio-only platforms: the shipped default (direct_meta).
+  // FB/IG publishing is byte-identical to the pre-seam call under direct_meta.
+  // Composio-only platforms skip this branch entirely — they never take the
+  // direct-Meta path regardless of the global selector.
+  if (!composioOnly && selector() === 'direct_meta') {
     return directPublish(request);
   }
 
-  const provider = (deps.publisherProvider ?? getPublisherProvider)();
-  const platform = metaPlatform(request.provider);
+  // For composio-only platforms, always use the Composio publisher. For
+  // selector-driven platforms that reach here (composio / auto mode), the
+  // platform-aware factory delegates to the selector as before.
+  const provider = (deps.publisherProvider ?? (() => getPublisherProviderForPlatform(platform)))();
 
   let result: PublishResult;
   try {

--- a/tests/composio-linkedin-publisher.test.ts
+++ b/tests/composio-linkedin-publisher.test.ts
@@ -704,6 +704,7 @@ test('#646 metaPlatform routing: provider=linkedin reaches the seam with platfor
     { tenantId: '42', provider: 'linkedin', content: 'hello linkedin', mediaUrls: [], scheduledFor: null },
     {
       selector: () => 'composio',
+      composioEnabled: () => true,
       directPublish: async () => {
         throw new Error('linkedin must never reach the direct-Meta path');
       },

--- a/tests/composio-reddit-publisher.test.ts
+++ b/tests/composio-reddit-publisher.test.ts
@@ -775,6 +775,7 @@ test('#641 metaPlatform routing: provider=reddit reaches the seam with platform=
     { tenantId: '42', provider: 'reddit', content: 'hello reddit', mediaUrls: [], scheduledFor: null },
     {
       selector: () => 'composio',
+      composioEnabled: () => true,
       directPublish: async () => {
         throw new Error('reddit must never reach the direct-Meta path');
       },

--- a/tests/publish-dispatch.test.ts
+++ b/tests/publish-dispatch.test.ts
@@ -291,6 +291,7 @@ test('#631 metaPlatform routing: provider=x reaches the seam with platform=x, NO
     { tenantId: '42', provider: 'x', content: 'hello x', mediaUrls: [], scheduledFor: null },
     {
       selector: () => 'composio',
+      composioEnabled: () => true,
       directPublish: async () => {
         throw new Error('x must never reach the direct-Meta path');
       },
@@ -342,6 +343,7 @@ test('#646 metaPlatform routing: provider=linkedin reaches the seam with platfor
     { tenantId: '42', provider: 'linkedin', content: 'hello linkedin', mediaUrls: [], scheduledFor: null },
     {
       selector: () => 'composio',
+      composioEnabled: () => true,
       directPublish: async () => {
         throw new Error('linkedin must never reach the direct-Meta path');
       },
@@ -387,4 +389,165 @@ test('auto selector also routes through the seam (not the direct path)', async (
   // The auto provider can resolve to direct_meta internally; the mapped marker reflects that.
   assert.equal(out.connectionId, 'direct_meta:facebook');
   assert.equal(out.platformPostId, 'fb_auto');
+});
+
+// ── Regression tests for #671: per-platform publish routing decoupled ────────
+//
+// Before the fix, `dispatchPublish` applied the `direct_meta` fast path
+// unconditionally for all platforms.  An X/Reddit/LinkedIn request with
+// selector='direct_meta' (the shipped prod default) would call directPublish,
+// which reaches normalizeMetaProvider and throws 'unsupported_provider' (400) —
+// so those platforms could never publish regardless of COMPOSIO_ENABLED.
+//
+// The fix gates the direct_meta fast path on `!composioOnly`, and for
+// composio-only platforms (x, reddit, linkedin) routes to the Composio
+// publisher REGARDLESS of the global selector when Composio is enabled.
+
+test('#671 PROVING: x/reddit/linkedin bypass direct_meta fast path when composio is enabled', async () => {
+  // PROVING TEST — fails against pre-fix code.
+  //
+  // Before the fix:
+  //   if (selector() === 'direct_meta') return directPublish(request);  // ran for ALL platforms
+  //
+  // After the fix:
+  //   if (!composioOnly && selector() === 'direct_meta') ...             // composio-only platforms skip it
+  //
+  // With the pre-fix code, directCalled would be true and calls.length would be 0
+  // for each composio-only platform, causing both assertions to fail.
+
+  for (const p of ['x', 'reddit', 'linkedin'] as const) {
+    let directCalled = false;
+    const calls: PublishPostInput[] = [];
+
+    const recordingProvider = {
+      kind: 'composio',
+      supports: () => true,
+      publishPost: async (input: PublishPostInput) => {
+        calls.push(input);
+        return {
+          provider: 'composio' as const,
+          platform: p,
+          externalPostId: `${p}_post_671`,
+          externalCampaignId: null,
+          externalAdId: null,
+          status: 'published' as const,
+          url: null,
+          rawResponse: {},
+        };
+      },
+    } as unknown as PublisherProvider;
+
+    const out = await dispatchPublish(
+      { tenantId: '15', provider: p, content: `hello ${p}`, mediaUrls: [], scheduledFor: null },
+      {
+        selector: () => 'direct_meta',   // the prod default selector
+        composioEnabled: () => true,
+        directPublish: async () => {
+          directCalled = true;
+          // Return a plausible result so the pre-fix path can be inspected via
+          // assertion — we do NOT throw here so the test fails on the assertion,
+          // not on an unexpected exception from directPublish.
+          // provider must be a SupportedMetaProvider (facebook|instagram); p is
+          // always a composio-only platform here so this return is never reached
+          // after the fix (asserted below as directCalled===false).
+          return {
+            provider: 'facebook' as const,
+            mode: 'live' as const,
+            platformPostId: 'WRONG_direct_path',
+            scheduledFor: null,
+            connectionId: 'conn_wrong',
+          };
+        },
+        publisherProvider: () => recordingProvider,
+      },
+    );
+
+    assert.equal(
+      directCalled,
+      false,
+      `${p}: directPublish must NOT be called — composio-only platforms bypass the direct_meta fast path`,
+    );
+    assert.equal(calls.length, 1, `${p}: publisherProvider.publishPost must be called exactly once`);
+    assert.equal(calls[0].platform, p, `${p}: publishPost must receive platform=${p}`);
+    assert.equal(out.platformPostId, `${p}_post_671`, `${p}: result must map through from the composio provider`);
+    assert.ok(
+      out.connectionId.includes(`:${p}`),
+      `${p}: connectionId must reference ${p}, got: ${out.connectionId}`,
+    );
+  }
+});
+
+test('#671 facebook and instagram stay on the direct_meta path (not composio-only)', async () => {
+  // FB and IG are NOT composio-only platforms. Under `direct_meta` they must
+  // still take the direct path — no change from the pre-fix behavior for them.
+  for (const p of ['facebook', 'instagram'] as const) {
+    let directCalled = false;
+    let providerBuilt = false;
+    const directResult: MetaPublishSuccess = {
+      provider: p,
+      mode: 'live',
+      platformPostId: `${p}_direct_671`,
+      scheduledFor: null,
+      connectionId: `conn_oauth_${p}`,
+    };
+
+    const out = await dispatchPublish(
+      { tenantId: '15', provider: p, content: `hello ${p}`, mediaUrls: [], scheduledFor: null },
+      {
+        selector: () => 'direct_meta',
+        composioEnabled: () => true,
+        directPublish: async (_r) => {
+          directCalled = true;
+          return directResult;
+        },
+        publisherProvider: () => {
+          providerBuilt = true;
+          return stubProvider({} as PublishResult).provider;
+        },
+      },
+    );
+
+    assert.equal(directCalled, true, `${p}: directPublish must be called on the direct_meta path`);
+    assert.equal(providerBuilt, false, `${p}: composio seam must NOT be built under direct_meta`);
+    assert.deepEqual(out, directResult, `${p}: result must be byte-identical to the direct path`);
+  }
+});
+
+test('#671 composio-only platform with composio disabled throws terminal provider_not_configured', async () => {
+  // When Composio is disabled (COMPOSIO_ENABLED=false / composioEnabled()===false),
+  // dispatching to a composio-only platform (x, reddit, linkedin) must throw a
+  // terminal MetaPublishError before contacting any provider.  This signals to
+  // handlers that the post was NEVER sent (safe to surface; never auto-retry).
+  for (const p of ['x', 'reddit', 'linkedin'] as const) {
+    let directCalled = false;
+    let providerBuilt = false;
+
+    await assert.rejects(
+      () =>
+        dispatchPublish(
+          { tenantId: '15', provider: p, content: `hello ${p}`, mediaUrls: [], scheduledFor: null },
+          {
+            selector: () => 'direct_meta',
+            composioEnabled: () => false,
+            directPublish: async () => {
+              directCalled = true;
+              throw new Error('directPublish must not be called for composio-only platform');
+            },
+            publisherProvider: () => {
+              providerBuilt = true;
+              return stubProvider({} as PublishResult).provider;
+            },
+          },
+        ),
+      (err: unknown) => {
+        assert.ok(err instanceof MetaPublishError, `${p}: must throw MetaPublishError`);
+        assert.equal(err.retryable, false, `${p}: error must be non-retryable (terminal)`);
+        assert.equal(err.code, 'provider_not_configured', `${p}: error code must be provider_not_configured`);
+        return true;
+      },
+    );
+
+    assert.equal(directCalled, false, `${p}: directPublish must not be called`);
+    assert.equal(providerBuilt, false, `${p}: publisherProvider must not be constructed`);
+  }
 });


### PR DESCRIPTION
Closes #671

## Problem
`dispatchPublish` applied the `direct_meta` fast path unconditionally for every platform. An X/Reddit/LinkedIn request under the shipped-prod `PUBLISH_PROVIDER=direct_meta` selector would call `publishToMetaGraph`, hit `normalizeMetaProvider`, and throw a terminal `unsupported_provider` (400) — so those platforms could never publish even with `COMPOSIO_ENABLED=true`. Publish routing was coupled to the global Meta selector instead of being decided per platform.

## Fix
- `provider-factory.ts`: additive `isComposioOnlyPublishPlatform` (Set{x, reddit, linkedin}) + `getPublisherProviderForPlatform`, which returns the pure Composio publisher for composio-only platforms and delegates to the existing selector-driven `getPublisherProvider` for everyone else. Existing exports untouched.
- `publish-dispatch.ts`: `dispatchPublish` resolves `platform` first. Composio-only platforms (1) throw a terminal `MetaPublishError('provider_not_configured', {status:400, retryable:false})` before any provider is built when Composio is disabled, and (2) otherwise always route to the Composio publisher regardless of the global selector. The `direct_meta` fast path is now gated on `!composioOnly`.

## Double-post / safety
Three mutually-exclusive terminal branches; no single dispatch can take both `directPublish` and the Composio seam. Composio-only platforms never enter the direct-Meta branch; FB/IG under `direct_meta` are byte-identical to the pre-seam call and never build the seam. The composio-only factory returns the *pure* Composio publisher (not the auto→direct fallback wrapper), so x/reddit/linkedin can never fall back to a Facebook Page even under `auto`. The disabled-Composio refusal is terminal (`retryable:false` → classified `permanent`, never auto-retried by the scheduled-dispatch worker) and fires before any provider is contacted — definitely-never-posted, no silent Meta fallback.

## Activation (prod)
x/reddit/linkedin publish activates in prod ONLY when ALL hold: `COMPOSIO_ENABLED=true` (already on), the per-platform `ARIES_X_ENABLED` / `ARIES_REDDIT_ENABLED` / `ARIES_LINKEDIN_ENABLED` flag is on, AND the toolkit is connected via Composio. With the flags OFF (default) the scheduler never admits these platforms, so the path stays dormant. **FB/IG stay on direct_meta — untouched.**

## Tests
`tests/publish-dispatch.test.ts` adds a proving regression (x/reddit/linkedin bypass the direct_meta fast path when Composio is enabled — fails pre-fix), an FB/IG byte-identical guard, and a composio-disabled terminal-refusal guard. Three pre-existing `selector:'composio'` routing tests inject `composioEnabled:()=>true` because the new guard correctly requires Composio enabled before reaching the seam. Focused suites green (publish-dispatch + composio reddit/linkedin publishers); `npm run verify` all gates green; banned-patterns clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoiY71TzLCK6FnwKourTW2