### PR TITLE
fix(integrations): route youtube publish through Composio (COMPOSIO_ONLY_PUBLISH_PLATFORMS)

### DIFF
--- a/backend/integrations/providers/provider-factory.ts
+++ b/backend/integrations/providers/provider-factory.ts
@@ -106,11 +106,11 @@ export function getCapabilityProvider(
  * of the global PUBLISH_PROVIDER selector. Facebook and Instagram keep the
  * selector-driven path (direct_meta by default) — no change to their behavior.
  *
- * YouTube and TikTok are intentionally excluded here: their publisher branches
- * do not exist yet (tracked in #636 / #647). They join this set only when a
- * Composio publisher branch is implemented and tested for them.
+ * TikTok is intentionally excluded here: its publisher branch does not exist
+ * yet (tracked in #647). It joins this set only when a Composio publisher
+ * branch is implemented and tested for it.
  */
-const COMPOSIO_ONLY_PUBLISH_PLATFORMS = new Set<IntegrationPlatform>(['x', 'reddit', 'linkedin']);
+const COMPOSIO_ONLY_PUBLISH_PLATFORMS = new Set<IntegrationPlatform>(['x', 'reddit', 'linkedin', 'youtube']);
 
 /** True when the platform can only publish through Composio (not direct Meta). */
 export function isComposioOnlyPublishPlatform(platform: IntegrationPlatform): boolean {
@@ -119,8 +119,8 @@ export function isComposioOnlyPublishPlatform(platform: IntegrationPlatform): bo
 
 /**
  * Platform-aware publisher factory. Composio-only platforms (x, reddit,
- * linkedin) always return the Composio publisher, regardless of the global
- * PUBLISH_PROVIDER selector. All other platforms (facebook, instagram, …)
+ * linkedin, youtube) always return the Composio publisher, regardless of the
+ * global PUBLISH_PROVIDER selector. All other platforms (facebook, instagram, …)
  * delegate to the existing selector-driven getPublisherProvider so their
  * behavior is byte-identical to before this change.
  */

--- a/backend/integrations/publish-dispatch.ts
+++ b/backend/integrations/publish-dispatch.ts
@@ -78,7 +78,7 @@ export async function dispatchPublish(
   const platform = metaPlatform(request.provider);
   const composioOnly = isComposioOnlyPublishPlatform(platform);
 
-  // Composio-only platforms (x, reddit, linkedin) require Composio to be enabled.
+  // Composio-only platforms (x, reddit, linkedin, youtube) require Composio to be enabled.
   // Reject with a terminal 400 before any provider is contacted so the handlers
   // classify this as definitely-never-posted (safe to surface, never auto-retry,
   // and the direct-Meta path is NEVER a fallback for these platforms).
@@ -92,8 +92,8 @@ export async function dispatchPublish(
 
   // Fast path for non-composio-only platforms: the shipped default (direct_meta).
   // FB/IG publishing is byte-identical to the pre-seam call under direct_meta.
-  // Composio-only platforms skip this branch entirely — they never take the
-  // direct-Meta path regardless of the global selector.
+  // Composio-only platforms (x, reddit, linkedin, youtube) skip this branch
+  // entirely — they never take the direct-Meta path regardless of the global selector.
   if (!composioOnly && selector() === 'direct_meta') {
     return directPublish(request);
   }

--- a/tests/composio-youtube-publisher.test.ts
+++ b/tests/composio-youtube-publisher.test.ts
@@ -515,6 +515,11 @@ test('#636 metaPlatform routing: provider=youtube reaches the seam with platform
     { tenantId: '42', provider: 'youtube', content: 'hello youtube', mediaUrls: [], scheduledFor: null },
     {
       selector: () => 'composio',
+      // youtube is now composio-only (#677): composioEnabled must be injected as
+      // true here, otherwise the real isComposioEnabled() reads the unset
+      // COMPOSIO_ENABLED env var, returns false, and the new composio-only guard
+      // throws provider_not_configured before reaching the seam.
+      composioEnabled: () => true,
       directPublish: async () => {
         throw new Error('youtube must never reach the direct-Meta path');
       },

--- a/tests/publish-dispatch.test.ts
+++ b/tests/publish-dispatch.test.ts
@@ -391,31 +391,42 @@ test('auto selector also routes through the seam (not the direct path)', async (
   assert.equal(out.platformPostId, 'fb_auto');
 });
 
-// ── Regression tests for #671: per-platform publish routing decoupled ────────
+// ── Regression tests for #671 + #677: per-platform publish routing decoupled ─
 //
-// Before the fix, `dispatchPublish` applied the `direct_meta` fast path
+// #671: Before the fix, `dispatchPublish` applied the `direct_meta` fast path
 // unconditionally for all platforms.  An X/Reddit/LinkedIn request with
 // selector='direct_meta' (the shipped prod default) would call directPublish,
 // which reaches normalizeMetaProvider and throws 'unsupported_provider' (400) —
 // so those platforms could never publish regardless of COMPOSIO_ENABLED.
 //
-// The fix gates the direct_meta fast path on `!composioOnly`, and for
-// composio-only platforms (x, reddit, linkedin) routes to the Composio
+// #677: YouTube was in metaPlatform() (correctly mapped to 'youtube') but was
+// NOT in COMPOSIO_ONLY_PUBLISH_PLATFORMS, so under direct_meta it took the fast
+// path → publishToMetaGraph('youtube') → terminal 'unsupported_provider'.
+// The fix adds 'youtube' to the COMPOSIO_ONLY set so it routes to Composio
+// regardless of the global selector (same guarantee as x/reddit/linkedin).
+//
+// The gate: the direct_meta fast path is now conditioned on `!composioOnly`, and
+// composio-only platforms (x, reddit, linkedin, youtube) route to the Composio
 // publisher REGARDLESS of the global selector when Composio is enabled.
 
-test('#671 PROVING: x/reddit/linkedin bypass direct_meta fast path when composio is enabled', async () => {
+test('#671/#677 PROVING: x/reddit/linkedin/youtube bypass direct_meta fast path when composio is enabled', async () => {
   // PROVING TEST — fails against pre-fix code.
   //
-  // Before the fix:
+  // Before the #671 fix:
   //   if (selector() === 'direct_meta') return directPublish(request);  // ran for ALL platforms
   //
-  // After the fix:
+  // After the #671 fix:
   //   if (!composioOnly && selector() === 'direct_meta') ...             // composio-only platforms skip it
   //
-  // With the pre-fix code, directCalled would be true and calls.length would be 0
-  // for each composio-only platform, causing both assertions to fail.
+  // Before the #677 fix: youtube was NOT in COMPOSIO_ONLY_PUBLISH_PLATFORMS, so
+  // composioOnly===false for youtube → direct_meta fast path fired → directPublish
+  // called with 'youtube' → publishToMetaGraph('youtube') → unsupported_provider.
+  // directCalled===true and calls.length===0, causing both assertions below to fail.
+  //
+  // After the #677 fix: youtube is in the set → composioOnly===true →
+  // direct_meta fast path skipped → publisherProvider.publishPost called.
 
-  for (const p of ['x', 'reddit', 'linkedin'] as const) {
+  for (const p of ['x', 'reddit', 'linkedin', 'youtube'] as const) {
     let directCalled = false;
     const calls: PublishPostInput[] = [];
 
@@ -513,12 +524,17 @@ test('#671 facebook and instagram stay on the direct_meta path (not composio-onl
   }
 });
 
-test('#671 composio-only platform with composio disabled throws terminal provider_not_configured', async () => {
+test('#671/#677 composio-only platform with composio disabled throws terminal provider_not_configured', async () => {
   // When Composio is disabled (COMPOSIO_ENABLED=false / composioEnabled()===false),
-  // dispatching to a composio-only platform (x, reddit, linkedin) must throw a
-  // terminal MetaPublishError before contacting any provider.  This signals to
-  // handlers that the post was NEVER sent (safe to surface; never auto-retry).
-  for (const p of ['x', 'reddit', 'linkedin'] as const) {
+  // dispatching to a composio-only platform (x, reddit, linkedin, youtube) must
+  // throw a terminal MetaPublishError before contacting any provider.  This
+  // signals to handlers that the post was NEVER sent (safe to surface; never
+  // auto-retry, and the direct-Meta path is NEVER a fallback for these platforms).
+  //
+  // #677 extension: youtube is now composio-only, so COMPOSIO_ENABLED=false with
+  // provider='youtube' must also throw provider_not_configured (not fall through
+  // to directPublish, which would throw a different error class).
+  for (const p of ['x', 'reddit', 'linkedin', 'youtube'] as const) {
     let directCalled = false;
     let providerBuilt = false;
 


### PR DESCRIPTION
Closes #677

Repairs the #675/#676 merge skew so YouTube publish reaches the Composio publisher under the prod `direct_meta` selector.

## Root cause
#675 (Closes #636) added `youtube` to `metaPlatform()` and built the YouTube publish branch (`composio-publisher-provider.ts:438`); #676 (#671) decoupled per-platform routing but its `COMPOSIO_ONLY_PUBLISH_PLATFORMS` set was `{x, reddit, linkedin}` (youtube excluded — its branch didn't exist on the #671 branch). The two merged sequentially without a combined CI run, so on master youtube took the `direct_meta` fast path → `publishToMetaGraph('youtube')` → terminal `unsupported_provider`. YouTube publish was dead despite #636 being closed.

## Change
Add `'youtube'` to `COMPOSIO_ONLY_PUBLISH_PLATFORMS` in `provider-factory.ts` (plus comment accuracy in `provider-factory.ts` and `publish-dispatch.ts` — no logic change in publish-dispatch). Now under `direct_meta` + Composio enabled, youtube → `composioOnly=true` → skips the direct-Meta fast path → `createComposioPublisherProvider` → the existing youtube still→video branch. With `COMPOSIO_ENABLED=false` it throws a terminal `provider_not_configured` (definitely-never-posted, no Meta fallback). FB/IG and x/reddit/linkedin behavior is unchanged.

## Tests
- `tests/publish-dispatch.test.ts` — #671 proving tests extended to include youtube (bypasses direct_meta fast path when Composio enabled; throws `provider_not_configured` when disabled).
- `tests/composio-youtube-publisher.test.ts` — `composioEnabled:()=>true` injected into the #636 routing test (youtube is now composio-only; same pattern as the #671 x/reddit/linkedin tests).
- Focused: publish-dispatch + composio-youtube-publisher = 33 pass / 0 fail. `npm run verify` = 17/17 gates green.

## Residual risk
Inert by default: `ARIES_YOUTUBE_ENABLED` defaults OFF, so the scheduler allowlist + dispatch admit gate never admit a youtube target until the flag is flipped. The routing change has zero effect on FB/IG/x/reddit/linkedin.