### PR TITLE
feat(integrations): Instagram insights adapter (analytics + comments) via Composio

### DIFF
--- a/backend/insights/adapters/instagram/index.ts
+++ b/backend/insights/adapters/instagram/index.ts
@@ -1,0 +1,449 @@
+/**
+ * backend/insights/adapters/instagram/index.ts
+ *
+ * Instagram insights adapter — backed by Composio (#692 analytics, #693 comments).
+ *
+ * Every platform call goes through the Composio gateway (`executeTool`) so the
+ * adapter depends on a small, mockable surface; tests inject a fake gateway and
+ * never touch the network. The verified Composio action slugs are the defaults,
+ * each overridable via `COMPOSIO_INSTAGRAM_<OP>_ACTION` (resolved through
+ * `ComposioConfig.actionSlugFor`).
+ *
+ * Method → action:
+ *   fetchPostList       → INSTAGRAM_GET_IG_USER_MEDIA      (per-post engagement)
+ *   fetchPostMetrics    → INSTAGRAM_GET_IG_MEDIA_INSIGHTS  (views + engagement)
+ *   fetchAccountMetrics → INSTAGRAM_GET_USER_INSIGHTS + INSTAGRAM_GET_USER_INFO
+ *   fetchComments       → INSTAGRAM_GET_IG_MEDIA_COMMENTS
+ *
+ * IG vs FB deltas:
+ *   - like_count/comments_count are on the MEDIA OBJECT (not .summary(true)).
+ *   - 'impressions' is DEPRECATED → use 'views' throughout.
+ *   - 'profile_views'/'impressions' are DEPRECATED for account insights.
+ *   - Per-post insights require Business/Creator + ≥1000 followers.
+ *     When restricted, fetchPostMetrics FAIL-SOFTs: falls back to the
+ *     engagementCache populated by fetchPostList, emits [] only when there is
+ *     no signal at all (never fabricates a 0-view row).
+ *   - media_type: IMAGE→image, VIDEO→video, CAROUSEL_ALBUM→carousel, REELS→reel.
+ *
+ * Dormant-safe: activates only when COMPOSIO_ENABLED + ANALYTICS_PROVIDER=composio
+ * (the same gate as Facebook). IG has no connected active row in prod today, so
+ * the adapter is live but idle until IG connect ships.
+ */
+
+import type {
+  InsightsAdapter,
+  InsightsAdapterContext,
+  DateRange,
+  RawAccountMetricsDay,
+  RawPost,
+  RawPostMetricsDay,
+  RawComment,
+} from '../_adapter.types';
+import type { ComposioConfig, ComposioOperation } from '@/backend/integrations/composio/composio-config';
+import type { ComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { resolveComposioConfig } from '@/backend/integrations/composio/composio-config';
+import { createComposioGateway } from '@/backend/integrations/composio/composio-client';
+import { num } from '@/backend/integrations/composio/analytics-mappers';
+
+// ── Verified default action slugs (env-overridable) ────────────────────────────
+
+const DEFAULT_SLUGS: Partial<Record<ComposioOperation, string>> = {
+  list_posts:       'INSTAGRAM_GET_IG_USER_MEDIA',
+  post_insights:    'INSTAGRAM_GET_IG_MEDIA_INSIGHTS',
+  account_insights: 'INSTAGRAM_GET_USER_INSIGHTS',
+  account_info:     'INSTAGRAM_GET_USER_INFO',
+  list_comments:    'INSTAGRAM_GET_IG_MEDIA_COMMENTS',
+};
+
+/**
+ * Media metric list for per-post insights. 'impressions' is DEPRECATED — use
+ * 'views'. 'saved' has no DB column but is carried in rawSource.
+ */
+const IG_POST_METRICS = ['views', 'reach', 'saved', 'likes', 'comments', 'shares', 'total_interactions'];
+
+/**
+ * Account-level daily metrics. 'profile_views' and 'impressions' are DEPRECATED.
+ * 'follower_count' returns an absolute snapshot per day (like FB's page_follows).
+ */
+const IG_ACCOUNT_METRICS = ['reach', 'follower_count', 'views'];
+
+const IG_MEDIA_FIELDS =
+  'id,caption,permalink,media_type,media_url,thumbnail_url,timestamp,like_count,comments_count';
+
+const IG_COMMENT_FIELDS = 'id,text,username,timestamp,like_count,parent_id';
+
+// ── Response unwrapping helpers (shared shape with FB adapter) ─────────────────
+
+/**
+ * Descend through Composio's `{ data: <toolPayload> }` envelope wrappers. The
+ * exact nesting (one vs two `.data` layers) varies by tool/SDK version, so we
+ * peel object-with-`data` wrappers until we hit an array or a leaf object.
+ */
+function unwrap(raw: unknown): unknown {
+  let cur = raw;
+  for (let i = 0; i < 3; i += 1) {
+    if (!cur || typeof cur !== 'object' || Array.isArray(cur)) break;
+    const obj = cur as Record<string, unknown>;
+    if (!('data' in obj)) break;
+    cur = obj.data;
+  }
+  return cur;
+}
+
+/** Resolve a Graph list response into its row array, however it is nested. */
+function unwrapToArray(raw: unknown): Array<Record<string, unknown>> {
+  const peeled = unwrap(raw);
+  if (Array.isArray(peeled)) return peeled as Array<Record<string, unknown>>;
+  if (peeled && typeof peeled === 'object' && Array.isArray((peeled as Record<string, unknown>).data)) {
+    return (peeled as Record<string, unknown>).data as Array<Record<string, unknown>>;
+  }
+  return [];
+}
+
+/** Resolve a Graph single-object response (e.g. user info). */
+function unwrapToObject(raw: unknown): Record<string, unknown> {
+  const peeled = unwrap(raw);
+  if (peeled && typeof peeled === 'object' && !Array.isArray(peeled)) {
+    return peeled as Record<string, unknown>;
+  }
+  return {};
+}
+
+function toDate(value: unknown): Date {
+  if (typeof value === 'string' && value.trim()) {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date(0);
+}
+
+function dateStr(value: unknown): string {
+  return toDate(value).toISOString().split('T')[0];
+}
+
+function igMediaType(row: Record<string, unknown>): RawPost['mediaType'] {
+  const mt = typeof row.media_type === 'string' ? row.media_type.toUpperCase() : '';
+  if (mt === 'VIDEO') return 'video';
+  if (mt === 'CAROUSEL_ALBUM') return 'carousel';
+  if (mt === 'REELS') return 'reel';
+  return 'image'; // IMAGE and unknown default to image
+}
+
+// ── Adapter ────────────────────────────────────────────────────────────────────
+
+export class InstagramInsightsAdapter implements InsightsAdapter {
+  readonly platform = 'instagram' as const;
+
+  /**
+   * Per-post engagement captured in fetchPostList from the media object's
+   * like_count / comments_count fields (no .summary(true) needed for IG).
+   * Read by fetchPostMetrics as fallback when post-level insights are restricted.
+   */
+  private readonly engagementCache = new Map<
+    string,
+    { likes: number | null; comments: number | null }
+  >();
+
+  constructor(
+    private readonly gateway: ComposioGateway,
+    private readonly config: ComposioConfig,
+    private readonly ctx: InsightsAdapterContext = {},
+  ) {}
+
+  private slugFor(op: ComposioOperation): string {
+    const override = this.config.actionSlugFor('instagram', op);
+    const slug = override ?? DEFAULT_SLUGS[op];
+    if (!slug) throw new Error(`No Composio Instagram action slug configured for "${op}".`);
+    return slug;
+  }
+
+  private connectedAccountId(): string {
+    const id = this.ctx.connectedAccountId?.trim();
+    if (!id) {
+      throw new Error('InstagramInsightsAdapter: no Composio connectedAccountId in context.');
+    }
+    return id;
+  }
+
+  /** Execute a tool; throw on a hard (successful=false) failure so the sync run
+   * is marked failed while already-committed rows are preserved. */
+  private async exec(op: ComposioOperation, args: Record<string, unknown>): Promise<unknown> {
+    const result = await this.gateway.executeTool(this.slugFor(op), {
+      connectedAccountId: this.connectedAccountId(),
+      arguments: args,
+    });
+    if (!result.successful) {
+      throw new Error(result.error ?? `Composio Instagram ${op} call reported unsuccessful.`);
+    }
+    return result.data ?? null;
+  }
+
+  /**
+   * Single page of up to 100 media items. IG returns like_count and
+   * comments_count directly on the media object — no .summary(true) needed.
+   * Results are cached in engagementCache for fetchPostMetrics fallback.
+   */
+  async fetchPostList(externalAccountId: string, _publishedAfter?: Date): Promise<RawPost[]> {
+    const data = await this.exec('list_posts', {
+      ig_user_id: externalAccountId,
+      fields: IG_MEDIA_FIELDS,
+      limit: 100,
+    });
+    const rows = unwrapToArray(data);
+
+    const posts: RawPost[] = [];
+    for (const row of rows) {
+      const externalPostId = typeof row.id === 'string' ? row.id : null;
+      if (!externalPostId) continue;
+
+      // Cache per-media engagement for fetchPostMetrics fallback. IG exposes
+      // like_count and comments_count directly on the media object.
+      this.engagementCache.set(externalPostId, {
+        likes: num(row.like_count),
+        comments: num(row.comments_count),
+      });
+
+      posts.push({
+        externalPostId,
+        publishedAt: toDate(row.timestamp),
+        mediaType: igMediaType(row),
+        title: null,
+        caption: typeof row.caption === 'string' ? row.caption : null,
+        permalink: typeof row.permalink === 'string' ? row.permalink : null,
+        thumbnailUrl:
+          typeof row.thumbnail_url === 'string' ? row.thumbnail_url
+          : typeof row.media_url === 'string' ? row.media_url
+          : null,
+        durationSeconds: null,
+      });
+    }
+    return posts;
+  }
+
+  async fetchAccountMetrics(
+    externalAccountId: string,
+    range: DateRange,
+  ): Promise<RawAccountMetricsDay[]> {
+    const insightsData = await this.exec('account_insights', {
+      ig_user_id: externalAccountId,
+      metric: IG_ACCOUNT_METRICS,
+      period: 'day',
+      since: range.from,
+      until: range.to,
+    });
+
+    // Follower snapshot is best-effort: a failure here must not drop the daily
+    // reach/views series we already fetched.
+    let followersCount: number | null = null;
+    try {
+      const details = unwrapToObject(
+        await this.exec('account_info', {
+          ig_user_id: externalAccountId,
+          fields: 'followers_count',
+        }),
+      );
+      followersCount = num(details.followers_count);
+    } catch {
+      followersCount = null;
+    }
+
+    // Pivot the per-metric time series into one record per day.
+    //   reach         → daily reach (unique accounts reached)
+    //   follower_count → absolute follower snapshot for that day (like FB page_follows)
+    //   views         → account/content views (replaces deprecated impressions)
+    // null = the metric had no value that day (never coerced to a fabricated 0).
+    type Day = {
+      reach: number | null;
+      followerCount: number | null;
+      views: number | null;
+    };
+    const byDay = new Map<string, Day>();
+    const ensure = (date: string): Day => {
+      let d = byDay.get(date);
+      if (!d) {
+        d = { reach: null, followerCount: null, views: null };
+        byDay.set(date, d);
+      }
+      return d;
+    };
+
+    for (const metric of unwrapToArray(insightsData)) {
+      const name = typeof metric.name === 'string' ? metric.name : null;
+      if (!name) continue;
+      const values = Array.isArray(metric.values) ? (metric.values as Array<Record<string, unknown>>) : [];
+      for (const v of values) {
+        const value = num(v.value);
+        if (value === null) continue;
+        const day = ensure(dateStr(v.end_time));
+        switch (name) {
+          case 'reach':          day.reach = value; break;
+          case 'follower_count': day.followerCount = value; break;
+          case 'views':          day.views = value; break;
+          default: break;
+        }
+      }
+    }
+
+    // Ensure the most recent day exists so the authoritative USER_INFO
+    // follower count below has a row to land on.
+    const latestDate = range.to;
+    if (followersCount !== null) ensure(latestDate);
+
+    const out: RawAccountMetricsDay[] = [];
+    for (const [date, d] of byDay) {
+      // Absolute follower count: on the latest day prefer the authoritative
+      // USER_INFO followers_count; otherwise use the daily follower_count metric.
+      // NEVER derived from a followersDelta.
+      const absoluteFollowers =
+        (date === latestDate && followersCount !== null ? followersCount : null) ?? d.followerCount;
+
+      // IG metrics don't include a daily follower-gain/loss breakdown from this
+      // endpoint, so followersDelta is always 0 (no fabricated subtraction).
+      const followersDelta = 0;
+
+      out.push({
+        date,
+        views: d.views ?? 0,
+        watchTimeMinutes: 0,
+        followers: absoluteFollowers ?? 0,
+        followersDelta,
+        // IG account insights at this level don't expose like/comment/share
+        // breakdown — those come from post-level insights.
+        likes: 0,
+        commentsCount: 0,
+        shares: 0,
+        // No composite engagement aggregate at the account level from these metrics.
+        rawSource: {
+          source: 'INSTAGRAM_GET_USER_INSIGHTS',
+          reach: d.reach,
+          follower_count: d.followerCount,
+          views: d.views,
+          followers_count: followersCount,
+        },
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Fetch per-post metrics via INSTAGRAM_GET_IG_MEDIA_INSIGHTS.
+   *
+   * Per-post insights require a Business/Creator account with ≥1000 followers.
+   * When the call fails or returns no signal (restricted account), we FAIL-SOFT:
+   * fall back to the like_count/comments_count cached from fetchPostList.
+   * We never fabricate a 0-view row — if there is truly no signal at all,
+   * we return [] (mirrors Facebook adapter nil-emission guard).
+   *
+   * 'impressions' is DEPRECATED; we request 'views' instead.
+   * 'saved' has no dedicated DB column but is carried in rawSource.
+   */
+  async fetchPostMetrics(externalPostId: string, _range?: DateRange): Promise<RawPostMetricsDay[]> {
+    const engagement = this.engagementCache.get(externalPostId) ?? null;
+
+    let views: number | null = null;
+    let reach: number | null = null;
+    let insightLikes: number | null = null;
+    let insightComments: number | null = null;
+    let insightShares: number | null = null;
+    let saved: number | null = null;
+    let totalInteractions: number | null = null;
+
+    try {
+      const data = await this.exec('post_insights', {
+        ig_media_id: externalPostId,
+        metric: IG_POST_METRICS,
+      });
+
+      for (const metric of unwrapToArray(data)) {
+        const name = typeof metric.name === 'string' ? metric.name : null;
+        if (!name) continue;
+        const values = Array.isArray(metric.values) ? (metric.values as Array<Record<string, unknown>>) : [];
+        // Take the last non-null value in the series (lifetime metrics typically
+        // have one entry; this handles both per-day and lifetime shapes).
+        let value: number | null = null;
+        for (let i = values.length - 1; i >= 0; i -= 1) {
+          const v = num(values[i]?.value);
+          if (v !== null) { value = v; break; }
+        }
+        switch (name) {
+          case 'views':               views = value; break;
+          case 'reach':               reach = value; break;
+          case 'likes':               insightLikes = value; break;
+          case 'comments':            insightComments = value; break;
+          case 'shares':              insightShares = value; break;
+          case 'saved':               saved = value; break;
+          case 'total_interactions':  totalInteractions = value; break;
+          default: break;
+        }
+      }
+    } catch {
+      // Post insights unavailable (restricted account, <1000 followers, API error).
+      // Fall back to engagementCache populated by fetchPostList. Never wedges the
+      // sync run for the whole post list — this post is handled gracefully.
+    }
+
+    // Only emit a row when there is a real signal — never fabricate a zero row
+    // for a post we have no data on (mirrors FB adapter nil-emission guard).
+    if (views === null && !engagement) return [];
+
+    const date = new Date().toISOString().split('T')[0];
+    return [
+      {
+        date,
+        views: views ?? 0,
+        watchTimeMinutes: 0,
+        avgViewDurationSec: 0,
+        avgViewPercentage: 0,
+        likes: insightLikes ?? engagement?.likes ?? 0,
+        commentsCount: insightComments ?? engagement?.comments ?? 0,
+        shares: insightShares ?? 0,
+        rawSource: {
+          source: 'INSTAGRAM_GET_IG_MEDIA_INSIGHTS',
+          views,
+          reach,
+          likes: insightLikes,
+          comments: insightComments,
+          shares: insightShares,
+          saved,
+          total_interactions: totalInteractions,
+          engagement_from_post_list: engagement,
+        },
+      },
+    ];
+  }
+
+  async fetchComments(externalPostId: string, limit = 100): Promise<RawComment[]> {
+    const data = await this.exec('list_comments', {
+      ig_media_id: externalPostId,
+      fields: IG_COMMENT_FIELDS,
+      limit: Math.min(Math.max(limit, 1), 100),
+    });
+
+    const out: RawComment[] = [];
+    for (const row of unwrapToArray(data)) {
+      const externalCommentId = typeof row.id === 'string' ? row.id : null;
+      if (!externalCommentId) continue;
+      out.push({
+        externalCommentId,
+        receivedAt: toDate(row.timestamp),
+        authorHandle: typeof row.username === 'string' ? row.username : null,
+        bodyText: typeof row.text === 'string' ? row.text : '',
+      });
+    }
+    return out;
+  }
+}
+
+/**
+ * Build a context-bound Instagram adapter wired to the live Composio gateway.
+ * Throws (via createComposioGateway) when Composio is enabled but no API key is
+ * configured — the dispatcher catches that and marks the sync run failed.
+ */
+export function createInstagramInsightsAdapter(
+  ctx: InsightsAdapterContext = {},
+  env: NodeJS.ProcessEnv = process.env,
+): InstagramInsightsAdapter {
+  const config = resolveComposioConfig(env);
+  const gateway = createComposioGateway(config);
+  return new InstagramInsightsAdapter(gateway, config!, ctx);
+}

--- a/backend/insights/sync/adapter-factory.ts
+++ b/backend/insights/sync/adapter-factory.ts
@@ -18,6 +18,7 @@ import type { Platform } from '../platforms/registry';
 import type { InsightsAdapter, InsightsAdapterContext } from '../adapters/_adapter.types';
 import { createYouTubeInsightsAdapter } from '../adapters/youtube/index';
 import { createFacebookInsightsAdapter } from '../adapters/facebook/index';
+import { createInstagramInsightsAdapter } from '../adapters/instagram/index';
 import { createXInsightsAdapter } from '../adapters/x/index';
 import { createRedditInsightsAdapter } from '../adapters/reddit/index';
 import { createLinkedInInsightsAdapter } from '../adapters/linkedin/index';
@@ -54,6 +55,20 @@ export function isComposioOnlyAnalyticsPlatform(platform: string): boolean {
  * youtube, reddit, linkedin — #679).
  */
 export function isFacebookInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isComposioEnabled(env) && analyticsProviderSelector(env) === 'composio';
+}
+
+/**
+ * Real off-switch for the Composio-backed Instagram insights path (#692/#693):
+ * active only when Composio is enabled (COMPOSIO_ENABLED=true) AND
+ * ANALYTICS_PROVIDER resolves to composio. Instagram is Meta-family — it uses
+ * the SAME gate as Facebook (no separate ARIES_INSTAGRAM_ENABLED flag). When
+ * COMPOSIO_ENABLED is false or ANALYTICS_PROVIDER=direct_meta, the IG adapter
+ * never activates. Dormant-safe: even though isInstagramInsightsEnabled is true
+ * in prod (ANALYTICS_PROVIDER=composio), no active IG connected_accounts row
+ * exists until IG connect ships, so the sync worker fan-out is idle.
+ */
+export function isInstagramInsightsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return isComposioEnabled(env) && analyticsProviderSelector(env) === 'composio';
 }
 
@@ -127,6 +142,15 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     }
     return createFacebookInsightsAdapter(ctx);
   },
+  instagram: (ctx) => {
+    if (!isInstagramInsightsEnabled()) {
+      throw new Error(
+        'Instagram insights adapter is disabled: set ANALYTICS_PROVIDER=composio ' +
+        'and COMPOSIO_ENABLED=true to enable Composio-backed Instagram analytics.',
+      );
+    }
+    return createInstagramInsightsAdapter(ctx);
+  },
   x: (ctx) => {
     if (!isXInsightsEnabled()) {
       throw new Error(
@@ -154,7 +178,6 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
     }
     return createLinkedInInsightsAdapter(ctx);
   },
-  // instagram: (ctx) => createInstagramInsightsAdapter(ctx),  ← out of scope (#596/#597 = FB only)
 };
 
 /**
@@ -167,6 +190,7 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
  * silently drift from the adapter's own enablement conditions.
  *
  *   facebook  → ANALYTICS_PROVIDER=composio
+ *   instagram → ANALYTICS_PROVIDER=composio  (same gate as facebook, no separate flag)
  *   x         → ARIES_X_ENABLED + COMPOSIO_ENABLED
  *   youtube   → ARIES_YOUTUBE_ENABLED + COMPOSIO_ENABLED
  *   reddit    → ARIES_REDDIT_ENABLED + COMPOSIO_ENABLED
@@ -175,6 +199,7 @@ const REGISTRY: Partial<Record<Platform, AdapterBuilder>> = {
  */
 export function isPlatformInsightsEnabled(platform: string, env: NodeJS.ProcessEnv = process.env): boolean {
   if (platform === 'facebook') return isFacebookInsightsEnabled(env);
+  if (platform === 'instagram') return isInstagramInsightsEnabled(env);
   if (platform === 'x') return isXInsightsEnabled(env);
   if (platform === 'youtube') return isYouTubeInsightsEnabled(env);
   if (platform === 'reddit') return isRedditInsightsEnabled(env);
@@ -189,6 +214,7 @@ export function isPlatformInsightsEnabled(platform: string, env: NodeJS.ProcessE
  */
 export function hasAdapter(platform: Platform, env: NodeJS.ProcessEnv = process.env): boolean {
   if (platform === 'facebook') return isFacebookInsightsEnabled(env);
+  if (platform === 'instagram') return isInstagramInsightsEnabled(env);
   if (platform === 'x') return isXInsightsEnabled(env);
   if (platform === 'youtube') return isYouTubeInsightsEnabled(env);
   if (platform === 'reddit') return isRedditInsightsEnabled(env);

--- a/backend/insights/sync/ensure-account.ts
+++ b/backend/insights/sync/ensure-account.ts
@@ -21,14 +21,16 @@
  * never throws (the worker tick must not wedge).
  *
  * Resolver per platform:
- *   facebook  → FACEBOOK_LIST_MANAGED_PAGES → page id
- *   youtube   → YOUTUBE_LIST_CHANNELS       → channel id
- *   x         → TWITTER_USER_LOOKUP_ME      → username/handle (#670)
- *   reddit    → REDDIT_GET_REDDIT_USER_ABOUT → username (#670)
+ *   facebook  → FACEBOOK_LIST_MANAGED_PAGES       → page id
+ *   instagram → INSTAGRAM_GET_USER_INFO ('me')     → ig user id + username (#692/#693)
+ *   youtube   → YOUTUBE_LIST_CHANNELS             → channel id
+ *   x         → TWITTER_USER_LOOKUP_ME            → username/handle (#670)
+ *   reddit    → REDDIT_GET_REDDIT_USER_ABOUT      → username (#670)
  *   linkedin  → no back-heal (URN resolved at connect via ensure-linkedin-urn.ts)
  *
- * Instagram is intentionally out of scope (#596/#597 are Facebook-only); add
- * platforms to BRIDGED_PLATFORMS when their adapter lands.
+ * Instagram is now bridged (#692/#693): both facebook and instagram are governed
+ * by the ANALYTICS_PROVIDER=composio gate (no separate ARIES_INSTAGRAM_ENABLED
+ * flag). Add platforms to BRIDGED_PLATFORMS when their adapter lands.
  */
 
 import pool from '@/lib/db';
@@ -37,32 +39,36 @@ import { isPlatformInsightsEnabled } from '@/backend/insights/sync/adapter-facto
 import { resolveComposioConfig, type ComposioConfig } from '@/backend/integrations/composio/composio-config';
 import { createComposioGateway, type ComposioGateway } from '@/backend/integrations/composio/composio-client';
 import { resolveFacebookManagedPage } from '@/backend/integrations/composio/facebook-page-resolver';
+import { resolveInstagramAccount } from '@/backend/integrations/composio/instagram-account-resolver';
 import { resolveYouTubeChannel } from '@/backend/integrations/composio/youtube-channel-resolver';
 import { resolveXUser } from '@/backend/integrations/composio/x-user-resolver';
 import { resolveRedditUser } from '@/backend/integrations/composio/reddit-user-resolver';
 
 /**
- * Unconditionally-bridged platforms when ANALYTICS_PROVIDER=composio. Exported
- * for test introspection. Composio-only platforms (x, youtube, reddit, linkedin)
- * are NOT listed here because they are conditional on both their rollout flag AND
- * COMPOSIO_ENABLED — they are included in the dynamic bridgedPlatforms() result
- * only when both conditions are met. See bridgedPlatforms() below.
+ * Platforms bridged unconditionally when ANALYTICS_PROVIDER=composio. Both
+ * facebook and instagram use the same ANALYTICS_PROVIDER gate (no separate
+ * ARIES_INSTAGRAM_ENABLED flag). Exported for test introspection.
+ * Composio-only platforms (x, youtube, reddit, linkedin) are NOT listed here
+ * because they are conditional on both their rollout flag AND COMPOSIO_ENABLED —
+ * they are included in the dynamic bridgedPlatforms() result only when both
+ * conditions are met. See bridgedPlatforms() below.
  */
-export const BRIDGED_PLATFORMS = ['facebook'] as const;
+export const BRIDGED_PLATFORMS = ['facebook', 'instagram'] as const;
 
 /**
  * Full bridged-platform list for this env, computed per-platform using the same
  * `is<P>InsightsEnabled` predicates as the adapter factory (via
  * isPlatformInsightsEnabled). The two can therefore never drift.
  *
- *   facebook → bridged iff ANALYTICS_PROVIDER=composio
- *   x        → bridged iff ARIES_X_ENABLED + COMPOSIO_ENABLED
- *   youtube  → bridged iff ARIES_YOUTUBE_ENABLED + COMPOSIO_ENABLED
- *   reddit   → bridged iff ARIES_REDDIT_ENABLED + COMPOSIO_ENABLED
- *   linkedin → bridged iff ARIES_LINKEDIN_ENABLED + COMPOSIO_ENABLED
+ *   facebook  → bridged iff ANALYTICS_PROVIDER=composio
+ *   instagram → bridged iff ANALYTICS_PROVIDER=composio (same gate as facebook)
+ *   x         → bridged iff ARIES_X_ENABLED + COMPOSIO_ENABLED
+ *   youtube   → bridged iff ARIES_YOUTUBE_ENABLED + COMPOSIO_ENABLED
+ *   reddit    → bridged iff ARIES_REDDIT_ENABLED + COMPOSIO_ENABLED
+ *   linkedin  → bridged iff ARIES_LINKEDIN_ENABLED + COMPOSIO_ENABLED
  */
 function bridgedPlatforms(env: NodeJS.ProcessEnv): string[] {
-  return ['facebook', 'x', 'youtube', 'reddit', 'linkedin'].filter(
+  return ['facebook', 'instagram', 'x', 'youtube', 'reddit', 'linkedin'].filter(
     (p) => isPlatformInsightsEnabled(p, env),
   );
 }
@@ -108,7 +114,7 @@ function log(obj: Record<string, unknown>): void {
  * Gated per-platform by the same predicates the adapter factory uses (via
  * isPlatformInsightsEnabled), so the bridge and adapter selections can never
  * drift:
- *   - Facebook is bridged only when ANALYTICS_PROVIDER=composio.
+ *   - Facebook and Instagram are bridged only when ANALYTICS_PROVIDER=composio.
  *   - Composio-only platforms (x, youtube, reddit, linkedin) are bridged only
  *     when their rollout flag AND COMPOSIO_ENABLED are both on — independent of
  *     ANALYTICS_PROVIDER, which governs facebook/instagram only.
@@ -165,11 +171,11 @@ export async function ensureInsightsAccountsForConnectedPlatforms(
     let pageName = row.external_account_name;
 
     if (!pageId) {
-      // Back-heal is available for facebook, youtube, x, and reddit. LinkedIn's
-      // URN is resolved at connect time via ensure-linkedin-urn.ts, so a null id
-      // there is not back-heal-able here — skip and let a later connect/re-auth
-      // populate it. Never invent an external account id.
-      if (!['facebook', 'youtube', 'x', 'reddit'].includes(row.platform)) {
+      // Back-heal is available for facebook, instagram, youtube, x, and reddit.
+      // LinkedIn's URN is resolved at connect time via ensure-linkedin-urn.ts, so
+      // a null id there is not back-heal-able here — skip and let a later
+      // connect/re-auth populate it. Never invent an external account id.
+      if (!['facebook', 'instagram', 'youtube', 'x', 'reddit'].includes(row.platform)) {
         skippedNoPage++;
         log({ event: 'insights_bridge_page_unresolved', tenantId: row.tenant_id, platform: row.platform, reason: 'no_external_account_id' });
         continue;
@@ -211,6 +217,17 @@ export async function ensureInsightsAccountsForConnectedPlatforms(
           if (user) {
             resolvedId = user.username;
             resolvedName = user.name;
+            resolvedManagedCount = 1;
+          }
+        } else if (row.platform === 'instagram') {
+          // Resolve the IG user id (numeric) via INSTAGRAM_GET_USER_INFO('me').
+          // The 'me' resolution is UNVERIFIED live (IG is not connected yet as of
+          // #692/#693); if it fails on first live connect, the fail-safe null just
+          // skips this tenant — it never wedges the FB/X sync.
+          const account = await resolveInstagramAccount(r.gateway, r.config, row.connected_account_id);
+          if (account) {
+            resolvedId = account.igUserId;
+            resolvedName = account.username;
             resolvedManagedCount = 1;
           }
         } else {

--- a/backend/integrations/composio/instagram-account-resolver.ts
+++ b/backend/integrations/composio/instagram-account-resolver.ts
@@ -1,0 +1,96 @@
+/**
+ * Resolve a tenant's Instagram user id and username from Composio.
+ *
+ * The IG user id (numeric) is stored as insights_accounts.external_account_id so
+ * the INSTAGRAM_GET_IG_USER_MEDIA and INSTAGRAM_GET_IG_MEDIA_INSIGHTS calls can
+ * pass it as `ig_user_id`. It is NOT part of the Composio connection metadata, so
+ * connect-time reconciliation leaves connected_accounts.external_account_id null
+ * for legacy or first-time connections. This helper calls the verified
+ * INSTAGRAM_GET_USER_INFO action (env-overridable via the `account_info` op) with
+ * `ig_user_id: 'me'` using the connection's connectedAccountId and returns the
+ * authenticated account's { igUserId, username }.
+ *
+ * NOTE: the `'me'` resolution is UNVERIFIED live (IG is not connected yet as of
+ * #692/#693). If it fails on first live connect, the documented fallback is to read
+ * the FB page's `instagram_business_account.id` edge from the Facebook page
+ * resolver — but the fail-safe null return here just skips this IG tenant and
+ * never wedges the FB/X sync or the worker tick.
+ *
+ * Fail-safe: returns null on an unsuccessful tool call, a wrapper response without
+ * a valid `id` field, or when the call errors. Never invents a user id and never
+ * throws — the insights-sync worker tick must not wedge.
+ *
+ * Response shape (Composio wraps the IG user object in one or two `{ data: ... }`
+ * envelopes):
+ *   One-level:  { data: { id, username, followers_count }, successful }
+ *   Two-level:  { data: { data: { id, username, followers_count } }, successful }
+ */
+
+import type { ComposioGateway } from './composio-client';
+import type { ComposioConfig } from './composio-config';
+
+export interface ResolvedInstagramAccount {
+  /** The numeric IG user id — stored verbatim as external_account_id. */
+  igUserId: string;
+  /** The Instagram @username (handle). */
+  username: string | null;
+}
+
+/** Default verified slug; overridable via COMPOSIO_INSTAGRAM_ACCOUNT_INFO_ACTION. */
+export const DEFAULT_INSTAGRAM_GET_ME_SLUG = 'INSTAGRAM_GET_USER_INFO';
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function trimmedString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/**
+ * Pull the IG user object out of Composio's envelope. Tries the nested shape
+ * first since Composio often wraps the Graph response in an extra envelope.
+ *   data.data.id  (two-level: Composio outer + Graph API body)
+ *   data.id       (one-level: tool version that partially unwraps)
+ */
+function extractAccount(rawData: unknown): Record<string, unknown> | null {
+  const data = asRecord(rawData);
+  if (!data) return null;
+
+  // Two-level: data.data.id
+  const inner = asRecord(data.data);
+  if (inner && trimmedString(inner.id)) return inner;
+
+  // One-level: data.id
+  if (trimmedString(data.id)) return data;
+
+  return null;
+}
+
+export async function resolveInstagramAccount(
+  gateway: ComposioGateway,
+  config: ComposioConfig,
+  connectedAccountId: string,
+): Promise<ResolvedInstagramAccount | null> {
+  const slug = config.actionSlugFor('instagram', 'account_info') ?? DEFAULT_INSTAGRAM_GET_ME_SLUG;
+  let result;
+  try {
+    result = await gateway.executeTool(slug, {
+      connectedAccountId,
+      arguments: { ig_user_id: 'me', fields: 'id,username,followers_count' },
+    });
+  } catch {
+    return null;
+  }
+  if (!result.successful) return null;
+
+  const account = extractAccount(result.data);
+  if (!account) return null;
+
+  const igUserId = trimmedString(account.id);
+  if (!igUserId) return null; // never invent a user id
+
+  return { igUserId, username: trimmedString(account.username) };
+}

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -6,11 +6,13 @@ import {
   BRIDGED_PLATFORMS,
 } from '@/backend/insights/sync/ensure-account';
 import type { Queryable } from '@/backend/integrations/composio/connection-store';
-import { getAdapter, hasAdapter, isFacebookInsightsEnabled, isComposioOnlyAnalyticsPlatform, isPlatformInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
+import { getAdapter, hasAdapter, isFacebookInsightsEnabled, isInstagramInsightsEnabled, isComposioOnlyAnalyticsPlatform, isPlatformInsightsEnabled } from '@/backend/insights/sync/adapter-factory';
 import { FacebookInsightsAdapter } from '@/backend/insights/adapters/facebook/index';
+import { InstagramInsightsAdapter } from '@/backend/insights/adapters/instagram/index';
 import { DEFAULT_LIST_MANAGED_PAGES_SLUG } from '@/backend/integrations/composio/facebook-page-resolver';
 import { DEFAULT_X_GET_ME_SLUG } from '@/backend/integrations/composio/x-user-resolver';
 import { DEFAULT_REDDIT_GET_ME_SLUG } from '@/backend/integrations/composio/reddit-user-resolver';
+import { DEFAULT_INSTAGRAM_GET_ME_SLUG } from '@/backend/integrations/composio/instagram-account-resolver';
 import { fakeConfig, fakeGateway } from './composio/helpers';
 
 interface RecordedQuery {
@@ -745,4 +747,168 @@ test('#679 isComposioOnlyAnalyticsPlatform: set is {x, reddit, linkedin, youtube
   assert.equal(isComposioOnlyAnalyticsPlatform('youtube'), true);
   assert.equal(isComposioOnlyAnalyticsPlatform('facebook'), false, 'facebook uses ANALYTICS_PROVIDER gate, not the composio-only set');
   assert.equal(isComposioOnlyAnalyticsPlatform('instagram'), false, 'instagram uses ANALYTICS_PROVIDER gate like facebook, not the composio-only set');
+});
+
+// ── Instagram adapter registration + adversarial bridge tests (#692/#693) ────
+//
+// Adversarial bar (team-lead review):
+//   FB byte-identical → existing tests above guard this (SELECT params + INSERT params unchanged)
+//   X unchanged       → existing X bridge tests above guard this
+//   IG dormant (c)    → test below: SELECT includes 'instagram', but no IG row returned → no upsert
+//   IG live-on-connect (d) → tests below: id present → direct upsert; id null → back-heal
+
+test('instagram is registered in the adapter factory: getAdapter + hasAdapter honor the ANALYTICS_PROVIDER gate', () => {
+  const prevKey = process.env.COMPOSIO_API_KEY;
+  const prevProvider = process.env.ANALYTICS_PROVIDER;
+  const prevComposio = process.env.COMPOSIO_ENABLED;
+  process.env.COMPOSIO_API_KEY = 'test-key';
+  process.env.ANALYTICS_PROVIDER = 'composio';
+  process.env.COMPOSIO_ENABLED = '1';
+  try {
+    assert.equal(isInstagramInsightsEnabled(COMPOSIO_ENV), true, 'IG enabled when COMPOSIO_ENABLED + ANALYTICS_PROVIDER=composio');
+    assert.equal(isInstagramInsightsEnabled(DIRECT_ENV), false, 'IG disabled when ANALYTICS_PROVIDER=direct_meta');
+    assert.equal(hasAdapter('instagram'), true, 'hasAdapter(instagram) true in composio env');
+    const adapter = getAdapter('instagram', { connectedAccountId: 'ca_ig_test' });
+    assert.ok(adapter instanceof InstagramInsightsAdapter, 'getAdapter returns InstagramInsightsAdapter');
+    assert.equal(adapter.platform, 'instagram');
+  } finally {
+    if (prevKey === undefined) delete process.env.COMPOSIO_API_KEY;
+    else process.env.COMPOSIO_API_KEY = prevKey;
+    if (prevProvider === undefined) delete process.env.ANALYTICS_PROVIDER;
+    else process.env.ANALYTICS_PROVIDER = prevProvider;
+    if (prevComposio === undefined) delete process.env.COMPOSIO_ENABLED;
+    else process.env.COMPOSIO_ENABLED = prevComposio;
+  }
+});
+
+test('(c) IG DORMANT: SELECT includes "instagram" (bridge widened) but no connected IG row returned → no IG upsert, no resolver call', async () => {
+  // Simulates an IG connection that is absent or in a non-connected status
+  // (the real SQL has WHERE status='connected' which filters it out; the fake DB
+  // simply returns no IG row). The bridge SELECT params must still include
+  // 'instagram' (proving the widening landed) but without a matching row there
+  // must be zero insights_accounts upserts for IG and zero resolver calls.
+  const db = recordingDb([
+    // Only a FB row present; no IG connected row (absent or reauthorization_required).
+    {
+      id: 5,
+      tenant_id: 15,
+      platform: 'facebook',
+      external_account_id: 'PAGE123',
+      external_account_name: 'Sugar Page',
+      connected_account_id: 'ca_fb',
+    },
+  ]);
+  const gateway = fakeGateway();
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+  });
+
+  // The SELECT must include 'instagram' — the bridge is active.
+  const select = db.queries[0];
+  assert.ok(select, 'a SELECT was issued');
+  assert.ok(
+    (select.params as unknown[]).includes('instagram'),
+    'SELECT params include "instagram" even when no IG row is present',
+  );
+
+  // No IG insights_accounts row upserted.
+  const igInsert = db.queries.find(
+    (q) => /INSERT INTO insights_accounts/i.test(q.text) && q.params[1] === 'instagram',
+  );
+  assert.equal(igInsert, undefined, 'no insights_accounts row upserted for instagram (no connected IG row)');
+
+  // No resolver call was made for IG (no row to back-heal).
+  assert.equal(gateway.calls.length, 0, 'no Composio call when no IG row returned');
+
+  // The FB row IS still processed normally (byte-identical behavior).
+  assert.equal(result.upserted, 1, 'the FB row is still upserted');
+  assert.equal(result.resolved, 0, 'no resolution — FB row had external_account_id present');
+});
+
+test('(d) IG LIVE-ON-CONNECT (external_account_id present): direct upsert, no resolver call', async () => {
+  // A tenant successfully connected their IG account and external_account_id is
+  // already populated (e.g. from the connect flow). The bridge must upsert directly —
+  // no INSTAGRAM_GET_USER_INFO call needed.
+  const db = recordingDb([
+    {
+      id: 22,
+      tenant_id: 15,
+      platform: 'instagram',
+      external_account_id: '12345678901',
+      external_account_name: 'sugarleather',
+      connected_account_id: 'ca_ig',
+    },
+  ]);
+  const gateway = fakeGateway();
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+  });
+
+  assert.equal(result.considered, 1);
+  assert.equal(result.upserted, 1);
+  assert.equal(result.resolved, 0, 'no resolution — external_account_id already present');
+  assert.equal(gateway.calls.length, 0, 'no Composio call when external_account_id is present');
+
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.ok(insert, 'an INSERT INTO insights_accounts was issued');
+  // IG user id (numeric) stored verbatim as external_account_id.
+  assert.deepEqual(insert!.params, [15, 'instagram', '12345678901', 'sugarleather']);
+});
+
+test('(d) IG LIVE-ON-CONNECT (external_account_id null): back-heals via resolveInstagramAccount ({ig_user_id:"me"}), upserts', async () => {
+  // The connect flow did not populate external_account_id (common for legacy or
+  // first-time IG connections). The bridge must call INSTAGRAM_GET_USER_INFO with
+  // {ig_user_id:'me'} to resolve the IG user id, persist it back to
+  // connected_accounts, then upsert insights_accounts.
+  const db = recordingDb([
+    {
+      id: 23,
+      tenant_id: 15,
+      platform: 'instagram',
+      external_account_id: null,
+      external_account_name: null,
+      connected_account_id: 'ca_ig_heal',
+    },
+  ]);
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { id: '98765432101', username: 'sugarleather_ig' } },
+    },
+  });
+
+  const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+  });
+
+  assert.equal(result.resolved, 1, 'IG user id was resolved via back-heal');
+  assert.equal(result.upserted, 1);
+  assert.equal(result.skippedNoPage, 0);
+
+  // It called INSTAGRAM_GET_USER_INFO with {ig_user_id:'me'} and the right connectedAccountId.
+  assert.equal(gateway.calls.length, 1);
+  assert.equal(gateway.calls[0].slug, DEFAULT_INSTAGRAM_GET_ME_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_ig_heal');
+  assert.deepEqual(
+    gateway.calls[0].options.arguments,
+    { ig_user_id: 'me', fields: 'id,username,followers_count' },
+    'resolver sends {ig_user_id:"me"} to get the authenticated account',
+  );
+
+  // It persisted the resolved IG user id back to connected_accounts.
+  const update = db.queries.find((q) => /UPDATE connected_accounts/i.test(q.text));
+  assert.ok(update, 'persists the resolved IG user id back to connected_accounts');
+  assert.equal(update!.params[0], '98765432101', 'ig user id is persisted');
+  assert.equal(update!.params[2], 23, 'keyed on the connection row id');
+
+  // And upserted insights_accounts with the resolved IG user id + username.
+  const insert = db.queries.find((q) => /INSERT INTO insights_accounts/i.test(q.text));
+  assert.ok(insert, 'an INSERT INTO insights_accounts was issued');
+  assert.deepEqual(insert!.params, [15, 'instagram', '98765432101', 'sugarleather_ig']);
 });

--- a/tests/insights-ensure-account.test.ts
+++ b/tests/insights-ensure-account.test.ts
@@ -175,8 +175,8 @@ test('the bridge does not throw when Composio resolution errors — it skips the
   assert.equal(result.upserted, 0);
 });
 
-test('Instagram is out of scope: the bridge only queries the bridged (FB) platforms', async () => {
-  assert.deepEqual([...BRIDGED_PLATFORMS], ['facebook']);
+test('The bridge queries both facebook and instagram when ANALYTICS_PROVIDER=composio (no connected rows → just the SELECT)', async () => {
+  assert.deepEqual([...BRIDGED_PLATFORMS], ['facebook', 'instagram']);
   const db = recordingDb([]);
   const result = await ensureInsightsAccountsForConnectedPlatforms(db, COMPOSIO_ENV);
   assert.equal(result.considered, 0);
@@ -286,14 +286,14 @@ test('X bridge: when ARIES_X_ENABLED=1 the DB query includes "x" alongside "face
   );
 });
 
-test('X bridge: when ARIES_X_ENABLED is off, the DB query only includes "facebook"', async () => {
+test('X bridge: when ARIES_X_ENABLED is off, the DB query includes facebook and instagram but not x', async () => {
   const db = recordingDb([]);
-  // FB requires COMPOSIO_ENABLED=1 + ANALYTICS_PROVIDER=composio since #681 product fix.
+  // FB and IG both require COMPOSIO_ENABLED=1 + ANALYTICS_PROVIDER=composio (#681/#692).
   const fbOnlyEnv = { ANALYTICS_PROVIDER: 'composio', COMPOSIO_ENABLED: '1' } as unknown as NodeJS.ProcessEnv;
   await ensureInsightsAccountsForConnectedPlatforms(db, fbOnlyEnv);
   const select = db.queries[0];
   assert.ok(select, 'issued a SELECT query');
-  assert.deepEqual(select.params, ['facebook'], 'only facebook when ARIES_X_ENABLED is off');
+  assert.deepEqual(select.params, ['facebook', 'instagram'], 'facebook and instagram bridged; x absent when ARIES_X_ENABLED is off');
 });
 
 test('YouTube bridge: when ARIES_YOUTUBE_ENABLED=1 the DB query includes "youtube" alongside "facebook"', async () => {
@@ -592,9 +592,10 @@ test('facebook is registered in the adapter factory and getAdapter binds the con
 
 // ── Adversarial tests: #679 composio-only analytics seam ──────────────────────
 
-test('#679 (a) golden — FB path: COMPOSIO_ENABLED=1 + ANALYTICS_PROVIDER=composio + no rollout flags → SELECT params exactly ["facebook"]', async () => {
-  // FB now requires both COMPOSIO_ENABLED and ANALYTICS_PROVIDER=composio (#681 product fix).
-  // With both set and no platform rollout flags, exactly facebook (and only facebook) must be bridged.
+test('#679 (a) golden — Meta-family path: COMPOSIO_ENABLED=1 + ANALYTICS_PROVIDER=composio + no rollout flags → SELECT params exactly ["facebook","instagram"]', async () => {
+  // FB and IG both require COMPOSIO_ENABLED + ANALYTICS_PROVIDER=composio (#681/#692).
+  // With both set and no platform rollout flags, exactly facebook + instagram must be bridged —
+  // no composio-only platforms (x, youtube, reddit, linkedin) leak in without their own flags.
   const db = recordingDb([]);
   const composioFbOnlyEnv = { ANALYTICS_PROVIDER: 'composio', COMPOSIO_ENABLED: '1' } as unknown as NodeJS.ProcessEnv;
   await ensureInsightsAccountsForConnectedPlatforms(db, composioFbOnlyEnv);
@@ -602,8 +603,8 @@ test('#679 (a) golden — FB path: COMPOSIO_ENABLED=1 + ANALYTICS_PROVIDER=compo
   assert.ok(select, 'a SELECT was issued');
   assert.deepEqual(
     select.params,
-    ['facebook'],
-    'FB path: params must be exactly ["facebook"] — no composio-only platforms leak in without their own flags',
+    ['facebook', 'instagram'],
+    'Meta-family path: params must be exactly ["facebook","instagram"] — no composio-only platforms leak in without their own flags',
   );
 });
 
@@ -728,8 +729,9 @@ test('#679 seam parity — isPlatformInsightsEnabled dispatches correctly for al
   assert.equal(isPlatformInsightsEnabled('reddit', fullEnv), true);
   assert.equal(isPlatformInsightsEnabled('linkedin', fullEnv), true);
 
+  // Instagram uses the same ANALYTICS_PROVIDER gate as facebook (no separate flag) → true in fullEnv.
+  assert.equal(isPlatformInsightsEnabled('instagram', fullEnv), true, 'instagram uses ANALYTICS_PROVIDER gate like facebook');
   // Unknown platform → always false
-  assert.equal(isPlatformInsightsEnabled('instagram', fullEnv), false, 'instagram is not in the seam');
   assert.equal(isPlatformInsightsEnabled('unknown', fullEnv), false);
 });
 
@@ -742,5 +744,5 @@ test('#679 isComposioOnlyAnalyticsPlatform: set is {x, reddit, linkedin, youtube
   assert.equal(isComposioOnlyAnalyticsPlatform('linkedin'), true);
   assert.equal(isComposioOnlyAnalyticsPlatform('youtube'), true);
   assert.equal(isComposioOnlyAnalyticsPlatform('facebook'), false, 'facebook uses ANALYTICS_PROVIDER gate, not the composio-only set');
-  assert.equal(isComposioOnlyAnalyticsPlatform('instagram'), false, 'instagram is out of scope');
+  assert.equal(isComposioOnlyAnalyticsPlatform('instagram'), false, 'instagram uses ANALYTICS_PROVIDER gate like facebook, not the composio-only set');
 });

--- a/tests/insights-instagram-account-resolver.test.ts
+++ b/tests/insights-instagram-account-resolver.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for resolveInstagramAccount (#692/#693).
+ *
+ * Locked behaviors:
+ *  - DEFAULT_INSTAGRAM_GET_ME_SLUG forwarded when no config override
+ *  - { ig_user_id: 'me' } forwarded in arguments
+ *  - connectedAccountId forwarded to executeTool
+ *  - Nested shape (data.data.id) → { igUserId, username }
+ *  - Direct shape (data.id)      → { igUserId, username }
+ *  - config `account_info` override honored
+ *  - successful:false → null  (fail-safe, never invents a user id)
+ *  - null / missing-id payload → null
+ *  - Blank-string id → null
+ *  - username is null when absent from payload
+ *
+ * Entirely self-contained: fake gateway + config, no Postgres, no Composio SDK.
+ * Mirrors the structure of tests/composio-x-user-resolver.test.ts.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveInstagramAccount,
+  DEFAULT_INSTAGRAM_GET_ME_SLUG,
+} from '@/backend/integrations/composio/instagram-account-resolver';
+import { fakeConfig, fakeGateway } from './composio/helpers';
+
+// ── 1. Default slug + forwarding ─────────────────────────────────────────────
+
+test('uses DEFAULT_INSTAGRAM_GET_USER_INFO slug, forwards {ig_user_id:"me"}, forwards connectedAccountId', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { id: '12345678901', username: 'sugarleather' } },
+    },
+  });
+  await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_42');
+  assert.equal(gateway.calls.length, 1, 'exactly one executeTool call');
+  assert.equal(gateway.calls[0].slug, DEFAULT_INSTAGRAM_GET_ME_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_ig_42');
+  assert.equal(gateway.calls[0].options.arguments?.ig_user_id, 'me');
+  assert.match(String(gateway.calls[0].options.arguments?.fields), /followers_count/);
+});
+
+// ── 2. Nested shape (data.data.*) ─────────────────────────────────────────────
+
+test('nested shape (data.data.id): resolves igUserId + username', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { id: '98765432101', username: 'aries_ig', followers_count: 1200 } },
+    },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.deepEqual(result, { igUserId: '98765432101', username: 'aries_ig' });
+});
+
+// ── 3. Direct shape (data.*) ─────────────────────────────────────────────────
+
+test('direct shape (data.id): resolves igUserId + username when extra envelope is absent', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { id: '11111111111', username: 'direct_ig_user' },
+    },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_2');
+  assert.deepEqual(result, { igUserId: '11111111111', username: 'direct_ig_user' });
+});
+
+// ── 4. account_info slug override ────────────────────────────────────────────
+
+test('honors account_info slug override (COMPOSIO_INSTAGRAM_ACCOUNT_INFO_ACTION)', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { id: '22222222222', username: 'override_user' } },
+    },
+  });
+  await resolveInstagramAccount(
+    gateway,
+    fakeConfig({ actions: { account_info: 'CUSTOM_IG_USER_LOOKUP_V2' } }),
+    'ca_ig_1',
+  );
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_IG_USER_LOOKUP_V2');
+  assert.notEqual(gateway.calls[0].slug, DEFAULT_INSTAGRAM_GET_ME_SLUG, 'override replaces the default');
+});
+
+// ── 5. Fail-safe: must return null, never invent a user id ───────────────────
+
+test('successful:false → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: false, error: 'unauthorized', data: null },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result, null);
+});
+
+test('successful:true but data is null → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: null },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result, null);
+});
+
+test('successful:true but data has no id field → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { username: 'noId', followers_count: 100 } },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result, null);
+});
+
+test('successful:true but data.data has no id field → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { username: 'noIdNested' } } },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result, null);
+});
+
+test('successful:true but id is blank string → null', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { id: '   ', username: 'blankId' } } },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result, null);
+});
+
+// ── 6. Optional username field ────────────────────────────────────────────────
+
+test('nested shape with id but no username → username is null', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { data: { id: '33333333333' } },
+    },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result?.igUserId, '33333333333');
+  assert.equal(result?.username, null);
+});
+
+test('direct shape with id but no username → username is null', async () => {
+  const gateway = fakeGateway({
+    executeResult: {
+      successful: true,
+      error: null,
+      data: { id: '44444444444' },
+    },
+  });
+  const result = await resolveInstagramAccount(gateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result?.igUserId, '44444444444');
+  assert.equal(result?.username, null);
+});
+
+// ── 7. Fail-safe on gateway throw ─────────────────────────────────────────────
+
+test('gateway throw → null (fail-safe, never propagates to the worker tick)', async () => {
+  const throwingGateway = {
+    ...fakeGateway(),
+    async executeTool() {
+      throw new Error('Composio 503');
+    },
+  };
+  const result = await resolveInstagramAccount(throwingGateway, fakeConfig(), 'ca_ig_1');
+  assert.equal(result, null);
+});

--- a/tests/insights-instagram-adapter.test.ts
+++ b/tests/insights-instagram-adapter.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Unit tests for the Instagram insights adapter (#692 analytics, #693 comments).
+ *
+ * Covers the full InsightsAdapter surface:
+ *   fetchPostList       → INSTAGRAM_GET_IG_USER_MEDIA
+ *   fetchPostMetrics    → INSTAGRAM_GET_IG_MEDIA_INSIGHTS (fail-soft + honesty bar)
+ *   fetchAccountMetrics → INSTAGRAM_GET_USER_INSIGHTS + INSTAGRAM_GET_USER_INFO
+ *   fetchComments       → INSTAGRAM_GET_IG_MEDIA_COMMENTS
+ *
+ * Uses a fake routing gateway and injected fakeConfig — no network, no database.
+ * Mirrors the structure of tests/insights-facebook-adapter.test.ts.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InstagramInsightsAdapter } from '@/backend/insights/adapters/instagram/index';
+import type {
+  ComposioGateway,
+  GatewayToolResult,
+} from '@/backend/integrations/composio/composio-client';
+import { fakeConfig } from './composio/helpers';
+
+interface RecordedCall {
+  slug: string;
+  connectedAccountId?: string;
+  arguments?: Record<string, unknown>;
+}
+
+/** Gateway that routes a canned result per action slug and records every call. */
+function routingGateway(
+  results: Record<string, GatewayToolResult>,
+): ComposioGateway & { calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    async findOrCreateManagedAuthConfig(s: string) { return `ac_${s}`; },
+    async initiateConnection() { return { connectionRequestId: 'cr', redirectUrl: null }; },
+    async listConnections() { return []; },
+    async getConnection() { return null; },
+    async deleteConnection() {},
+    async executeTool(slug, options) {
+      calls.push({ slug, connectedAccountId: options.connectedAccountId, arguments: options.arguments });
+      return results[slug] ?? { data: { data: [] }, successful: true, error: null };
+    },
+    async uploadFile(input) {
+      return { name: 'staged', mimetype: 'application/octet-stream', s3key: `s3/${input.toolSlug}` };
+    },
+  };
+}
+
+const ctx = { connectedAccountId: 'ca_ig_1' };
+const IG_USER_ID = 'ig_123456789';
+const IG_POST_ID = 'ig_post_111';
+
+// ── fetchPostList ─────────────────────────────────────────────────────────────
+
+test('fetchPostList: builds INSTAGRAM_GET_IG_USER_MEDIA with ig_user_id, maps IMAGE→image, captures like_count/comments_count', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_USER_MEDIA: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          {
+            id: IG_POST_ID,
+            caption: 'Hello IG world',
+            permalink: 'https://www.instagram.com/p/abc123/',
+            media_type: 'IMAGE',
+            media_url: 'https://img/photo.jpg',
+            thumbnail_url: 'https://img/thumb.jpg',
+            timestamp: '2026-06-10T12:00:00+0000',
+            like_count: 55,
+            comments_count: 8,
+          },
+        ],
+      },
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const posts = await adapter.fetchPostList(IG_USER_ID);
+
+  assert.equal(gateway.calls[0].slug, 'INSTAGRAM_GET_IG_USER_MEDIA');
+  assert.equal(gateway.calls[0].connectedAccountId, 'ca_ig_1');
+  assert.equal(gateway.calls[0].arguments?.ig_user_id, IG_USER_ID);
+  // Fields must include the engagement columns so the cache can be primed
+  assert.match(String(gateway.calls[0].arguments?.fields), /like_count/);
+  assert.match(String(gateway.calls[0].arguments?.fields), /comments_count/);
+
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].externalPostId, IG_POST_ID);
+  assert.equal(posts[0].mediaType, 'image');
+  assert.equal(posts[0].caption, 'Hello IG world');
+  assert.equal(posts[0].permalink, 'https://www.instagram.com/p/abc123/');
+  // thumbnail_url takes priority over media_url
+  assert.equal(posts[0].thumbnailUrl, 'https://img/thumb.jpg');
+});
+
+test('fetchPostList: maps VIDEO→video, CAROUSEL_ALBUM→carousel, REELS→reel; falls back to media_url for thumbnail when thumbnail_url absent', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_USER_MEDIA: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { id: 'vid1',      media_type: 'VIDEO',         media_url: 'https://img/v.mp4', timestamp: '2026-06-10T10:00:00+0000', like_count: 0, comments_count: 0 },
+          { id: 'carousel1', media_type: 'CAROUSEL_ALBUM', media_url: 'https://img/c.jpg', timestamp: '2026-06-10T10:00:00+0000', like_count: 0, comments_count: 0 },
+          { id: 'reel1',     media_type: 'REELS',          media_url: 'https://img/r.mp4', timestamp: '2026-06-10T10:00:00+0000', like_count: 0, comments_count: 0 },
+        ],
+      },
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const posts = await adapter.fetchPostList(IG_USER_ID);
+  assert.equal(posts.length, 3);
+
+  const vid = posts.find((p) => p.externalPostId === 'vid1');
+  assert.equal(vid?.mediaType, 'video');
+  // Falls back to media_url when thumbnail_url absent
+  assert.equal(vid?.thumbnailUrl, 'https://img/v.mp4');
+
+  const carousel = posts.find((p) => p.externalPostId === 'carousel1');
+  assert.equal(carousel?.mediaType, 'carousel');
+
+  const reel = posts.find((p) => p.externalPostId === 'reel1');
+  assert.equal(reel?.mediaType, 'reel');
+});
+
+// ── fetchPostMetrics ──────────────────────────────────────────────────────────
+
+test('fetchPostMetrics: views/reach/saved from INSTAGRAM_GET_IG_MEDIA_INSIGHTS; likes/comments from insights when available', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_USER_MEDIA: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { id: IG_POST_ID, timestamp: '2026-06-10T10:00:00+0000', like_count: 100, comments_count: 15 },
+        ],
+      },
+    },
+    INSTAGRAM_GET_IG_MEDIA_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { name: 'views',    values: [{ value: 4200 }] },
+          { name: 'reach',    values: [{ value: 3900 }] },
+          { name: 'saved',    values: [{ value: 60 }] },
+          { name: 'likes',    values: [{ value: 88 }] },
+          { name: 'comments', values: [{ value: 12 }] },
+          { name: 'shares',   values: [{ value: 5 }] },
+        ],
+      },
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  // Prime the engagement cache so fetchPostMetrics can fall back to it for this post.
+  await adapter.fetchPostList(IG_USER_ID);
+  const metrics = await adapter.fetchPostMetrics(IG_POST_ID);
+
+  const insightsCall = gateway.calls.find((c) => c.slug === 'INSTAGRAM_GET_IG_MEDIA_INSIGHTS');
+  assert.ok(insightsCall, 'calls INSTAGRAM_GET_IG_MEDIA_INSIGHTS');
+  assert.equal(insightsCall?.arguments?.ig_media_id, IG_POST_ID);
+  assert.equal(insightsCall?.connectedAccountId, 'ca_ig_1');
+
+  assert.equal(metrics.length, 1);
+  assert.equal(metrics[0].views, 4200);          // from MEDIA_INSIGHTS
+  assert.equal(metrics[0].likes, 88);            // from MEDIA_INSIGHTS (not list cache)
+  assert.equal(metrics[0].commentsCount, 12);    // from MEDIA_INSIGHTS
+  assert.equal(metrics[0].shares, 5);
+  // saved is in rawSource (no dedicated DB column)
+  assert.equal(metrics[0].rawSource.saved, 60);
+  assert.equal(metrics[0].rawSource.reach, 3900);
+});
+
+test('fetchPostMetrics: likes/comments fall back to cached list engagement when insights return no breakdown', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_USER_MEDIA: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { id: IG_POST_ID, timestamp: '2026-06-10T10:00:00+0000', like_count: 77, comments_count: 9 },
+        ],
+      },
+    },
+    // Insights only return views — no likes/comments breakdown.
+    INSTAGRAM_GET_IG_MEDIA_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { name: 'views', values: [{ value: 1500 }] },
+        ],
+      },
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  await adapter.fetchPostList(IG_USER_ID);
+  const metrics = await adapter.fetchPostMetrics(IG_POST_ID);
+
+  assert.equal(metrics.length, 1);
+  assert.equal(metrics[0].views, 1500);   // from MEDIA_INSIGHTS
+  assert.equal(metrics[0].likes, 77);    // from engagement cache (fetchPostList captured like_count)
+  assert.equal(metrics[0].commentsCount, 9); // from engagement cache
+});
+
+test('HONESTY BAR: restricted insights (<1000 followers) with no engagement cache → [], never a fabricated 0-view row', async () => {
+  // Simulates an account under the 1000-follower threshold where the IG API denies
+  // per-post insights. The adapter must NOT fabricate { views: 0, likes: 0, ... }.
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_MEDIA_INSIGHTS: {
+      successful: false,
+      error: 'This media object is not accessible.',
+      data: null,
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  // No fetchPostList call → engagement cache is empty.
+  const metrics = await adapter.fetchPostMetrics('ig_post_restricted');
+  assert.deepEqual(metrics, [], 'restricted account with no cache → [], never a fabricated 0-view row');
+  // Also verify with empty data response (the API returns 200 but no metrics).
+  const gateway2 = routingGateway({
+    INSTAGRAM_GET_IG_MEDIA_INSIGHTS: { successful: true, error: null, data: { data: [] } },
+  });
+  const adapter2 = new InstagramInsightsAdapter(gateway2, fakeConfig({ actions: {} }), ctx);
+  const metrics2 = await adapter2.fetchPostMetrics('ig_post_empty');
+  assert.deepEqual(metrics2, [], 'empty insights data and no cache → [], never a 0-view row');
+});
+
+test('fetchPostMetrics: fail-soft on unsuccessful insights call → falls back to engagement cache when available', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_USER_MEDIA: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { id: IG_POST_ID, timestamp: '2026-06-10T10:00:00+0000', like_count: 44, comments_count: 6 },
+        ],
+      },
+    },
+    // Insights call fails (restricted/rate-limited).
+    INSTAGRAM_GET_IG_MEDIA_INSIGHTS: {
+      successful: false,
+      error: 'rate limited (code 32)',
+      data: null,
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  // Prime the cache first.
+  await adapter.fetchPostList(IG_USER_ID);
+  // Must not throw — fail-soft path uses cache.
+  const metrics = await adapter.fetchPostMetrics(IG_POST_ID);
+
+  assert.equal(metrics.length, 1, 'emits a row because engagement cache has data');
+  // views is null → coerced to 0 (API had no data; NOT fabricated — we have engagement signal)
+  assert.equal(metrics[0].views, 0);
+  assert.equal(metrics[0].likes, 44);        // from engagement cache
+  assert.equal(metrics[0].commentsCount, 6); // from engagement cache
+});
+
+// ── fetchAccountMetrics ───────────────────────────────────────────────────────
+
+test('fetchAccountMetrics: pivots INSTAGRAM_GET_USER_INSIGHTS per day + folds INSTAGRAM_GET_USER_INFO followers', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_USER_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { name: 'views',          values: [{ value: 800, end_time: '2026-06-09T07:00:00+0000' }, { value: 950, end_time: '2026-06-10T07:00:00+0000' }] },
+          { name: 'reach',          values: [{ value: 700, end_time: '2026-06-09T07:00:00+0000' }, { value: 820, end_time: '2026-06-10T07:00:00+0000' }] },
+          { name: 'follower_count', values: [{ value: 1100, end_time: '2026-06-09T07:00:00+0000' }, { value: 1110, end_time: '2026-06-10T07:00:00+0000' }] },
+        ],
+      },
+    },
+    INSTAGRAM_GET_USER_INFO: {
+      successful: true,
+      error: null,
+      // USER_INFO provides the authoritative current follower count
+      data: { data: { id: IG_USER_ID, followers_count: 1234 } },
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const days = await adapter.fetchAccountMetrics(IG_USER_ID, { from: '2026-06-09', to: '2026-06-10' });
+
+  const insightsCall = gateway.calls.find((c) => c.slug === 'INSTAGRAM_GET_USER_INSIGHTS');
+  assert.ok(insightsCall, 'calls INSTAGRAM_GET_USER_INSIGHTS');
+  assert.equal(insightsCall?.arguments?.ig_user_id, IG_USER_ID);
+  assert.equal(insightsCall?.arguments?.since, '2026-06-09');
+  assert.equal(insightsCall?.arguments?.until, '2026-06-10');
+  assert.equal(insightsCall?.arguments?.period, 'day');
+
+  const infoCall = gateway.calls.find((c) => c.slug === 'INSTAGRAM_GET_USER_INFO');
+  assert.ok(infoCall, 'fetches followers via INSTAGRAM_GET_USER_INFO');
+  assert.equal(infoCall?.arguments?.ig_user_id, IG_USER_ID);
+  assert.match(String(infoCall?.arguments?.fields), /followers_count/);
+
+  const d9 = days.find((d) => d.date === '2026-06-09');
+  const d10 = days.find((d) => d.date === '2026-06-10');
+  assert.ok(d9, 'June 9 is present');
+  assert.ok(d10, 'June 10 is present');
+
+  assert.equal(d9?.views, 800);
+  // On the non-latest day the daily follower_count metric is used
+  assert.equal(d9?.followers, 1100);
+
+  assert.equal(d10?.views, 950);
+  // On the latest day (range.to), the authoritative USER_INFO followers_count overrides
+  assert.equal(d10?.followers, 1234, 'USER_INFO followers_count stamped on the latest day');
+});
+
+test('fetchAccountMetrics: INSTAGRAM_GET_USER_INFO failure → day series still emitted, follower_count from daily metric', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_USER_INSIGHTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { name: 'views',          values: [{ value: 500, end_time: '2026-06-10T07:00:00+0000' }] },
+          { name: 'follower_count', values: [{ value: 1000, end_time: '2026-06-10T07:00:00+0000' }] },
+        ],
+      },
+    },
+    // USER_INFO fails — must not drop the day series.
+    INSTAGRAM_GET_USER_INFO: { successful: false, error: 'unauthorized', data: null },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const days = await adapter.fetchAccountMetrics(IG_USER_ID, { from: '2026-06-10', to: '2026-06-10' });
+
+  assert.equal(days.length, 1, 'day series still emitted when USER_INFO fails');
+  assert.equal(days[0].views, 500);
+  // Falls back to daily follower_count metric from USER_INSIGHTS
+  assert.equal(days[0].followers, 1000, 'followers from daily follower_count metric when USER_INFO fails');
+});
+
+// ── fetchComments ─────────────────────────────────────────────────────────────
+
+test('fetchComments: maps INSTAGRAM_GET_IG_MEDIA_COMMENTS (username→authorHandle, text→bodyText, timestamp→receivedAt)', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_MEDIA_COMMENTS: {
+      successful: true,
+      error: null,
+      data: {
+        data: [
+          { id: 'ig_cmt_888', text: 'lovely!', username: 'jane_doe', timestamp: '2026-06-11T09:00:00+0000' },
+          { id: 'ig_cmt_889', text: 'where to buy?', username: 'john_roe', timestamp: '2026-06-11T10:00:00+0000' },
+        ],
+      },
+    },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+
+  const comments = await adapter.fetchComments(IG_POST_ID, 50);
+  const call = gateway.calls[0];
+  assert.equal(call.slug, 'INSTAGRAM_GET_IG_MEDIA_COMMENTS');
+  assert.equal(call.arguments?.ig_media_id, IG_POST_ID);
+  assert.equal(call.arguments?.limit, 50);
+  assert.match(String(call.arguments?.fields), /username/);
+  assert.match(String(call.arguments?.fields), /text/);
+
+  assert.equal(comments.length, 2);
+  assert.equal(comments[0].externalCommentId, 'ig_cmt_888');
+  assert.equal(comments[0].authorHandle, 'jane_doe');   // username → authorHandle
+  assert.equal(comments[0].bodyText, 'lovely!');         // text → bodyText
+  assert.ok(comments[0].receivedAt instanceof Date, 'receivedAt is a Date');
+  assert.equal(comments[1].externalCommentId, 'ig_cmt_889');
+  assert.equal(comments[1].authorHandle, 'john_roe');
+});
+
+// ── Slug overrides, error paths, auth guard ───────────────────────────────────
+
+test('an env override replaces the default action slug', async () => {
+  const gateway = routingGateway({
+    CUSTOM_IG_LIST_POSTS: { successful: true, error: null, data: { data: [] } },
+  });
+  const adapter = new InstagramInsightsAdapter(
+    gateway,
+    fakeConfig({ actions: { list_posts: 'CUSTOM_IG_LIST_POSTS' } }),
+    ctx,
+  );
+  await adapter.fetchPostList(IG_USER_ID);
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_IG_LIST_POSTS');
+});
+
+test('an unsuccessful tool call throws (so the sync run is marked failed, partial rows preserved)', async () => {
+  const gateway = routingGateway({
+    INSTAGRAM_GET_IG_MEDIA_COMMENTS: { successful: false, error: 'instagram api error (code 10)', data: null },
+  });
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), ctx);
+  await assert.rejects(() => adapter.fetchComments(IG_POST_ID), /instagram api error/);
+});
+
+test('a missing connectedAccountId is a clear error, never a silent unauthenticated call', async () => {
+  const gateway = routingGateway({});
+  // No connectedAccountId in context
+  const adapter = new InstagramInsightsAdapter(gateway, fakeConfig({ actions: {} }), {});
+  await assert.rejects(() => adapter.fetchPostList(IG_USER_ID), /connectedAccountId/);
+  assert.equal(gateway.calls.length, 0, 'no tool call without a connected account');
+});


### PR DESCRIPTION
Closes #692
Closes #693

## What
Adds the Composio-backed **Instagram insights adapter** (analytics #692 + comments #693), mirroring the existing Facebook adapter:
- NEW `backend/insights/adapters/instagram/index.ts` — fetchPostList / fetchAccountMetrics / fetchPostMetrics / fetchComments via verified `INSTAGRAM_*` Composio action slugs.
- NEW `backend/integrations/composio/instagram-account-resolver.ts` — fail-safe `INSTAGRAM_GET_USER_INFO('me')` id resolver.
- `adapter-factory.ts` — `isInstagramInsightsEnabled` (mirrors FB: `COMPOSIO_ENABLED && ANALYTICS_PROVIDER=composio`, **no new flag**), REGISTRY builder, `isPlatformInsightsEnabled`/`hasAdapter` branches.
- `ensure-account.ts` — `BRIDGED_PLATFORMS=['facebook','instagram']`, bridge IN-clause + IG back-heal branch.
- `capabilities.ts` and `analytics-mappers.ts` UNCHANGED (IG already has the full capability set; no new MAPPERS entry → full-suite mapper invariant stays green).

## Dormant-safe (load-bearing)
Prod runs `ANALYTICS_PROVIDER=composio`, so `isInstagramInsightsEnabled` is **true** on merge and 'instagram' joins the bridge SELECT IN-clause immediately. It is dormant **only** because the bridge SELECT filters `WHERE status='connected'` and the sole IG `connected_accounts` row is `status='reauthorization_required'` → zero IG rows returned → **zero IG insights_accounts upserts + zero resolver calls**. FB/X provisioning is byte-identical (test (c) proves SELECT widens to include 'instagram' yet no IG upsert/resolver call occurs).

## FB + live-X synced rows byte-identical
The only live-path change is the SELECT IN-clause widening + the new IG branch (reached only for `platform='instagram'` rows). FB's and X's resolver branches/predicates are untouched; `dispatcher.ts` and the sync worker are not in the diff. IG goes live **only** when an IG Business account connects.

## Wedge isolation (respects the insights-sync-worker-wedge history)
Resolver is fail-safe null (never throws); ensure-account wraps each resolver in try/catch; `syncAccountForTenant` converts any adapter throw to a failed `SyncResult`; `syncAllAccountsForTenant` is sequential (no Promise.all); the worker has per-tenant try/catch + `tickSafe` finally that resets the overlap guard. An IG-adapter or IG-resolver throw can never wedge the FB/X tick.

## Honesty
`fetchPostMetrics` fail-softs on restricted/<1000-follower accounts (falls back to the engagement cache; emits `[]` when there is no signal) — never an invented `views:0` row. Resolver `'me'` path is verified-on-first-connect; worst case is 'IG doesn't enroll until verified', never a wedge or wrong id.

## Test evidence
- New IG adapter (#692/#693), IG resolver, and IG dormant/live-on-connect ensure-account suites — all green.
- FB + X bridge/adapter suites unchanged + passing.
- `npm run verify` GREEN; `guardrails:agent` passed; banned-patterns clean.

## Residual risk
The `'me'` IG-id resolution is unverified against a live IG connection (no IG Business account connected yet). The fail-safe null-skip bounds the worst case to 'IG does not enroll until first verified connect'.