### PR TITLE
fix(integrations): route composio-only analytics independent of the global ANALYTICS_PROVIDER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -402,7 +402,7 @@ COMPOSIO_FACEBOOK_LIST_COMMENTS_ACTION=
 
 # X (Twitter) analytics + comment replies (#632/#633), read by the insights-sync
 # worker's X adapter (backend/insights/adapters/x). The X insights path turns on
-# ONLY when ARIES_X_ENABLED=true AND ANALYTICS_PROVIDER=composio; otherwise the
+# ONLY when ARIES_X_ENABLED=true AND COMPOSIO_ENABLED=true; otherwise the
 # bridge no-ops, the adapter never activates, and no Composio tool runs. The
 # verified slugs below are the CODE DEFAULTS, so analytics works with them unset;
 # set them only to pin a different toolkit version. The adapter authenticates
@@ -422,7 +422,7 @@ COMPOSIO_X_LIST_COMMENTS_ACTION=
 
 # YouTube analytics + comments (#637/#638), read by the insights-sync worker's
 # YouTube adapter (backend/insights/adapters/youtube). The YouTube insights path
-# turns on ONLY when ARIES_YOUTUBE_ENABLED=true AND ANALYTICS_PROVIDER=composio;
+# turns on ONLY when ARIES_YOUTUBE_ENABLED=true AND COMPOSIO_ENABLED=true;
 # otherwise the bridge no-ops, the adapter never activates, and no Composio tool
 # runs. The verified slugs below are the CODE DEFAULTS, so analytics works with
 # them unset; set them only to pin a different toolkit version. The adapter
@@ -444,7 +444,7 @@ COMPOSIO_YOUTUBE_LIST_COMMENTS_ACTION=
 # Reddit analytics + comments (#642 analytics, #643 comments), read by the
 # insights-sync worker's Reddit adapter (backend/insights/adapters/reddit). The
 # Reddit insights path turns on ONLY when ARIES_REDDIT_ENABLED=true AND
-# ANALYTICS_PROVIDER=composio; otherwise the bridge no-ops, the adapter never
+# COMPOSIO_ENABLED=true; otherwise the bridge no-ops, the adapter never
 # activates, and no Composio tool runs. REUSES ARIES_REDDIT_ENABLED from the #641
 # publish path (no new flag). The verified slugs below are the CODE DEFAULTS, so
 # analytics works with them unset; set them only to pin a different toolkit
@@ -467,7 +467,7 @@ COMPOSIO_REDDIT_POST_INSIGHTS_ACTION=
 COMPOSIO_REDDIT_LIST_COMMENTS_ACTION=
 # LinkedIn analytics (#647), read by the insights-sync worker's LinkedIn adapter
 # (backend/insights/adapters/linkedin). The LinkedIn insights path turns on ONLY
-# when ARIES_LINKEDIN_ENABLED=true AND ANALYTICS_PROVIDER=composio; otherwise the
+# when ARIES_LINKEDIN_ENABLED=true AND COMPOSIO_ENABLED=true; otherwise the
 # bridge no-ops, the adapter never activates, and no Composio tool runs. The
 # verified slug below is the CODE DEFAULT, so analytics works with it unset; set
 # it only to pin a different toolkit version. The adapter authenticates every call

--- a/backend/insights/sync/adapter-factory.ts
+++ b/backend/insights/sync/adapter-factory.ts
@@ -21,9 +21,28 @@ import { createFacebookInsightsAdapter } from '../adapters/facebook/index';
 import { createXInsightsAdapter } from '../adapters/x/index';
 import { createRedditInsightsAdapter } from '../adapters/reddit/index';
 import { createLinkedInInsightsAdapter } from '../adapters/linkedin/index';
-import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled, isLinkedInEnabled } from '@/backend/integrations/providers/integration-config';
+import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled, isLinkedInEnabled, isComposioEnabled } from '@/backend/integrations/providers/integration-config';
 
 type AdapterBuilder = (ctx: InsightsAdapterContext) => InsightsAdapter;
+
+/**
+ * Platforms that are ALWAYS Composio-backed for analytics — they have no
+ * direct-Meta analytics path and are therefore independent of the global
+ * ANALYTICS_PROVIDER selector. Their enablement is keyed on COMPOSIO_ENABLED
+ * (not on ANALYTICS_PROVIDER, which governs facebook/instagram only).
+ *
+ * NOTE: youtube IS in this set (it has a working insights adapter) even though
+ * it is absent from the publish-only set COMPOSIO_ONLY_PUBLISH_PLATFORMS in
+ * backend/integrations/providers/provider-factory.ts. The two sets are
+ * intentionally separate and must NOT be merged — analytics and publish have
+ * different activation axes.
+ */
+const COMPOSIO_ONLY_ANALYTICS_PLATFORMS = new Set<Platform>(['x', 'reddit', 'linkedin', 'youtube']);
+
+/** True when the platform's analytics are exclusively Composio-backed. */
+export function isComposioOnlyAnalyticsPlatform(platform: string): boolean {
+  return COMPOSIO_ONLY_ANALYTICS_PLATFORMS.has(platform as Platform);
+}
 
 /**
  * Real off-switch for the Composio-backed Facebook insights path: only active
@@ -37,47 +56,53 @@ export function isFacebookInsightsEnabled(env: NodeJS.ProcessEnv = process.env):
 
 /**
  * Real off-switch for the Composio-backed X (Twitter) insights path: active only
- * when the X rollout flag is ON (ARIES_X_ENABLED) AND analytics is on Composio
- * (ANALYTICS_PROVIDER=composio). Reuses the existing isXEnabled flag — X insights
- * does not add a new flag. Default OFF on both axes → the X adapter never
- * activates and no Composio tool is ever executed.
+ * when the X rollout flag is ON (ARIES_X_ENABLED) AND Composio is enabled
+ * (COMPOSIO_ENABLED=true). X is a composio-only platform — it has no direct-Meta
+ * analytics path — so its gate is COMPOSIO_ENABLED, not ANALYTICS_PROVIDER.
+ * Reuses the existing isXEnabled flag — X insights does not add a new flag.
+ * Default OFF on both axes → the X adapter never activates and no Composio tool
+ * is ever executed.
  */
 export function isXInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return isXEnabled(env) && analyticsProviderSelector(env) === 'composio';
+  return isXEnabled(env) && isComposioEnabled(env);
 }
 
 /**
  * Real off-switch for the Composio-backed YouTube insights path: active only when
- * the YouTube rollout flag is ON (ARIES_YOUTUBE_ENABLED) AND analytics is on
- * Composio (ANALYTICS_PROVIDER=composio). NEW flag (not ARIES_X_ENABLED). Default
- * OFF on both axes → the YouTube adapter never activates and no Composio tool is
- * ever executed; the previously registered throwing skeleton is gone.
+ * the YouTube rollout flag is ON (ARIES_YOUTUBE_ENABLED) AND Composio is enabled
+ * (COMPOSIO_ENABLED=true). YouTube is a composio-only platform — so its gate is
+ * COMPOSIO_ENABLED, not ANALYTICS_PROVIDER. NEW flag (not ARIES_X_ENABLED).
+ * Default OFF on both axes → the YouTube adapter never activates and no Composio
+ * tool is ever executed; the previously registered throwing skeleton is gone.
  */
 export function isYouTubeInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return isYouTubeEnabled(env) && analyticsProviderSelector(env) === 'composio';
+  return isYouTubeEnabled(env) && isComposioEnabled(env);
 }
 
 /**
  * Real off-switch for the Composio-backed Reddit insights path: active only when
- * the Reddit rollout flag is ON (ARIES_REDDIT_ENABLED) AND analytics is on
- * Composio (ANALYTICS_PROVIDER=composio). REUSES the existing isRedditEnabled
+ * the Reddit rollout flag is ON (ARIES_REDDIT_ENABLED) AND Composio is enabled
+ * (COMPOSIO_ENABLED=true). Reddit is a composio-only platform — so its gate is
+ * COMPOSIO_ENABLED, not ANALYTICS_PROVIDER. REUSES the existing isRedditEnabled
  * flag from the Reddit publish path (#641) — Reddit insights does NOT add a new
  * flag. Default OFF on both axes → the Reddit adapter never activates and no
  * Composio tool is ever executed.
  */
 export function isRedditInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return isRedditEnabled(env) && analyticsProviderSelector(env) === 'composio';
+  return isRedditEnabled(env) && isComposioEnabled(env);
 }
 
 /**
  * Real off-switch for the Composio-backed LinkedIn insights path (#647): active
- * only when the LinkedIn rollout flag is ON (ARIES_LINKEDIN_ENABLED) AND analytics
- * is on Composio (ANALYTICS_PROVIDER=composio). Reuses the existing isLinkedInEnabled
- * flag — LinkedIn insights does NOT add a new flag. Default OFF on both axes → the
- * LinkedIn adapter never activates and no Composio tool is ever executed.
+ * only when the LinkedIn rollout flag is ON (ARIES_LINKEDIN_ENABLED) AND Composio
+ * is enabled (COMPOSIO_ENABLED=true). LinkedIn is a composio-only platform — so
+ * its gate is COMPOSIO_ENABLED, not ANALYTICS_PROVIDER. Reuses the existing
+ * isLinkedInEnabled flag — LinkedIn insights does NOT add a new flag. Default OFF
+ * on both axes → the LinkedIn adapter never activates and no Composio tool is
+ * ever executed.
  */
 export function isLinkedInInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return isLinkedInEnabled(env) && analyticsProviderSelector(env) === 'composio';
+  return isLinkedInEnabled(env) && isComposioEnabled(env);
 }
 
 const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
@@ -85,7 +110,7 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     if (!isYouTubeInsightsEnabled()) {
       throw new Error(
         'YouTube insights adapter is disabled: set ARIES_YOUTUBE_ENABLED=1 and ' +
-        'ANALYTICS_PROVIDER=composio to enable Composio-backed YouTube analytics.',
+        'COMPOSIO_ENABLED=true to enable Composio-backed YouTube analytics.',
       );
     }
     return createYouTubeInsightsAdapter(ctx);
@@ -103,7 +128,7 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     if (!isXInsightsEnabled()) {
       throw new Error(
         'X insights adapter is disabled: set ARIES_X_ENABLED=1 and ' +
-        'ANALYTICS_PROVIDER=composio to enable Composio-backed X analytics.',
+        'COMPOSIO_ENABLED=true to enable Composio-backed X analytics.',
       );
     }
     return createXInsightsAdapter(ctx);
@@ -112,7 +137,7 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     if (!isRedditInsightsEnabled()) {
       throw new Error(
         'Reddit insights adapter is disabled: set ARIES_REDDIT_ENABLED=1 and ' +
-        'ANALYTICS_PROVIDER=composio to enable Composio-backed Reddit analytics.',
+        'COMPOSIO_ENABLED=true to enable Composio-backed Reddit analytics.',
       );
     }
     return createRedditInsightsAdapter(ctx);
@@ -121,13 +146,38 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     if (!isLinkedInInsightsEnabled()) {
       throw new Error(
         'LinkedIn insights adapter is disabled: set ARIES_LINKEDIN_ENABLED=1 and ' +
-        'ANALYTICS_PROVIDER=composio to enable Composio-backed LinkedIn analytics.',
+        'COMPOSIO_ENABLED=true to enable Composio-backed LinkedIn analytics.',
       );
     }
     return createLinkedInInsightsAdapter(ctx);
   },
   // instagram: (ctx) => createInstagramInsightsAdapter(ctx),  ← out of scope (#596/#597 = FB only)
 };
+
+/**
+ * Per-platform predicate dispatcher that accepts an untyped string. True when a
+ * live insights adapter is enabled for the given platform in the supplied env.
+ *
+ * This is the single source-of-truth bridge between ensure-account.ts (which
+ * builds the bridged-platform list from strings) and the typed `is<P>InsightsEnabled`
+ * predicates above. By routing through this function, ensure-account.ts can never
+ * silently drift from the adapter's own enablement conditions.
+ *
+ *   facebook  → ANALYTICS_PROVIDER=composio
+ *   x         → ARIES_X_ENABLED + COMPOSIO_ENABLED
+ *   youtube   → ARIES_YOUTUBE_ENABLED + COMPOSIO_ENABLED
+ *   reddit    → ARIES_REDDIT_ENABLED + COMPOSIO_ENABLED
+ *   linkedin  → ARIES_LINKEDIN_ENABLED + COMPOSIO_ENABLED
+ *   anything else → false
+ */
+export function isPlatformInsightsEnabled(platform: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (platform === 'facebook') return isFacebookInsightsEnabled(env);
+  if (platform === 'x') return isXInsightsEnabled(env);
+  if (platform === 'youtube') return isYouTubeInsightsEnabled(env);
+  if (platform === 'reddit') return isRedditInsightsEnabled(env);
+  if (platform === 'linkedin') return isLinkedInInsightsEnabled(env);
+  return false;
+}
 
 /**
  * Returns true only if a live adapter is available for the platform. For

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -33,7 +33,7 @@
 
 import pool from '@/lib/db';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
-import { analyticsProviderSelector, isXEnabled, isYouTubeEnabled, isRedditEnabled, isLinkedInEnabled } from '@/backend/integrations/providers/integration-config';
+import { isPlatformInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
 import { resolveComposioConfig, type ComposioConfig } from '@/backend/integrations/composio/composio-config';
 import { createComposioGateway, type ComposioGateway } from '@/backend/integrations/composio/composio-client';
 import { resolveFacebookManagedPage } from '@/backend/integrations/composio/facebook-page-resolver';
@@ -42,26 +42,29 @@ import { resolveXUser } from '@/backend/integrations/composio/x-user-resolver';
 import { resolveRedditUser } from '@/backend/integrations/composio/reddit-user-resolver';
 
 /**
- * Platforms whose Composio connections should be projected into insights_accounts.
- * X (Twitter), YouTube, and LinkedIn are only bridged when their rollout flag is
- * ON (ARIES_X_ENABLED / ARIES_YOUTUBE_ENABLED / ARIES_LINKEDIN_ENABLED), computed
- * dynamically by `bridgedPlatforms` below — the const itself is never mutated, so
- * a flag-OFF environment is byte-identical to the FB-only bridge.
+ * Unconditionally-bridged platforms when ANALYTICS_PROVIDER=composio. Exported
+ * for test introspection. Composio-only platforms (x, youtube, reddit, linkedin)
+ * are NOT listed here because they are conditional on both their rollout flag AND
+ * COMPOSIO_ENABLED — they are included in the dynamic bridgedPlatforms() result
+ * only when both conditions are met. See bridgedPlatforms() below.
  */
 export const BRIDGED_PLATFORMS = ['facebook'] as const;
 
 /**
- * The bridged-platform list for this env: FB always; X only when ARIES_X_ENABLED;
- * YouTube only when ARIES_YOUTUBE_ENABLED; Reddit only when ARIES_REDDIT_ENABLED;
- * LinkedIn only when ARIES_LINKEDIN_ENABLED.
+ * Full bridged-platform list for this env, computed per-platform using the same
+ * `is<P>InsightsEnabled` predicates as the adapter factory (via
+ * isPlatformInsightsEnabled). The two can therefore never drift.
+ *
+ *   facebook → bridged iff ANALYTICS_PROVIDER=composio
+ *   x        → bridged iff ARIES_X_ENABLED + COMPOSIO_ENABLED
+ *   youtube  → bridged iff ARIES_YOUTUBE_ENABLED + COMPOSIO_ENABLED
+ *   reddit   → bridged iff ARIES_REDDIT_ENABLED + COMPOSIO_ENABLED
+ *   linkedin → bridged iff ARIES_LINKEDIN_ENABLED + COMPOSIO_ENABLED
  */
 function bridgedPlatforms(env: NodeJS.ProcessEnv): string[] {
-  const list: string[] = [...BRIDGED_PLATFORMS];
-  if (isXEnabled(env)) list.push('x');
-  if (isYouTubeEnabled(env)) list.push('youtube');
-  if (isRedditEnabled(env)) list.push('reddit');
-  if (isLinkedInEnabled(env)) list.push('linkedin');
-  return list;
+  return ['facebook', 'x', 'youtube', 'reddit', 'linkedin'].filter(
+    (p) => isPlatformInsightsEnabled(p, env),
+  );
 }
 
 interface BridgeRow {
@@ -102,20 +105,24 @@ function log(obj: Record<string, unknown>): void {
  * connections. Safe to call every tick: the UNIQUE (tenant_id, platform,
  * external_account_id) constraint collapses re-runs onto the existing row.
  *
- * Gated by the same off-switch as the adapter (ANALYTICS_PROVIDER=composio):
- * when analytics is not on Composio this is a no-op, so nothing is populated and
- * the worker stays a clean no-op (no failed sync runs for a disabled path).
+ * Gated per-platform by the same predicates the adapter factory uses (via
+ * isPlatformInsightsEnabled), so the bridge and adapter selections can never
+ * drift:
+ *   - Facebook is bridged only when ANALYTICS_PROVIDER=composio.
+ *   - Composio-only platforms (x, youtube, reddit, linkedin) are bridged only
+ *     when their rollout flag AND COMPOSIO_ENABLED are both on — independent of
+ *     ANALYTICS_PROVIDER, which governs facebook/instagram only.
+ * When no platform is enabled the function is a clean no-op (no DB query issued).
  */
 export async function ensureInsightsAccountsForConnectedPlatforms(
   db: Queryable = pool,
   env: NodeJS.ProcessEnv = process.env,
   deps: EnsureAccountsDeps = {},
 ): Promise<EnsureAccountsResult> {
-  if (analyticsProviderSelector(env) !== 'composio') {
-    return { considered: 0, upserted: 0, resolved: 0, skippedNoPage: 0, skippedReason: 'analytics_provider_not_composio' };
-  }
-
   const platforms = bridgedPlatforms(env);
+  if (platforms.length === 0) {
+    return { considered: 0, upserted: 0, resolved: 0, skippedNoPage: 0, skippedReason: 'no_enabled_analytics_platforms' };
+  }
   const placeholders = platforms.map((_, i) => `$${i + 1}`).join(', ');
   // NOTE: external_account_id is intentionally NOT filtered here — a null Page id
   // is back-healed below rather than skipped (the prod connection data gap).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,7 +525,7 @@ services:
       # X (Twitter) analytics + comment replies (#632/#633), read by the
       # insights-sync worker's X adapter (backend/insights/adapters/x). The X
       # insights path (account bridge + adapter) turns on ONLY when
-      # ARIES_X_ENABLED=true AND ANALYTICS_PROVIDER=composio; otherwise dormant.
+      # ARIES_X_ENABLED=true AND COMPOSIO_ENABLED=true; otherwise dormant.
       # AUTH_CONFIG_ID is the tenant's Composio auth config; the *_ACTION slugs
       # are optional (verified code defaults: TWITTER_POST_LOOKUP_BY_POST_ID(S),
       # TWITTER_RECENT_SEARCH).
@@ -537,7 +537,7 @@ services:
       # YouTube analytics + comments (#637/#638), read by the insights-sync
       # worker's YouTube adapter (backend/insights/adapters/youtube). The YouTube
       # insights path (account bridge + adapter) turns on ONLY when
-      # ARIES_YOUTUBE_ENABLED=true AND ANALYTICS_PROVIDER=composio; otherwise
+      # ARIES_YOUTUBE_ENABLED=true AND COMPOSIO_ENABLED=true; otherwise
       # dormant. AUTH_CONFIG_ID is the tenant's Composio auth config; the *_ACTION
       # slugs are optional (verified code defaults: YOUTUBE_LIST_CHANNEL_VIDEOS,
       # YOUTUBE_GET_VIDEO_DETAILS_BATCH, YOUTUBE_LIST_COMMENT_THREADS2).
@@ -549,7 +549,7 @@ services:
       # Reddit analytics + comments (#642/#643), read by the insights-sync worker's
       # Reddit adapter (backend/insights/adapters/reddit). The Reddit insights path
       # (account bridge + adapter) turns on ONLY when ARIES_REDDIT_ENABLED=true AND
-      # ANALYTICS_PROVIDER=composio; otherwise dormant. REUSES ARIES_REDDIT_ENABLED
+      # COMPOSIO_ENABLED=true; otherwise dormant. REUSES ARIES_REDDIT_ENABLED
       # from the #641 publish path (no new flag). This flag MUST be set on the
       # worker (not just aries-app): the worker process runs the insights sync, so
       # without it here the sidecar reads it false and Reddit insights stay dormant
@@ -564,7 +564,7 @@ services:
       # LinkedIn analytics (#647), read by the insights-sync worker's LinkedIn
       # adapter (backend/insights/adapters/linkedin). The LinkedIn insights path
       # (account bridge + adapter) turns on ONLY when ARIES_LINKEDIN_ENABLED=true
-      # AND ANALYTICS_PROVIDER=composio; otherwise dormant. AUTH_CONFIG_ID is the
+      # AND COMPOSIO_ENABLED=true; otherwise dormant. AUTH_CONFIG_ID is the
       # tenant's Composio auth config; POST_INSIGHTS_ACTION is optional (verified
       # code default: LINKEDIN_LIST_REACTIONS). Personal-reactions-only — there is
       # no list-comments slug (LinkedIn has no Composio list-comments action, #648).

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -6,7 +6,7 @@ import {
   BRIDGED_PLATFORMS,
 } from '@/backend/insights/sync/ensure-account';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
-import { getAdapter, hasAdapter, isFacebookInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
+import { getAdapter, hasAdapter, isFacebookInsightsEnabled, isComposioOnlyAnalyticsPlatform, isPlatformInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
 import { FacebookInsightsAdapter } from '@/backend/insights/adapters/facebook/index';
 import { DEFAULT_LIST_MANAGED_PAGES_SLUG } from '@/backend/integrations/composio/facebook-page-resolver';
 import { DEFAULT_X_GET_ME_SLUG } from '@/backend/integrations/composio/x-user-resolver';
@@ -190,7 +190,7 @@ test('M4 off-switch: the bridge no-ops (no DB query) when ANALYTICS_PROVIDER != 
   ]);
   const result = await ensureInsightsAccountsForConnectedPlatforms(db, DIRECT_ENV);
   assert.equal(result.upserted, 0);
-  assert.equal(result.skippedReason, 'analytics_provider_not_composio');
+  assert.equal(result.skippedReason, 'no_enabled_analytics_platforms');
   assert.equal(db.queries.length, 0, 'no DB query at all when the path is disabled');
 });
 
@@ -214,6 +214,7 @@ test('X bridge: when ARIES_X_ENABLED=1 the DB query includes "x" alongside "face
   const db = recordingDb([]);
   const xEnv = {
     ANALYTICS_PROVIDER: 'composio',
+    COMPOSIO_ENABLED: '1',
     ARIES_X_ENABLED: '1',
   } as unknown as NodeJS.ProcessEnv;
   await ensureInsightsAccountsForConnectedPlatforms(db, xEnv);
@@ -243,6 +244,7 @@ test('YouTube bridge: when ARIES_YOUTUBE_ENABLED=1 the DB query includes "youtub
   const db = recordingDb([]);
   const ytEnv = {
     ANALYTICS_PROVIDER: 'composio',
+    COMPOSIO_ENABLED: '1',
     ARIES_YOUTUBE_ENABLED: '1',
   } as unknown as NodeJS.ProcessEnv;
   await ensureInsightsAccountsForConnectedPlatforms(db, ytEnv);
@@ -275,6 +277,7 @@ test('Reddit bridge: when ARIES_REDDIT_ENABLED=1 the DB query includes "reddit" 
   const db = recordingDb([]);
   const redditEnv = {
     ANALYTICS_PROVIDER: 'composio',
+    COMPOSIO_ENABLED: '1',
     ARIES_REDDIT_ENABLED: '1',
   } as unknown as NodeJS.ProcessEnv;
   await ensureInsightsAccountsForConnectedPlatforms(db, redditEnv);
@@ -295,6 +298,7 @@ test('LinkedIn bridge: when ARIES_LINKEDIN_ENABLED=1 the DB query includes "link
   const db = recordingDb([]);
   const liEnv = {
     ANALYTICS_PROVIDER: 'composio',
+    COMPOSIO_ENABLED: '1',
     ARIES_LINKEDIN_ENABLED: '1',
   } as unknown as NodeJS.ProcessEnv;
   await ensureInsightsAccountsForConnectedPlatforms(db, liEnv);
@@ -358,7 +362,7 @@ test('X bridge back-heals the username and upserts an insights_accounts row', as
 
   const result = await ensureInsightsAccountsForConnectedPlatforms(
     db,
-    { ANALYTICS_PROVIDER: 'composio', ARIES_X_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
+    { ANALYTICS_PROVIDER: 'composio', COMPOSIO_ENABLED: '1', ARIES_X_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
     { gateway, config: fakeConfig({ actions: {} }) },
   );
 
@@ -403,7 +407,7 @@ test('Reddit bridge back-heals the username and upserts an insights_accounts row
 
   const result = await ensureInsightsAccountsForConnectedPlatforms(
     db,
-    { ANALYTICS_PROVIDER: 'composio', ARIES_REDDIT_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
+    { ANALYTICS_PROVIDER: 'composio', COMPOSIO_ENABLED: '1', ARIES_REDDIT_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
     { gateway, config: fakeConfig({ actions: {} }) },
   );
 
@@ -448,7 +452,7 @@ test('regression: FB row with external_account_id set still upserts directly whe
 
   const result = await ensureInsightsAccountsForConnectedPlatforms(
     db,
-    { ANALYTICS_PROVIDER: 'composio', ARIES_X_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
+    { ANALYTICS_PROVIDER: 'composio', COMPOSIO_ENABLED: '1', ARIES_X_ENABLED: '1' } as unknown as NodeJS.ProcessEnv,
     { gateway, config: fakeConfig({ actions: {} }) },
   );
 
@@ -484,6 +488,7 @@ test('regression: YouTube back-heal still routes to channel resolver when X and 
     db,
     {
       ANALYTICS_PROVIDER: 'composio',
+      COMPOSIO_ENABLED: '1',
       ARIES_YOUTUBE_ENABLED: '1',
       ARIES_X_ENABLED: '1',
       ARIES_REDDIT_ENABLED: '1',
@@ -520,4 +525,156 @@ test('facebook is registered in the adapter factory and getAdapter binds the con
     if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
     else process.env.ANALYTICS_PROVIDER = prevProvider;
   }
+});
+
+// ── Adversarial tests: #679 composio-only analytics seam ──────────────────────
+
+test('#679 (a) golden — FB path byte-identical to pre-fix: ANALYTICS_PROVIDER=composio + no rollout flags → SELECT params exactly ["facebook"]', async () => {
+  // This behavior must be byte-identical to pre-fix: a plain ANALYTICS_PROVIDER=composio
+  // env with no rollout flags must still only bridge facebook and nothing else.
+  const db = recordingDb([]);
+  const composioFbOnlyEnv = { ANALYTICS_PROVIDER: 'composio' } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, composioFbOnlyEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'a SELECT was issued');
+  assert.deepEqual(
+    select.params,
+    ['facebook'],
+    'FB path: params must be exactly ["facebook"] — no composio-only platforms leak in without their own flags',
+  );
+});
+
+test('#679 (a) golden — direct_meta no-op byte-identical to pre-fix: ANALYTICS_PROVIDER=direct_meta + no flags → zero DB queries', async () => {
+  // Pre-fix: early-return fired with skippedReason 'analytics_provider_not_composio'.
+  // Post-fix: per-platform bridgedPlatforms() returns [] → same no-op, new reason string.
+  const db = recordingDb([]);
+  const directMetaEnv = { ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv;
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, directMetaEnv);
+  assert.equal(db.queries.length, 0, 'zero DB queries when all platforms are disabled');
+  assert.equal(result.upserted, 0);
+  assert.equal(result.skippedReason, 'no_enabled_analytics_platforms');
+});
+
+test('#679 (b) dormancy — ARIES_REDDIT_ENABLED OFF + COMPOSIO_ENABLED=1 + ANALYTICS_PROVIDER=composio → reddit NOT in SELECT params, no reddit row upserted', async () => {
+  // Proves the rollout flag gates reddit independently of COMPOSIO_ENABLED.
+  // COMPOSIO_ENABLED=1 is on (Composio globally active) but the Reddit flag is absent.
+  const db = recordingDb([]);
+  const dormantRedditEnv = {
+    COMPOSIO_ENABLED: '1',
+    ANALYTICS_PROVIDER: 'composio',
+    // ARIES_REDDIT_ENABLED intentionally absent
+  } as unknown as NodeJS.ProcessEnv;
+  await ensureInsightsAccountsForConnectedPlatforms(db, dormantRedditEnv);
+  const select = db.queries[0];
+  assert.ok(select, 'a SELECT was issued (facebook is still bridged)');
+  assert.ok(
+    !(select.params as unknown[]).includes('reddit'),
+    'reddit must NOT appear in SELECT params when ARIES_REDDIT_ENABLED is off (dormancy)',
+  );
+  assert.ok(
+    (select.params as unknown[]).includes('facebook'),
+    'facebook must still be bridged via ANALYTICS_PROVIDER=composio (independent of COMPOSIO_ENABLED)',
+  );
+  // No INSERT should have fired for reddit.
+  const redditInsert = db.queries.find(
+    (q) => /INSERT INTO insights_accounts/i.test(q.text) && q.params[1] === 'reddit',
+  );
+  assert.equal(redditInsert, undefined, 'no insights_accounts row upserted for reddit when dormant');
+});
+
+test('#679 (c) NEW behavior — ARIES_REDDIT_ENABLED=1 + COMPOSIO_ENABLED=1 + ANALYTICS_PROVIDER=direct_meta → SELECT includes "reddit", excludes "facebook"; reddit upserts via Composio back-heal', async () => {
+  // THE POINT OF THE FIX: reddit can provision through Composio even when the
+  // ANALYTICS_PROVIDER selector is 'direct_meta' (which governs facebook/instagram only).
+  //
+  // Pre-fix proof this would FAIL: ensure-account.ts had an all-or-nothing early-return:
+  //   if (selector !== 'composio') return { skippedReason: 'analytics_provider_not_composio' }
+  // With ANALYTICS_PROVIDER=direct_meta, selector!=='composio', so the function returned
+  // immediately with upserted=0. The (c) assertion below (upserted===1) would have failed.
+  const db = recordingDb([
+    {
+      id: 21,
+      tenant_id: 15,
+      platform: 'reddit',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_reddit_c',
+    },
+  ]);
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { name: 'sugar_reddit' } },
+    },
+  });
+  const newBehaviorEnv = {
+    ARIES_REDDIT_ENABLED: '1',
+    COMPOSIO_ENABLED: '1',
+    ANALYTICS_PROVIDER: 'direct_meta',
+  } as unknown as NodeJS.ProcessEnv;
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, newBehaviorEnv, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+  });
+
+  // SELECT params must include 'reddit' and must NOT include 'facebook'.
+  const select = db.queries[0];
+  assert.ok(select, 'a SELECT was issued');
+  assert.ok(
+    (select.params as unknown[]).includes('reddit'),
+    'reddit must be in SELECT params (ARIES_REDDIT_ENABLED=1 + COMPOSIO_ENABLED=1)',
+  );
+  assert.ok(
+    !(select.params as unknown[]).includes('facebook'),
+    'facebook must NOT be in SELECT params (ANALYTICS_PROVIDER=direct_meta disables FB path)',
+  );
+
+  // Reddit row must have been resolved via back-heal and upserted.
+  assert.equal(result.resolved, 1, 'reddit username was resolved via Composio back-heal');
+  assert.equal(result.upserted, 1, 'reddit insights_accounts row was upserted');
+
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.ok(insert, 'an INSERT INTO insights_accounts was issued for reddit');
+  assert.deepEqual(insert!.params, [15, 'reddit', 'sugar_reddit', 'sugar_reddit']);
+});
+
+test('#679 seam parity — isPlatformInsightsEnabled dispatches correctly for all five platforms', () => {
+  const allOffEnv = {} as unknown as NodeJS.ProcessEnv;
+  const fbOnlyEnv = { ANALYTICS_PROVIDER: 'composio' } as unknown as NodeJS.ProcessEnv;
+  const redditOnlyEnv = { ARIES_REDDIT_ENABLED: '1', COMPOSIO_ENABLED: '1' } as unknown as NodeJS.ProcessEnv;
+  const fullEnv = { ANALYTICS_PROVIDER: 'composio', COMPOSIO_ENABLED: '1', ARIES_X_ENABLED: '1', ARIES_REDDIT_ENABLED: '1', ARIES_YOUTUBE_ENABLED: '1', ARIES_LINKEDIN_ENABLED: '1' } as unknown as NodeJS.ProcessEnv;
+
+  // facebook → ANALYTICS_PROVIDER gate (not affected by COMPOSIO_ENABLED)
+  assert.equal(isPlatformInsightsEnabled('facebook', fbOnlyEnv), true);
+  assert.equal(isPlatformInsightsEnabled('facebook', allOffEnv), false);
+  assert.equal(isPlatformInsightsEnabled('facebook', redditOnlyEnv), false, 'ANALYTICS_PROVIDER alone gates FB — COMPOSIO_ENABLED does not enable FB');
+
+  // composio-only platforms → rollout flag + COMPOSIO_ENABLED
+  assert.equal(isPlatformInsightsEnabled('reddit', redditOnlyEnv), true);
+  assert.equal(isPlatformInsightsEnabled('reddit', fbOnlyEnv), false, 'ANALYTICS_PROVIDER=composio alone does not enable reddit');
+  assert.equal(isPlatformInsightsEnabled('reddit', { ARIES_REDDIT_ENABLED: '1' } as unknown as NodeJS.ProcessEnv), false, 'ARIES_REDDIT_ENABLED without COMPOSIO_ENABLED → disabled');
+
+  // All five enabled together
+  assert.equal(isPlatformInsightsEnabled('facebook', fullEnv), true);
+  assert.equal(isPlatformInsightsEnabled('x', fullEnv), true);
+  assert.equal(isPlatformInsightsEnabled('youtube', fullEnv), true);
+  assert.equal(isPlatformInsightsEnabled('reddit', fullEnv), true);
+  assert.equal(isPlatformInsightsEnabled('linkedin', fullEnv), true);
+
+  // Unknown platform → always false
+  assert.equal(isPlatformInsightsEnabled('instagram', fullEnv), false, 'instagram is not in the seam');
+  assert.equal(isPlatformInsightsEnabled('unknown', fullEnv), false);
+});
+
+test('#679 isComposioOnlyAnalyticsPlatform: set is {x, reddit, linkedin, youtube}; facebook excluded', () => {
+  // These four platforms use COMPOSIO_ENABLED as their gate (not ANALYTICS_PROVIDER).
+  // NOTE: youtube IS in this set even though it is absent from the publish-only
+  // COMPOSIO_ONLY_PUBLISH_PLATFORMS — analytics and publish have different activation axes.
+  assert.equal(isComposioOnlyAnalyticsPlatform('x'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('reddit'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('linkedin'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('youtube'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('facebook'), false, 'facebook uses ANALYTICS_PROVIDER gate, not the composio-only set');
+  assert.equal(isComposioOnlyAnalyticsPlatform('instagram'), false, 'instagram is out of scope');
 });

--- a/tests/insights-linkedin-adapter.test.ts
+++ b/tests/insights-linkedin-adapter.test.ts
@@ -17,6 +17,7 @@ import {
   hasAdapter,
   getAdapter,
   isLinkedInInsightsEnabled,
+  isComposioOnlyAnalyticsPlatform,
 } from '@/backend/insights/sync/adapter-factory';
 import { platformSupports } from '@/backend/insights/platforms/capabilities';
 import type {
@@ -400,43 +401,58 @@ test('capabilities: platformSupports("linkedin","account_daily_metrics") is fals
 
 // ── Dormancy / off-switch ─────────────────────────────────────────────────────
 
-const LI_COMPOSIO_ENV = {
+// #679: LinkedIn gates on ARIES_LINKEDIN_ENABLED + COMPOSIO_ENABLED (not ANALYTICS_PROVIDER).
+const LI_ENABLED_ENV = {
   ARIES_LINKEDIN_ENABLED: '1',
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
+// ARIES_LINKEDIN_ENABLED absent — flag off.
 const FLAG_OFF_ENV = {
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-const PROVIDER_OFF_ENV = {
+// ARIES_LINKEDIN_ENABLED on but COMPOSIO_ENABLED absent — composio infrastructure off.
+const COMPOSIO_OFF_ENV = {
   ARIES_LINKEDIN_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-test('dormancy: isLinkedInInsightsEnabled requires BOTH ARIES_LINKEDIN_ENABLED=1 AND ANALYTICS_PROVIDER=composio', () => {
-  assert.equal(isLinkedInInsightsEnabled(LI_COMPOSIO_ENV), true, 'both flags on → enabled');
+test('dormancy: isLinkedInInsightsEnabled requires BOTH ARIES_LINKEDIN_ENABLED=1 AND COMPOSIO_ENABLED=1 (ANALYTICS_PROVIDER is irrelevant for LinkedIn)', () => {
+  assert.equal(isLinkedInInsightsEnabled(LI_ENABLED_ENV), true, 'both flags on → enabled');
   assert.equal(isLinkedInInsightsEnabled(FLAG_OFF_ENV), false, 'ARIES_LINKEDIN_ENABLED absent → disabled');
-  assert.equal(isLinkedInInsightsEnabled(PROVIDER_OFF_ENV), false, 'ANALYTICS_PROVIDER!=composio → disabled');
+  assert.equal(isLinkedInInsightsEnabled(COMPOSIO_OFF_ENV), false, 'COMPOSIO_ENABLED absent → disabled');
   assert.equal(
     isLinkedInInsightsEnabled({} as unknown as NodeJS.ProcessEnv),
     false,
     'no flags → disabled (default OFF)',
   );
+  // #679 (c) proof at adapter level: ANALYTICS_PROVIDER=direct_meta does NOT block LinkedIn.
+  assert.equal(
+    isLinkedInInsightsEnabled({ ARIES_LINKEDIN_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): LinkedIn enabled even when ANALYTICS_PROVIDER=direct_meta',
+  );
 });
 
 test('dormancy: hasAdapter("linkedin") mirrors isLinkedInInsightsEnabled for all flag combinations', () => {
-  assert.equal(hasAdapter('linkedin', LI_COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('linkedin', LI_ENABLED_ENV), true);
   assert.equal(hasAdapter('linkedin', FLAG_OFF_ENV), false);
-  assert.equal(hasAdapter('linkedin', PROVIDER_OFF_ENV), false);
+  assert.equal(hasAdapter('linkedin', COMPOSIO_OFF_ENV), false);
   assert.equal(hasAdapter('linkedin', {} as unknown as NodeJS.ProcessEnv), false);
+  // #679 (c): hasAdapter mirrors the same new-behavior case.
+  assert.equal(
+    hasAdapter('linkedin', { ARIES_LINKEDIN_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): hasAdapter("linkedin") true when ARIES_LINKEDIN_ENABLED+COMPOSIO_ENABLED regardless of ANALYTICS_PROVIDER',
+  );
 });
 
 test('dormancy: getAdapter("linkedin") throws a diagnostic error mentioning ARIES_LINKEDIN_ENABLED when disabled', () => {
   const prevLi = process.env.ARIES_LINKEDIN_ENABLED;
-  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  const prevComposio = process.env.COMPOSIO_ENABLED;
   // Ensure both axes are off so the REGISTRY guard fires.
   delete process.env.ARIES_LINKEDIN_ENABLED;
-  process.env.ANALYTICS_PROVIDER = 'direct_meta';
+  delete process.env.COMPOSIO_ENABLED;
   try {
     assert.throws(
       () => getAdapter('linkedin', { connectedAccountId: 'ca_li', tenantId: 1 }),
@@ -446,7 +462,12 @@ test('dormancy: getAdapter("linkedin") throws a diagnostic error mentioning ARIE
   } finally {
     if (prevLi === undefined) delete process.env.ARIES_LINKEDIN_ENABLED;
     else process.env.ARIES_LINKEDIN_ENABLED = prevLi;
-    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
-    else process.env.ANALYTICS_PROVIDER = prevProvider;
+    if (prevComposio === undefined) delete process.env.COMPOSIO_ENABLED;
+    else process.env.COMPOSIO_ENABLED = prevComposio;
   }
+});
+
+test('#679 isComposioOnlyAnalyticsPlatform: linkedin is in the composio-only set', () => {
+  assert.equal(isComposioOnlyAnalyticsPlatform('linkedin'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('facebook'), false, 'facebook uses ANALYTICS_PROVIDER gate');
 });

--- a/tests/insights-reddit-adapter.test.ts
+++ b/tests/insights-reddit-adapter.test.ts
@@ -16,6 +16,7 @@ import {
   hasAdapter,
   getAdapter,
   isRedditInsightsEnabled,
+  isComposioOnlyAnalyticsPlatform,
 } from '@/backend/insights/sync/adapter-factory';
 import type {
   ComposioGateway,
@@ -417,43 +418,58 @@ test('fetchAccountMetrics: always returns [] — Reddit has no verified account-
 
 // ── Dormancy / off-switch ─────────────────────────────────────────────────────
 
-const REDDIT_COMPOSIO_ENV = {
+// #679: composio-only platforms gate on ARIES_<P>_ENABLED + COMPOSIO_ENABLED (not ANALYTICS_PROVIDER).
+const REDDIT_ENABLED_ENV = {
   ARIES_REDDIT_ENABLED: '1',
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
+// ARIES_REDDIT_ENABLED absent — flag off (ANALYTICS_PROVIDER is irrelevant for reddit).
 const FLAG_OFF_ENV = {
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-const PROVIDER_OFF_ENV = {
+// ARIES_REDDIT_ENABLED on but COMPOSIO_ENABLED absent — composio infrastructure off.
+const COMPOSIO_OFF_ENV = {
   ARIES_REDDIT_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-test('dormancy: isRedditInsightsEnabled requires BOTH ARIES_REDDIT_ENABLED=1 AND ANALYTICS_PROVIDER=composio', () => {
-  assert.equal(isRedditInsightsEnabled(REDDIT_COMPOSIO_ENV), true, 'both flags on → enabled');
+test('dormancy: isRedditInsightsEnabled requires BOTH ARIES_REDDIT_ENABLED=1 AND COMPOSIO_ENABLED=1 (ANALYTICS_PROVIDER is irrelevant for reddit)', () => {
+  assert.equal(isRedditInsightsEnabled(REDDIT_ENABLED_ENV), true, 'both flags on → enabled');
   assert.equal(isRedditInsightsEnabled(FLAG_OFF_ENV), false, 'ARIES_REDDIT_ENABLED absent → disabled');
-  assert.equal(isRedditInsightsEnabled(PROVIDER_OFF_ENV), false, 'ANALYTICS_PROVIDER!=composio → disabled');
+  assert.equal(isRedditInsightsEnabled(COMPOSIO_OFF_ENV), false, 'COMPOSIO_ENABLED absent → disabled');
   assert.equal(
     isRedditInsightsEnabled({} as unknown as NodeJS.ProcessEnv),
     false,
     'no flags → disabled (default OFF)',
   );
+  // #679 (c) proof at adapter level: ANALYTICS_PROVIDER=direct_meta does NOT block reddit.
+  assert.equal(
+    isRedditInsightsEnabled({ ARIES_REDDIT_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): reddit enabled even when ANALYTICS_PROVIDER=direct_meta',
+  );
 });
 
 test('dormancy: hasAdapter("reddit") mirrors isRedditInsightsEnabled for all flag combinations', () => {
-  assert.equal(hasAdapter('reddit', REDDIT_COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('reddit', REDDIT_ENABLED_ENV), true);
   assert.equal(hasAdapter('reddit', FLAG_OFF_ENV), false);
-  assert.equal(hasAdapter('reddit', PROVIDER_OFF_ENV), false);
+  assert.equal(hasAdapter('reddit', COMPOSIO_OFF_ENV), false);
   assert.equal(hasAdapter('reddit', {} as unknown as NodeJS.ProcessEnv), false);
+  // #679 (c): hasAdapter mirrors the same new-behavior case.
+  assert.equal(
+    hasAdapter('reddit', { ARIES_REDDIT_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): hasAdapter("reddit") true when ARIES_REDDIT_ENABLED+COMPOSIO_ENABLED regardless of ANALYTICS_PROVIDER',
+  );
 });
 
 test('dormancy: getAdapter("reddit") throws a diagnostic error mentioning ARIES_REDDIT_ENABLED when disabled', () => {
   const prevReddit = process.env.ARIES_REDDIT_ENABLED;
-  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  const prevComposio = process.env.COMPOSIO_ENABLED;
   // Ensure both axes are off so the REGISTRY guard fires.
   delete process.env.ARIES_REDDIT_ENABLED;
-  process.env.ANALYTICS_PROVIDER = 'direct_meta';
+  delete process.env.COMPOSIO_ENABLED;
   try {
     assert.throws(
       () => getAdapter('reddit', { connectedAccountId: 'ca_reddit', tenantId: 1 }),
@@ -463,7 +479,12 @@ test('dormancy: getAdapter("reddit") throws a diagnostic error mentioning ARIES_
   } finally {
     if (prevReddit === undefined) delete process.env.ARIES_REDDIT_ENABLED;
     else process.env.ARIES_REDDIT_ENABLED = prevReddit;
-    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
-    else process.env.ANALYTICS_PROVIDER = prevProvider;
+    if (prevComposio === undefined) delete process.env.COMPOSIO_ENABLED;
+    else process.env.COMPOSIO_ENABLED = prevComposio;
   }
+});
+
+test('#679 isComposioOnlyAnalyticsPlatform: reddit is in the composio-only set', () => {
+  assert.equal(isComposioOnlyAnalyticsPlatform('reddit'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('facebook'), false, 'facebook uses ANALYTICS_PROVIDER gate');
 });

--- a/tests/insights-x-adapter.test.ts
+++ b/tests/insights-x-adapter.test.ts
@@ -16,6 +16,7 @@ import {
   hasAdapter,
   getAdapter,
   isXInsightsEnabled,
+  isComposioOnlyAnalyticsPlatform,
 } from '@/backend/insights/sync/adapter-factory';
 import type {
   ComposioGateway,
@@ -339,43 +340,58 @@ test('fetchAccountMetrics: always returns [] — no verified X account-insights 
 
 // ── Dormancy / off-switch ─────────────────────────────────────────────────────
 
-const X_COMPOSIO_ENV = {
+// #679: X gates on ARIES_X_ENABLED + COMPOSIO_ENABLED (not ANALYTICS_PROVIDER).
+const X_ENABLED_ENV = {
   ARIES_X_ENABLED: '1',
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
+// ARIES_X_ENABLED absent — flag off.
 const FLAG_OFF_ENV = {
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-const PROVIDER_OFF_ENV = {
+// ARIES_X_ENABLED on but COMPOSIO_ENABLED absent — composio infrastructure off.
+const COMPOSIO_OFF_ENV = {
   ARIES_X_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-test('dormancy: isXInsightsEnabled requires BOTH ARIES_X_ENABLED=1 AND ANALYTICS_PROVIDER=composio', () => {
-  assert.equal(isXInsightsEnabled(X_COMPOSIO_ENV), true, 'both flags on → enabled');
+test('dormancy: isXInsightsEnabled requires BOTH ARIES_X_ENABLED=1 AND COMPOSIO_ENABLED=1 (ANALYTICS_PROVIDER is irrelevant for X)', () => {
+  assert.equal(isXInsightsEnabled(X_ENABLED_ENV), true, 'both flags on → enabled');
   assert.equal(isXInsightsEnabled(FLAG_OFF_ENV), false, 'ARIES_X_ENABLED absent → disabled');
-  assert.equal(isXInsightsEnabled(PROVIDER_OFF_ENV), false, 'ANALYTICS_PROVIDER!=composio → disabled');
+  assert.equal(isXInsightsEnabled(COMPOSIO_OFF_ENV), false, 'COMPOSIO_ENABLED absent → disabled');
   assert.equal(
     isXInsightsEnabled({} as unknown as NodeJS.ProcessEnv),
     false,
     'no flags → disabled (default OFF)',
   );
+  // #679 (c) proof at adapter level: ANALYTICS_PROVIDER=direct_meta does NOT block X.
+  assert.equal(
+    isXInsightsEnabled({ ARIES_X_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): X enabled even when ANALYTICS_PROVIDER=direct_meta',
+  );
 });
 
 test('dormancy: hasAdapter("x") mirrors isXInsightsEnabled for all flag combinations', () => {
-  assert.equal(hasAdapter('x', X_COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('x', X_ENABLED_ENV), true);
   assert.equal(hasAdapter('x', FLAG_OFF_ENV), false);
-  assert.equal(hasAdapter('x', PROVIDER_OFF_ENV), false);
+  assert.equal(hasAdapter('x', COMPOSIO_OFF_ENV), false);
   assert.equal(hasAdapter('x', {} as unknown as NodeJS.ProcessEnv), false);
+  // #679 (c): hasAdapter mirrors the same new-behavior case.
+  assert.equal(
+    hasAdapter('x', { ARIES_X_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): hasAdapter("x") true when ARIES_X_ENABLED+COMPOSIO_ENABLED regardless of ANALYTICS_PROVIDER',
+  );
 });
 
 test('dormancy: getAdapter("x") throws a diagnostic error when ARIES_X_ENABLED is off', () => {
   const prevX = process.env.ARIES_X_ENABLED;
-  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  const prevComposio = process.env.COMPOSIO_ENABLED;
   // Ensure both axes are off so the REGISTRY guard fires.
   delete process.env.ARIES_X_ENABLED;
-  process.env.ANALYTICS_PROVIDER = 'direct_meta';
+  delete process.env.COMPOSIO_ENABLED;
   try {
     assert.throws(
       () => getAdapter('x', { connectedAccountId: 'ca_x', tenantId: 1 }),
@@ -384,7 +400,12 @@ test('dormancy: getAdapter("x") throws a diagnostic error when ARIES_X_ENABLED i
   } finally {
     if (prevX === undefined) delete process.env.ARIES_X_ENABLED;
     else process.env.ARIES_X_ENABLED = prevX;
-    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
-    else process.env.ANALYTICS_PROVIDER = prevProvider;
+    if (prevComposio === undefined) delete process.env.COMPOSIO_ENABLED;
+    else process.env.COMPOSIO_ENABLED = prevComposio;
   }
+});
+
+test('#679 isComposioOnlyAnalyticsPlatform: x is in the composio-only set', () => {
+  assert.equal(isComposioOnlyAnalyticsPlatform('x'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('facebook'), false, 'facebook uses ANALYTICS_PROVIDER gate');
 });

--- a/tests/insights-youtube-adapter.test.ts
+++ b/tests/insights-youtube-adapter.test.ts
@@ -16,6 +16,7 @@ import {
   hasAdapter,
   getAdapter,
   isYouTubeInsightsEnabled,
+  isComposioOnlyAnalyticsPlatform,
 } from '@/backend/insights/sync/adapter-factory';
 import type {
   ComposioGateway,
@@ -383,43 +384,60 @@ test('.items unwrap: adapter reads row array from {data:{items:[...]}} (YouTube 
 
 // ── Dormancy / off-switch ─────────────────────────────────────────────────────
 
-const YT_COMPOSIO_ENV = {
+// #679: YouTube gates on ARIES_YOUTUBE_ENABLED + COMPOSIO_ENABLED (not ANALYTICS_PROVIDER).
+// NOTE: youtube IS in the composio-only analytics set even though it is absent from
+// the publish-only COMPOSIO_ONLY_PUBLISH_PLATFORMS — the two sets are intentionally separate.
+const YT_ENABLED_ENV = {
   ARIES_YOUTUBE_ENABLED: '1',
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
+// ARIES_YOUTUBE_ENABLED absent — flag off.
 const FLAG_OFF_ENV = {
-  ANALYTICS_PROVIDER: 'composio',
+  COMPOSIO_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-const PROVIDER_OFF_ENV = {
+// ARIES_YOUTUBE_ENABLED on but COMPOSIO_ENABLED absent — composio infrastructure off.
+const COMPOSIO_OFF_ENV = {
   ARIES_YOUTUBE_ENABLED: '1',
 } as unknown as NodeJS.ProcessEnv;
 
-test('dormancy: isYouTubeInsightsEnabled requires BOTH ARIES_YOUTUBE_ENABLED=1 AND ANALYTICS_PROVIDER=composio', () => {
-  assert.equal(isYouTubeInsightsEnabled(YT_COMPOSIO_ENV), true, 'both flags on → enabled');
+test('dormancy: isYouTubeInsightsEnabled requires BOTH ARIES_YOUTUBE_ENABLED=1 AND COMPOSIO_ENABLED=1 (ANALYTICS_PROVIDER is irrelevant for YouTube)', () => {
+  assert.equal(isYouTubeInsightsEnabled(YT_ENABLED_ENV), true, 'both flags on → enabled');
   assert.equal(isYouTubeInsightsEnabled(FLAG_OFF_ENV), false, 'ARIES_YOUTUBE_ENABLED absent → disabled');
-  assert.equal(isYouTubeInsightsEnabled(PROVIDER_OFF_ENV), false, 'ANALYTICS_PROVIDER!=composio → disabled');
+  assert.equal(isYouTubeInsightsEnabled(COMPOSIO_OFF_ENV), false, 'COMPOSIO_ENABLED absent → disabled');
   assert.equal(
     isYouTubeInsightsEnabled({} as unknown as NodeJS.ProcessEnv),
     false,
     'no flags → disabled (default OFF)',
   );
+  // #679 (c) proof at adapter level: ANALYTICS_PROVIDER=direct_meta does NOT block YouTube.
+  assert.equal(
+    isYouTubeInsightsEnabled({ ARIES_YOUTUBE_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): YouTube enabled even when ANALYTICS_PROVIDER=direct_meta',
+  );
 });
 
 test('dormancy: hasAdapter("youtube") mirrors isYouTubeInsightsEnabled for all flag combinations', () => {
-  assert.equal(hasAdapter('youtube', YT_COMPOSIO_ENV), true);
+  assert.equal(hasAdapter('youtube', YT_ENABLED_ENV), true);
   assert.equal(hasAdapter('youtube', FLAG_OFF_ENV), false);
-  assert.equal(hasAdapter('youtube', PROVIDER_OFF_ENV), false);
+  assert.equal(hasAdapter('youtube', COMPOSIO_OFF_ENV), false);
   assert.equal(hasAdapter('youtube', {} as unknown as NodeJS.ProcessEnv), false);
+  // #679 (c): hasAdapter mirrors the same new-behavior case.
+  assert.equal(
+    hasAdapter('youtube', { ARIES_YOUTUBE_ENABLED: '1', COMPOSIO_ENABLED: '1', ANALYTICS_PROVIDER: 'direct_meta' } as unknown as NodeJS.ProcessEnv),
+    true,
+    '#679 (c): hasAdapter("youtube") true when ARIES_YOUTUBE_ENABLED+COMPOSIO_ENABLED regardless of ANALYTICS_PROVIDER',
+  );
 });
 
 test('dormancy: getAdapter("youtube") throws a diagnostic error mentioning ARIES_YOUTUBE_ENABLED when disabled', () => {
   const prevYt = process.env.ARIES_YOUTUBE_ENABLED;
-  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  const prevComposio = process.env.COMPOSIO_ENABLED;
   // Ensure both axes are off so the REGISTRY guard fires.
   delete process.env.ARIES_YOUTUBE_ENABLED;
-  process.env.ANALYTICS_PROVIDER = 'direct_meta';
+  delete process.env.COMPOSIO_ENABLED;
   try {
     assert.throws(
       () => getAdapter('youtube', { connectedAccountId: 'ca_yt', tenantId: 1 }),
@@ -429,7 +447,12 @@ test('dormancy: getAdapter("youtube") throws a diagnostic error mentioning ARIES
   } finally {
     if (prevYt === undefined) delete process.env.ARIES_YOUTUBE_ENABLED;
     else process.env.ARIES_YOUTUBE_ENABLED = prevYt;
-    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
-    else process.env.ANALYTICS_PROVIDER = prevProvider;
+    if (prevComposio === undefined) delete process.env.COMPOSIO_ENABLED;
+    else process.env.COMPOSIO_ENABLED = prevComposio;
   }
+});
+
+test('#679 isComposioOnlyAnalyticsPlatform: youtube is in the composio-only analytics set (distinct from publish set)', () => {
+  assert.equal(isComposioOnlyAnalyticsPlatform('youtube'), true);
+  assert.equal(isComposioOnlyAnalyticsPlatform('facebook'), false, 'facebook uses ANALYTICS_PROVIDER gate');
 });


### PR DESCRIPTION
Closes #679

## Root cause
The insights bridge (`ensure-account.ts`) and adapter factory gated the four composio-only analytics platforms (x/reddit/linkedin/youtube) on `ANALYTICS_PROVIDER==='composio'`. That selector governs the **facebook/instagram** direct-Meta-vs-Composio choice only; coupling the composio-only platforms to it meant a deployment running `ANALYTICS_PROVIDER=direct_meta` (FB analytics on direct Meta) could never turn on X/Reddit/LinkedIn/YouTube analytics, even with their rollout flag + Composio both on. This is the analytics mirror of the publish decouple in #671.

## What changed
- `backend/insights/sync/adapter-factory.ts`: `is{X,YouTube,Reddit,LinkedIn}InsightsEnabled` now gate on `is<P>Enabled && isComposioEnabled` instead of `&& analyticsProviderSelector==='composio'`. `isFacebookInsightsEnabled` is **unchanged** (still `selector==='composio'`). New `isComposioOnlyAnalyticsPlatform` set {x,reddit,linkedin,youtube} (separate from the publish set) + single-source `isPlatformInsightsEnabled(platform, env)` dispatcher.
- `backend/insights/sync/ensure-account.ts`: removed the all-or-nothing `if (selector!=='composio') return` early-return; `bridgedPlatforms()` now filters per-platform through `isPlatformInsightsEnabled` (FB iff selector===composio; others iff flag && COMPOSIO_ENABLED). Empty list → `skippedReason:'no_enabled_analytics_platforms'` (no consumer branches on this string; the worker only reads the count fields).
- Doc-comment updates in docker-compose.yml / .env.example.

## Byte-identical in current prod
Prod runs `ANALYTICS_PROVIDER=composio` + `COMPOSIO_ENABLED=true`. **Facebook** bridge inclusion + adapter selection route solely through the untouched `isFacebookInsightsEnabled` (selector-gated) — identical for every ANALYTICS_PROVIDER/COMPOSIO_ENABLED value. **Instagram** is never bridged and has no registered adapter — unchanged. For the composio-only platforms, the only delta is `&& isComposioEnabled` replacing the function-wide selector gate; with COMPOSIO_ENABLED=true that membership is identical to pre-fix, and the SELECT param order is preserved (`['facebook','x','youtube','reddit','linkedin'].filter(...)`). This makes composio-only analytics independent of the FB/IG selector, symmetric with #671 (publish).

## Test evidence
- Adversarial coverage added: golden FB-only + direct_meta no-op byte-identity, flag-OFF dormancy under COMPOSIO_ENABLED+composio, and new-behavior (`ANALYTICS_PROVIDER=direct_meta` + flag + COMPOSIO_ENABLED → platform bridges & upserts via Composio back-heal). `isPlatformInsightsEnabled` seam parity + `isComposioOnlyAnalyticsPlatform` set membership.
- 5 affected insights suites: 79 pass / 0 fail. `npm run verify` green. `npm run guardrails:agent` passed.

## Residual risk
Low. Pure flag-routing change; no DB-pool fan-out (bridge stays a single serial SELECT + per-row upsert), no tenant-isolation change, no schema change. Composio-only platforms remain default-OFF (rollout flags ship OFF).