### PR TITLE
fix(insights): honest per-post Comments/Shares columns — gate on capability

### DIFF
--- a/backend/insights/platforms/capabilities.ts
+++ b/backend/insights/platforms/capabilities.ts
@@ -17,6 +17,7 @@ export type PlatformCapability =
   | 'post_list'               // list of published posts / videos
   | 'post_daily_metrics'      // per-post daily breakdowns
   | 'post_view_count'         // per-post view/impression count (youtube, instagram, facebook only)
+  | 'post_share_count'        // per-post share count (facebook shares, instagram shares, x retweet_count only)
   | 'comments'                // per-post comment fetch
   | 'audience_demographics'   // age/gender/country breakdown
   | 'watch_time'              // cumulative watch-time minutes
@@ -41,6 +42,7 @@ export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapabil
     'post_list',
     'post_daily_metrics',
     'post_view_count',
+    'post_share_count',
     'comments',
     'audience_demographics',
     'reach_impressions',
@@ -51,6 +53,7 @@ export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapabil
     'post_list',
     'post_daily_metrics',
     'post_view_count',
+    'post_share_count',
     'comments',
     'reach_impressions',
   ]),
@@ -61,6 +64,7 @@ export const PLATFORM_CAPABILITIES: Record<Platform, ReadonlySet<PlatformCapabil
   x: new Set<PlatformCapability>([
     'post_list',
     'post_daily_metrics',
+    'post_share_count',
     'comments',
   ]),
   // Reddit: per-post engagement (score/num_comments/upvote_ratio via

--- a/frontend/aries-v1/analytics-screen.tsx
+++ b/frontend/aries-v1/analytics-screen.tsx
@@ -72,6 +72,8 @@ export default function AriesAnalyticsScreen({
 
   const accountMetricsSupported = platformSupports(platform, 'account_daily_metrics');
   const postViewsSupported = platformSupports(platform, 'post_view_count');
+  const commentsSupported = platformSupports(platform, 'comments');
+  const postSharesSupported = platformSupports(platform, 'post_share_count');
 
   const label = PLATFORM_LABELS[platform];
 
@@ -90,8 +92,8 @@ export default function AriesAnalyticsScreen({
                 <th className="py-3 pr-4 font-semibold">Published</th>
                 {postViewsSupported && <th className="py-3 pr-4 text-right font-semibold">Views</th>}
                 <th className="py-3 pr-4 text-right font-semibold">Likes</th>
-                <th className="py-3 pr-4 text-right font-semibold">Comments</th>
-                <th className="py-3 text-right font-semibold">Shares</th>
+                {commentsSupported && <th className="py-3 pr-4 text-right font-semibold">Comments</th>}
+                {postSharesSupported && <th className="py-3 text-right font-semibold">Shares</th>}
               </tr>
             </thead>
             <tbody>
@@ -105,8 +107,8 @@ export default function AriesAnalyticsScreen({
                     <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalViews)}</td>
                   )}
                   <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalLikes)}</td>
-                  <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalComments)}</td>
-                  <td className="py-3 text-right">{formatNumber(post.metrics.totalShares)}</td>
+                  {commentsSupported && <td className="py-3 pr-4 text-right">{formatNumber(post.metrics.totalComments)}</td>}
+                  {postSharesSupported && <td className="py-3 text-right">{formatNumber(post.metrics.totalShares)}</td>}
                 </tr>
               ))}
             </tbody>

--- a/tests/insights-dashboard-ui.test.ts
+++ b/tests/insights-dashboard-ui.test.ts
@@ -209,6 +209,72 @@ test('comments screen has honest LinkedIn subtitle that does not promise Aries r
   assert.match(commentsScreen, /Comments on your Facebook posts[\s\S]{0,200}Reply directly from\s+Aries/);
 });
 
+// ─── #687 honest per-post Comments/Shares column gating ─────────────────────
+
+test('analytics screen derives commentsSupported and postSharesSupported from capabilities (#687)', () => {
+  // Both capability checks must appear in the source — they drive the column gates below.
+  assert.match(analyticsScreen, /platformSupports\(platform,\s*'comments'\)/);
+  assert.match(analyticsScreen, /platformSupports\(platform,\s*'post_share_count'\)/);
+  // Both derived booleans must be referenced in the template (not dead code).
+  assert.match(analyticsScreen, /commentsSupported/);
+  assert.match(analyticsScreen, /postSharesSupported/);
+});
+
+test('analytics screen gates Comments <th>/<td> on commentsSupported and Shares <th>/<td> on postSharesSupported (#687)', () => {
+  // Comments header cell is wrapped in a commentsSupported conditional — mirroring #684 Views gate.
+  assert.match(analyticsScreen, /commentsSupported && <th[^>]*>Comments<\/th>/);
+  // Shares header cell is wrapped in a postSharesSupported conditional.
+  assert.match(analyticsScreen, /postSharesSupported && <th[^>]*>Shares<\/th>/);
+  // Comments data cell is also gated (commentsSupported precedes totalComments in the template).
+  assert.match(analyticsScreen, /commentsSupported[\s\S]{0,300}totalComments/);
+  // Shares data cell is also gated (postSharesSupported precedes totalShares in the template).
+  assert.match(analyticsScreen, /postSharesSupported[\s\S]{0,300}totalShares/);
+});
+
+test('analytics screen Likes column is unconditional — not gated on any capability (#687)', () => {
+  // The Likes <th> is present and unconditional.
+  assert.match(analyticsScreen, /<th[^>]*>Likes<\/th>/);
+  // It must NOT be preceded by any Supported guard on the same JSX expression.
+  assert.doesNotMatch(analyticsScreen, /\w+Supported\s*&&\s*<th[^>]*>Likes<\/th>/);
+  // totalLikes is referenced (the <td> always renders).
+  assert.match(analyticsScreen, /totalLikes/);
+  // The Likes <td> is not gated — no Supported gate immediately before the td bearing totalLikes.
+  assert.doesNotMatch(analyticsScreen, /\w+Supported\s*&&\s*<td[\s\S]{0,80}totalLikes/);
+});
+
+test('capabilities.ts: post_share_count TRUE for facebook/instagram/x, FALSE for reddit/youtube/linkedin; comments FALSE for linkedin only (#687)', () => {
+  // Platforms that expose a real per-post share count.
+  assert.equal(platformSupports('facebook', 'post_share_count'), true, 'facebook should support post_share_count');
+  assert.equal(platformSupports('instagram', 'post_share_count'), true, 'instagram should support post_share_count');
+  assert.equal(platformSupports('x', 'post_share_count'), true, 'x should support post_share_count');
+  // Platforms that do NOT expose a per-post share count (no fabricated zeros).
+  assert.equal(platformSupports('reddit', 'post_share_count'), false, 'reddit must NOT support post_share_count');
+  assert.equal(platformSupports('youtube', 'post_share_count'), false, 'youtube must NOT support post_share_count');
+  assert.equal(platformSupports('linkedin', 'post_share_count'), false, 'linkedin must NOT support post_share_count');
+  // Existing #648 invariant: comments present for all except linkedin.
+  assert.equal(platformSupports('facebook', 'comments'), true, 'facebook should support comments');
+  assert.equal(platformSupports('instagram', 'comments'), true, 'instagram should support comments');
+  assert.equal(platformSupports('x', 'comments'), true, 'x should support comments');
+  assert.equal(platformSupports('reddit', 'comments'), true, 'reddit should support comments');
+  assert.equal(platformSupports('youtube', 'comments'), true, 'youtube should support comments');
+  assert.equal(platformSupports('linkedin', 'comments'), false, 'linkedin must NOT support comments');
+});
+
+test('golden: facebook and instagram still render both Comments and Shares columns after #687 (byte-identical)', () => {
+  // FB and IG both have 'comments' AND 'post_share_count' — so commentsSupported and
+  // postSharesSupported are true for those platforms and neither column is hidden.
+  assert.equal(platformSupports('facebook', 'comments'), true, 'facebook: comments must still be supported');
+  assert.equal(platformSupports('facebook', 'post_share_count'), true, 'facebook: post_share_count must still be supported');
+  assert.equal(platformSupports('instagram', 'comments'), true, 'instagram: comments must still be supported');
+  assert.equal(platformSupports('instagram', 'post_share_count'), true, 'instagram: post_share_count must still be supported');
+  // The conditional expressions that produce the th and td cells are present in the template —
+  // when both booleans are true (FB/IG) those cells are rendered, so the live render is unchanged.
+  assert.match(analyticsScreen, /commentsSupported && <th[^>]*>Comments<\/th>/);
+  assert.match(analyticsScreen, /postSharesSupported && <th[^>]*>Shares<\/th>/);
+  assert.match(analyticsScreen, /commentsSupported[\s\S]{0,300}totalComments/);
+  assert.match(analyticsScreen, /postSharesSupported[\s\S]{0,300}totalShares/);
+});
+
 test('capabilities.ts: post_view_count present for youtube/instagram/facebook, absent for x/reddit/linkedin (#684)', () => {
   // Platforms that expose per-post view/impression counts.
   assert.equal(platformSupports('youtube', 'post_view_count'), true, 'youtube should support post_view_count');


### PR DESCRIPTION
Closes #687

Extends the #684 capability-gating pattern to the per-post performance table's **Comments** and **Shares** columns, which were rendered unconditionally and therefore fabricated a `0` for platforms that expose no real value (Brendan's never-fabricate rule, must-fix-before-activation).

## What changed
- `backend/insights/platforms/capabilities.ts`: add a new additive `'post_share_count'` capability, granted only to **facebook, instagram, x** — verified against the adapters (FB `shares.count`, IG `GET_IG_MEDIA_INSIGHTS` `shares`, X `retweet_count`). reddit/youtube/linkedin hardcode `shares: 0`, so they are omitted.
- `frontend/aries-v1/analytics-screen.tsx`: Comments `<th>`/`<td>` gated on `platformSupports(platform,'comments')`; Shares `<th>`/`<td>` gated on `platformSupports(platform,'post_share_count')`. Likes stay ungated (every platform has real likes). Header and body cells gate on the same boolean so columns stay aligned.

## Properties
- **FB/IG byte-identical:** facebook + instagram have BOTH `comments` and `post_share_count`, so both columns render exactly as before. Live prod tenants are FB/IG → no-regression.
- **Honest omission for unsupported platforms:** linkedin omits Comments (#648 invariant preserved) and Shares; reddit/youtube omit Shares; x keeps both (real `reply_count` + `retweet_count`). No fabricated zeros.
- **Ships dormant:** only changes column rendering for x/reddit/linkedin/youtube, all flag-off in prod.
- Additive union member — no rename, so no `=== '<old>'` audit owed. `platformSupports` is client-safe (capabilities uses `import type` from registry; registry has zero imports).

## Test evidence
Focused gate `tests/insights-dashboard-ui.test.ts` 20/20 (pre-fix baseline had 2 failures guarding the defect). `npm run verify` GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoiY71TzLCK6FnwKourTW2