### PR TITLE
fix(integrations): reliable Composio connect reconcile (slug-agnostic match + surfaced errors)

### DIFF
--- a/app/api/integrations/composio/handlers.ts
+++ b/app/api/integrations/composio/handlers.ts
@@ -23,6 +23,7 @@ import {
   getAccountConnectionProvider,
   getCapabilityProvider,
   resolveIntegrationConfig,
+  type AccountConnectionProvider,
 } from '@/backend/integrations/providers';
 import { IntegrationError } from '@/backend/integrations/providers/errors';
 import { notConnectedAccount } from '@/backend/integrations/composio/connection-store';
@@ -122,32 +123,52 @@ export async function handleComposioConnect(
   }
 }
 
-export async function handleComposioList(loader?: TenantContextLoader): Promise<Response> {
+export async function handleComposioList(
+  loader?: TenantContextLoader,
+  provider: AccountConnectionProvider | null = getAccountConnectionProvider(),
+): Promise<Response> {
   const tenantResult = await loadTenantContextOrResponse(loader);
   if ('response' in tenantResult) return tenantResult.response;
   const { tenantId } = tenantResult.tenantContext;
 
   const config = resolveIntegrationConfig();
-  const provider = getAccountConnectionProvider();
 
   const externalUserId = externalUserIdFor(tenantId);
+  // Per-platform reconcile failures captured as frontend-safe advisories (#699).
+  // A Composio outage must NOT blank the whole screen, so these are recorded and
+  // surfaced per card rather than failing the request.
+  const reconcileErrors = new Map<IntegrationPlatform, string>();
   let stored: Awaited<ReturnType<NonNullable<typeof provider>['listConnections']>> = [];
   if (provider) {
     try {
       stored = await provider.listConnections(externalUserId, { tenantId });
       // Reconcile any pending connections: once the user has approved out-of-band,
       // this flips the stored row from `pending` to `connected` and records the
-      // connected-account id. Best-effort — a refresh failure leaves the row as-is.
+      // connected-account id. A refresh failure no longer silently leaves the row
+      // stranded as `pending` (#699) — we record a frontend-safe per-platform
+      // advisory and still re-read + return 200.
       const pending = stored.filter((c) => c.status === 'pending');
       if (pending.length > 0) {
         await Promise.all(
           pending.map((c) =>
-            provider.refreshConnectionStatus(externalUserId, c.platform, { tenantId }).catch(() => null),
+            provider
+              .refreshConnectionStatus(externalUserId, c.platform, { tenantId })
+              .then(() => undefined)
+              .catch((error: unknown) => {
+                reconcileErrors.set(
+                  c.platform,
+                  error instanceof IntegrationError
+                    ? error.message
+                    : "We couldn't confirm this connection. Please try again.",
+                );
+              }),
           ),
         );
         stored = await provider.listConnections(externalUserId, { tenantId });
       }
     } catch (error) {
+      // A genuine DB read failure (not a per-platform reconcile failure) — the
+      // list itself could not be read, so a 500 is correct.
       return errorResponse(error);
     }
   }
@@ -157,7 +178,11 @@ export async function handleComposioList(loader?: TenantContextLoader): Promise<
   const byPlatform = new Map(stored.map((c) => [c.platform, c]));
   const connections = connectablePlatforms().map((platform) => {
     const account = byPlatform.get(platform) ?? notConnectedAccount(tenantId, externalUserId, platform, 'composio');
-    return { ...account, prerequisites: platformPrerequisites(platform) };
+    return {
+      ...account,
+      prerequisites: platformPrerequisites(platform),
+      reconcileError: reconcileErrors.get(platform) ?? null,
+    };
   });
 
   return json({

--- a/backend/integrations/composio/composio-account-provider.ts
+++ b/backend/integrations/composio/composio-account-provider.ts
@@ -28,7 +28,7 @@ import {
   upsertConnection,
   type Queryable,
 } from './connection-store';
-import { ComposioConfigError } from './errors';
+import { ComposioConfigError, ComposioError } from './errors';
 import { isActiveStatus, mapComposioStatus } from './status-map';
 import { resolveFacebookManagedPage } from './facebook-page-resolver';
 import { resolveLinkedInAuthorUrn } from './linkedin-author-resolver';
@@ -164,18 +164,43 @@ export class ComposioAccountProvider implements AccountConnectionProvider {
         authConfigIds: authConfigId ? [authConfigId] : undefined,
       });
     } catch {
-      // Fall back to whatever we already have stored.
-      return getConnectionRow(tenantId, platform, this.db);
+      // Could not reach Composio to confirm the live status. Surface a
+      // frontend-safe error (NEVER the raw SDK text) instead of silently
+      // returning the stored `pending` row — that swallowing is exactly what
+      // stranded an ACTIVE connection as pending (#699). The caller turns this
+      // into a per-platform advisory and still returns 200.
+      throw new ComposioError(
+        'composio_reconcile_failed',
+        'Could not reach Composio to confirm this connection. Please try again.',
+        { status: 502, retryable: true },
+      );
     }
 
     // When several platforms share COMPOSIO_DEFAULT_AUTH_CONFIG_ID the
     // auth-config filter returns connections for ALL of them, so narrow to this
     // platform's toolkit before picking — otherwise we could persist another
-    // platform's connected-account id onto this row. If no connection reports a
-    // toolkit slug (older payloads), fall back to the unfiltered set.
+    // platform's connected-account id onto this row.
     const expectedSlug = this.config.toolkitSlugFor(platform);
     const slugMatched = connections.filter((c) => c.toolkitSlug === expectedSlug);
-    const candidates = slugMatched.length > 0 ? slugMatched : connections.some((c) => c.toolkitSlug) ? [] : connections;
+
+    // A Composio auth config is toolkit-bound, so a non-null id that is NOT the
+    // shared COMPOSIO_DEFAULT_AUTH_CONFIG_ID already returns only this platform's
+    // connections — an exact-slug mismatch (e.g. 'instagram_business' vs the
+    // hard-coded 'instagram') must not strand an ACTIVE connection as pending
+    // (#699). When platforms share the default we cannot disambiguate by slug, so
+    // we keep the conservative empty set. If no connection reports a toolkit slug
+    // (older payloads), fall back to the unfiltered set.
+    const defaultAuthConfigId = this.config.defaultAuthConfigId();
+    const platformScoped = authConfigId !== null && authConfigId !== defaultAuthConfigId;
+
+    const candidates =
+      slugMatched.length > 0
+        ? slugMatched
+        : platformScoped
+          ? connections
+          : connections.some((c) => c.toolkitSlug)
+            ? []
+            : connections;
 
     const active = candidates.find((c) => isActiveStatus(c.status)) ?? candidates[0];
     if (!active) {

--- a/backend/integrations/composio/composio-config.ts
+++ b/backend/integrations/composio/composio-config.ts
@@ -15,7 +15,12 @@
  */
 
 import type { IntegrationPlatform } from '../providers/types';
-import { composioApiKey, composioAuthConfigId, composioToolkitVersion } from '../providers/integration-config';
+import {
+  composioApiKey,
+  composioAuthConfigId,
+  composioDefaultAuthConfigId,
+  composioToolkitVersion,
+} from '../providers/integration-config';
 
 /** Stable Composio toolkit slug per platform. */
 export const TOOLKIT_SLUG: Record<IntegrationPlatform, string> = {
@@ -72,6 +77,13 @@ export interface ComposioConfig {
   authConfigIdFor(platform: IntegrationPlatform): string | null;
   toolkitSlugFor(platform: IntegrationPlatform): string;
   actionSlugFor(platform: IntegrationPlatform, op: ComposioOperation): string | null;
+  /**
+   * The shared default auth-config id (COMPOSIO_DEFAULT_AUTH_CONFIG_ID), or null
+   * when unset. Lets the reconcile path tell a platform-scoped (toolkit-bound)
+   * auth config apart from the shared default that several Meta-family platforms
+   * fall back to.
+   */
+  defaultAuthConfigId(): string | null;
 }
 
 /**
@@ -88,5 +100,6 @@ export function resolveComposioConfig(env: NodeJS.ProcessEnv = process.env): Com
     authConfigIdFor: (platform) => composioAuthConfigId(platform, env),
     toolkitSlugFor: (platform) => TOOLKIT_SLUG[platform],
     actionSlugFor: (platform, op) => actionSlug(platform, op, env),
+    defaultAuthConfigId: () => composioDefaultAuthConfigId(env),
   };
 }

--- a/backend/integrations/providers/integration-config.ts
+++ b/backend/integrations/providers/integration-config.ts
@@ -138,8 +138,20 @@ export function composioAuthConfigId(
   // never inherit COMPOSIO_DEFAULT_AUTH_CONFIG_ID (typically a Meta-family config)
   // or a future accidental connect attempt would target the wrong toolkit (#690).
   if (platform === 'reddit' || platform === 'x' || platform === 'tiktok') return null;
-  const fallback = env.COMPOSIO_DEFAULT_AUTH_CONFIG_ID?.trim();
-  return fallback || null;
+  return composioDefaultAuthConfigId(env);
+}
+
+/**
+ * The shared default Composio auth-config id (COMPOSIO_DEFAULT_AUTH_CONFIG_ID),
+ * trimmed and normalized to null when unset/blank. This is the auth config that
+ * Meta-family platforms (facebook/instagram/meta_ads) fall back to when they
+ * have no per-platform id, so several platforms can share it. Single source of
+ * truth — the per-platform `composioAuthConfigId` fallback reuses this, and the
+ * reconcile path uses it to tell "shared default" (ambiguous, can't disambiguate
+ * by auth config) from a "platform-scoped" (toolkit-bound) auth config.
+ */
+export function composioDefaultAuthConfigId(env: NodeJS.ProcessEnv = process.env): string | null {
+  return env.COMPOSIO_DEFAULT_AUTH_CONFIG_ID?.trim() || null;
 }
 
 export function composioApiKey(env: NodeJS.ProcessEnv = process.env): string | null {

--- a/frontend/integrations/composio-connections-screen.tsx
+++ b/frontend/integrations/composio-connections-screen.tsx
@@ -9,7 +9,13 @@
  * config. The flow is: see status -> click Connect -> approve -> done.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Bounded eager-reconcile schedule: ~5 attempts, backoff starting ~2s, ~30s
+// total. After returning from OAuth a row can briefly read `pending` until
+// Composio activates the connection; we poll a few times so the card flips to
+// "Connected" without a manual refresh, then stop (#699).
+const RECONCILE_DELAYS_MS = [2000, 4000, 6000, 8000, 10000];
 
 type Capabilities = {
   canPublishOrganic: boolean;
@@ -29,6 +35,7 @@ type Connection = {
   externalAccountName: string | null;
   capabilities: Capabilities | null;
   prerequisites?: string[];
+  reconcileError?: string | null;
 };
 
 type ListResponse = {
@@ -89,6 +96,10 @@ export default function ComposioConnectionsScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  // Bounded retry bookkeeping for the eager reconcile (refs so changing them
+  // never re-renders / re-runs the polling effect).
+  const reconcileAttemptsRef = useRef(0);
+  const justReturnedFromOAuthRef = useRef(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -108,6 +119,38 @@ export default function ComposioConnectionsScreen() {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Detect a return from OAuth (?connected=<platform>) once on mount. This runs
+  // before the first load resolves, so the polling effect sees it.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    justReturnedFromOAuthRef.current = new URLSearchParams(window.location.search).has('connected');
+  }, []);
+
+  // Bounded eager reconcile: while any connection is still `pending` (or the
+  // operator just returned from OAuth), re-load a few times so the card flips to
+  // "Connected" on its own. Stops as soon as no row is pending or the budget is
+  // spent, leaving the reconnect affordance + any advisory visible (#699).
+  useEffect(() => {
+    if (!data) return;
+    const hasPending = data.connections.some((c) => c.status === 'pending');
+    // Guarantee at least one reconcile poll right after returning from OAuth,
+    // even if the first snapshot hasn't flipped to `pending` yet.
+    const forcedByReturn = justReturnedFromOAuthRef.current && reconcileAttemptsRef.current === 0;
+    if (!hasPending && !forcedByReturn) {
+      // Converged (or nothing to wait on): reset the budget + clear the flag.
+      reconcileAttemptsRef.current = 0;
+      justReturnedFromOAuthRef.current = false;
+      return;
+    }
+    if (reconcileAttemptsRef.current >= RECONCILE_DELAYS_MS.length) return;
+    const delay = RECONCILE_DELAYS_MS[reconcileAttemptsRef.current];
+    reconcileAttemptsRef.current += 1;
+    const timer = setTimeout(() => {
+      void load();
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [data, load]);
 
   const connect = useCallback(async (platform: string) => {
     setBusy(platform);
@@ -230,6 +273,11 @@ export default function ComposioConnectionsScreen() {
                     <li key={i}>• {p}</li>
                   ))}
                 </ul>
+              )}
+              {conn.reconcileError && (
+                <div className="mt-4 rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-xs text-rose-200">
+                  {conn.reconcileError}
+                </div>
               )}
             </div>
           );

--- a/tests/composio-account-provider.test.ts
+++ b/tests/composio-account-provider.test.ts
@@ -1,20 +1,20 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 
-import { ComposioAccountProvider } from '@/backend/integrations/composio/composio-account-provider';
-import { ComposioConfigError } from '@/backend/integrations/composio/errors';
-import type { GatewayConnection } from '@/backend/integrations/composio/composio-client';
-import { fakeConfig, fakeGateway, fakeDb } from './composio/helpers';
+import { ComposioAccountProvider } from "@/backend/integrations/composio/composio-account-provider";
+import { ComposioError, ComposioConfigError } from "@/backend/integrations/composio/errors";
+import type { GatewayConnection, ComposioGateway } from "@/backend/integrations/composio/composio-client";
+import { fakeConfig, fakeGateway, fakeDb } from "./composio/helpers";
 
-const tenantId = '42';
-const userId = 'aries-tenant-42';
+const tenantId = "42";
+const userId = "aries-tenant-42";
 
-function conn(id: string, toolkitSlug: string, status = 'ACTIVE'): GatewayConnection {
+function conn(id: string, toolkitSlug: string, status = "ACTIVE"): GatewayConnection {
   return {
     id,
     status,
     statusReason: null,
-    authConfigId: 'shared_default',
+    authConfigId: "shared_default",
     toolkitSlug,
     externalAccountId: `ext_${id}`,
     externalAccountName: `${toolkitSlug} acct`,
@@ -22,7 +22,7 @@ function conn(id: string, toolkitSlug: string, status = 'ACTIVE'): GatewayConnec
   };
 }
 
-test('createConnectLink with no configured auth config auto-provisions a managed one', async () => {
+test("createConnectLink with no configured auth config auto-provisions a managed one", async () => {
   // No env auth config -> the provider asks the gateway to find-or-create a
   // Composio-managed auth config for the toolkit, so connecting needs zero
   // dashboard setup.
@@ -31,29 +31,133 @@ test('createConnectLink with no configured auth config auto-provisions a managed
     fakeConfig({ authConfigId: null }),
     fakeDb(),
   );
-  const result = await provider.createConnectLink(userId, 'facebook', 'full', { tenantId });
-  assert.equal(result.connectUrl, 'https://composio.dev/connect/abc');
+  const result = await provider.createConnectLink(userId, "facebook", "full", { tenantId });
+  assert.equal(result.connectUrl, "https://composio.dev/connect/abc");
 });
 
-test('createConnectLink returns the redirect URL and persists a pending row', async () => {
+test("createConnectLink returns the redirect URL and persists a pending row", async () => {
   // Default fakeDb returns a row for the upsert's RETURNING clause (Postgres
   // always returns the upserted row), matching real behavior.
   const db = fakeDb();
   const provider = new ComposioAccountProvider(fakeGateway(), fakeConfig(), db);
-  const result = await provider.createConnectLink(userId, 'facebook', 'full', { tenantId });
-  assert.equal(result.connectUrl, 'https://composio.dev/connect/abc');
+  const result = await provider.createConnectLink(userId, "facebook", "full", { tenantId });
+  assert.equal(result.connectUrl, "https://composio.dev/connect/abc");
   assert.ok(db.queries.some((q) => /insert into connected_accounts/i.test(q.text)));
 });
 
-test('refreshConnectionStatus picks the toolkit-matching connection under a shared default auth config', async () => {
+test("refreshConnectionStatus picks the toolkit-matching connection under a shared default auth config", async () => {
   // Both an instagram and a facebook connection come back (shared default
   // auth config). Refreshing facebook must NOT store the instagram account id.
-  const gateway = fakeGateway({ connections: [conn('ca_ig', 'instagram'), conn('ca_fb', 'facebook')] });
+  const gateway = fakeGateway({ connections: [conn("ca_ig", "instagram"), conn("ca_fb", "facebook")] });
   const db = fakeDb();
   const provider = new ComposioAccountProvider(gateway, fakeConfig(), db);
-  await provider.refreshConnectionStatus(userId, 'facebook', { tenantId });
+  await provider.refreshConnectionStatus(userId, "facebook", { tenantId });
   const upsert = db.queries.find((q) => /insert into connected_accounts/i.test(q.text));
-  assert.ok(upsert, 'expected an upsert');
+  assert.ok(upsert, "expected an upsert");
   // connected_account_id is param index 5 (1-based $5) -> array index 4.
-  assert.equal(upsert!.params[4], 'ca_fb', 'must persist the facebook connected-account id, not instagram');
+  assert.equal(upsert!.params[4], "ca_fb", "must persist the facebook connected-account id, not instagram");
+});
+
+// ── Fix A: #699 — platform-scoped authConfig admits non-exact-slug ACTIVE conn ──
+
+test("#699 Fix A: platform-scoped authConfig with non-exact toolkitSlug ACTIVE connection reconciles to connected", async () => {
+  // Root of #699: Instagram Composio connections report toolkitSlug
+  // 'instagram_business' rather than the hard-coded 'instagram'. With a
+  // platform-specific (non-default) authConfigId, the filter previously
+  // returned candidates=[] on any slug mismatch and left the row stranded as
+  // pending. The fix: when platformScoped=true (authConfigId !== null AND !=
+  // defaultAuthConfigId), fall through to admitting ALL returned connections
+  // (they are already this-platform-only). Pre-fix: no upsert fired. Post-fix:
+  // the ACTIVE connection is persisted as 'connected'.
+  const gateway = fakeGateway({
+    connections: [conn("ca_ig_biz", "instagram_business", "ACTIVE")],
+  });
+  const db = fakeDb();
+  // authConfigId is platform-specific; defaultAuthConfigId stays null (the default
+  // when unset). platformScoped = 'ac_ig_specific' !== null && !== null = true.
+  const provider = new ComposioAccountProvider(
+    gateway,
+    fakeConfig({ authConfigId: "ac_ig_specific" }),
+    db,
+  );
+  await provider.refreshConnectionStatus(userId, "instagram", { tenantId });
+  const upsert = db.queries.find((q) => /insert into connected_accounts/i.test(q.text));
+  assert.ok(upsert, "expected an upsert INSERT for the ACTIVE connection");
+  // $5 = connectedAccountId (array index 4, 0-based)
+  assert.equal(upsert!.params[4], "ca_ig_biz",
+    "must persist the instagram_business connected-account id, not leave it as pending");
+  // $9 = status (array index 8)
+  assert.equal(upsert!.params[8], "connected",
+    "status must be persisted as 'connected' for an ACTIVE Composio connection");
+});
+
+// ── Fix A safety: shared-default must still not cross-contaminate platforms ──
+
+test("#699 Fix A regression: shared-default authConfig does not cross-contaminate platforms on slug mismatch", async () => {
+  // When authConfigId === defaultAuthConfigId (the shared default), listConnections
+  // returns connections for ALL platforms. The slug guard must still prevent a
+  // non-matching platform's connected-account id from being persisted onto a
+  // different platform's row. With shared default + zero exact slug matches,
+  // candidates=[] → no upsert.
+  const gateway = fakeGateway({
+    connections: [
+      conn("ca_fb", "facebook"),
+      conn("ca_ig_biz", "instagram_business"),
+    ],
+  });
+  const db = fakeDb();
+  // authConfigId === defaultAuthConfigId: the shared-default path.
+  const provider = new ComposioAccountProvider(
+    gateway,
+    fakeConfig({ authConfigId: "ac_default", defaultAuthConfigId: "ac_default" }),
+    db,
+  );
+  // Refresh for 'instagram': slugMatched=[] (neither 'facebook' nor 'instagram_business'
+  // equals 'instagram'); platformScoped=false; candidates=[] (both have slugs).
+  await provider.refreshConnectionStatus(userId, "instagram", { tenantId });
+  const upserts = db.queries.filter((q) => /insert into connected_accounts/i.test(q.text));
+  assert.equal(
+    upserts.length,
+    0,
+    "shared-default path must NOT upsert any row when no connection's slug exactly matches the platform",
+  );
+});
+
+// ── Fix B: gateway.listConnections rejection rethrows frontend-safe ComposioError ──
+
+test("#699 Fix B: refreshConnectionStatus rethrows a frontend-safe ComposioError when listConnections rejects", async () => {
+  // Pre-fix: a gateway network error caused refreshConnectionStatus to silently
+  // return the stored 'pending' row, masking the failure and stranding the
+  // connection forever. The fix: rethrow as ComposioError with
+  // reason='composio_reconcile_failed' and a generic message (never the raw SDK
+  // text). The caller (handleComposioList) catches this per-platform and records
+  // a frontend-safe advisory without failing the whole list request.
+  const rawSdkError = "SENTINEL_RAW_SDK_TEXT: internal Composio SDK failure";
+  const throwingGateway: ComposioGateway = {
+    ...fakeGateway(),
+    async listConnections(): Promise<GatewayConnection[]> {
+      throw new Error(rawSdkError);
+    },
+  };
+  const provider = new ComposioAccountProvider(throwingGateway, fakeConfig(), fakeDb());
+
+  await assert.rejects(
+    () => provider.refreshConnectionStatus(userId, "instagram", { tenantId }),
+    (err: unknown) => {
+      assert.ok(
+        err instanceof ComposioError,
+        `expected ComposioError to be thrown, got ${String(err)}`,
+      );
+      assert.equal(
+        (err as ComposioError).code,
+        "composio_reconcile_failed",
+        `expected reason composio_reconcile_failed; got ${(err as ComposioError).code}`,
+      );
+      assert.ok(
+        !err.message.includes(rawSdkError),
+        `message must NOT include raw SDK error text; got: ${err.message}`,
+      );
+      return true;
+    },
+  );
 });

--- a/tests/composio-bounded-reconcile-surface.test.ts
+++ b/tests/composio-bounded-reconcile-surface.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Source-structure assertion test for the bounded eager-reconcile implementation
+ * in the Composio connections screen (#699 Fix B.2).
+ *
+ * The connections screen must:
+ *  a. Reference `reconcileError` to render per-connection advisories.
+ *  b. Implement a BOUNDED retry budget via RECONCILE_DELAYS_MS (a fixed array
+ *     of delay values, not an open-ended polling loop) so the screen stops
+ *     polling after ~5 attempts once OAuth returns and does not spin forever.
+ *  c. Key the retry trigger off a `pending` status check so reconcile only
+ *     fires while at least one connection is still unresolved.
+ *  d. Detect the `?connected=` search param to guarantee at least one reconcile
+ *     poll immediately after the OAuth redirect back to the app.
+ *
+ * These are source-level assertions (readFileSync) rather than render tests --
+ * the patterns are stable identifiers that survive minor formatting changes.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+const screenSource = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'integrations', 'composio-connections-screen.tsx'),
+  'utf8',
+);
+
+// -- a. reconcileError rendered in the screen ---------------------------------
+
+test('#699 Fix B.2: composio-connections-screen renders reconcileError advisory', () => {
+  assert.ok(
+    screenSource.includes('reconcileError'),
+    'screen must reference reconcileError to surface per-platform reconcile failure advisories',
+  );
+});
+
+// -- b. bounded retry via RECONCILE_DELAYS_MS constant -----------------------
+
+test('#699 Fix B.2: composio-connections-screen implements bounded retry via RECONCILE_DELAYS_MS', () => {
+  assert.ok(
+    screenSource.includes('RECONCILE_DELAYS_MS'),
+    'screen must define RECONCILE_DELAYS_MS to bound the eager-reconcile retry budget',
+  );
+  // The constant must be an array (bounded list of delay values, not a count).
+  assert.match(
+    screenSource,
+    /RECONCILE_DELAYS_MS\s*=\s*\[/,
+    'RECONCILE_DELAYS_MS must be an array literal (bounded delay schedule, not a scalar)',
+  );
+  // The attempt counter must be capped against the array length so the retry
+  // stops once the budget is spent.
+  assert.ok(
+    screenSource.includes('RECONCILE_DELAYS_MS.length'),
+    'screen must guard the retry loop against RECONCILE_DELAYS_MS.length to stop after budget',
+  );
+});
+
+// -- c. retry trigger keyed off pending status --------------------------------
+
+test('#699 Fix B.2: composio-connections-screen retry loop keys off pending connection status', () => {
+  assert.ok(
+    screenSource.includes('pending'),
+    'screen must check for a pending status to decide whether to continue reconcile polling',
+  );
+  // The pending check must be part of a conditional expression that controls
+  // re-loading, not just a status label.
+  const hasPendingConditional = /hasPending|status.*pending|pending.*status/.test(screenSource);
+  assert.ok(
+    hasPendingConditional,
+    'screen must use a hasPending / status===pending conditional to gate the retry loop',
+  );
+});
+
+// -- d. ?connected= detection for immediate post-OAuth poll -------------------
+
+test('#699 Fix B.2: composio-connections-screen detects ?connected= search param after OAuth return', () => {
+  // The screen must read window.location.search to detect a return from OAuth.
+  assert.ok(
+    screenSource.includes('window.location.search'),
+    'screen must read window.location.search to detect a return from OAuth (?connected=)',
+  );
+  // URLSearchParams.has('connected') must be called to check for the param.
+  assert.ok(
+    screenSource.includes('.has(') && screenSource.includes('connected'),
+    "screen must call URLSearchParams.has to detect the ?connected= param post-OAuth",
+  );
+});

--- a/tests/composio-client-toolkit-version.test.ts
+++ b/tests/composio-client-toolkit-version.test.ts
@@ -45,6 +45,7 @@ function configWith(toolkitVersion?: string): ComposioConfig {
     authConfigIdFor: () => null,
     toolkitSlugFor: (p) => p,
     actionSlugFor: () => null,
+    defaultAuthConfigId: () => null,
   };
 }
 

--- a/tests/composio-reconcile-surfacing.test.ts
+++ b/tests/composio-reconcile-surfacing.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression coverage for #699: Composio reconcile error surfacing.
+ *
+ * Fix B wired two guarantees into handleComposioList:
+ *  1. Every connection object in the response carries a `reconcileError` field
+ *     (null on success, a frontend-safe string on per-platform reconcile failure).
+ *  2. A per-platform reconcile failure (refreshConnectionStatus throws) records
+ *     a frontend-safe advisory into the response and still returns HTTP 200 —
+ *     a Composio outage must NOT blank the whole connections screen.
+ *
+ * Both guarantees are exercised here via an injected provider (the 2nd param
+ * of handleComposioList added by the fix) so no live DB or Composio SDK is needed.
+ *
+ * Failure modes locked:
+ *  a. null-provider path (Composio not configured): every connection carries
+ *     reconcileError: null (field must exist, value must be null).
+ *  b. provider whose refreshConnectionStatus throws for one platform: that
+ *     platform's connection carries a non-null, frontend-safe reconcileError
+ *     string and the response is still 200.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { handleComposioList } from "@/app/api/integrations/composio/handlers";
+import { ComposioError } from "@/backend/integrations/composio/errors";
+import type { AccountConnectionProvider } from "@/backend/integrations/providers/interfaces";
+import type { ConnectedAccount, IntegrationPlatform } from "@/backend/integrations/providers/types";
+import type { TenantRole } from "@/lib/tenant-context";
+
+// ── Tenant loader ─────────────────────────────────────────────────────────────
+
+const tenantLoader = async () => ({
+  userId: "user_1",
+  tenantId: "1",
+  tenantSlug: "test-tenant",
+  role: "tenant_admin" as TenantRole,
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prev = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(vars)) {
+    prev.set(k, process.env[k]);
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  return fn().finally(() => {
+    for (const [k, original] of prev) {
+      if (original === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = original;
+      }
+    }
+  });
+}
+
+/** Minimal placeholder ConnectedAccount for faking listConnections results. */
+function pendingAccount(platform: IntegrationPlatform): ConnectedAccount {
+  const now = new Date(0).toISOString();
+  return {
+    id: `${platform}:pending`,
+    tenantId: "1",
+    externalUserId: "aries-tenant-1",
+    platform,
+    provider: "composio",
+    connectedAccountId: null,
+    authConfigId: null,
+    externalAccountId: null,
+    externalAccountName: null,
+    status: "pending",
+    capabilities: null,
+    lastCapabilityCheckAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * A minimal AccountConnectionProvider stub. listConnections returns the
+ * supplied rows; refreshConnectionStatus either resolves or rejects depending
+ * on whether the platform is in the `throwFor` set.
+ */
+function fakeProvider(opts: {
+  rows: ConnectedAccount[];
+  throwFor?: Set<IntegrationPlatform>;
+  rawErrorText?: string;
+}): AccountConnectionProvider {
+  const rawErr = opts.rawErrorText ?? "SENTINEL_RAW_TEXT_MUST_NOT_APPEAR";
+  return {
+    kind: "composio" as const,
+    async listConnections() {
+      return opts.rows;
+    },
+    async refreshConnectionStatus(_userId, platform) {
+      if (opts.throwFor?.has(platform)) {
+        throw new ComposioError(
+          "composio_reconcile_failed",
+          "Could not reach Composio to confirm this connection. Please try again.",
+          { status: 502, retryable: true },
+        );
+      }
+      // Return the first matching row as-is (simulating a no-op refresh)
+      return opts.rows.find((r) => r.platform === platform) ?? null;
+    },
+    async createConnectLink() {
+      throw new Error("not implemented in stub");
+    },
+    async getConnection() {
+      return null;
+    },
+    async disconnectConnection() {
+      return { disconnected: false };
+    },
+  };
+}
+
+// ── a. null-provider: every connection carries reconcileError: null ───────────
+
+test("#699 handleComposioList null-provider: every connection object has reconcileError field equal to null", async () => {
+  // Composio not configured (provider = null). The handler still builds
+  // placeholder rows for every connectable platform and MUST attach
+  // reconcileError: null to each. Pre-fix: the field was absent (undefined).
+  await withEnv({ ARIES_X_ENABLED: undefined }, async () => {
+    const response = await handleComposioList(tenantLoader, null);
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      connections: Array<{ platform: string; reconcileError: unknown }>;
+    };
+    assert.ok(Array.isArray(body.connections), "connections must be an array");
+    assert.ok(body.connections.length > 0, "must have at least one connection slot");
+    for (const conn of body.connections) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(conn, "reconcileError"),
+        `connection for ${conn.platform} must have a reconcileError field (was absent pre-fix)`,
+      );
+      assert.equal(
+        conn.reconcileError,
+        null,
+        `reconcileError for ${conn.platform} must be null when no reconcile was attempted`,
+      );
+    }
+  });
+});
+
+// ── b. reconcile failure → per-platform advisory, still 200 ──────────────────
+
+test("#699 handleComposioList: per-platform refreshConnectionStatus throw records frontend-safe advisory, response still 200", async () => {
+  // Inject a provider that returns an instagram pending row (triggering the
+  // reconcile path) and throws a ComposioError for instagram.
+  // The handler must: (1) still return 200, (2) carry a non-null reconcileError
+  // on the instagram connection, (3) never include raw SDK text.
+  await withEnv({ ARIES_X_ENABLED: undefined }, async () => {
+    const provider = fakeProvider({
+      rows: [pendingAccount("instagram")],
+      throwFor: new Set<IntegrationPlatform>(["instagram"]),
+    });
+    const response = await handleComposioList(tenantLoader, provider);
+    assert.equal(
+      response.status,
+      200,
+      "A per-platform reconcile failure must NOT kill the list request (must return 200)",
+    );
+    const body = (await response.json()) as {
+      connections: Array<{ platform: string; reconcileError: string | null }>;
+    };
+    assert.ok(Array.isArray(body.connections), "connections must be an array");
+
+    // Every connection must still carry the reconcileError field.
+    for (const conn of body.connections) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(conn, "reconcileError"),
+        `connection for ${conn.platform} must have a reconcileError field`,
+      );
+    }
+
+    // The instagram slot must carry a non-null, frontend-safe advisory.
+    const igConn = body.connections.find((c) => c.platform === "instagram");
+    assert.ok(igConn, "instagram connection must be present in the response");
+    assert.notEqual(
+      igConn.reconcileError,
+      null,
+      "instagram reconcileError must be non-null when refreshConnectionStatus throws",
+    );
+    // Cast to string after the null assertion — TypeScript does not narrow on
+    // assert.notEqual, so a non-null assertion is required to call string methods.
+    const reconcileErrMsg: string = igConn.reconcileError as string;
+    assert.equal(typeof reconcileErrMsg, "string",
+      "instagram reconcileError must be a string");
+    // Sanity: the advisory must not leak the raw error sentinel that the
+    // platform-scoped code would have originally exposed.
+    const RAW_SENTINEL = "SENTINEL_RAW_TEXT_MUST_NOT_APPEAR";
+    assert.ok(
+      !reconcileErrMsg.includes(RAW_SENTINEL),
+      `reconcileError must NOT include raw SDK error text; got: ${reconcileErrMsg}`,
+    );
+    assert.ok(
+      reconcileErrMsg.length > 0,
+      "reconcileError must be a non-empty string so the UI has something to render",
+    );
+  });
+});

--- a/tests/composio/helpers.ts
+++ b/tests/composio/helpers.ts
@@ -15,6 +15,7 @@ export interface RecordedExecute {
 export function fakeConfig(overrides?: {
   actions?: Partial<Record<ComposioOperation, string>>;
   authConfigId?: string | null;
+  defaultAuthConfigId?: string | null;
 }): ComposioConfig {
   const actions = overrides?.actions ?? {};
   const hasAuthOverride = overrides ? Object.prototype.hasOwnProperty.call(overrides, 'authConfigId') : false;
@@ -23,6 +24,7 @@ export function fakeConfig(overrides?: {
     authConfigIdFor: () => (hasAuthOverride ? (overrides!.authConfigId ?? null) : 'auth_cfg_test'),
     toolkitSlugFor: (p: IntegrationPlatform) => p,
     actionSlugFor: (_p: IntegrationPlatform, op: ComposioOperation) => actions[op] ?? null,
+    defaultAuthConfigId: () => overrides?.defaultAuthConfigId ?? null,
   };
 }
 


### PR DESCRIPTION
Closes #699

## Problem
On the prod-live FB/IG connect path, an ACTIVE Composio connection could be stranded forever as `pending`:
1. **Slug drift** — Instagram connections report `toolkitSlug='instagram_business'`, not the hard-coded `'instagram'`. The reconcile filter required an exact slug match, so a real ACTIVE connection never flipped to `connected`.
2. **Swallowed reconcile failures** — when `listConnections` couldn't reach Composio, `refreshConnectionStatus` silently returned the stored `pending` row, masking the outage and leaving the card stuck with no signal to the operator.

## Fix A — slug-agnostic match, gated by a platform-specific auth config
`refreshConnectionStatus` now uses tiered candidate selection. An exact-slug match is byte-identical to before. On an exact-slug MISS it falls through to admitting ALL `listConnections` results **only** when the auth config is platform-scoped (`authConfigId !== null && authConfigId !== COMPOSIO_DEFAULT_AUTH_CONFIG_ID`). A Composio auth config is toolkit-bound, so a non-default id already returns this-platform-only connections (the gateway passes `authConfigIds` straight to `connectedAccounts.list`) — admitting them on a drifted slug is safe and flips the ACTIVE connection to `connected`. When platforms share the default, slug can't disambiguate, so the conservative empty set is kept (no cross-tenant/cross-platform contamination). reddit/x (null auth config) are unaffected (byte-identical legacy path). Supporting: `ComposioConfig.defaultAuthConfigId()` + `composioDefaultAuthConfigId()` (single source of truth; the per-platform fallback was refactored to reuse it, exclusion logic byte-identical).

## Fix B — stop swallowing reconcile errors; surface them frontend-safe
- B.1: on a `listConnections` failure, `refreshConnectionStatus` now rethrows a frontend-safe `ComposioError` (`composio_reconcile_failed`, generic message — never the raw SDK text or token) instead of returning the stale `pending` row.
- B.1 (route): `handleComposioList` catches reconcile failures per-platform and attaches a frontend-safe `reconcileError` advisory to each connection, still returning **200** (a Composio outage no longer blanks the whole screen). A genuine list-read failure still returns 500. No new DB fan-out (the per-platform `Promise.all` over pending rows is pre-existing). New optional injected-provider 2nd param defaults to `getAccountConnectionProvider()` at call-time, so existing callers are unchanged.
- B.2: the connections screen surfaces the `reconcileError` advisory, detects `?connected=` on return from OAuth, and runs a **bounded** eager reconcile (5 attempts, capped ~30s, stops when no row is pending) so a card flips to "Connected" on its own — no new sidecar/worker.

## Test evidence
- `tests/composio-account-provider.test.ts` (+3): platform-scoped non-exact slug → reconciles to `connected`; shared-default + slug-miss → no upsert (no cross-contamination); `listConnections` rejection → rethrows frontend-safe `ComposioError` with sentinel raw text absent.
- `tests/composio-reconcile-surfacing.test.ts` (new): every connection carries `reconcileError` (null on success); per-platform throw → non-null frontend-safe advisory + still 200; raw sentinel never leaks.
- `tests/composio-bounded-reconcile-surface.test.ts` (new): bounded retry budget, pending-keyed trigger, `?connected=` detection.
- Focused composio gate: 62/62 green. Typecheck clean. Banned-pattern check ok. `npm run guardrails:agent` passed (unique diff).

## Operational residual (for Brendan)
A platform that rides the **shared** `COMPOSIO_DEFAULT_AUTH_CONFIG_ID` whose toolkit slug drifts still can't be auto-disambiguated (the fix conservatively keeps it `pending` to avoid cross-platform contamination). The remedy is to set that platform's own `COMPOSIO_<PLATFORM>_AUTH_CONFIG_ID` (e.g. `COMPOSIO_INSTAGRAM_AUTH_CONFIG_ID`) so its connection list becomes toolkit-scoped and the slug-agnostic fall-through engages.

## Residual risk
Low. Default/shared-config path is unchanged and conservative; the new fall-through only engages for a toolkit-bound (platform-scoped) auth config where the gateway has already filtered to a single toolkit. Frontend payloads stay frontend-safe (generic advisory strings only). reddit/x/tiktok paths byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoiY71TzLCK6FnwKourTW2