### PR TITLE
fix(calendar): open the calendar on the current month, not the earliest event

### DIFF
--- a/frontend/aries-v1/presenters/calendar-presenter.tsx
+++ b/frontend/aries-v1/presenters/calendar-presenter.tsx
@@ -117,9 +117,7 @@ export default function CalendarPresenter({
 }: CalendarPresenterProps) {
   const timeZone = model.timeZone;
   const [view, setView] = useState<CalendarMode>('month');
-  const [currentDate, setCurrentDate] = useState(() =>
-    getInitialCalendarDate(model.events, timeZone),
-  );
+  const [currentDate, setCurrentDate] = useState(() => new Date());
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [rescheduleEventId, setRescheduleEventId] = useState<string | null>(null);
   const [scheduleTrayPost, setScheduleTrayPost] = useState<UnscheduledPost | null>(null);
@@ -1003,21 +1001,6 @@ function InfoPanel(props: { label: string; value: string }) {
  * still a local `Date` walk (cheap, zone-agnostic for "which 42 cells"); only
  * the event-to-cell match and "today" use tenant-zone keys.
  */
-
-function getInitialCalendarDate(events: CalendarEvent[], timeZone: string): Date {
-  const now = Date.now();
-  const nextUpcoming = events.find((event) => event.timestamp >= now);
-  const anchorIso = nextUpcoming?.scheduledForIso ?? events[0]?.scheduledForIso;
-  if (anchorIso) {
-    // Build a local Date positioned on the tenant-zone civil day of the anchor
-    // event so the grid opens on the month that actually contains it.
-    const parts = tenantZoneParts(anchorIso, timeZone);
-    if (parts) {
-      return new Date(parts.year, parts.month - 1, parts.day);
-    }
-  }
-  return new Date();
-}
 
 function startOfMonth(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), 1);

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -232,6 +232,12 @@ const steps = [
     args: ['--test', 'tests/onboarding/variant-board-render.component.test.ts'],
   },
   {
+    // #705 regression: calendar-presenter must open on the current month, not
+    // the earliest queued event (which could be months in the past).
+    name: 'calendar initial-month regression (#705)',
+    args: ['--test', 'tests/calendar-initial-month.test.ts'],
+  },
+  {
     // #684 regression: analytics screen must gate the summary grid + Views column
     // on per-platform capabilities (account_daily_metrics / post_view_count) and
     // render an honest EmptyStatePanel — not fabricated zeros — for unsupported

--- a/tests/calendar-drag.component.test.ts
+++ b/tests/calendar-drag.component.test.ts
@@ -15,6 +15,18 @@ import {
 import { createCalendarViewModel } from '../frontend/aries-v1/view-models/calendar';
 import type { ScheduledPostItem, UnscheduledPostItem } from '../lib/api/aries-v1';
 
+// Derive a stable current-month fixture date so the calendar's default view
+// (which opens on new Date() after the #705 fix) renders the test fixtures
+// without navigating away. Using 14:00 UTC on the 15th avoids midnight
+// roll-overs in any host timezone and stays well clear of month boundaries.
+const _d = new Date();
+const _y = _d.getFullYear();
+const _m = String(_d.getMonth() + 1).padStart(2, '0');
+/** ISO timestamp for the 15th of the current month at 14:00 UTC. */
+const FIXTURE_CURRENT_MONTH_ISO = `${_y}-${_m}-15T14:00:00.000Z`;
+/** YYYY-MM-DD key matching the cell the presenter renders for that timestamp. */
+const FIXTURE_CURRENT_MONTH_DAY_KEY = `${_y}-${_m}-15`;
+
 function buildScheduledPost(overrides: Partial<ScheduledPostItem> = {}): ScheduledPostItem {
   return {
     id: '901',
@@ -25,7 +37,7 @@ function buildScheduledPost(overrides: Partial<ScheduledPostItem> = {}): Schedul
     caption: 'Queued carousel',
     platform: 'facebook',
     targetPlatforms: ['facebook', 'instagram'],
-    scheduledFor: '2026-04-15T14:00:00.000Z',
+    scheduledFor: FIXTURE_CURRENT_MONTH_ISO,
     dispatchStatus: 'pending',
     dispatchedAt: null,
     errorAt: null,
@@ -73,7 +85,7 @@ test('resolveDragSchedule is a no-op when an event is dropped on its own cell', 
     posts: [],
     timeZone: 'America/New_York',
   }).events[0];
-  // The event's dayKey is 2026-04-15 (14:00Z in NY). Dropping it there is a no-op.
+  // The event's dayKey is in the current month (FIXTURE_CURRENT_MONTH_ISO at 14:00Z). Dropping it there is a no-op.
   assert.equal(resolveDragSchedule({ kind: 'event', event }, event.dayKey), null);
 });
 
@@ -110,7 +122,7 @@ test('CalendarPresenter renders droppable cells and draggable tiles under jsdom'
   const { render, cleanup } = await import('@testing-library/react');
 
   const model = createCalendarViewModel({
-    scheduledPosts: [buildScheduledPost({ scheduledFor: '2026-04-15T14:00:00.000Z' })],
+    scheduledPosts: [buildScheduledPost({ scheduledFor: FIXTURE_CURRENT_MONTH_ISO })],
     posts: [],
     unscheduledPosts: [{ ...buildUnscheduled(), href: '/dashboard/social-content/job-9' }],
     timeZone: 'America/New_York',
@@ -138,8 +150,8 @@ test('CalendarPresenter renders droppable cells and draggable tiles under jsdom'
     const trayItem = container.querySelector('[data-testid="tray-item-77"]');
     assert.ok(trayItem, 'the backlog post should render a draggable tray item');
 
-    // The 2026-04-15 cell exists as a drop target (tenant-zone day key).
-    const targetCell = container.querySelector('[data-testid="cell-2026-04-15"]');
+    // The current-month day-15 cell exists as a drop target (tenant-zone day key).
+    const targetCell = container.querySelector(`[data-testid="cell-${FIXTURE_CURRENT_MONTH_DAY_KEY}"]`);
     assert.ok(targetCell, 'the tenant-zone target cell should be droppable');
   } finally {
     cleanup();

--- a/tests/calendar-initial-month.test.ts
+++ b/tests/calendar-initial-month.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression test for #705 — calendar-presenter initial visible month.
+ *
+ * BUG: useState(() => getInitialCalendarDate(model.events, timeZone)) anchored
+ * the initial month to the earliest queued event. When all events are in the
+ * past (e.g. April/May while today is June), the calendar opened on the past
+ * month instead of the current one.
+ *
+ * FIX: useState(() => new Date()) — the calendar always opens on today.
+ *
+ * FAIL-BEFORE: getInitialCalendarDate with all-past events returns the
+ * earliest event date (April 2026). The heading renders "April 2026".
+ * expectedMonthLabel is "June 2026". assert.ok(monthHeading) fails.
+ *
+ * PASS-AFTER: new Date() produces the current month. The heading matches
+ * expectedMonthLabel.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installJsdom } from './helpers/jsdom-env';
+
+// DOM must exist before React / @dnd-kit / @testing-library load.
+installJsdom();
+
+import React from 'react';
+
+import { createCalendarViewModel } from '../frontend/aries-v1/view-models/calendar';
+import type { ScheduledPostItem } from '../lib/api/aries-v1';
+
+// Compute the expected heading label once from the wall-clock "today". The
+// presenter's useState(() => new Date()) runs at render time in the same
+// test invocation — both will always be in the same month.
+const expectedMonthLabel = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  year: 'numeric',
+}).format(new Date());
+
+function buildPastScheduledPost(
+  overrides: Partial<ScheduledPostItem> = {},
+): ScheduledPostItem {
+  return {
+    id: '801',
+    postId: '11',
+    jobId: 'job-past-1',
+    tenantId: 7,
+    title: 'Old dispatched post',
+    caption: 'Old dispatched post',
+    platform: 'facebook',
+    targetPlatforms: ['facebook'],
+    // April 10 2026 — well in the past relative to the June 2026 fix date.
+    scheduledFor: '2026-04-10T12:00:00.000Z',
+    dispatchStatus: 'dispatched',
+    dispatchedAt: '2026-04-10T12:05:00.000Z',
+    errorAt: null,
+    errorMessage: null,
+    updatedAt: '2026-04-10T00:00:00.000Z',
+    dispatches: [],
+    ...overrides,
+  };
+}
+
+test(
+  'CalendarPresenter opens on the current month when all events are in the past',
+  async () => {
+    const { render, cleanup } = await import('@testing-library/react');
+    const { default: CalendarPresenter } = await import(
+      '../frontend/aries-v1/presenters/calendar-presenter'
+    );
+
+    // Two events, both in April 2026 (past). Pre-fix: getInitialCalendarDate
+    // returns the April event → heading shows "April 2026". Post-fix: new Date()
+    // → heading shows the current month.
+    const model = createCalendarViewModel({
+      scheduledPosts: [
+        buildPastScheduledPost({
+          id: '801',
+          postId: '11',
+          scheduledFor: '2026-04-10T12:00:00.000Z',
+        }),
+        buildPastScheduledPost({
+          id: '802',
+          postId: '12',
+          scheduledFor: '2026-04-20T14:00:00.000Z',
+        }),
+      ],
+      posts: [],
+      timeZone: 'America/New_York',
+    });
+
+    const { container } = render(
+      React.createElement(CalendarPresenter, { model }),
+    );
+
+    try {
+      // The calendar renders several h2 elements:
+      //   "Calendar" (static title)
+      //   "<Month> <Year>" (the live initial-month heading we care about)
+      //   "Social content status at a glance" (static)
+      //   "Backlog" (unscheduled tray)
+      // Only the month heading will exactly match expectedMonthLabel.
+      const headings = Array.from(container.querySelectorAll('h2'));
+      const monthHeading = headings.find(
+        (h) => h.textContent?.trim() === expectedMonthLabel,
+      );
+
+      assert.ok(
+        monthHeading,
+        `Calendar should open on the current month ("${expectedMonthLabel}") but none of the h2 headings matched. ` +
+          `Rendered headings: ${headings.map((h) => JSON.stringify(h.textContent?.trim())).join(', ')}. ` +
+          `This means the calendar anchored to an event month rather than today (pre-fix regression).`,
+      );
+    } finally {
+      cleanup();
+    }
+  },
+);

--- a/tests/e2e/calendar-smoke.test.ts
+++ b/tests/e2e/calendar-smoke.test.ts
@@ -18,6 +18,15 @@ import type { ScheduledPostItem } from '../../lib/api/aries-v1';
  * tree mounts under a DOM with real data and the queued posts surface.
  */
 
+// Derive stable current-month fixture dates so the calendar's default view
+// (which opens on new Date() after the #705 fix) renders the test fixtures
+// without navigating away. 14:00/16:30 UTC avoids midnight roll-overs.
+const _d = new Date();
+const _y = _d.getFullYear();
+const _m = String(_d.getMonth() + 1).padStart(2, '0');
+const FIXTURE_DAY_15_ISO = `${_y}-${_m}-15T14:00:00.000Z`;
+const FIXTURE_DAY_20_ISO = `${_y}-${_m}-20T16:30:00.000Z`;
+
 function buildScheduledPost(overrides: Partial<ScheduledPostItem> = {}): ScheduledPostItem {
   return {
     id: '901',
@@ -28,7 +37,7 @@ function buildScheduledPost(overrides: Partial<ScheduledPostItem> = {}): Schedul
     caption: 'Spring sale carousel',
     platform: 'facebook',
     targetPlatforms: ['facebook', 'instagram'],
-    scheduledFor: '2026-04-15T14:00:00.000Z',
+    scheduledFor: FIXTURE_DAY_15_ISO,
     dispatchStatus: 'pending',
     dispatchedAt: null,
     errorAt: null,
@@ -52,7 +61,7 @@ test('calendar smoke: planner mounts and renders queued posts', async () => {
         id: '902',
         postId: '43',
         title: 'Retargeting refresh',
-        scheduledFor: '2026-04-20T16:30:00.000Z',
+        scheduledFor: FIXTURE_DAY_20_ISO,
         dispatchStatus: 'dispatched',
       }),
     ],


### PR DESCRIPTION
Closes #705

## Root cause
The calendar's initial visible month was seeded from the earliest *queued* event:
`useState(() => getInitialCalendarDate(model.events, timeZone))`. `getInitialCalendarDate`
anchored to the next-upcoming event, falling back to the first event in the list — so when a
tenant's queued/dispatched posts all sat in a past month (e.g. April/May while today is June),
the calendar opened on that past month instead of the current one. The operator landed on a
stale, mostly-empty grid.

## Fix
Seed the initial visible month from the wall clock: `useState(() => new Date())`. The calendar
now always opens on today's month. This matches the component's existing "today" highlight and
the **Today** button, which already use `new Date()` directly — so the initial state is now
consistent with the rest of the component. Removed the now-unused `getInitialCalendarDate`
helper (single call site, no other references). Event-to-cell rendering and the tenant-zone
"today" key are unchanged.

## Test evidence
- New jsdom regression `tests/calendar-initial-month.test.ts`: renders `CalendarPresenter` with
  all-past (April 2026) events and asserts a month heading equals the **current** month label,
  computed at runtime from `new Date()` (not hardcoded) so it holds across month rollover.
  Fail-before confirmed: pre-fix the heading rendered the past event's month ("April 2026").
- Wired as a `npm run verify` step (#705); full `verify` suite green (19 steps).

## Residual risk
Low. Pure client-side initial-state change; no Hermes, DB, tenant-context, or secret surface.
Nit for a future touch of this file: the `tenantZoneParts` import is now orphaned (the repo does
not enforce `noUnusedLocals`, so it is inert and does not affect CI or runtime).

Root cause surfaced by the autonomous prod QA loop (#705).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoiY71TzLCK6FnwKourTW2