### PR TITLE
fix(insights): honest unavailable states for unsupported analytics metrics

### DIFF
--- a/backend/insights/platforms/capabilities.ts
+++ b/backend/insights/platforms/capabilities.ts
@@ -16,6 +16,7 @@ export type PlatformCapability =
   | 'account_daily_metrics'   // channel-level daily views, followers, watch time
   | 'post_list'               // list of published posts / videos
   | 'post_daily_metrics'      // per-post daily breakdowns
+  | 'post_view_count'         // per-post view/impression count (youtube, instagram, facebook only)
   | 'comments'                // per-post comment fetch
   | 'audience_demographics'   // age/gender/country breakdown
   | 'watch_time'              // cumulative watch-time minutes
@@ -32,12 +33,14 @@ export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapabil
   youtube: new Set<PlatformCapability>([
     'post_list',
     'post_daily_metrics',
+    'post_view_count',
     'comments',
   ]),
   instagram: new Set<PlatformCapability>([
     'account_daily_metrics',
     'post_list',
     'post_daily_metrics',
+    'post_view_count',
     'comments',
     'audience_demographics',
     'reach_impressions',
@@ -47,6 +50,7 @@ export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapabil
     'account_daily_metrics',
     'post_list',
     'post_daily_metrics',
+    'post_view_count',
     'comments',
     'reach_impressions',
   ]),

--- a/frontend/aries-v1/analytics-screen.tsx
+++ b/frontend/aries-v1/analytics-screen.tsx
@@ -15,6 +15,7 @@ import type { InsightsAccountMetricPoint, InsightsPostItem } from '@/lib/api/ari
 import { useInsightsAnalytics } from '@/hooks/use-insights-analytics';
 import type { Platform } from '@/backend/insights/platforms/registry';
 import { PLATFORM_LABELS } from '@/backend/insights/platforms/registry';
+import { platformSupports } from '@/backend/insights/platforms/capabilities';
 
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { EmptyStatePanel, LoadingStateGrid, MetricCard, ShellPanel } from './components';
@@ -32,6 +33,14 @@ function formatDay(value: string): string {
   return value.slice(0, 10) || '—';
 }
 
+// Per-platform reasons why account-level metrics are unavailable.
+// Must be honest and specific — never a fabricated zero or generic stub.
+const ACCOUNT_METRICS_UNAVAILABLE_REASON: Partial<Record<Platform, string>> = {
+  x: 'Impressions require a paid X API tier.',
+  reddit: "Reddit doesn't expose reach/impression metrics.",
+  linkedin: 'Account-level analytics need LinkedIn organization access.',
+};
+
 export default function AriesAnalyticsScreen({
   enabledPlatforms = ['facebook'],
 }: {
@@ -46,6 +55,8 @@ export default function AriesAnalyticsScreen({
   const series: InsightsAccountMetricPoint[] = data?.accountMetrics.series ?? [];
   const posts: InsightsPostItem[] = data?.posts.posts ?? [];
 
+  // hasData is only consulted in the accountMetricsSupported path (facebook/instagram).
+  // For unsupported-account-metrics platforms the sections are independently gated.
   const hasData = Boolean(
     summary &&
       (summary.totalViews > 0 ||
@@ -59,7 +70,53 @@ export default function AriesAnalyticsScreen({
         posts.length > 0),
   );
 
+  const accountMetricsSupported = platformSupports(platform, 'account_daily_metrics');
+  const postViewsSupported = platformSupports(platform, 'post_view_count');
+
   const label = PLATFORM_LABELS[platform];
+
+  // Shared posts table — rendered in both the supported and unsupported account-metrics
+  // paths. Views column is omitted for platforms that don't surface per-post view counts
+  // (x, reddit, linkedin). For youtube/instagram/facebook postViewsSupported=true so the
+  // column renders as it does today.
+  const postsTable = (
+    <ShellPanel eyebrow="Posts" title="Per-post performance">
+      {posts.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-white/10 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+                <th className="py-3 pr-4 font-semibold">Post</th>
+                <th className="py-3 pr-4 font-semibold">Published</th>
+                {postViewsSupported && <th className="py-3 pr-4 text-right font-semibold">Views</th>}
+                <th className="py-3 pr-4 text-right font-semibold">Likes</th>
+                <th className="py-3 pr-4 text-right font-semibold">Comments</th>
+                <th className="py-3 text-right font-semibold">Shares</th>
+              </tr>
+            </thead>
+            <tbody>
+              {posts.map((post) => (
+                <tr key={post.id} className="border-b border-white/[0.06] text-white/75">
+                  <td className="max-w-[18rem] truncate py-3 pr-4 text-white/90">
+                    {post.title?.trim() || post.externalPostId}
+                  </td>
+                  <td className="py-3 pr-4 text-white/55">{formatDay(post.publishedAt)}</td>
+                  {postViewsSupported && (
+                    <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalViews)}</td>
+                  )}
+                  <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalLikes)}</td>
+                  <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalComments)}</td>
+                  <td className="py-3 text-right">{formatNumber(post.metrics.totalShares)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-sm text-white/55">No post-level metrics yet.</p>
+      )}
+    </ShellPanel>
+  );
 
   return (
     <div className="space-y-5">
@@ -102,6 +159,20 @@ export default function AriesAnalyticsScreen({
             Try again
           </button>
         </div>
+      ) : !accountMetricsSupported ? (
+        // Platform doesn't expose account-level metrics (x, reddit, linkedin, youtube).
+        // Show an honest panel instead of fabricated zeros, then render post-level data
+        // if any exists. The per-post Views column is also gated by postViewsSupported.
+        <>
+          <EmptyStatePanel
+            title={`Account analytics aren't available for ${label}`}
+            description={
+              ACCOUNT_METRICS_UNAVAILABLE_REASON[platform] ??
+              'Account-level metrics are not available for this platform.'
+            }
+          />
+          {postsTable}
+        </>
       ) : !hasData || !summary ? (
         <EmptyStatePanel
           title="No analytics yet"
@@ -154,40 +225,7 @@ export default function AriesAnalyticsScreen({
             )}
           </ShellPanel>
 
-          <ShellPanel eyebrow="Posts" title="Per-post performance">
-            {posts.length > 0 ? (
-              <div className="overflow-x-auto">
-                <table className="w-full min-w-[640px] border-collapse text-left text-sm">
-                  <thead>
-                    <tr className="border-b border-white/10 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
-                      <th className="py-3 pr-4 font-semibold">Post</th>
-                      <th className="py-3 pr-4 font-semibold">Published</th>
-                      <th className="py-3 pr-4 text-right font-semibold">Views</th>
-                      <th className="py-3 pr-4 text-right font-semibold">Likes</th>
-                      <th className="py-3 pr-4 text-right font-semibold">Comments</th>
-                      <th className="py-3 text-right font-semibold">Shares</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {posts.map((post) => (
-                      <tr key={post.id} className="border-b border-white/[0.06] text-white/75">
-                        <td className="max-w-[18rem] truncate py-3 pr-4 text-white/90">
-                          {post.title?.trim() || post.externalPostId}
-                        </td>
-                        <td className="py-3 pr-4 text-white/55">{formatDay(post.publishedAt)}</td>
-                        <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalViews)}</td>
-                        <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalLikes)}</td>
-                        <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalComments)}</td>
-                        <td className="py-3 text-right">{formatNumber(post.metrics.totalShares)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <p className="text-sm text-white/55">No post-level metrics yet.</p>
-            )}
-          </ShellPanel>
+          {postsTable}
         </>
       )}
     </div>

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -231,6 +231,14 @@ const steps = [
     name: 'onboarding variant board render (jsdom)',
     args: ['--test', 'tests/onboarding/variant-board-render.component.test.ts'],
   },
+  {
+    // #684 regression: analytics screen must gate the summary grid + Views column
+    // on per-platform capabilities (account_daily_metrics / post_view_count) and
+    // render an honest EmptyStatePanel — not fabricated zeros — for unsupported
+    // platforms (x, reddit, linkedin for grid; x/reddit/linkedin for Views column).
+    name: 'insights dashboard UI source assertions (#648, #684)',
+    args: ['--test', 'tests/insights-dashboard-ui.test.ts'],
+  },
 ];
 
 for (const [index, step] of steps.entries()) {

--- a/tests/insights-dashboard-ui.test.ts
+++ b/tests/insights-dashboard-ui.test.ts
@@ -5,6 +5,7 @@ import test from 'node:test';
 
 import { resolveProjectRoot } from './helpers/project-root';
 import { APP_ROUTES, getRouteById } from '../frontend/app-shell/routes';
+import { platformSupports } from '../backend/insights/platforms/capabilities';
 
 const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
 
@@ -148,4 +149,54 @@ test('comments read-api exposes replied state so the inbox can render it', () =>
   assert.match(readApi, /c\.replied_at/);
   assert.match(readApi, /isReplied:/);
   assert.match(readApi, /repliedAt:/);
+});
+
+// ─── #684 honest analytics "metric unavailable" states ───────────────────────
+
+test('analytics screen imports platformSupports and derives accountMetricsSupported + postViewsSupported (#684)', () => {
+  // Import of platformSupports from the capabilities module must be present.
+  assert.match(analyticsScreen, /import.*platformSupports.*from.*capabilities/);
+  // accountMetricsSupported is derived by calling platformSupports for 'account_daily_metrics'.
+  assert.match(analyticsScreen, /platformSupports\(platform,\s*'account_daily_metrics'\)/);
+  // postViewsSupported is derived by calling platformSupports for 'post_view_count'.
+  assert.match(analyticsScreen, /platformSupports\(platform,\s*'post_view_count'\)/);
+  // Both derived booleans are referenced in the template (not dead code).
+  assert.match(analyticsScreen, /accountMetricsSupported/);
+  assert.match(analyticsScreen, /postViewsSupported/);
+});
+
+test('analytics screen renders honest EmptyStatePanel with per-platform reasons when account metrics unsupported (#684)', () => {
+  // The !accountMetricsSupported branch must drive an EmptyStatePanel — not fabricated zeros.
+  assert.match(analyticsScreen, /!accountMetricsSupported[\s\S]*?EmptyStatePanel/);
+  // The per-platform reason lookup map must be declared.
+  assert.match(analyticsScreen, /ACCOUNT_METRICS_UNAVAILABLE_REASON/);
+  // X: honest "paid tier" reason.
+  assert.match(analyticsScreen, /paid X API tier/);
+  // Reddit: honest "doesn't expose" reason.
+  assert.match(analyticsScreen, /Reddit.*expose/);
+  // LinkedIn: honest "organization" scope reason.
+  assert.match(analyticsScreen, /LinkedIn organization/);
+});
+
+test('analytics screen gates the Views <th> and <td> on post_view_count capability (#684)', () => {
+  // Header cell for Views is wrapped in a postViewsSupported conditional.
+  assert.match(analyticsScreen, /postViewsSupported && <th[^>]*>Views<\/th>/);
+  // Data cell rendering totalViews is also wrapped in a postViewsSupported conditional.
+  assert.match(analyticsScreen, /postViewsSupported[\s\S]{0,300}totalViews/);
+});
+
+test('capabilities.ts: post_view_count present for youtube/instagram/facebook, absent for x/reddit/linkedin (#684)', () => {
+  // Platforms that expose per-post view/impression counts.
+  assert.equal(platformSupports('youtube', 'post_view_count'), true, 'youtube should support post_view_count');
+  assert.equal(platformSupports('instagram', 'post_view_count'), true, 'instagram should support post_view_count');
+  assert.equal(platformSupports('facebook', 'post_view_count'), true, 'facebook should support post_view_count');
+  // Platforms that do NOT expose per-post view counts (no fabricated zeros).
+  assert.equal(platformSupports('x', 'post_view_count'), false, 'x must NOT support post_view_count');
+  assert.equal(platformSupports('reddit', 'post_view_count'), false, 'reddit must NOT support post_view_count');
+  assert.equal(platformSupports('linkedin', 'post_view_count'), false, 'linkedin must NOT support post_view_count');
+  // Existing invariant: account_daily_metrics absent for x/reddit/linkedin/youtube.
+  assert.equal(platformSupports('x', 'account_daily_metrics'), false, 'x must NOT support account_daily_metrics');
+  assert.equal(platformSupports('reddit', 'account_daily_metrics'), false, 'reddit must NOT support account_daily_metrics');
+  assert.equal(platformSupports('linkedin', 'account_daily_metrics'), false, 'linkedin must NOT support account_daily_metrics');
+  assert.equal(platformSupports('youtube', 'account_daily_metrics'), false, 'youtube must NOT support account_daily_metrics');
 });


### PR DESCRIPTION
Closes #684

## Problem
The analytics summary rendered fabricated zeros ("Views 0 · Followers 0…") for x/reddit/linkedin/youtube. Their `insights_account_metrics_daily` is empty, but `hasData` keyed on `posts.length > 0`, so the summary grid showed invented zeros — violating Brendan's hard rule: never show fabricated zeros.

## Fix
- `backend/insights/platforms/capabilities.ts`: added a `post_view_count` capability to {youtube, instagram, facebook} only.
- `frontend/aries-v1/analytics-screen.tsx`: gate the summary grid + trend on `platformSupports(platform, 'account_daily_metrics')` — when false, render an honest `EmptyStatePanel` with a per-platform reason (X: paid API tier; Reddit: no reach/impression metric; LinkedIn: needs org access; generic fallback for YouTube) and still show the posts table. Gate the per-post Views column on `platformSupports(platform, 'post_view_count')` — kept for youtube/instagram/facebook, omitted for x/reddit/linkedin. Reason copy is inline and contains no banned strings.
- Tests: 4 new assertions in `tests/insights-dashboard-ui.test.ts`, registered as step 18 of `scripts/verify-regression-suite.mjs`.

## FB / IG byte-identical (the critical property)
For facebook and instagram, `platformSupports(_, 'account_daily_metrics')` and `platformSupports(_, 'post_view_count')` are **both true**, so:
- They never enter the new `!accountMetricsSupported` branch — the control flow falls through to the existing `!hasData` / full-grid paths exactly as before.
- The posts table was extracted to a `postsTable` const that is identical to the previous inline block except the Views `<th>`/`<td>` are now wrapped in `{postViewsSupported && …}`. With `postViewsSupported === true`, React renders `true && <el>` as `<el>` — identical DOM. ShellPanel props, table classNames, `key={post.id}`, and all other cells are unchanged.

Net: zero rendered-output change for facebook/instagram.

## Safety / scope
- Ships **dormant**: the new states are only reachable for x/reddit/linkedin/youtube, which are flag-gated OFF in prod. Currently-live tenants (facebook default, instagram) are unaffected.
- `capabilities.ts` is client-safe (only `import type { Platform }`; no `pool`/`next/server`) — no server-only import leaks into the client bundle.
- Surfaces honest platform limits per Brendan's hard rule instead of fabricated zeros.

## Test evidence
- Focused `tests/insights-dashboard-ui.test.ts`: 14/14 pass.
- `npm run verify`: 18/18 green (now includes the UI test as step 18).
- `npm run typecheck`: clean (union add compiles, no exhaustiveness break).
- banned-patterns: clean.