### PR TITLE
fix(insights): honest LinkedIn comments subtitle (resolve contradiction with unavailable panel)

### DIFF
--- a/frontend/aries-v1/comments-screen.tsx
+++ b/frontend/aries-v1/comments-screen.tsx
@@ -100,6 +100,11 @@ export default function AriesCommentsScreen({
             Comments on your Facebook posts, grouped by the post they belong to. Reply directly from
             Aries when native reply is enabled for your account.
           </p>
+        ) : platform === 'linkedin' ? (
+          <p className="max-w-3xl text-sm leading-7 text-white/65">
+            LinkedIn comment retrieval isn&apos;t supported by the integration used here. Visit
+            LinkedIn directly to read and respond to comments.
+          </p>
         ) : (
           <p className="max-w-3xl text-sm leading-7 text-white/65">
             Comments on your {label} posts, grouped by the post they belong to. Reply directly from

--- a/tests/insights-dashboard-ui.test.ts
+++ b/tests/insights-dashboard-ui.test.ts
@@ -185,6 +185,30 @@ test('analytics screen gates the Views <th> and <td> on post_view_count capabili
   assert.match(analyticsScreen, /postViewsSupported[\s\S]{0,300}totalViews/);
 });
 
+// ─── #688 honest LinkedIn comments subtitle (no reply contradiction) ─────────
+
+test('comments screen has honest LinkedIn subtitle that does not promise Aries reply (#688)', () => {
+  // POSITIVE: The LinkedIn-specific subtitle text must exist in the source.
+  assert.match(commentsScreen, /LinkedIn comment retrieval isn/);
+  assert.match(commentsScreen, /LinkedIn directly to read and respond to comments/);
+  // STRUCTURAL: The linkedin subtitle branch is interposed between the facebook branch and the
+  // generic else subtitle — verifying the 3-way conditional (facebook → linkedin → generic).
+  assert.match(
+    commentsScreen,
+    /platform === 'facebook'[\s\S]{0,1000}platform === 'linkedin'[\s\S]{0,500}LinkedIn comment retrieval isn/,
+  );
+  // NEGATIVE: The LinkedIn subtitle must NOT promise "Reply directly from Aries" within
+  // its own branch (the pre-fix contradiction with the EmptyStatePanel below).
+  // From "LinkedIn comment retrieval" to the generic-else "Reply directly from Aries" is
+  // ~320 chars; the 100-char window stays inside the LinkedIn subtitle itself.
+  assert.doesNotMatch(commentsScreen, /LinkedIn comment retrieval[\s\S]{0,100}Reply directly from Aries/);
+  // GOLDEN (#648): The honest EmptyStatePanel for LinkedIn is still rendered beneath.
+  assert.match(commentsScreen, /platform === 'linkedin'[\s\S]*?EmptyStatePanel/);
+  assert.match(commentsScreen, /Comments aren.*t available for LinkedIn/);
+  // GOLDEN: The Facebook subtitle (which does promise Aries reply) is unchanged.
+  assert.match(commentsScreen, /Comments on your Facebook posts[\s\S]{0,200}Reply directly from\s+Aries/);
+});
+
 test('capabilities.ts: post_view_count present for youtube/instagram/facebook, absent for x/reddit/linkedin (#684)', () => {
   // Platforms that expose per-post view/impression counts.
   assert.equal(platformSupports('youtube', 'post_view_count'), true, 'youtube should support post_view_count');


### PR DESCRIPTION
Closes #688

## Problem
The comments screen subtitle for LinkedIn fell through to the generic-else copy ("Comments on your LinkedIn posts... Reply directly from Aries when native reply is enabled"), which promised comment retrieval + Aries reply. That directly contradicted the honest `EmptyStatePanel` rendered below it ("Comments aren't available for LinkedIn. LinkedIn doesn't support listing post comments via the integration used here.").

## Fix
Inserted a `platform === 'linkedin'` arm into the subtitle ternary (`frontend/aries-v1/comments-screen.tsx`) with honest copy: "LinkedIn comment retrieval isn't supported by the integration used here. Visit LinkedIn directly to read and respond to comments." No more comment/reply promise — the subtitle now agrees with the panel.

## Scope / safety
- Facebook subtitle and the generic-else subtitle (x / reddit / youtube / instagram) are **byte-identical** — pure 5-line insertion, no copy drift.
- The honest LinkedIn `EmptyStatePanel` below is **unchanged**.
- No rendering-path or logic change beyond the subtitle string; the LinkedIn short-circuit to `EmptyStatePanel` already existed.

## Tests
- `tests/insights-dashboard-ui.test.ts` (#688): positive (new copy present), structural (facebook → linkedin → generic ordering), negative (no "Reply directly from Aries" inside the LinkedIn branch), and golden assertions (Facebook subtitle + honest panel intact). 15/15 pass; fails on the pre-fix baseline.
- `npm run verify` green; banned-patterns clean; `guardrails:agent` passed (unique diff).

## Residual risk
None — presentational copy only, no secrets, no tenant paths, no behavior change.