### PR TITLE
fix(integrations): route FB/IG connect through Composio (not legacy OAuth) + clear stuck rows

### DIFF
--- a/frontend/aries-v1/instagram-publish-drawer.tsx
+++ b/frontend/aries-v1/instagram-publish-drawer.tsx
@@ -297,7 +297,7 @@ export default function InstagramPublishDrawer(props: InstagramPublishDrawerProp
                     ) : null}
                     {showReconnect ? (
                       <a
-                        href="/oauth/connect/instagram?mode=reconnect"
+                        href="/dashboard/settings/channel-integrations"
                         data-testid="ig-publish-reconnect"
                         className="inline-flex items-center gap-1.5 rounded-full border border-rose-300/30 bg-rose-300/10 px-3 py-1.5 text-xs font-medium text-rose-100 transition hover:bg-rose-300/20"
                       >

--- a/frontend/aries-v1/presenters/dashboard-home-presenter.tsx
+++ b/frontend/aries-v1/presenters/dashboard-home-presenter.tsx
@@ -596,8 +596,13 @@ export default function DashboardHomePresenter({
                       </div>
                       <div className="flex-1" aria-hidden />
                       {channel.health !== 'connected' ? (
+                        // Connect/Reconnect routes operators to the canonical
+                        // Composio "Channel Integrations" screen rather than the
+                        // legacy direct-Meta OAuth broker at /oauth/connect/*
+                        // (no longer the connect path; IG there is a dead branch
+                        // that errors). Composio brokers every platform (#704).
                         <Link
-                          href={`/oauth/connect/${encodeURIComponent(channel.id)}?mode=${channel.health === 'attention' ? 'reconnect' : 'connect'}`}
+                          href="/dashboard/settings/channel-integrations"
                           className="mt-3 box-border flex w-full min-h-[2.5rem] shrink-0 items-center justify-center rounded-lg border border-transparent bg-[#2a2a35] px-3 text-center text-[0.9rem] font-medium text-white transition-colors hover:bg-[#34343f]"
                         >
                           {channel.health === 'attention' ? 'Reconnect' : 'Connect'}

--- a/frontend/aries-v1/settings-screen.tsx
+++ b/frontend/aries-v1/settings-screen.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { useIntegrations } from '@/hooks/use-integrations';
 import { useBusinessProfile } from '@/hooks/use-business-profile';
@@ -11,6 +12,7 @@ import { EmptyStatePanel, LoadingStateGrid, ShellPanel, StatusChip } from './com
 import { connectedProfileLabel } from './connected-profile-labels';
 
 export default function AriesSettingsScreen() {
+  const router = useRouter();
   const integrations = useIntegrations({ autoLoad: true });
   const business = useBusinessProfile({ autoLoad: true });
   const [businessName, setBusinessName] = useState('');
@@ -61,6 +63,14 @@ export default function AriesSettingsScreen() {
   ) {
     const card = integrationCards.find((item) => item.platform === platform);
     if (!card) {
+      return;
+    }
+    // Connect/Reconnect are brokered by Composio on the canonical "Channel
+    // Integrations" screen, NOT the legacy direct-Meta OAuth path the shared
+    // integrations hook would otherwise call (#704). Disconnect of an existing
+    // connection keeps its current behavior so live connections are untouched.
+    if (action === 'connect' || action === 'reconnect') {
+      router.push('/dashboard/settings/channel-integrations');
       return;
     }
     await integrations.runAction(action, card);

--- a/frontend/integrations/composio-connections-screen.tsx
+++ b/frontend/integrations/composio-connections-screen.tsx
@@ -216,6 +216,13 @@ export default function ComposioConnectionsScreen() {
           const caps = conn.capabilities;
           const st = statusText(conn.status, caps);
           const isConnected = conn.status === 'connected';
+          // A pending / reauthorization_required / error row has an EXISTING
+          // connection record that can be cleared. A truly not_connected row has
+          // nothing to clear (#703).
+          const hasClearableRow =
+            conn.status === 'pending' ||
+            conn.status === 'reauthorization_required' ||
+            conn.status === 'error';
           return (
             <div key={conn.platform} className="rounded-xl border border-slate-700 bg-slate-900/40 p-5">
               <div className="flex items-start justify-between gap-4">
@@ -239,14 +246,30 @@ export default function ComposioConnectionsScreen() {
                       {busy === conn.platform ? '…' : 'Disconnect'}
                     </button>
                   ) : (
-                    <button
-                      type="button"
-                      onClick={() => connect(conn.platform)}
-                      disabled={busy === conn.platform || (data ? !data.composioEnabled : true)}
-                      className="rounded-lg bg-violet-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50"
-                    >
-                      {busy === conn.platform ? 'Starting…' : 'Connect'}
-                    </button>
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => connect(conn.platform)}
+                        disabled={busy === conn.platform || (data ? !data.composioEnabled : true)}
+                        className="rounded-lg bg-violet-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50"
+                      >
+                        {busy === conn.platform ? 'Starting…' : 'Connect'}
+                      </button>
+                      {hasClearableRow && (
+                        // Clear a stuck row via the same disconnect handler (the
+                        // backend deletes unconditionally), so a pending / error /
+                        // reauthorization_required card isn't limited to Connect —
+                        // which would upsert ANOTHER pending row (#703).
+                        <button
+                          type="button"
+                          onClick={() => disconnect(conn.platform)}
+                          disabled={busy === conn.platform}
+                          className="rounded-lg border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800 disabled:opacity-50"
+                        >
+                          {busy === conn.platform ? '…' : 'Clear'}
+                        </button>
+                      )}
+                    </>
                   )}
                 </div>
               </div>

--- a/frontend/onboarding/pipeline-intake/steps/ConnectPlatformsStep.tsx
+++ b/frontend/onboarding/pipeline-intake/steps/ConnectPlatformsStep.tsx
@@ -7,7 +7,12 @@ import StepContainer from '../components/StepContainer';
 const META_PLATFORM = 'facebook';
 const IG_PLATFORM = 'instagram';
 
-const META_OAUTH_HREF = '/oauth/connect/facebook';
+// Connect Facebook/Instagram through the canonical Composio connections screen
+// (the "Channel Integrations" surface), NOT the legacy direct-Meta OAuth broker
+// at /oauth/connect/* (which is no longer the connect path and, for Instagram,
+// is a dead branch that errors). Composio brokers the account connection and
+// returns the operator to this same screen on completion (#704).
+const META_OAUTH_HREF = '/dashboard/settings/channel-integrations';
 
 export type ConnectionState =
   | 'connected'

--- a/tests/channel-integrations-composio-surface.test.ts
+++ b/tests/channel-integrations-composio-surface.test.ts
@@ -44,3 +44,90 @@ test('the Composio OAuth callback returns the operator to the in-dashboard conne
 test('the standalone /connections route redirects to the canonical in-dashboard surface', () => {
   assert.match(connectionsPageSource, /redirect\('\/dashboard\/settings\/channel-integrations'\)/);
 });
+
+// ─── #703: Clear affordance for stuck rows in ComposioConnectionsScreen ───────
+
+const composioConnectionsScreenSource = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'integrations', 'composio-connections-screen.tsx'),
+  'utf8',
+);
+
+test('#703: composio-connections-screen defines hasClearableRow for pending/reauthorization_required/error', () => {
+  // The hasClearableRow gate must cover exactly the three non-terminal stuck
+  // statuses. A not_connected row has no existing connection record to clear.
+  assert.ok(
+    composioConnectionsScreenSource.includes("hasClearableRow"),
+    'screen must define a hasClearableRow variable to gate the Clear button',
+  );
+  // All three stuck statuses must be in the gate.
+  const gateIdx = composioConnectionsScreenSource.indexOf('hasClearableRow');
+  const gateBlock = composioConnectionsScreenSource.slice(gateIdx, gateIdx + 200);
+  assert.ok(
+    gateBlock.includes("'pending'") || gateBlock.includes('"pending"'),
+    'hasClearableRow must include pending status',
+  );
+  assert.ok(
+    gateBlock.includes("'reauthorization_required'") || gateBlock.includes('"reauthorization_required"'),
+    'hasClearableRow must include reauthorization_required status',
+  );
+  assert.ok(
+    gateBlock.includes("'error'") || gateBlock.includes('"error"'),
+    'hasClearableRow must include error status',
+  );
+  // not_connected must NOT appear in the hasClearableRow gate.
+  assert.ok(
+    !gateBlock.includes("'not_connected'") && !gateBlock.includes('"not_connected"'),
+    'hasClearableRow must NOT include not_connected — that status has no record to clear',
+  );
+});
+
+test('#703: composio-connections-screen renders a Clear button gated on hasClearableRow, wired to disconnect', () => {
+  // The Clear button must only appear when hasClearableRow is true (i.e. not for
+  // not_connected rows) and must call the same disconnect handler as the
+  // connected-branch Disconnect button.
+  const clearBtnIdx = composioConnectionsScreenSource.indexOf("'Clear'");
+  assert.ok(clearBtnIdx >= 0, "screen must render a 'Clear' button label");
+
+  // The block around the Clear button must be guarded by hasClearableRow.
+  // Look back up to 900 chars from the button label for the hasClearableRow gate.
+  // (The gate expression is ~776 chars before the Clear string label in the render output.)
+  const windowBefore = composioConnectionsScreenSource.slice(
+    Math.max(0, clearBtnIdx - 900),
+    clearBtnIdx,
+  );
+  assert.ok(
+    windowBefore.includes('hasClearableRow'),
+    'Clear button must be wrapped in a hasClearableRow conditional',
+  );
+
+  // The onClick must call disconnect.
+  // The onClick attribute is ~318 chars before the 'Clear' string label, so use a 400-char lookback.
+  const btnBlock = composioConnectionsScreenSource.slice(clearBtnIdx - 400, clearBtnIdx + 50);
+  assert.ok(
+    btnBlock.includes('disconnect('),
+    "Clear button's onClick must call the disconnect handler",
+  );
+});
+
+test('#703: composio-connections-screen connected branch renders Disconnect (not Clear)', () => {
+  // The connected branch renders a Disconnect button. This is distinct from the
+  // non-connected branch's Clear button: a live connection must say "Disconnect",
+  // not "Clear" (which is for stuck/partial rows).
+  const isConnectedBranchIdx = composioConnectionsScreenSource.indexOf('isConnected ?');
+  assert.ok(isConnectedBranchIdx >= 0, 'screen must have an isConnected branch');
+
+  // Within ~450 chars of the isConnected branch the Disconnect label appears
+  // (the button text is inside the button children, after the className prop).
+  const connectedBlock = composioConnectionsScreenSource.slice(
+    isConnectedBranchIdx,
+    isConnectedBranchIdx + 500,
+  );
+  assert.ok(
+    connectedBlock.includes("'Disconnect'") || connectedBlock.includes('"Disconnect"'),
+    'the connected branch must render a Disconnect button, not a Clear button',
+  );
+  assert.ok(
+    !connectedBlock.includes("'Clear'") && !connectedBlock.includes('"Clear"'),
+    'the connected branch must not render a Clear button — that is only for stuck rows',
+  );
+});

--- a/tests/connect-routes-to-composio.test.ts
+++ b/tests/connect-routes-to-composio.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+/**
+ * Adversarial regression suite for #704.
+ *
+ * Each of the four surfaces that previously linked FB/IG connect/reconnect to
+ * the legacy /oauth/connect/* direct-Meta OAuth broker must now route to the
+ * canonical Composio connect surface at /dashboard/settings/channel-integrations.
+ *
+ * Fail-before: before the fix, each surface contained a quoted '/oauth/connect/<platform>'
+ * href or push target; after the fix, all four must reference the Composio surface and
+ * no quoted functional reference to /oauth/connect/ may exist.
+ *
+ * Note: source comments may mention /oauth/connect/ as documentation; the negative
+ * assertion is scoped to quoted string literals (the form that appears in code, not
+ * prose), so documentation comments do not trip it.
+ */
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+const COMPOSIO_SURFACE = '/dashboard/settings/channel-integrations';
+// Quoted form only — prose comments use the bare path without surrounding quotes
+// and should not be flagged.
+const LEGACY_OAUTH_SQ = "'/oauth/connect/";
+const LEGACY_OAUTH_DQ = '"/oauth/connect/';
+
+function noLegacyOAuthRef(src: string): boolean {
+  return !src.includes(LEGACY_OAUTH_SQ) && !src.includes(LEGACY_OAUTH_DQ);
+}
+
+// ─── Surface 1: Dashboard Home Presenter ─────────────────────────────────────
+
+test('dashboard-home-presenter: connect/reconnect Link points to Composio surface, not legacy OAuth', () => {
+  const src = readFileSync(
+    path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'presenters', 'dashboard-home-presenter.tsx'),
+    'utf8',
+  );
+
+  assert.ok(
+    src.includes(`href="${COMPOSIO_SURFACE}"`),
+    'dashboard-home-presenter must render a Link href to the Composio channel-integrations surface',
+  );
+  assert.ok(
+    noLegacyOAuthRef(src),
+    'dashboard-home-presenter must not contain a quoted /oauth/connect/ functional reference',
+  );
+});
+
+// ─── Surface 2: Settings Screen ───────────────────────────────────────────────
+
+test('settings-screen: handleIntegrationAction routes connect/reconnect to Composio surface, not legacy OAuth', () => {
+  const src = readFileSync(
+    path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'settings-screen.tsx'),
+    'utf8',
+  );
+
+  assert.ok(
+    src.includes(`'${COMPOSIO_SURFACE}'`) || src.includes(`"${COMPOSIO_SURFACE}"`),
+    'settings-screen handleIntegrationAction must push to the Composio channel-integrations surface',
+  );
+  assert.ok(
+    noLegacyOAuthRef(src),
+    'settings-screen must not contain a quoted /oauth/connect/ functional reference',
+  );
+  // Structural check: the connect/reconnect branch pushes to Composio, not legacy.
+  const handleFnStart = src.indexOf('handleIntegrationAction');
+  assert.ok(handleFnStart >= 0, 'settings-screen must define handleIntegrationAction');
+  // 800-char window covers the full function body (router.push is ~610 chars in).
+  const fnBody = src.slice(handleFnStart, handleFnStart + 800);
+  assert.ok(
+    fnBody.includes(COMPOSIO_SURFACE),
+    'handleIntegrationAction body must contain the Composio surface path',
+  );
+});
+
+// ─── Surface 3: Onboarding ConnectPlatformsStep ───────────────────────────────
+
+test('ConnectPlatformsStep: META_OAUTH_HREF constant is the Composio surface, not legacy OAuth', () => {
+  const src = readFileSync(
+    path.join(
+      PROJECT_ROOT,
+      'frontend',
+      'onboarding',
+      'pipeline-intake',
+      'steps',
+      'ConnectPlatformsStep.tsx',
+    ),
+    'utf8',
+  );
+
+  assert.ok(
+    src.includes(`'${COMPOSIO_SURFACE}'`) || src.includes(`"${COMPOSIO_SURFACE}"`),
+    'ConnectPlatformsStep META_OAUTH_HREF must be set to the Composio surface',
+  );
+  assert.ok(
+    noLegacyOAuthRef(src),
+    'ConnectPlatformsStep must not contain a quoted /oauth/connect/ functional reference',
+  );
+  // Confirm the constant declaration is the Composio surface.
+  const metaHrefIdx = src.indexOf('META_OAUTH_HREF');
+  assert.ok(metaHrefIdx >= 0, 'ConnectPlatformsStep must declare META_OAUTH_HREF');
+  const constDecl = src.slice(metaHrefIdx, metaHrefIdx + 80);
+  assert.ok(
+    constDecl.includes(COMPOSIO_SURFACE),
+    'META_OAUTH_HREF constant must be assigned the Composio surface path',
+  );
+});
+
+// ─── Surface 4: Instagram Publish Drawer (reconnect link) ─────────────────────
+
+test('instagram-publish-drawer: reconnect anchor href is Composio surface, not legacy OAuth', () => {
+  const src = readFileSync(
+    path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'instagram-publish-drawer.tsx'),
+    'utf8',
+  );
+
+  assert.ok(
+    src.includes(`"${COMPOSIO_SURFACE}"`) || src.includes(`'${COMPOSIO_SURFACE}'`),
+    'instagram-publish-drawer reconnect anchor must href to the Composio channel-integrations surface',
+  );
+  assert.ok(
+    noLegacyOAuthRef(src),
+    'instagram-publish-drawer must not contain a quoted /oauth/connect/ functional reference',
+  );
+});

--- a/tests/onboarding-connect-step.test.ts
+++ b/tests/onboarding-connect-step.test.ts
@@ -253,7 +253,10 @@ test('Connect step renders both Meta and Instagram cards even if only one comes 
   assert.equal(igCard.props['data-state'], 'not_connected');
 });
 
-test('Connect cards link to the Meta OAuth route by default', async () => {
+test('Connect cards route to the Composio channel-integrations surface, not legacy OAuth', async () => {
+  // Regression guard for #704: the onboarding ConnectPlatformsStep CTAs must
+  // point to /dashboard/settings/channel-integrations (the Composio connect
+  // surface), NOT the legacy /oauth/connect/* direct-Meta OAuth path.
   const { act, create } = await import('react-test-renderer');
   let root!: import('react-test-renderer').ReactTestRenderer;
 
@@ -279,8 +282,15 @@ test('Connect cards link to the Meta OAuth route by default', async () => {
 
   const fbCta = root.root.findByProps({ 'data-testid': 'connect-card-cta-facebook' });
   const igCta = root.root.findByProps({ 'data-testid': 'connect-card-cta-instagram' });
-  assert.equal(fbCta.props.href, '/oauth/connect/facebook');
-  assert.equal(igCta.props.href, '/oauth/connect/facebook');
+  assert.equal(fbCta.props.href, '/dashboard/settings/channel-integrations',
+    'FB connect CTA must route to the Composio surface, not /oauth/connect/*');
+  assert.equal(igCta.props.href, '/dashboard/settings/channel-integrations',
+    'IG connect CTA must route to the Composio surface, not /oauth/connect/*');
+  // Explicit anti-regression: neither CTA may reference the legacy path.
+  assert.ok(!fbCta.props.href.startsWith('/oauth/connect/'),
+    'FB connect CTA must not reference the legacy /oauth/connect/ path');
+  assert.ok(!igCta.props.href.startsWith('/oauth/connect/'),
+    'IG connect CTA must not reference the legacy /oauth/connect/ path');
 });
 
 test('Connect step never renders LinkedIn, X, TikTok, YouTube, or Reddit cards', async () => {


### PR DESCRIPTION
Closes #704
Closes #703

## #704 (sev:HIGH) — connect-correctness: FB/IG Connect/Reconnect must route through Composio
The QA-loop connect audit found four UI surfaces that still wired Facebook/Instagram **Connect/Reconnect** to the legacy direct-Meta OAuth broker at `/oauth/connect/*` — which is no longer the connect path (and, for Instagram, a dead branch in `backend/integrations/oauth-authorize-urls.ts` that throws). Composio now brokers every platform, so all four were repointed to the canonical Composio surface `/dashboard/settings/channel-integrations` (→ `ComposioConnectionsScreen` → `POST /api/integrations/composio/<platform>/connect` → `handleComposioConnect`):

- `frontend/aries-v1/presenters/dashboard-home-presenter.tsx` — the Connect/Reconnect `<Link href>`
- `frontend/aries-v1/settings-screen.tsx` — `handleIntegrationAction` intercepts `connect`/`reconnect` and `router.push`es to the Composio surface; **disconnect falls through to the shared `useIntegrations` hook unchanged**
- `frontend/onboarding/pipeline-intake/steps/ConnectPlatformsStep.tsx` — the `META_OAUTH_HREF` constant
- `frontend/aries-v1/instagram-publish-drawer.tsx` — the reconnect `<a href>`

**FB connect is intact.** The repoints only change what a *new* Connect/Reconnect click navigates to — no connection state, token path, or Composio publish/connect backend is touched. The shared `hooks/use-integrations.ts` and the settings-screen disconnect path are unmodified. Reachability was audited: the 3 other `/oauth/connect`-referencing screens (`app-shell/dashboard-console`, `aries-v1/channel-integrations-screen`, `settings/integrations`) have no importers (unmounted); the other two mounted `useIntegrations` consumers (`home-dashboard`, `business-profile-screen`) use the hook only for disconnect/status and already link to the Composio surface; `META_CONNECT_REDIRECT_DESTINATION` is informational-only (the gate never redirects to it — the real advisory CTA is already the Composio surface). The legacy IG throw is now unreachable from the UI.

## #703 (sev:MEDIUM) — cannot clear a stuck Instagram connection
`frontend/integrations/composio-connections-screen.tsx` now renders a **Clear** button for non-connected rows whose status is `pending`/`reauthorization_required`/`error` (an existing record that can be cleared), wired to the existing `disconnect()` handler (`DELETE /api/integrations/composio/<platform>`, tenant-isolated, returns 2xx even when nothing was deleted). A `not_connected` row shows **Connect** only (nothing to clear). The connected branch (**Disconnect**) is byte-identical.

## Tests
- New adversarial `tests/connect-routes-to-composio.test.ts` locks the composio-for-all invariant: each of the 4 surfaces targets the Composio surface and no quoted `/oauth/connect/` functional reference remains (fails pre-fix via the positive assertion).
- `tests/onboarding-connect-step.test.ts` updated to assert the Composio target + anti-regression on the legacy path.
- `tests/channel-integrations-composio-surface.test.ts` adds #703 Clear-button coverage (gate covers exactly the 3 clearable statuses, excludes `not_connected`, wired to `disconnect`, connected branch still renders Disconnect).
- `npm run verify` green (18 steps); focused gate 34/34; 50/50 across the affected files.

## Residual risk
Low. Frontend-navigation-only changes plus one button; no DB fan-out, no backend/token changes, no banned patterns. The legacy `/oauth/connect/[provider]` route remains reachable by direct URL (intentionally retained) but nothing in the UI links into it.

Credit: surfaced by the autonomous prod QA-loop connect audit (#704/#703).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoiY71TzLCK6FnwKourTW2