### PR TITLE
chore(integrations): gate TikTok out of connect until Composio supports the journey

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -261,6 +261,9 @@ COMPOSIO_API_KEY=
 # unsupported_platform 400 as today. Flip to true once the X auth-config below
 # is provisioned in Composio.
 ARIES_X_ENABLED=false
+# TikTok connect rollout flag. Default OFF — gated out until Composio supports
+# TikTok comments/reply actions + the publish app completes Meta audit.
+ARIES_TIKTOK_ENABLED=false
 # Reddit publish rollout flag. Default OFF — ships the publish path dormant
 # (Reddit already CONNECTS via Composio; this flag gates publish only). When OFF,
 # a `reddit` schedule still 400s invalid_platforms and dispatch 400s

--- a/backend/integrations/providers/index.ts
+++ b/backend/integrations/providers/index.ts
@@ -15,6 +15,7 @@ export {
   parseFlag,
   isComposioEnabled,
   isXEnabled,
+  isTikTokEnabled,
   isRedditEnabled,
   isLinkedInEnabled,
   connectablePlatforms,

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -37,6 +37,17 @@ export function isXEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
+ * TikTok connect rollout flag. Default OFF — ships TikTok dormant because it
+ * cannot reach the 5-gate golden journey today: Composio has no TikTok
+ * comments/reply actions, public publish is audit-gated, and analytics is
+ * account-level only. Gate it out until Composio adds the missing actions and
+ * the publish app is audited. NEW flag — never reuse ARIES_X_ENABLED.
+ */
+export function isTikTokEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseFlag(env.ARIES_TIKTOK_ENABLED);
+}
+
+/**
  * YouTube rollout flag (#637 analytics, #638 comments, #636 publish). Default
  * OFF — ships the Composio-backed YouTube insights adapter AND the still→video
  * publish path dormant. YouTube already *connects* via Composio, so this flag
@@ -85,11 +96,16 @@ export function isLinkedInEnabled(env: NodeJS.ProcessEnv = process.env): boolean
  * chokepoint for flag-gated platforms: when `ARIES_X_ENABLED` is OFF, `'x'` is
  * filtered out everywhere (connect/capabilities/disconnect gate + the UI list),
  * so the platform is byte-for-byte invisible until the flag flips on.
+ * `ARIES_TIKTOK_ENABLED` gates `'tiktok'` the same way — dormant by default
+ * until Composio adds the missing comments/reply actions and publish is audited.
  */
 export function connectablePlatforms(
   env: NodeJS.ProcessEnv = process.env,
 ): readonly IntegrationPlatform[] {
-  return isXEnabled(env) ? INTEGRATION_PLATFORMS : INTEGRATION_PLATFORMS.filter((p) => p !== 'x');
+  const excluded = new Set<IntegrationPlatform>();
+  if (!isXEnabled(env)) excluded.add('x');
+  if (!isTikTokEnabled(env)) excluded.add('tiktok');
+  return INTEGRATION_PLATFORMS.filter((p) => !excluded.has(p));
 }
 
 export function publishProviderSelector(env: NodeJS.ProcessEnv = process.env): ProviderSelector {
@@ -118,10 +134,10 @@ export function composioAuthConfigId(
   const specific = perPlatform[platform]?.trim();
   if (specific) return specific;
   // reddit + x are toolkit-specific (reddit provisions Composio-managed auth;
-  // x needs its own custom OAuth app). Neither may inherit
-  // COMPOSIO_DEFAULT_AUTH_CONFIG_ID (typically a Meta-family config) or connect
-  // would target the wrong toolkit (#669).
-  if (platform === 'reddit' || platform === 'x') return null;
+  // x needs its own custom OAuth app). tiktok is gated-out/dormant and must
+  // never inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID (typically a Meta-family config)
+  // or a future accidental connect attempt would target the wrong toolkit (#690).
+  if (platform === 'reddit' || platform === 'x' || platform === 'tiktok') return null;
   const fallback = env.COMPOSIO_DEFAULT_AUTH_CONFIG_ID?.trim();
   return fallback || null;
 }

--- a/backend/integrations/publish-dispatch.ts
+++ b/backend/integrations/publish-dispatch.ts
@@ -37,21 +37,22 @@ import { isComposioEnabled, type ProviderSelector } from './providers/integratio
 import type { IntegrationPlatform, PublishResult } from './providers/types';
 import { publishNeverReachedPlatform } from './publish-outcome';
 
-function metaPlatform(provider: string): IntegrationPlatform {
+export function metaPlatform(provider: string): IntegrationPlatform {
   // Map the dispatch request's provider string to the integration platform the
   // provider seam services. X (Twitter), Reddit, LinkedIn and YouTube are each
-  // their own Composio-only platform; Instagram maps to instagram; everything
-  // else maps to facebook (the direct route's two-way split). Without the
-  // explicit cases, 'x'/'reddit'/'linkedin'/'youtube' would fall through to
-  // 'facebook' and be sent to a Facebook Page. None reaches the direct_meta fast
-  // path (normalizeMetaProvider throws a terminal 400), and
-  // DirectMetaProvider.supports() is false for them, so they can never post to FB.
+  // their own Composio-only platform; Instagram maps to instagram; tiktok now
+  // throws explicitly (gated out — no Composio publish path) so it never
+  // silently falls through to 'facebook' and posts to a Facebook Page (#690);
+  // everything else maps to facebook (the direct route's two-way split).
   const normalized = provider.trim().toLowerCase();
   if (normalized === 'x') return 'x';
   if (normalized === 'reddit') return 'reddit';
   if (normalized === 'linkedin') return 'linkedin';
   if (normalized === 'youtube') return 'youtube';
   if (normalized === 'instagram') return 'instagram';
+  if (normalized === 'tiktok') {
+    throw new Error('tiktok is not a supported publish platform (gated out; no Composio publish path)');
+  }
   return 'facebook';
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,9 @@ services:
       # X (Twitter) connect rollout flag — default OFF ships the platform dormant
       # (card hidden; connect/capabilities 400 unsupported_platform as today).
       ARIES_X_ENABLED: ${ARIES_X_ENABLED:-false}
+      # TikTok connect rollout flag — default OFF ships TikTok dormant (gated out;
+      # no Composio comments/reply + publish audit-gated). Pair with .env.
+      ARIES_TIKTOK_ENABLED: ${ARIES_TIKTOK_ENABLED:-false}
       # Reddit publish rollout flag — default OFF ships the publish path dormant
       # (Reddit already connects; this gates publish only). When OFF a reddit
       # schedule/dispatch is rejected exactly as today.

--- a/tests/composio-tiktok-connect.test.ts
+++ b/tests/composio-tiktok-connect.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Regression coverage for #690: TikTok gated out of Composio connect by
+ * ARIES_TIKTOK_ENABLED (default OFF).
+ *
+ * TikTok cannot complete the 5-gate golden journey today: Composio has no
+ * TikTok comments/reply actions, public publish is audit-gated, and analytics
+ * is account-level only. The platform is fully dormant until those gaps close.
+ *
+ * Failure modes locked:
+ *  - Flag OFF: 'tiktok' absent from connectablePlatforms, platformOr400 returns
+ *    400 unsupported_platform, list endpoint returns 6 slots (no x, no tiktok).
+ *  - Flag ON:  'tiktok' present in connectablePlatforms, platformOr400 passes
+ *    through, list endpoint returns 7 slots including tiktok (x still dormant).
+ *  - Auth-config #690: tiktok must NOT inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID
+ *    (a Meta-family config); explicit COMPOSIO_TIKTOK_AUTH_CONFIG_ID still works.
+ *  - metaPlatform #690 defense-in-depth: metaPlatform('tiktok') must throw so
+ *    a dormant tiktok post can never silently dispatch to facebook.
+ *  - Regression guard: the 6 still-connectable platforms remain byte-identical.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  connectablePlatforms,
+  isTikTokEnabled,
+  composioAuthConfigId,
+  isIntegrationPlatform,
+} from '@/backend/integrations/providers';
+import { TOOLKIT_SLUG } from '@/backend/integrations/composio/composio-config';
+import {
+  handleComposioConnect,
+  handleComposioList,
+} from '@/app/api/integrations/composio/handlers';
+import { metaPlatform } from '@/backend/integrations/publish-dispatch';
+import type { TenantRole } from '@/lib/tenant-context';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal NodeJS.ProcessEnv from a plain object. */
+const mkEnv = (o: Record<string, string>): NodeJS.ProcessEnv =>
+  o as unknown as NodeJS.ProcessEnv;
+
+/**
+ * Set/restore a subset of process.env keys around an async callback.
+ * Pass `undefined` as the value to delete the key during the callback.
+ */
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prev = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(vars)) {
+    prev.set(k, process.env[k]);
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  return fn().finally(() => {
+    for (const [k, original] of prev) {
+      if (original === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = original;
+      }
+    }
+  });
+}
+
+/**
+ * Fake tenant loader — matches the TenantContextLoader signature used by the
+ * handlers. Composio tests in this file do not exercise auth logic, so any
+ * valid tenant shape is sufficient.
+ */
+const tenantLoader = async () => ({
+  userId: 'user_1',
+  tenantId: '1',
+  tenantSlug: 'test-tenant',
+  role: 'tenant_admin' as TenantRole,
+});
+
+// ── 1. Dormancy: flag OFF / unset ────────────────────────────────────────────
+
+test('connectablePlatforms flag-OFF: does not include tiktok', () => {
+  const platforms = connectablePlatforms(mkEnv({}));
+  assert.ok(
+    !platforms.includes('tiktok'),
+    "'tiktok' must not be in connectablePlatforms when ARIES_TIKTOK_ENABLED is unset",
+  );
+  assert.equal(platforms.length, 6, 'exactly 6 platforms when flag is off (no x, no tiktok)');
+});
+
+test('isTikTokEnabled: returns false when ARIES_TIKTOK_ENABLED is unset', () => {
+  assert.equal(isTikTokEnabled(mkEnv({})), false);
+});
+
+test('isTikTokEnabled: returns false for non-truthy values', () => {
+  for (const v of ['0', 'false', 'no', 'off', '']) {
+    assert.equal(
+      isTikTokEnabled(mkEnv({ ARIES_TIKTOK_ENABLED: v })),
+      false,
+      `isTikTokEnabled must be false for ARIES_TIKTOK_ENABLED=${JSON.stringify(v)}`,
+    );
+  }
+});
+
+test('handleComposioConnect tiktok flag-OFF: returns 400 unsupported_platform', async () => {
+  // platformOr400 is called before tenant loading; no loader needed for flag-OFF.
+  await withEnv({ ARIES_TIKTOK_ENABLED: undefined }, async () => {
+    const req = new Request(
+      'https://aries.example.com/api/integrations/composio/tiktok/connect',
+      {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+    const response = await handleComposioConnect(req, 'tiktok');
+    const body = (await response.json()) as { reason: string; message: string };
+    assert.equal(response.status, 400);
+    assert.equal(body.reason, 'unsupported_platform');
+  });
+});
+
+test('handleComposioList flag-OFF: response connections do not include tiktok', async () => {
+  await withEnv({ ARIES_TIKTOK_ENABLED: undefined }, async () => {
+    const response = await handleComposioList(tenantLoader);
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      connections: Array<{ platform: string }>;
+    };
+    const platforms = body.connections.map((c) => c.platform);
+    assert.ok(
+      !platforms.includes('tiktok'),
+      "tiktok must not appear in connection list when ARIES_TIKTOK_ENABLED is off",
+    );
+    assert.equal(platforms.length, 6, '6 connection slots when flag is off (no x, no tiktok)');
+  });
+});
+
+// ── 2. Fix proof: flag ON ────────────────────────────────────────────────────
+
+test('connectablePlatforms flag-ON: includes tiktok (7 total, x still dormant)', () => {
+  // Only ARIES_TIKTOK_ENABLED is set; X stays off → 7 platforms total.
+  const platforms = connectablePlatforms(mkEnv({ ARIES_TIKTOK_ENABLED: '1' }));
+  assert.ok(
+    platforms.includes('tiktok'),
+    "'tiktok' must be in connectablePlatforms when ARIES_TIKTOK_ENABLED=1",
+  );
+  assert.equal(platforms.length, 7, '7 platforms when flag is on (x still dormant)');
+});
+
+test('isTikTokEnabled: true for all canonical truthy values', () => {
+  for (const v of ['1', 'true', 'yes', 'on']) {
+    assert.equal(
+      isTikTokEnabled(mkEnv({ ARIES_TIKTOK_ENABLED: v })),
+      true,
+      `isTikTokEnabled must be true for ARIES_TIKTOK_ENABLED=${v}`,
+    );
+  }
+});
+
+test('handleComposioConnect tiktok flag-ON: passes the platform gate (no 400 unsupported_platform)', async () => {
+  // With the flag ON, platformOr400 lets 'tiktok' through. Without Composio
+  // configured (COMPOSIO_ENABLED unset), the handler returns 409 composio_disabled
+  // — but the point is it must NOT return 400 unsupported_platform.
+  await withEnv({ ARIES_TIKTOK_ENABLED: '1' }, async () => {
+    const req = new Request(
+      'https://aries.example.com/api/integrations/composio/tiktok/connect',
+      {
+        method: 'POST',
+        body: JSON.stringify({}),
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+    const response = await handleComposioConnect(req, 'tiktok', tenantLoader);
+    const body = (await response.json()) as { reason?: string };
+    assert.notEqual(
+      response.status,
+      400,
+      'status must not be 400 when tiktok is enabled',
+    );
+    assert.notEqual(
+      body.reason,
+      'unsupported_platform',
+      'reason must not be unsupported_platform when tiktok is enabled',
+    );
+  });
+});
+
+test('handleComposioList flag-ON: response connections include tiktok (7 slots, x still dormant)', async () => {
+  // Only ARIES_TIKTOK_ENABLED is set; X stays off → 7 slots total.
+  await withEnv({ ARIES_TIKTOK_ENABLED: '1' }, async () => {
+    const response = await handleComposioList(tenantLoader);
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      connections: Array<{ platform: string }>;
+    };
+    const platforms = body.connections.map((c) => c.platform);
+    assert.ok(
+      platforms.includes('tiktok'),
+      "tiktok must appear in connection list when ARIES_TIKTOK_ENABLED=1",
+    );
+    assert.equal(platforms.length, 7, '7 connection slots when flag is on (x still dormant)');
+  });
+});
+
+// ── 3. Config wiring ─────────────────────────────────────────────────────────
+
+test('TOOLKIT_SLUG.tiktok === tiktok (Composio toolkit name for TikTok)', () => {
+  assert.equal(TOOLKIT_SLUG.tiktok, 'tiktok');
+});
+
+test('composioAuthConfigId tiktok: reads COMPOSIO_TIKTOK_AUTH_CONFIG_ID when set', () => {
+  assert.equal(
+    composioAuthConfigId('tiktok', mkEnv({ COMPOSIO_TIKTOK_AUTH_CONFIG_ID: 'ac_tt' })),
+    'ac_tt',
+  );
+});
+
+test('composioAuthConfigId tiktok: returns null when COMPOSIO_TIKTOK_AUTH_CONFIG_ID is unset', () => {
+  assert.equal(composioAuthConfigId('tiktok', mkEnv({})), null);
+});
+
+test('composioAuthConfigId tiktok: returns null when only COMPOSIO_DEFAULT_AUTH_CONFIG_ID is set (no default fallback, #690)', () => {
+  // tiktok must NOT inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID — that is typically
+  // a Meta-family config and would route a TikTok connection through the wrong
+  // toolkit if the platform is ever accidentally unblocked (#690 defense-in-depth).
+  assert.equal(
+    composioAuthConfigId('tiktok', mkEnv({ COMPOSIO_DEFAULT_AUTH_CONFIG_ID: 'ac_default' })),
+    null,
+  );
+});
+
+// ── 4. metaPlatform #690 defense-in-depth ────────────────────────────────────
+
+test('metaPlatform tiktok: throws (gated out — no Composio publish path, #690)', () => {
+  // A dormant tiktok post must never silently fall through to facebook in the
+  // publish dispatch seam. metaPlatform('tiktok') is the explicit throw guard.
+  assert.throws(
+    () => metaPlatform('tiktok'),
+    /tiktok is not a supported publish platform/,
+  );
+});
+
+test('metaPlatform sanity: facebook and instagram still map correctly', () => {
+  assert.equal(metaPlatform('facebook'), 'facebook');
+  assert.equal(metaPlatform('instagram'), 'instagram');
+});
+
+// ── 5. Regression guard: the 6 still-connectable platforms remain byte-identical ──
+
+test('connectablePlatforms flag-OFF: all 6 still-connectable platforms present (no x, no tiktok)', () => {
+  const off = connectablePlatforms(mkEnv({}));
+  const original6 = [
+    'facebook',
+    'instagram',
+    'meta_ads',
+    'youtube',
+    'linkedin',
+    'reddit',
+  ] as const;
+  for (const p of original6) {
+    assert.ok(off.includes(p), `${p} must be present with flag OFF`);
+  }
+});
+
+test('connectablePlatforms flag-ON: all 7 platforms present (6 base + tiktok, x still dormant)', () => {
+  const on = connectablePlatforms(mkEnv({ ARIES_TIKTOK_ENABLED: '1' }));
+  const all7 = [
+    'facebook',
+    'instagram',
+    'meta_ads',
+    'tiktok',
+    'youtube',
+    'linkedin',
+    'reddit',
+  ] as const;
+  for (const p of all7) {
+    assert.ok(on.includes(p), `${p} must be present with flag ON`);
+  }
+});
+
+test('isIntegrationPlatform tiktok: always true regardless of flag (pure type guard)', () => {
+  // The type guard checks INTEGRATION_PLATFORMS array membership, not the env flag.
+  // The dormancy chokepoint is connectablePlatforms(), not this predicate.
+  assert.equal(isIntegrationPlatform('tiktok'), true);
+});

--- a/tests/composio-x-connect.test.ts
+++ b/tests/composio-x-connect.test.ts
@@ -4,11 +4,11 @@
  *
  * Failure modes locked:
  *  - Flag OFF: 'x' absent from connectablePlatforms, platformOr400 returns 400
- *    unsupported_platform, list endpoint returns 7 slots (no x).
+ *    unsupported_platform, list endpoint returns 6 slots (no x, no tiktok).
  *  - Flag ON:  'x' present in connectablePlatforms, platformOr400 passes through,
- *    list endpoint returns 8 slots including x.
+ *    list endpoint returns 7 slots including x (tiktok still dormant).
  *  - Config: TOOLKIT_SLUG.x === 'twitter'; COMPOSIO_X_AUTH_CONFIG_ID read correctly.
- *  - Regression guard: all 7 original platforms remain byte-identical.
+ *  - Regression guard: all 6 still-connectable platforms remain byte-identical.
  */
 
 import { test } from 'node:test';
@@ -81,7 +81,7 @@ test('connectablePlatforms flag-OFF: does not include x', () => {
     !platforms.includes('x'),
     "'x' must not be in connectablePlatforms when ARIES_X_ENABLED is unset",
   );
-  assert.equal(platforms.length, 7, 'exactly 7 platforms when flag is off');
+  assert.equal(platforms.length, 6, 'exactly 6 platforms when flag is off (no x, no tiktok)');
 });
 
 test('isXEnabled: returns false when ARIES_X_ENABLED is unset', () => {
@@ -128,19 +128,19 @@ test('handleComposioList flag-OFF: response connections do not include x', async
       !platforms.includes('x'),
       "x must not appear in connection list when ARIES_X_ENABLED is off",
     );
-    assert.equal(platforms.length, 7, '7 connection slots when flag is off');
+    assert.equal(platforms.length, 6, '6 connection slots when flag is off (no x, no tiktok)');
   });
 });
 
 // ── 2. Fix proof: flag ON ────────────────────────────────────────────────────
 
-test('connectablePlatforms flag-ON: includes x (8 total)', () => {
+test('connectablePlatforms flag-ON: includes x (7 total, tiktok still dormant)', () => {
   const platforms = connectablePlatforms(mkEnv({ ARIES_X_ENABLED: '1' }));
   assert.ok(
     platforms.includes('x'),
     "'x' must be in connectablePlatforms when ARIES_X_ENABLED=1",
   );
-  assert.equal(platforms.length, 8, '8 platforms when flag is on');
+  assert.equal(platforms.length, 7, '7 platforms when flag is on (tiktok still dormant)');
 });
 
 test('isXEnabled: true for all canonical truthy values', () => {
@@ -181,7 +181,7 @@ test('handleComposioConnect x flag-ON: passes the platform gate (no 400 unsuppor
   });
 });
 
-test('handleComposioList flag-ON: response connections include x (8 slots)', async () => {
+test('handleComposioList flag-ON: response connections include x (7 slots, tiktok still dormant)', async () => {
   await withEnv({ ARIES_X_ENABLED: '1' }, async () => {
     const response = await handleComposioList(tenantLoader);
     assert.equal(response.status, 200);
@@ -193,7 +193,7 @@ test('handleComposioList flag-ON: response connections include x (8 slots)', asy
       platforms.includes('x'),
       "x must appear in connection list when ARIES_X_ENABLED=1",
     );
-    assert.equal(platforms.length, 8, '8 connection slots when flag is on');
+    assert.equal(platforms.length, 7, '7 connection slots when flag is on (tiktok still dormant)');
   });
 });
 
@@ -239,9 +239,10 @@ test('composioAuthConfigId reddit: returns null when only COMPOSIO_DEFAULT_AUTH_
 });
 
 test('composioAuthConfigId regression: managed platforms still fall back to COMPOSIO_DEFAULT_AUTH_CONFIG_ID (#669)', () => {
-  // The exclusion is narrow — only reddit + x are excluded from the DEFAULT
+  // The exclusion is narrow — only reddit + x + tiktok are excluded from the DEFAULT
   // fallback. All other platforms (facebook, instagram, meta_ads, youtube,
-  // linkedin, tiktok) must still inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID.
+  // linkedin) must still inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID.
+  // tiktok→null is asserted in composio-tiktok-connect.test.ts (#690).
   const env = mkEnv({ COMPOSIO_DEFAULT_AUTH_CONFIG_ID: 'ac_default' });
   const managed = [
     'facebook',
@@ -249,7 +250,6 @@ test('composioAuthConfigId regression: managed platforms still fall back to COMP
     'meta_ads',
     'youtube',
     'linkedin',
-    'tiktok',
   ] as const;
   for (const platform of managed) {
     assert.equal(
@@ -260,37 +260,35 @@ test('composioAuthConfigId regression: managed platforms still fall back to COMP
   }
 });
 
-// ── 4. Regression guard: the other 7 platforms remain byte-identical ─────────
+// ── 4. Regression guard: the other 6 still-connectable platforms remain byte-identical ──
 
-test('connectablePlatforms flag-OFF: all 7 original platforms still present', () => {
+test('connectablePlatforms flag-OFF: all 6 still-connectable platforms present (no x, no tiktok)', () => {
   const off = connectablePlatforms(mkEnv({}));
-  const original7 = [
+  const original6 = [
     'facebook',
     'instagram',
     'meta_ads',
-    'tiktok',
     'youtube',
     'linkedin',
     'reddit',
   ] as const;
-  for (const p of original7) {
+  for (const p of original6) {
     assert.ok(off.includes(p), `${p} must be present with flag OFF`);
   }
 });
 
-test('connectablePlatforms flag-ON: all 8 platforms present (original 7 + x)', () => {
+test('connectablePlatforms flag-ON: all 7 platforms present (6 base + x, tiktok still dormant)', () => {
   const on = connectablePlatforms(mkEnv({ ARIES_X_ENABLED: '1' }));
-  const all8 = [
+  const all7 = [
     'facebook',
     'instagram',
     'meta_ads',
-    'tiktok',
     'youtube',
     'linkedin',
     'reddit',
     'x',
   ] as const;
-  for (const p of all8) {
+  for (const p of all7) {
     assert.ok(on.includes(p), `${p} must be present with flag ON`);
   }
 });


### PR DESCRIPTION
Closes #690

## What changed
Ships TikTok dormant behind a new `ARIES_TIKTOK_ENABLED` flag (default OFF), mirroring the existing X connect chokepoint, plus the #690 `metaPlatform` hardening. No behavior change for the live platforms — this ships dormant.

### (a) TikTok gated out of connect (`ARIES_TIKTOK_ENABLED`, default OFF)
TikTok cannot reach the 5-gate production golden journey today: Composio has no TikTok comments/reply actions, public publish is audit-gated, and analytics is account-level only. Rather than expose a connect card that dead-ends, TikTok is gated out the same way X is:
- New `isTikTokEnabled(env)` (default OFF), mirroring `isXEnabled`.
- `connectablePlatforms` now filters BOTH `'x'` and `'tiktok'` via an exclusion `Set` — X semantics are byte-identical (dropped unless `isXEnabled`), tiktok dropped unless `isTikTokEnabled`, nothing else changes. The other 6 platforms (facebook, instagram, meta_ads, youtube, linkedin, reddit) are untouched.
- Flag OFF (default): `connectablePlatforms` returns 6 slots, connect/list/capabilities return `400 unsupported_platform`, the card is invisible.

### (b) #690: `metaPlatform` hardening + no default auth-config inheritance
- `metaPlatform` is now exported and **throws** explicitly on provider `'tiktok'` instead of silently falling through to `'facebook'` (which would post TikTok content to a Facebook Page). Defense-in-depth: no live caller passes `'tiktok'` to `dispatchPublish` today — the scheduled-dispatch route allowlists tiktok out (`unsupported_provider`) before dispatch, and `app/api/publish/dispatch` only calls `dispatchPublish` for `isMetaProvider` providers — so this throw is unreachable in normal flow and strictly safer than the old fallthrough.
- `composioAuthConfigId('tiktok')` now returns `null` (joins reddit + x) so tiktok can never inherit `COMPOSIO_DEFAULT_AUTH_CONFIG_ID` (a Meta-family config) and target the wrong toolkit on a future accidental connect attempt.

### Wiring + tests
- `.env.example` + `docker-compose.yml` (aries-app service only): `ARIES_TIKTOK_ENABLED` default false (two-place rule).
- `IntegrationPlatform` union is unchanged — `'tiktok'` was already a member, so no union-widening audit needed. The DB `connected_accounts` CHECK still covers tiktok (existing rows unaffected).
- `tests/composio-tiktok-connect.test.ts`: new, 18 tests (dormancy flag-OFF, fix-proof flag-ON, auth-config #690 null, `metaPlatform('tiktok')` throws, regression guard on the 6 still-connectable platforms).
- `tests/composio-x-connect.test.ts`: golden platform counts retightened (flag-OFF 7→6, X-ON 8→7), tiktok removed from the still-present + managed-auth-config sets.

## Test evidence
- `npm run verify` green (18 suites).
- Focused composio connect gate 37/37; reviewer re-ran the 6 platform-list-touching suites (68/68 pass) to confirm the `full-suite` gate stays green.
- `npm run validate:banned-patterns` clean; `npm run guardrails:agent` passed (unique diff).

## Residual risk
None for live platforms — ships dormant (flag default OFF, byte-identical behavior for the 6 connectable platforms and X's existing flag). Flip `ARIES_TIKTOK_ENABLED=1` only once Composio adds TikTok comments/reply actions and the publish app is audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoiY71TzLCK6FnwKourTW2