### PR TITLE
feat(integrations): Instagram native comment reply via Composio

### DIFF
--- a/backend/integrations/composio/composio-reply.ts
+++ b/backend/integrations/composio/composio-reply.ts
@@ -18,9 +18,9 @@
  *     -> handler leaves the claim, surfaces needs_manual_reconciliation, NEVER
  *     auto-retries (a retry of a reply that secretly posted is a duplicate).
  *
- * Routing: only Facebook is wired here (the verified Composio action). Instagram
- * comment-reply via Composio has no verified action, so an IG reply stays on the
- * direct path even under PUBLISH_PROVIDER=composio (see shouldUseComposioReply).
+ * Routing: Facebook and Instagram are wired here (both have verified Composio
+ * actions). Under PUBLISH_PROVIDER=direct_meta, both fall back to the direct-Meta
+ * path unchanged (shouldUseComposioReply returns false when not composio).
  */
 
 import { MetaPublishError, normalizeMetaProvider } from '../meta-publishing';
@@ -43,6 +43,9 @@ type Env = Partial<Record<string, string | undefined>>;
 /** Verified default; overridable via COMPOSIO_FACEBOOK_REPLY_COMMENT_ACTION. */
 export const DEFAULT_FB_CREATE_COMMENT_SLUG = 'FACEBOOK_CREATE_COMMENT';
 
+/** Verified default; overridable via COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION. */
+export const DEFAULT_IG_CREATE_COMMENT_REPLY_SLUG = 'INSTAGRAM_POST_IG_COMMENT_REPLIES';
+
 export interface ComposioReplyDeps {
   gateway?: ComposioGateway;
   config?: ComposioConfig | null;
@@ -53,11 +56,12 @@ export interface ComposioReplyDeps {
  * True when an operator reply should be routed through Composio instead of the
  * direct Graph path. Mirrors how publishing chooses its provider
  * (effectivePublishProvider === 'composio', which already honors the
- * COMPOSIO_ENABLED master switch). Scoped to Facebook — the only platform with a
- * verified Composio reply action.
+ * COMPOSIO_ENABLED master switch). Covers Facebook and Instagram — both have
+ * verified Composio reply actions. Under PUBLISH_PROVIDER=direct_meta, both
+ * platforms fall through to the direct-Meta path (replyToComment) unchanged.
  */
 export function shouldUseComposioReply(platform: string, env: Env = process.env): boolean {
-  return platform === 'facebook' && effectivePublishProvider(env as NodeJS.ProcessEnv) === 'composio';
+  return (platform === 'facebook' || platform === 'instagram') && effectivePublishProvider(env as NodeJS.ProcessEnv) === 'composio';
 }
 
 /** Created comment id lands at data.id (or one nested data wrap). */
@@ -123,10 +127,15 @@ export async function replyToCommentViaComposio(
     );
   }
 
-  // Verified default applies to Facebook only; an env override can extend it.
+  // Env override wins (COMPOSIO_FACEBOOK_REPLY_COMMENT_ACTION or
+  // COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION); else the verified default slug.
   const slug =
     config.actionSlugFor(provider, 'reply_comment') ??
-    (provider === 'facebook' ? DEFAULT_FB_CREATE_COMMENT_SLUG : null);
+    (provider === 'facebook'
+      ? DEFAULT_FB_CREATE_COMMENT_SLUG
+      : provider === 'instagram'
+        ? DEFAULT_IG_CREATE_COMMENT_REPLY_SLUG
+        : null);
   if (!slug) {
     throw new MetaPublishError(
       'reply_not_supported',
@@ -135,20 +144,30 @@ export async function replyToCommentViaComposio(
     );
   }
 
+  // Per-provider args differ:
+  //   Facebook (FACEBOOK_CREATE_COMMENT): object_id is the trailing comment-own
+  //     id (see replyTargetCommentId). Compound "{post_story_fbid}_{comment_id}"
+  //     is stripped to avoid the #621 502 misparse (Composio derives the acting
+  //     Page from the first "_"-delimited segment and ignores page_id).
+  //   Instagram (INSTAGRAM_POST_IG_COMMENT_REPLIES): ig_comment_id is the raw
+  //     stored external_comment_id (IG IDs are not compound — no stripping).
+  //     Message ≤300 chars + ≤4 hashtags + ≤1 URL per IG API; over-long messages
+  //     are surfaced by the Composio tool as successful:false (composio_reply_failed,
+  //     definitively-never-posted) — safe to retry after shortening. No silent
+  //     truncation (unlike the LinkedIn clamp) since a truncated IG reply is
+  //     confusing UX; the handler's MAX_REPLY_LENGTH=8000 guards abusive payloads.
+  const toolArgs: Record<string, unknown> =
+    provider === 'instagram'
+      ? { ig_comment_id: req.externalCommentId, message }
+      : { object_id: replyTargetCommentId(req.externalCommentId), message };
+
   const gateway = deps.gateway ?? createComposioGateway(config);
 
   let result;
   try {
     result = await gateway.executeTool(slug, {
       connectedAccountId: conn.connectedAccountId,
-      // object_id = the trailing comment-own id — NOT the compound form stored
-      // in external_comment_id ("{post_story_fbid}_{comment_id}"). Composio
-      // derives the acting Page from the first "_"-delimited segment of
-      // object_id and ignores any explicit page_id argument, so passing the
-      // compound id causes it to misparse the post_story_fbid as the page id
-      // (root cause of #621). Stripping to the trailing segment is the correct
-      // reply-target id for FACEBOOK_CREATE_COMMENT. See live probe notes in PR.
-      arguments: { object_id: replyTargetCommentId(req.externalCommentId), message },
+      arguments: toolArgs,
     });
   } catch (err) {
     // Transport/unknown: the reply MAY have reached Meta — treat as outcome

--- a/tests/composio-reply.test.ts
+++ b/tests/composio-reply.test.ts
@@ -5,6 +5,7 @@ import {
   replyToCommentViaComposio,
   shouldUseComposioReply,
   DEFAULT_FB_CREATE_COMMENT_SLUG,
+  DEFAULT_IG_CREATE_COMMENT_REPLY_SLUG,
 } from '@/backend/integrations/composio/composio-reply';
 import { MetaPublishError, classifyMetaPublishFailure } from '@/backend/integrations/meta-publishing';
 import { fakeConfig, fakeGateway, fakeDb } from './composio/helpers';
@@ -36,8 +37,22 @@ test('shouldUseComposioReply: composio selected but master switch OFF → false'
   assert.equal(shouldUseComposioReply('facebook', { PUBLISH_PROVIDER: 'composio' }), false);
 });
 
-test('shouldUseComposioReply: instagram is never routed via Composio (no verified action)', () => {
-  assert.equal(shouldUseComposioReply('instagram', { COMPOSIO_ENABLED: 'true', PUBLISH_PROVIDER: 'composio' }), false);
+test('shouldUseComposioReply: IG + composio enabled+selected → true (#694)', () => {
+  // After fix: Instagram IS admitted to the Composio reply path when composio is selected.
+  assert.equal(
+    shouldUseComposioReply('instagram', { COMPOSIO_ENABLED: 'true', PUBLISH_PROVIDER: 'composio' }),
+    true,
+  );
+});
+
+test('shouldUseComposioReply: IG but direct_meta → false (falls back to direct-Graph path)', () => {
+  assert.equal(shouldUseComposioReply('instagram', { COMPOSIO_ENABLED: 'true', PUBLISH_PROVIDER: 'direct_meta' }), false);
+  assert.equal(shouldUseComposioReply('instagram', {}), false);
+});
+
+test('shouldUseComposioReply: IG composio selected but master switch OFF → false', () => {
+  // effectivePublishProvider forces direct_meta when COMPOSIO_ENABLED is off.
+  assert.equal(shouldUseComposioReply('instagram', { PUBLISH_PROVIDER: 'composio' }), false);
 });
 
 // ── replyToCommentViaComposio ───────────────────────────────────────────────────
@@ -199,6 +214,165 @@ test('empty reply text is rejected before any tool call', async () => {
   const gateway = fakeGateway();
   await assert.rejects(
     () => replyToCommentViaComposio({ ...baseReq, message: '   ' }, {}, { gateway, config: fakeConfig({ actions: {} }), db: fakeDb() }),
+    (err: unknown) => err instanceof MetaPublishError && err.code === 'missing_reply_text',
+  );
+  assert.equal(gateway.calls.length, 0);
+});
+
+// ── replyToCommentViaComposio for Instagram (#694) ─────────────────────────────
+//
+// The fix admitted Instagram to the Composio reply path. IG args are different
+// from FB: `ig_comment_id` is the raw external comment id (NOT stripped like
+// the FB `object_id`), and the slug is DEFAULT_IG_CREATE_COMMENT_REPLY_SLUG.
+
+const igReq = {
+  tenantId: '42',
+  provider: 'instagram',
+  externalCommentId: '17841405822304914',
+  message: 'Love this post!',
+};
+
+test('IG success: calls INSTAGRAM_POST_IG_COMMENT_REPLIES with {ig_comment_id, message} args', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'ig_reply_1' } },
+  });
+  const out = await replyToCommentViaComposio(igReq, {}, {
+    gateway,
+    config: fakeConfig({ actions: {} }),
+    db: fakeDb(),
+  });
+
+  assert.equal(out.platformReplyId, 'ig_reply_1');
+  assert.equal(out.provider, 'instagram');
+  assert.equal(gateway.calls[0].slug, DEFAULT_IG_CREATE_COMMENT_REPLY_SLUG);
+  assert.equal(gateway.calls[0].options.connectedAccountId, 'ca_123');
+  // IG args use ig_comment_id — NOT the FB object_id field.
+  assert.deepEqual(gateway.calls[0].options.arguments, {
+    ig_comment_id: '17841405822304914',
+    message: 'Love this post!',
+  });
+});
+
+test('IG: raw externalCommentId is passed as ig_comment_id with NO stripping (IG ids are not compound)', async () => {
+  // Unlike FB ("{post_story_fbid}_{comment_id}" compound → trailing-segment strip),
+  // Instagram comment ids are not compound. The raw stored external_comment_id must
+  // be forwarded to Composio unchanged as `ig_comment_id`. This is the load-bearing
+  // behavioral difference between the IG and FB paths.
+  const compoundLookingId = 'PREFIX_17841405822304914';
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { id: 'ig_reply_no_strip' } },
+  });
+  await replyToCommentViaComposio(
+    { ...igReq, externalCommentId: compoundLookingId },
+    {},
+    { gateway, config: fakeConfig({ actions: {} }), db: fakeDb() },
+  );
+  const args = gateway.calls[0].options.arguments as Record<string, string>;
+  // Must be the raw id, NOT the trailing segment.
+  assert.equal(args.ig_comment_id, compoundLookingId, 'ig_comment_id must be the raw id (no stripping)');
+  // Must NOT send object_id (the FB field).
+  assert.equal('object_id' in args, false, 'must NOT send object_id for IG');
+});
+
+test('IG success: reads nested data.data.id wrapper too', async () => {
+  const gateway = fakeGateway({
+    executeResult: { successful: true, error: null, data: { data: { id: 'ig_reply_nested' } } },
+  });
+  const out = await replyToCommentViaComposio(igReq, {}, { gateway, config: fakeConfig({ actions: {} }), db: fakeDb() });
+  assert.equal(out.platformReplyId, 'ig_reply_nested');
+});
+
+test('IG: explicit failure (successful:false) → composio_reply_failed / definitely_never_posted (rollback safe)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: false, error: 'comment not accessible', data: null } });
+  await assert.rejects(
+    () => replyToCommentViaComposio(igReq, {}, { gateway, config: fakeConfig({ actions: {} }), db: fakeDb() }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_failed');
+      assert.equal(err.outcomeUnknown, false);
+      assert.equal(classifyMetaPublishFailure(err), 'definitely_never_posted');
+      return true;
+    },
+  );
+});
+
+test('IG: 2xx without a comment id → composio_reply_missing_id / outcome_unknown (no rollback, no auto-retry)', async () => {
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: {} } });
+  await assert.rejects(
+    () => replyToCommentViaComposio(igReq, {}, { gateway, config: fakeConfig({ actions: {} }), db: fakeDb() }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_missing_id');
+      assert.equal(err.outcomeUnknown, true);
+      assert.equal(classifyMetaPublishFailure(err), 'outcome_unknown');
+      return true;
+    },
+  );
+});
+
+test('IG: transport error (gateway throws) → composio_reply_unconfirmed / outcome_unknown (reply may have posted)', async () => {
+  const gateway = {
+    ...fakeGateway(),
+    async executeTool() {
+      throw new Error('ECONNRESET talking to Composio IG endpoint');
+    },
+  };
+  await assert.rejects(
+    () => replyToCommentViaComposio(igReq, {}, { gateway, config: fakeConfig({ actions: {} }), db: fakeDb() }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'composio_reply_unconfirmed');
+      assert.equal(err.outcomeUnknown, true);
+      assert.equal(classifyMetaPublishFailure(err), 'outcome_unknown');
+      return true;
+    },
+  );
+});
+
+test('IG: no active connection → oauth_token_missing (never-posted, reconnect)', async () => {
+  const gateway = fakeGateway();
+  await assert.rejects(
+    () => replyToCommentViaComposio(igReq, {}, { gateway, config: fakeConfig({ actions: {} }), db: fakeDb({ connectionRow: null }) }),
+    (err: unknown) => {
+      assert.ok(err instanceof MetaPublishError);
+      assert.equal(err.code, 'oauth_token_missing');
+      assert.equal(err.outcomeUnknown, false);
+      return true;
+    },
+  );
+  assert.equal(gateway.calls.length, 0, 'no tool call without a connection');
+});
+
+test('IG: COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION env override replaces the default IG slug (via fakeConfig)', async () => {
+  // Mirrors the existing FB "an env/config override replaces the default reply slug" test.
+  const gateway = fakeGateway({ executeResult: { successful: true, error: null, data: { id: 'ig_custom_reply' } } });
+  await replyToCommentViaComposio(igReq, {}, {
+    gateway,
+    config: fakeConfig({ actions: { reply_comment: 'CUSTOM_IG_ACTION' } }),
+    db: fakeDb(),
+  });
+  assert.equal(gateway.calls[0].slug, 'CUSTOM_IG_ACTION');
+});
+
+test('IG: COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION wired through resolveComposioConfig env chain', async () => {
+  // Exercises the actual env-var-name → actionEnvKey('instagram', 'reply_comment')
+  // → 'COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION' → slug chain without any network call.
+  const { resolveComposioConfig } = await import('@/backend/integrations/composio/composio-config');
+  const env = {
+    COMPOSIO_API_KEY: 'test-key-for-env-chain-test',
+    COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION: 'MY_CUSTOM_IG_REPLY_SLUG',
+  } as unknown as NodeJS.ProcessEnv;
+  const config = resolveComposioConfig(env);
+  assert.ok(config, 'resolveComposioConfig must return a config when API key is set');
+  const slug = config.actionSlugFor('instagram', 'reply_comment');
+  assert.equal(slug, 'MY_CUSTOM_IG_REPLY_SLUG',
+    'COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION must override the default IG reply slug');
+});
+
+test('IG: empty reply text is rejected before any tool call', async () => {
+  const gateway = fakeGateway();
+  await assert.rejects(
+    () => replyToCommentViaComposio({ ...igReq, message: '   ' }, {}, { gateway, config: fakeConfig({ actions: {} }), db: fakeDb() }),
     (err: unknown) => err instanceof MetaPublishError && err.code === 'missing_reply_text',
   );
   assert.equal(gateway.calls.length, 0);


### PR DESCRIPTION
Closes #694

Admits Instagram to the Composio native comment-reply seam — the last IG gate of the production golden journey. Scoped to `backend/integrations/composio/composio-reply.ts` (+ tests).

## What changed
- `shouldUseComposioReply` now admits `instagram` (composio-gated, same as facebook): `(platform === 'facebook' || platform === 'instagram') && effectivePublishProvider === 'composio'`.
- `replyToCommentViaComposio` IG branch uses `INSTAGRAM_POST_IG_COMMENT_REPLIES` with args `{ ig_comment_id: req.externalCommentId, message }`. Env-overridable via `COMPOSIO_INSTAGRAM_REPLY_COMMENT_ACTION`.
- New default slug constant `DEFAULT_IG_CREATE_COMMENT_REPLY_SLUG`.

## Review evidence
- **FB byte-identical:** IG is a NEW arm in the `slug`/`toolArgs` ternaries, not a modification of FB. Facebook still resolves `DEFAULT_FB_CREATE_COMMENT_SLUG` + `{ object_id: replyTargetCommentId(...), message }` (trailing-segment strip for the #621 compound-id misparse). x/reddit/linkedin/youtube reply path (`replyToCommentViaComposioForPlatform`) untouched.
- **IG inherits the outcome-unknown / rollback taxonomy:** IG flows through the identical post-args classification — `successful:false` → `composio_reply_failed` (definitely-never-posted, rollback-safe); 2xx with no reply id → `composio_reply_missing_id` (outcome-unknown, never auto-retried); transport throw → `composio_reply_unconfirmed` (outcome-unknown). No IG-specific divergence; no reply-dup or wrong-rollback path.
- **IG id passthrough:** raw stored `external_comment_id` → `ig_comment_id` with NO compound stripping (IG ids are not `{post}_{comment}` compound, unlike FB). Test proves no stripping + no stray `object_id`.
- **Direct-Meta fallback:** under `PUBLISH_PROVIDER=direct_meta` (non-prod), `shouldUseComposioReply('instagram')` is false → handler routes to the unchanged direct `replyToComment` (`/{ig-comment-id}/replies`). Mirrors FB.
- **Gated by `ARIES_NATIVE_REPLY_ENABLED`** (unchanged); tenant-isolated claim + connection load (`WHERE id=$1 AND tenant_id=$2`); frontend-safe errors (no token/raw-SDK leak); banned patterns clean; no Promise.all / DB fan-out.

## Tests
- `tests/composio-reply.test.ts`: IG success (`{ig_comment_id, message}` + slug), no-strip passthrough, nested id, all three taxonomy classes, env override (direct + via `resolveComposioConfig` chain), empty-text reject, FB golden unchanged — 26/26.
- `npm run verify` green; banned-patterns clean; `guardrails:agent` passed (rebased onto latest master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoiY71TzLCK6FnwKourTW2