### PR TITLE
docs: Diátaxis tutorials, how-tos, and API/worker reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,24 @@ in `.env` at a database the container can reach. See
 
 ## Documentation
 
-| Doc | What it covers |
-|-----|----------------|
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture and the Hermes execution boundary |
-| [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Running Aries AI locally, environment variables |
-| [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Production deployment with Docker |
-| [docs/OAUTH_SCOPES.md](docs/OAUTH_SCOPES.md) | OAuth providers and required scopes |
-| [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) | Auth, tenant isolation, callback trust boundary |
-| [docs/COMMERCIAL.md](docs/COMMERCIAL.md) | What is open source vs. commercial / managed hosting |
+Full documentation lives in [`docs/`](docs/README.md), organized by the
+[Diátaxis](https://diataxis.fr) framework. Highlights:
+
+| Doc | Quadrant | What it covers |
+|-----|----------|----------------|
+| [docs/tutorials/first-week-of-content.md](docs/tutorials/first-week-of-content.md) | Tutorial | Onboard a tenant, generate, review, approve, and schedule a week |
+| [docs/how-to/generate-and-approve-a-week.md](docs/how-to/generate-and-approve-a-week.md) | How-to | Submit a weekly job and walk the approval stages (UI and API) |
+| [docs/how-to/connect-a-social-platform.md](docs/how-to/connect-a-social-platform.md) | How-to | Connect a channel via OAuth/Composio; token storage; reconnecting |
+| [docs/how-to/integrate-hermes.md](docs/how-to/integrate-hermes.md) | How-to | Point Aries at Hermes and wire the authenticated callback |
+| [docs/how-to/run-background-workers.md](docs/how-to/run-background-workers.md) | How-to | Run and operate the sidecar and in-process workers |
+| [docs/reference/api-jobs-and-callbacks.md](docs/reference/api-jobs-and-callbacks.md) | Reference | The jobs API, approve route, and Hermes callback contract |
+| [docs/reference/background-workers.md](docs/reference/background-workers.md) | Reference | Every worker: command, cadence, env gates, defaults |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Explanation | System architecture and the Hermes execution boundary |
+| [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | How-to | Running Aries AI locally, environment variables |
+| [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | How-to | Production deployment with Docker |
+| [docs/OAUTH_SCOPES.md](docs/OAUTH_SCOPES.md) | Reference | OAuth providers and required scopes |
+| [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md) | Explanation | Auth, tenant isolation, callback trust boundary |
+| [docs/COMMERCIAL.md](docs/COMMERCIAL.md) | Explanation | What is open source vs. commercial / managed hosting |
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ legacy compatibility shim and are not the supported path.
 ## Tech stack
 
 - **Framework:** Next.js App Router (`next` 16.x)
-- **UI:** React 18, Tailwind CSS v4
+- **UI:** React 19, Tailwind CSS v4
 - **Auth:** `next-auth` v5
 - **Data:** PostgreSQL (`pg`) + generated runtime files under `DATA_ROOT`
 - **Execution:** Hermes run submission + authenticated `/api/internal/hermes/runs` callbacks

--- a/ROUTE_MANIFEST.md
+++ b/ROUTE_MANIFEST.md
@@ -17,8 +17,8 @@ This manifest lists the supported direct route contract for the current Aries ru
 | Route | Surface | Purpose |
 |---|---|---|
 | `/dashboard` | App shell | Operator overview |
-| `/dashboard/campaigns` | App shell | Campaign list and workspace entrypoint |
-| `/dashboard/campaigns/:campaignId` | App shell | Campaign workspace |
+| `/dashboard/social-content` | App shell | Weekly social content list and workspace entrypoint |
+| `/dashboard/social-content/:postId` | App shell | Social content post workspace |
 | `/dashboard/posts` | App shell | Publish controls |
 | `/dashboard/calendar` | App shell | Calendar and sync controls |
 | `/dashboard/results` | App shell | Runtime-backed results overview |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# Aries AI documentation
+
+Developer and operator documentation, organized by the
+[Diátaxis](https://diataxis.fr) framework. Each section serves a different reader
+need.
+
+## Tutorials
+
+Learning-oriented walkthroughs. Start here if you are new to Aries.
+
+- [Generate and approve your first week of content](tutorials/first-week-of-content.md)
+
+## How-to guides
+
+Task-oriented guides for getting a specific job done.
+
+- [Generate and approve a week of social content](how-to/generate-and-approve-a-week.md)
+- [Connect a social platform](how-to/connect-a-social-platform.md)
+- [Connect Aries to a Hermes execution endpoint](how-to/integrate-hermes.md)
+- [Run and operate the background workers](how-to/run-background-workers.md)
+- [Self-hosting Aries AI](SELF_HOSTING.md) - local setup and the full environment-variable reference
+- [Production deployment](DEPLOYMENT.md)
+
+## Reference
+
+Complete, factual descriptions of the surface you build against.
+
+- [API: social-content jobs and callbacks](reference/api-jobs-and-callbacks.md)
+- [Background workers](reference/background-workers.md)
+- [OAuth providers and scopes](OAUTH_SCOPES.md)
+- [System reference](SYSTEM-REFERENCE.md) - the full route and surface inventory
+
+## Explanation
+
+Background on why Aries works the way it does.
+
+- [Architecture and the Hermes execution boundary](ARCHITECTURE.md)
+- [Security model](SECURITY_MODEL.md) - auth, tenant isolation, the callback trust boundary
+- [Commercial vs open source](COMMERCIAL.md)
+- [Honcho integration](honcho-integration.md)
+- [Composio integration](integrations/composio.md)
+
+## Internal history
+
+`plans/`, `audits/`, `prd/`, `product/`, and `operations/` hold planning notes,
+PRD audits, and product specs. They record how Aries was built and are not
+maintained as current product documentation; prefer the sections above for
+how the system behaves today.

--- a/docs/how-to/connect-a-social-platform.md
+++ b/docs/how-to/connect-a-social-platform.md
@@ -1,0 +1,109 @@
+# How to connect a social platform
+
+Connect a publishing channel so Aries can publish approved posts to it and sync insights back.
+
+This is an operator task. You start the connection in the dashboard, the channel owner grants access through the provider's OAuth screen, and Aries stores the resulting tokens (encrypted) so it can publish and pull insights. Connecting one channel takes a few minutes.
+
+## Prerequisites
+
+- An Aries account with access to the dashboard. Tenant identity is derived server-side from your session, not from any request body, so you must be signed in.
+- Admin access on the provider account you are connecting (for example, a Facebook account that owns at least one Page with the admin role).
+- Provider client credentials configured in the environment for the channel you want. Each provider's env vars, requested scopes, and callback URL are listed in [docs/OAUTH_SCOPES.md](../OAUTH_SCOPES.md). A channel with missing credentials shows as `disabled` / `health: error` in the UI.
+- `OAUTH_TOKEN_ENCRYPTION_KEY` set to a stable 32-byte key. Without it, token encryption fails and the connect callback returns `provider_unavailable`. See [Token storage and encryption](#token-storage-and-encryption).
+
+## Steps
+
+1. **Open the connect surface.** Go to `/dashboard/settings/channel-integrations` (source: `app/dashboard/settings/channel-integrations/page.tsx`). This page renders `<ComposioConnectionsScreen />` inside the dashboard shell with `currentRouteId="channelIntegrations"`. Composio is now the primary connect surface and brokers Facebook, Instagram, and the other toolkits. Expected result: a list of channel cards, each showing a connection state and the actions available for it.
+
+2. **Read the card state before acting.** These exact field names are the Aries broker API representation (`GET /api/integrations`); the Composio screen renders the same connection states with its own labels, so match on the meaning (connected, pending, needs reconnect, not connected, error) rather than the literal string. In the broker shape, each card carries a `connection_state` (`connected`, `connection_pending`, `disabled`, `reauth_required`, `not_connected`, or `connection_error`), a `health` value (`healthy`, `degraded`, `error`, `unknown`), and an `available_actions` list. A channel you have not connected yet shows `not_connected` with `available_actions` `['connect', 'view_permissions']`. Expected result: you can tell which action to take from the card.
+
+3. **Start the connect flow.** Click the channel's connect action. The rendered Composio screen posts to `POST /api/integrations/composio/{provider}/connect`, reads a `connectUrl` from the response, and navigates the browser to it. The direct Aries broker API documented below is a separate path: `POST /api/integrations/connect` (also backed by `POST /api/oauth/{provider}/start`, which delegates straight to `handleIntegrationsConnect`). If you are calling that API directly, the request body field is `platform`:
+
+   ```bash
+   curl -i -X POST https://<your-host>/api/integrations/connect \
+     -H 'content-type: application/json' \
+     --data '{"platform":"linkedin"}'
+   ```
+
+   The server builds the broker payload in `buildOauthConnectInput` (`lib/oauth-connect-input.ts`): `{ tenant_id, redirect_uri, scopes }`. The `scopes` default to `PROVIDER_REGISTRY[provider].default_scopes`, so you do not pass scopes yourself. The `redirect_uri` is derived from `APP_BASE_URL`. Expected result: HTTP 200 with `broker_status: 'ok'` and an `authorization_url` (source: `backend/integrations/connect.ts`).
+
+4. **Authorize with the provider.** Send the channel owner to the `authorization_url` and have them grant the requested scopes. The provider redirects back to the registered callback route `GET /api/auth/oauth/{provider}/callback`, handled by `handleOauthCallbackHttp` (`backend/integrations/callback.ts`). An equivalent `GET /api/oauth/{provider}/callback` route runs the same handler. For a browser flow (`Accept: text/html`), the callback issues a 302 redirect to `/oauth/connect/{provider}?result=connected` on success or `result=error` on failure. Expected result: Aries exchanges the authorization code for tokens and marks the connection `connected`.
+
+5. **Pick a Page for Meta (Facebook/Instagram only).** If the Meta account owns more than one Page, the callback returns `broker_status: 'picker_required'` and redirects to `/onboarding/connect/meta/select-page`. Choose the Page to publish from; the selection is submitted to `POST /api/oauth/meta/select-page`. A single-Page account is selected automatically and skips the picker. Expected result: the chosen Facebook Page (and its linked Instagram business account, if any) is connected.
+
+## Token storage and encryption
+
+Aries writes tokens to the `oauth_tokens` table in PostgreSQL (`backend/integrations/oauth-tokens-db.ts`, `INSERT INTO oauth_tokens ...`). The access and refresh tokens are never stored in plaintext: they go into the `access_token_enc` and `refresh_token_enc` columns.
+
+Encryption is AES-256-GCM via `encryptToken` / `decryptToken` (`backend/integrations/oauth-crypto.ts`). The key comes from `OAUTH_TOKEN_ENCRYPTION_KEY` and must be 32 bytes (read as base64 if it matches a base64 pattern, otherwise utf8). Ciphertext is stored as a JSON envelope: `{ v: 1, alg: 'aes-256-gcm', iv, tag, ct }`.
+
+Generate a key once and keep it stable:
+
+```bash
+OAUTH_TOKEN_ENCRYPTION_KEY=$(openssl rand -base64 32)
+```
+
+Rotating this key invalidates every stored token (existing ciphertext can no longer be decrypted), so all channels would need reconnecting. Keep it stable. See [docs/OAUTH_SCOPES.md](../OAUTH_SCOPES.md) for the same guidance.
+
+Note on Meta: Meta is env-managed, not user-OAuth-brokered. Its long-lived Page token comes from `META_ACCESS_TOKEN`. In the UI this maps to `status_reason === 'env_managed'`, and the card exposes only `['view_permissions']` (no `sync_now` or `disconnect`).
+
+## Verification
+
+- **In the UI:** reload `/dashboard/settings/channel-integrations`. The channel card should show `connection_state: 'connected'` and `health: 'healthy'`, with `available_actions` `['sync_now', 'disconnect', 'view_permissions']` (Meta shows only `['view_permissions']`). The card's `connected_account` reflects the external account, and `expires_at` carries the token expiry.
+
+- **Via the API:** fetch all statuses with `GET /api/integrations` (handled by `handleIntegrationsGet`). Expected result: HTTP 200 with a JSON page payload whose `cards[]` include your channel as `connected`.
+
+  ```bash
+  curl -s https://<your-host>/api/integrations
+  ```
+
+- **Confirm insights sync works:** trigger a sync with `POST /api/integrations/sync` and the `platform` field. Insights platforms (`youtube`, `instagram`, `facebook`) sync directly and return HTTP 200 with per-account results; other providers run through a workflow and return HTTP 202 `accepted`.
+
+  ```bash
+  curl -i -X POST https://<your-host>/api/integrations/sync \
+    -H 'content-type: application/json' \
+    --data '{"platform":"youtube"}'
+  ```
+
+## Reconnecting an expired channel
+
+When a token expires or access is revoked, the connection status becomes `token_expired`, `revoked`, or `permission_denied`. The card then shows `connection_state: 'reauth_required'` with `available_actions` `['reconnect', 'view_permissions']`. A proactive refresh sweeper (`backend/integrations/refresh-sweeper.ts`) also tries to renew tokens before they lapse.
+
+To reconnect:
+
+1. **Click reconnect on the card.** This calls `handleOauthReconnect` (`app/api/integrations/handlers.ts`), which looks up the connection by provider and tenant. If there is no existing `integration_id`, it returns HTTP 404 `connection_not_found` (there is nothing to reconnect; use the connect flow instead). Otherwise it calls `oauthReconnect` with the stored `connection_id`, a fresh `redirect_uri`, scopes, and optional `auth_type`. To force the provider's full re-auth screen, pass `auth_type: 'reauthenticate'`. Expected result: HTTP 200 with `broker_status: 'ok'` and a new `authorization_url`.
+
+2. **Re-authorize with the provider** using the new `authorization_url`, same as the first connect. Expected result: the card returns to `connected` / `healthy`.
+
+You can also renew a still-valid token without a full re-auth via `POST /api/oauth/{provider}/refresh` (`oauthRefresh`). The tenant is derived server-side; a body-level `tenant_id` is ignored. Optional body fields: `token_expires_in_seconds` and `refresh_expires_in_seconds`. It returns HTTP 200 when `broker_status === 'ok'`, otherwise 400, and 403 if you are not authenticated.
+
+```bash
+curl -i -X POST https://<your-host>/api/oauth/linkedin/refresh \
+  -H 'content-type: application/json' \
+  --data '{"token_expires_in_seconds":3600}'
+```
+
+To remove a channel, use the card's disconnect action or `POST /api/integrations/disconnect` (also `POST /api/oauth/{provider}/disconnect`) with the `platform` field. Disconnect returns HTTP 404 `connection_not_found` when there is no live connection to remove.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Connect returns HTTP 503 `provider_unavailable` | Provider client credentials are missing, or `OAUTH_TOKEN_ENCRYPTION_KEY` is unset/invalid. The crypto layer throws `missing_required_fields:OAUTH_TOKEN_ENCRYPTION_KEY` (empty) or `validation_error:OAUTH_TOKEN_ENCRYPTION_KEY_must_be_32_bytes` (wrong length), and the callback maps these to `provider_unavailable`. | Set the provider env vars (see [docs/OAUTH_SCOPES.md](../OAUTH_SCOPES.md)) and a valid 32-byte `OAUTH_TOKEN_ENCRYPTION_KEY`. |
+| Connect returns HTTP 409 `already_connected` | The channel is already connected for this tenant. | Use `sync_now` or `reconnect` instead of connecting again. |
+| Card shows `disabled` / `health: error` | The provider is misconfigured (`connection_status === 'misconfigured'`), so `available_actions` is empty. | Fix the provider credentials, then reload the page. |
+| Callback returns HTTP 401 `authorization_denied` | The user declined consent (`error=access_denied`) at the provider. | Re-run the connect flow and approve the requested scopes. |
+| Callback returns HTTP 400 `invalid_state` | The state token is missing, too short, not found, mismatched, or expired (the pending state has a TTL). | Restart the connect flow from the dashboard so a fresh state is issued; do not reuse an old `authorization_url`. |
+| Callback returns HTTP 400 `missing_required_fields` | The provider redirected back without an authorization `code`. | Retry the connect flow. |
+| Callback returns HTTP 409 `provider_callback_error` | The provider rejected the token exchange. For Meta, a common case is `meta_no_pages_available`: the account owns no Pages. | Connect a provider account in good standing. For Meta, use a Facebook account that owns at least one Page with the admin role. |
+| Reconnect returns HTTP 404 `connection_not_found` | There is no existing connection (`integration_id`) to reconnect. | Use the connect flow (step 3) instead of reconnect. |
+| Refresh returns HTTP 403 | You are not authenticated; `getTenantContext()` threw. | Sign in and retry. |
+| Meta card has no `sync_now` / `disconnect` | Meta is env-managed (`status_reason === 'env_managed'`) with a long-lived token from `META_ACCESS_TOKEN`. | Manage the Meta token through the environment, not the UI. The default Graph API version is `v21.0` (`META_GRAPH_API_VERSION`). |
+
+> Note on callback routes: the broker constructs the provider `redirect_uri` as `${APP_BASE_URL}/api/auth/oauth/{provider}/callback` (in `lib/oauth-connect-input.ts` and `handleOauthReconnect`), and `docs/OAUTH_SCOPES.md` registers callback URLs with the same `/api/auth/oauth/...` path. That route exists (`app/api/auth/oauth/[provider]/callback/route.ts`), and so does a shorter `/api/oauth/{provider}/callback` route (`app/api/oauth/[provider]/callback/route.ts`); both delegate to `handleOauthCallbackHttp`. The registered callback URL therefore resolves to a real handler. The same `/api/auth/oauth/...` tree also exposes `connect`, `disconnect`, and `reconnect` routes.
+
+## Related
+
+- [OAuth providers and scopes](../OAUTH_SCOPES.md)
+- [How to generate and approve a week of social content](../how-to/generate-and-approve-a-week.md)
+- [Security model](../SECURITY_MODEL.md)

--- a/docs/how-to/generate-and-approve-a-week.md
+++ b/docs/how-to/generate-and-approve-a-week.md
@@ -1,0 +1,213 @@
+# How to generate and approve a week of social content
+
+Submit a weekly social-content job, walk it through the approval stages (strategy -> production -> publish), then edit and schedule the resulting posts. This guide covers the dashboard UI and the API.
+
+## Prerequisites
+
+- A tenant account that has finished onboarding. Jobs and approvals both return HTTP 409 with `reason: 'onboarding_required'` until onboarding is complete.
+- For the API path: a way to call the app's HTTP endpoints with your tenant session (the same cookies/headers your browser sends). Tenant identity and the approving actor are derived server-side from this context, not from the request body.
+- A connected social platform (for example Meta/Instagram) if you intend to live-publish. See [../how-to/connect-a-social-platform.md](../how-to/connect-a-social-platform.md).
+
+## What a "week" is
+
+The weekly job type is `weekly_social_content`. On the social-content route the submitted `jobType` field is ignored: `resolveRequestedJobType` always resolves to `weekly_social_content` (`app/api/marketing/jobs/handler.ts`).
+
+Default scope, from `DEFAULT_SOCIAL_CONTENT_COUNTS` in `backend/social-content/types.ts` (this is the constant the normalizer reads):
+
+| Field | Default | Cap |
+| --- | --- | --- |
+| `postWindowDays` | 7 | clamped 1-14 |
+| `staticPostCount` | 7 | floored at 0 |
+| `storyCount` | 1 | floored at 0 |
+| `imageCreativeCount` | 6 | max 6 |
+| `videoScriptCount` | 1 | floored at 0 |
+| `videoRenderCount` | 0 | max 1 |
+| `channels` | `['meta','instagram']` | enum: `meta\|instagram\|linkedin\|x\|tiktok\|youtube` |
+
+The window-day bounds can be overridden with the env vars `ARIES_SOCIAL_CONTENT_WINDOW_DAYS_MIN` and `ARIES_SOCIAL_CONTENT_WINDOW_DAYS_MAX` (`backend/social-content/payload.ts`). Normalization is in `normalizeWeeklySocialContentPayload`; the day clamp is `clampWeeklyWindowDays`.
+
+## Steps
+
+### Option A: the dashboard UI
+
+1. Open `/dashboard/social-content/new`. You land on the "New Social Content" screen (page title `New Social Content · Aries AI`). This route renders the shared `MarketingNewJobScreen` form (`app/dashboard/social-content/new/page.tsx`).
+2. Fill in the brand fields. The form maps to the same payload keys the API uses: brand URL, business name, business type, primary goal, audience, offer, brand voice, style vibe, channels, and the per-week counts. Leave the counts untouched to accept the weekly defaults above.
+3. Optionally attach brand assets. The form uploads them under the `brandAssets` field into the job workspace.
+4. Submit. The job is created (HTTP 202 under the hood) and you are redirected into the dashboard for that job.
+   - Expected result: a new job appears with status reflecting `social_content_job_status` and the first stage in `social_content_stage`.
+5. Walk the approval checkpoints from the job's dashboard as each stage finishes generating. The job pauses at each checkpoint with stage status `awaiting_approval`. Approve in order: the weekly plan (strategy), then production (post copy, image creatives, video script/render), then publish.
+6. After the production stage is approved, edit and schedule. Adjust caption/hashtags/CTA on the generated posts, then approve the publish checkpoint to schedule or live-publish. Pick platforms at this step (see `publishConfig` below).
+
+### Option B: the API
+
+The three endpoints (all thin wrappers that set `responseDialect: 'social-content'`):
+
+- `POST /api/social-content/jobs` (`app/api/social-content/jobs/route.ts`)
+- `GET /api/social-content/jobs/{jobId}` (`app/api/social-content/jobs/[jobId]/route.ts`)
+- `POST /api/social-content/jobs/{jobId}/approve` (`app/api/social-content/jobs/[jobId]/approve/route.ts`)
+
+1. **Create the job.** POST JSON with `{ jobType, payload }` (the route accepts JSON or `multipart/form-data`; for file uploads use FormData with `brandAssets`). For JSON, `payload` defaults to `{}` if omitted, and `jobType` is ignored on this route.
+
+   ```bash
+   curl -X POST https://YOUR_HOST/api/social-content/jobs \
+     -H 'Content-Type: application/json' \
+     --cookie "$ARIES_SESSION_COOKIE" \
+     -d '{
+       "jobType": "weekly_social_content",
+       "payload": {
+         "brandUrl": "https://example.com",
+         "businessName": "Example Co",
+         "businessType": "ecommerce",
+         "primaryGoal": "drive sales",
+         "audience": "small business owners",
+         "channels": ["meta", "instagram"],
+         "postWindowDays": 7
+       }
+     }'
+   ```
+
+   Expected result: HTTP **202** with a body containing `social_content_job_status`, `social_content_stage`, `jobId`, `jobType` (`weekly_social_content`), `approvalRequired`, `approval`, `reason`, `message`, and `jobStatusUrl` (a status PAGE path, `/social-content/status?jobId=<id>`). Save the `jobId`.
+
+   Note: counts you send are normalized. `postWindowDays` is clamped to 1-14 (default 7), `imageCreativeCount` is capped at 6, `videoRenderCount` is capped at 1, and the rest are floored at 0. Token-like strings in the payload are redacted before persistence (`redactTokenLikeString`), so do not rely on putting secrets in any field.
+
+2. **Poll status.** GET the job to see which stage is waiting on you.
+
+   ```bash
+   curl https://YOUR_HOST/api/social-content/jobs/JOB_ID \
+     --cookie "$ARIES_SESSION_COOKIE"
+   ```
+
+   Expected result: HTTP **200** (with an `x-cache` response header). The body includes `social_content_job_state`, `social_content_job_status`, `social_content_stage`, `social_content_stage_status`, `approvalRequired`, `approval`, `stageCards`, `artifacts`, `timeline`, `nextStep`, `publishConfig`, `contentBrief`, `postWindow`, `plannedPostCount`, `createdPostCount`, and `jobType: 'weekly_social_content'`. Wait until `social_content_stage_status` is `awaiting_approval` before approving.
+
+3. **Approve the weekly plan (strategy).** Use `approvalStep: approve_weekly_plan`, which maps to the `strategy` stage (`stageFromSocialApprovalStep`).
+
+   ```bash
+   curl -X POST https://YOUR_HOST/api/social-content/jobs/JOB_ID/approve \
+     -H 'Content-Type: application/json' \
+     --cookie "$ARIES_SESSION_COOKIE" \
+     -d '{
+       "approved": true,
+       "approvalStep": "approve_weekly_plan",
+       "approvedBy": "you@example.com"
+     }'
+   ```
+
+   Expected result: HTTP **202** with `approval_status: "submitted"`, `social_content_approval_status`, `jobId`, `resumedStage`, `completed`, `approvalId`, `reason`, `jobStatusUrl`, and `jobType: 'weekly_social_content'`. (`approved` defaults to `true` if omitted, but send it explicitly.)
+
+4. **Approve production.** As copy and creatives finish, approve the production checkpoints. These steps all map to the `production` stage: `approve_post_copy`, `approve_image_creatives`, `approve_video_script`, `approve_video_render`. Re-poll status (step 2) between each, then:
+
+   ```bash
+   curl -X POST https://YOUR_HOST/api/social-content/jobs/JOB_ID/approve \
+     -H 'Content-Type: application/json' \
+     --cookie "$ARIES_SESSION_COOKIE" \
+     -d '{
+       "approved": true,
+       "approvalStep": "approve_post_copy",
+       "approvedBy": "you@example.com"
+     }'
+   ```
+
+   You can also drive stages directly with `approvedStages` (any of `research`, `strategy`, `production`, `publish`); if you send `approvedStages` it takes precedence over the stage derived from `approvalStep`.
+
+5. **Edit and schedule, then approve publish.** Edit the generated post copy/creatives in the dashboard first. Then approve the final checkpoint with `approve_publish` (maps to `publish`) and choose where it goes via `publishConfig`. Request keys are camelCase and map to the orchestrator's snake_case fields:
+
+   ```bash
+   curl -X POST https://YOUR_HOST/api/social-content/jobs/JOB_ID/approve \
+     -H 'Content-Type: application/json' \
+     --cookie "$ARIES_SESSION_COOKIE" \
+     -d '{
+       "approved": true,
+       "approvalStep": "approve_publish",
+       "approvedBy": "you@example.com",
+       "resumePublishIfNeeded": true,
+       "publishConfig": {
+         "platforms": ["meta", "instagram"],
+         "livePublishPlatforms": ["meta"],
+         "videoRenderPlatforms": []
+       }
+     }'
+   ```
+
+   - `publishConfig.platforms` -> `platforms`
+   - `publishConfig.livePublishPlatforms` -> `live_publish_platforms`
+   - `publishConfig.videoRenderPlatforms` -> `video_render_platforms`
+
+   Expected result: HTTP **202**, same shape as step 3. Posts on `livePublishPlatforms` go out live; the rest are scheduled within the post window.
+
+### Denying a checkpoint
+
+To reject instead of approve, send `approved: false`. This routes to `denySocialContentJob`. You can add `denialReasonCode` (validated against the known codes) and `denialNote` (alias `note`):
+
+```bash
+curl -X POST https://YOUR_HOST/api/social-content/jobs/JOB_ID/approve \
+  -H 'Content-Type: application/json' \
+  --cookie "$ARIES_SESSION_COOKIE" \
+  -d '{
+    "approved": false,
+    "approvalStep": "approve_post_copy",
+    "approvedBy": "you@example.com",
+    "denialNote": "Tone is off, regenerate."
+  }'
+```
+
+A denial also returns HTTP 202 with `approval_status: "submitted"` for the social-content dialect.
+
+## Text-only run
+
+There is no dedicated text-only flag. Zero out the image and video counts; the normalizer floors each at 0, so zero is preserved:
+
+```json
+{
+  "jobType": "weekly_social_content",
+  "payload": {
+    "brandUrl": "https://example.com",
+    "businessType": "ecommerce",
+    "primaryGoal": "drive sales",
+    "staticPostCount": 7,
+    "storyCount": 0,
+    "imageCreativeCount": 0,
+    "videoScriptCount": 0,
+    "videoRenderCount": 0
+  }
+}
+```
+
+Set `storyCount: 0` to suppress the default image story, `imageCreativeCount: 0` to suppress generated images, and both `videoScriptCount: 0` and `videoRenderCount: 0` to suppress video. Sending `renderVideoAfterApproval: false` also zeroes the video render count, but set the script count to 0 as well to fully suppress video.
+
+## Verification
+
+- After create: you got HTTP 202 and a `jobId`. GET the job and confirm `jobType` is `weekly_social_content` and `social_content_stage` is set.
+- During approval: GET the job between steps and confirm `social_content_stage` advances and `social_content_stage_status` moves off `awaiting_approval` for the stage you just approved. The full stage enum is `intake | research | planning | plan_review | copy_production | image_briefing | image_generation | creative_review | social_copy_finalize | video_script | video_review | video_render | publish_review | completed | failed` (`backend/social-content/types.ts`).
+- After publish: GET the job and check `plannedPostCount`/`createdPostCount` and `publishConfig`. Posts on live platforms publish immediately; scheduled posts appear in the timeline.
+
+## Troubleshooting
+
+**Create (`POST /api/social-content/jobs`)**
+
+- **HTTP 409, `reason: 'onboarding_required'`** - finish tenant onboarding, then resubmit.
+- **HTTP 400, `unsupported_job_type:...`** - only relevant off the social-content route; on this route `jobType` is forced to `weekly_social_content`.
+- **HTTP 400, competitor URL error** (`COMPETITOR_URL_INVALID_ERROR` / `COMPETITOR_URL_SOCIAL_ERROR`) - the `competitorUrl` you sent failed validation; fix or omit it.
+- **HTTP 400, `missing_required_fields:...`** - supply the listed fields (typically brand URL, business type, primary goal).
+- **HTTP 422, `brand_kit_...`** - a brand-kit precondition failed; check brand assets/config.
+- **HTTP 501, `workflow_missing_for_route:...`** - the weekly workflow is not registered in this environment; this is a deployment issue, not your request.
+- **HTTP 500** - unhandled server error; check the `error` message and server logs.
+
+**Status (`GET /api/social-content/jobs/{jobId}`)**
+
+- **HTTP 404** - job not found, or it belongs to a different tenant than your session. Confirm the `jobId` and that you are signed in as the owning tenant.
+- **HTTP 409, `onboarding_required`** - finish onboarding.
+
+**Approve (`POST /api/social-content/jobs/{jobId}/approve`)**
+
+- **HTTP 404, `reason: 'marketing_job_not_found'`** - job not found or tenant mismatch.
+- **HTTP 400, `error: 'approvedBy is required.'`, `reason: 'missing_approved_by'`** - include a non-empty `approvedBy`.
+- **HTTP 409, `reason: 'approval_not_available'`** - the job is not waiting on an active checkpoint right now. Re-poll status until `social_content_stage_status` is `awaiting_approval`.
+- **HTTP 409, `reason: 'approval_stage_not_selected'`** - the checkpoint you targeted is not the one currently open; match `approvalStep`/`approvedStages` to the current stage.
+- **HTTP 501, `reason: 'workflow_missing_for_route'`** - workflow not registered; deployment issue.
+- **HTTP 500** - unhandled server error; check the `error` message.
+
+## Related
+
+- [Tutorial: generate and approve your first week of content](../tutorials/first-week-of-content.md)
+- [API reference: social-content jobs and callbacks](../reference/api-jobs-and-callbacks.md)
+- [How to connect a social platform](../how-to/connect-a-social-platform.md)

--- a/docs/how-to/integrate-hermes.md
+++ b/docs/how-to/integrate-hermes.md
@@ -1,0 +1,222 @@
+# How to connect Aries to a Hermes execution endpoint
+
+Point Aries at a Hermes gateway, wire the authenticated callback route, and confirm the link before you run a workflow.
+
+Aries does not execute workflows. It submits them to Hermes and ingests results back through a callback route protected by two layers of auth. This guide covers the env vars Aries needs to submit runs, the inbound callback route's two-layer auth, and how to verify the connection. For why the boundary is split this way (and why the outbound and inbound secrets are different), read [Hermes callback execution boundary](../ARCHITECTURE.md) instead.
+
+## Prerequisites
+
+- A running Hermes gateway you can reach over HTTP, plus its `API_SERVER_KEY` value.
+- The Aries app deployed with a Postgres database (the callback layer reads the `oauth_callback_tokens` table).
+- Shell access to edit the Aries `.env` file. Copy `.env.example` if you have not already.
+- Basic familiarity with environment variables and bearer-token auth.
+
+## Steps
+
+### 1. Select Hermes as the execution provider
+
+Set both provider switches in your `.env`:
+
+```bash
+ARIES_EXECUTION_PROVIDER=hermes
+ARIES_MARKETING_EXECUTION_PROVIDER=hermes
+```
+
+Expected result: Aries routes run submissions through the Hermes port (`backend/marketing/ports/hermes.ts`) rather than any other provider.
+
+### 2. Set the four required submission vars
+
+Aries refuses to submit a run unless all four of these are present. The check lives in `configurationError()` in `backend/marketing/ports/hermes.ts`; a missing value yields `hermes_gateway_not_configured`.
+
+```bash
+# Outbound: where Aries sends runs, and the key it presents.
+HERMES_GATEWAY_URL=http://127.0.0.1:8642
+HERMES_API_SERVER_KEY=replace-with-the-value-of-API_SERVER_KEY-from-your-hermes-env
+
+# Inbound: secret for the callback route, and the base URL Aries hands to Hermes.
+INTERNAL_API_SECRET=your-internal-callback-secret
+APP_BASE_URL=https://your-app.example.com
+```
+
+Notes:
+
+- `HERMES_GATEWAY_URL` has its trailing slashes stripped before use. Aries submits to `POST <HERMES_GATEWAY_URL>/v1/runs` with header `Authorization: Bearer <HERMES_API_SERVER_KEY>`.
+- `INTERNAL_API_SECRET` and `HERMES_API_SERVER_KEY` are deliberately separate secrets. The first is inbound (Hermes -> Aries), the second is outbound (Aries -> Hermes). See [the architecture doc](../ARCHITECTURE.md) for the rationale.
+- `APP_BASE_URL` is used to build the callback URL Aries sends with every submission: `<APP_BASE_URL>/api/internal/hermes/runs`.
+
+Expected result: Aries can now build a valid submission and a valid callback URL.
+
+### 3. (Optional) Route marketing stages to separate Hermes profiles
+
+The weekly marketing pipeline can split execution across three Hermes profiles. Each stage var falls back to the main `HERMES_GATEWAY_URL` / `HERMES_API_SERVER_KEY` when left blank, so a single-gateway deployment can leave all six empty.
+
+```bash
+HERMES_RESEARCH_GATEWAY_URL=
+HERMES_RESEARCH_API_SERVER_KEY=
+HERMES_STRATEGIST_GATEWAY_URL=
+HERMES_STRATEGIST_API_SERVER_KEY=
+HERMES_CONTENT_GATEWAY_URL=
+HERMES_CONTENT_API_SERVER_KEY=
+```
+
+Stage-to-var mapping (from `backend/marketing/ports/hermes.ts`):
+
+| Stage | Gateway var | Key var |
+|---|---|---|
+| Research | `HERMES_RESEARCH_GATEWAY_URL` | `HERMES_RESEARCH_API_SERVER_KEY` |
+| Strategy + publish | `HERMES_STRATEGIST_GATEWAY_URL` | `HERMES_STRATEGIST_API_SERVER_KEY` |
+| Production | `HERMES_CONTENT_GATEWAY_URL` | `HERMES_CONTENT_API_SERVER_KEY` |
+
+Documented ports for a multi-gateway setup: research/default `8642`, strategist `8654`, content `8655`.
+
+Expected result: each stage submits to its own gateway with its own key, or falls back to the main pair when blank.
+
+### 4. (Optional) Tune session, timeout, and poll behaviour
+
+```bash
+HERMES_SESSION_KEY=main
+HERMES_RUN_TIMEOUT_MS=1200000
+HERMES_POLL_INTERVAL_MS=
+```
+
+- `HERMES_SESSION_KEY` names the Hermes session. `.env.example` ships `main`. Note: if the var is unset, the code default in `sessionKey()` is `marketing`, so set it explicitly to avoid surprises.
+- `HERMES_RUN_TIMEOUT_MS` is the per-run terminal-poll budget. `.env.example` ships `1200000` (20 minutes); if the var is unset, the code default in `pollRunUntilTerminal()` is `120000` (2 minutes).
+- `HERMES_POLL_INTERVAL_MS` blank uses the built-in default (`2000`ms), clamped to a `50`ms floor.
+
+Expected result: submissions carry your chosen session key and timeout.
+
+### 5. Keep the reconciler running
+
+This is the key operational fact: Hermes `/v1/runs` is a **polled** API. The gateway executes asynchronously and does **not** POST your `callback_url`. A durable reconciler side-process polls in-flight runs to completion and feeds the same callback handler internally. Do not expect Hermes itself to call your route. See [the architecture doc](../ARCHITECTURE.md) for the full model.
+
+```bash
+ARIES_RECONCILER_ENABLED=1
+ARIES_RECONCILER_INTERVAL_MS=60000
+# HERMES_RECONCILER_POLL_TIMEOUT_MS=15000
+```
+
+- `ARIES_RECONCILER_ENABLED=1` is the default. Leave it on, or runs never advance to completion.
+- `ARIES_RECONCILER_INTERVAL_MS` defaults to `60000` (60s).
+- `HERMES_RECONCILER_POLL_TIMEOUT_MS` is the per-poll Hermes `GET` timeout, default `15000` (15s).
+
+Expected result: finished runs are reconciled and their state advances even though the gateway never calls back.
+
+### 6. Understand the inbound callback route's two-layer auth
+
+The route `POST /api/internal/hermes/runs` (`app/api/internal/hermes/runs/route.ts`) is the trusted ingestion boundary for run results. You do not call it by hand, but you must configure both layers correctly so the reconciler (and any direct caller) can pass.
+
+**Layer 1, transport.** `verifyInternalCallbackRequest` (`lib/internal-callback-auth.ts`) checks the request's `Authorization: Bearer <token>` against `INTERNAL_API_SECRET` using a constant-time compare.
+
+**Layer 2, per-run token.** Every submission includes a `callback_auth` object plus a per-run `callback_token` (32 random bytes, hex). At submission time Aries stores its SHA-256 hash:
+
+```sql
+INSERT INTO oauth_callback_tokens (token_hash, aries_run_id, tenant_id)
+VALUES ($1, $2, $3)
+ON CONFLICT (token_hash) DO NOTHING
+```
+
+On callback, `verifyCallbackToken` reads `callback_token` from the body, hashes it with SHA-256, and looks it up:
+
+```sql
+SELECT token_hash, aries_run_id FROM oauth_callback_tokens WHERE token_hash = $1 LIMIT 1
+```
+
+It then timing-safe compares the hash and requires the row's `aries_run_id` to match the payload's `aries_run_id`.
+
+The `callback_auth` object Aries sends to Hermes looks like this:
+
+```json
+{
+  "type": "internal_api_secret_bearer",
+  "secret_ref": "INTERNAL_API_SECRET",
+  "callback_token": "<per-run plaintext token>"
+}
+```
+
+The inbound callback body Aries expects (validated by `parseHermesRunCallbackPayload` in `backend/execution/hermes-callbacks.ts`):
+
+- Required: `aries_run_id` (must match `^arun_<uuid>$`), `event_id`, `status`, plus `callback_token` for layer 2.
+- Optional: `hermes_run_id`, `stage`, `output`, `approval`, `error`, `protocol_version`.
+- `status` is one of: `running`, `requires_approval`, `completed`, `failed`, `cancelled`, `stopped`.
+- `approval` object: `stage`, `approval_step`, `workflow_step_id`, `prompt`, `resume_token`.
+- `error` object: `code`, `message`, `retryable`.
+- Correlation: `hermes_run_id` must equal the stored `external_run_id`. Duplicate `event_id` values are deduped (idempotent).
+
+A success response is `{ "status": ..., "ariesRunId": ..., "duplicate": ... }`.
+
+Expected result: only callbacks that present the right transport secret **and** a valid per-run token reach `handleHermesRunCallback`.
+
+## Verification
+
+### Check the health endpoint
+
+```bash
+curl -i http://localhost:3000/api/health/hermes
+```
+
+`GET /api/health/hermes` (`app/api/health/hermes/route.ts`) runs `probeHermesSocialContentRuntime(process.env)` and returns the report JSON. HTTP `200` means `report.ok` is true; `503` means the runtime contract is not satisfied. Read the JSON body for the failing field.
+
+### Confirm the transport layer rejects bad auth
+
+```bash
+curl -i -X POST http://localhost:3000/api/internal/hermes/runs \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+With no `Authorization` header you should get `401 missing_internal_callback_secret`. This proves the route is live and layer 1 is enforcing. (Do not send a real bearer token from your shell history; this check is only to confirm rejection behaviour.)
+
+### Submit a real run
+
+Trigger a workflow through the normal Aries UI or API. A correctly wired endpoint produces a `run_id` in the Hermes response (absence yields `hermes_gateway_response_invalid`), and within one reconciler interval the run advances toward `completed`. Aries polls status with `GET <HERMES_GATEWAY_URL>/v1/runs/<runId>`.
+
+## Troubleshooting
+
+### Submission fails with `hermes_gateway_not_configured`
+
+One of the four required vars is missing or blank: `HERMES_GATEWAY_URL`, `HERMES_API_SERVER_KEY`, `INTERNAL_API_SECRET`, `APP_BASE_URL`. Set all four (Step 2) and restart.
+
+### Submission fails with `hermes_gateway_response_invalid`
+
+Hermes accepted the request but the JSON response had no `run_id`. Check that `HERMES_GATEWAY_URL` points at a real Hermes `/v1/runs` endpoint and that `HERMES_API_SERVER_KEY` matches the gateway's `API_SERVER_KEY`.
+
+### Callback returns `503 internal_api_secret_not_configured`
+
+`INTERNAL_API_SECRET` is unset on the Aries side. Set it and restart the app.
+
+### Callback returns `401 missing_internal_callback_secret`
+
+The request had no `Authorization` header, or it was not a well-formed `Bearer <token>`. The caller must send `Authorization: Bearer <INTERNAL_API_SECRET>`.
+
+### Callback returns `403 invalid_internal_callback_secret`
+
+The bearer token did not match `INTERNAL_API_SECRET`. The outbound side (Hermes env, or the reconciler) and the inbound side disagree on the secret. Make them equal.
+
+### Callback returns `400 invalid_json` or `400 invalid_hermes_callback_payload`
+
+The body was not valid JSON, or it failed `parseHermesRunCallbackPayload`. Confirm all required fields are present and that `aries_run_id` matches `^arun_<uuid>$`.
+
+### Callback returns `403 missing_callback_token` or `403 invalid_callback_token`
+
+Layer 2 failed. `missing_callback_token` means the body had no `callback_token`. `invalid_callback_token` means the SHA-256 hash was not found in `oauth_callback_tokens`, or its stored `aries_run_id` did not match the payload. Note: the hash is only persisted when the run's `tenant_id` parses to a positive integer, so a submission without a valid tenant will never have a stored token to match.
+
+### Callback returns `404 execution_run_not_found` or `409 execution_run_locked`
+
+`handleHermesRunCallback` could not find the run (`404`) or the run record was locked by a concurrent write (`409`). For `409`, the reconciler retries on its next sweep.
+
+### Runs never complete even though Hermes finished them
+
+Confirm `ARIES_RECONCILER_ENABLED=1`. The gateway does not call your callback route; the reconciler does the driving. If it is disabled, in-flight runs stall.
+
+## Advanced flags (not in `.env.example`)
+
+These exist in `backend/marketing/ports/hermes.ts` but are not standard config. Do not rely on them in production setups:
+
+- `HERMES_POLL_BRIDGE_ENABLED` (in-process fallback bridge; on unless set to `0`/`false`).
+- `HERMES_SYNC_POLL_FOR_TESTS` (test-only synchronous polling).
+
+## Related
+
+- [Architecture and the Hermes execution boundary](../ARCHITECTURE.md)
+- [API reference: social-content jobs and callbacks](../reference/api-jobs-and-callbacks.md)
+- [Security model](../SECURITY_MODEL.md)

--- a/docs/how-to/run-background-workers.md
+++ b/docs/how-to/run-background-workers.md
@@ -1,0 +1,186 @@
+# How to run and operate the background workers
+
+Run Aries' background automation, enable the opt-in workers, dry-run the draft-expiry sweep, and confirm a worker is actually doing work.
+
+Aries runs background jobs in two places: workers spawned inside the app container by `scripts/start-runtime.mjs`, and standalone sidecar workers that run as their own Docker Compose services. This guide covers the operator tasks. For the per-worker field-by-field breakdown, see the [background workers reference](../reference/background-workers.md).
+
+## Prerequisites
+
+- Shell access to the host running `docker compose`, in the repo root (where `docker-compose.yml` lives).
+- The app image built and the `aries-app` service running and healthy. Every sidecar declares `depends_on: aries-app condition: service_healthy`, so a sidecar will not start until `aries-app` reports healthy.
+- A `.env` file (or exported environment) loaded by Compose. The worker gates and intervals below are read from there.
+- For workers that call back into the app (`aries-scheduled-posts-worker`, `aries-weekly-trigger-worker`): `INTERNAL_API_SECRET` set. Those workers authenticate to the app's internal routes with `Authorization: Bearer ${INTERNAL_API_SECRET}`. (`aries-honcho-performance-worker` does not call the app; it writes to Honcho directly via `recordPerformanceEvent`.)
+
+## Background, in one paragraph
+
+The `aries-app` container starts with `scripts/start-runtime.mjs`. It first runs `scripts/init-db.js` synchronously (idempotent `CREATE/ALTER ... IF NOT EXISTS`); if init-db exits non-zero, start-runtime calls `process.exit(1)` and refuses to fork anything. It then forks the Next.js runtime plus four in-process sibling workers, each behind its own env gate:
+
+| In-process worker | Gate | Default |
+| --- | --- | --- |
+| partner-attribution-outbox | `PARTNER_ATTRIBUTION_ENABLED` | OFF (opt-in, compose `:-false`) |
+| stale-run-reaper | `ARIES_REAPER_ENABLED` | ON in compose (`:-1`) |
+| hermes-kanban-gc | `ARIES_KANBAN_GC_ENABLED` | ON (opt-out, compose `:-1`) |
+| hermes-reconciler | `ARIES_RECONCILER_ENABLED` | ON (opt-out, compose `:-1`) |
+
+Separately, six sidecar Compose services run the same app image with a different `command`:
+
+| Service | Command | Default state | Cadence |
+| --- | --- | --- | --- |
+| `aries-scheduled-posts-worker` | `node scripts/automations/scheduled-posts-worker.mjs` | Always on | every 60s (hardcoded) |
+| `aries-weekly-trigger-worker` | `node_modules/.bin/tsx scripts/automations/weekly-job-trigger-worker.ts` | OFF (`ARIES_WEEKLY_TRIGGER_ENABLED:-0`) | every 15m |
+| `aries-draft-expiry-sweep-worker` | `node_modules/.bin/tsx scripts/automations/draft-expiry-sweep-worker.ts` | OFF (`ARIES_DRAFT_EXPIRY_ENABLED:-0`) | every 6h |
+| `aries-hermes-gc-worker` | `node_modules/.bin/tsx scripts/automations/gc-missing-hermes-assets-worker.ts` | OFF (`ARIES_HERMES_GC_ENABLED:-0`) | every 6h |
+| `aries-insights-sync-worker` | `node_modules/.bin/tsx scripts/automations/insights-sync-worker.ts` | Always on | every 30m (hardcoded) |
+| `aries-honcho-performance-worker` | `npx tsx scripts/automations/honcho-performance-worker.ts` | Ledger writes ON (`HONCHO_WRITE_PUBLISH_ENABLED:-true`) | every 30m (hardcoded) |
+
+Gate parsing (`workerGateEnabled` in `start-runtime.mjs`) treats `1/true/yes/on` as truthy and `0/false/no/off` as falsy. Anything unset or unrecognized falls back to that gate's shipped default.
+
+## Steps
+
+### 1. Bring up the app and all workers
+
+Start the stack. Compose starts `aries-app`, waits for it to be healthy, then starts each sidecar.
+
+```bash
+docker compose up -d
+```
+
+Expected result: `docker compose ps` lists `aries-app` plus the six sidecar services, all `running`. Sidecars whose gate is off still run; they idle rather than exit (see step 4).
+
+### 2. Enable an opt-in sidecar worker via its env gate
+
+The opt-in sidecars ship dormant. To enable one, set its gate to a truthy value and recreate the service. Example for the weekly trigger:
+
+```bash
+# In your .env (or environment):
+ARIES_WEEKLY_TRIGGER_ENABLED=1
+```
+
+```bash
+docker compose up -d aries-weekly-trigger-worker
+```
+
+The same pattern enables the other opt-in workers:
+
+- Draft-expiry sweep: `ARIES_DRAFT_EXPIRY_ENABLED=1`, then recreate `aries-draft-expiry-sweep-worker`.
+- Hermes asset GC: `ARIES_HERMES_GC_ENABLED=1`, then recreate `aries-hermes-gc-worker`.
+
+Expected result: the service logs a `starting;` line instead of the `idling` line. The gate is read once at process start, so you must recreate (not just edit `.env`) for a change to take effect.
+
+### 3. Enable or disable an in-process worker
+
+The in-process workers live inside `aries-app`, so changing their gate means recreating `aries-app`. For example, to turn on the partner-attribution outbox (off by default):
+
+```bash
+# In your .env:
+PARTNER_ATTRIBUTION_ENABLED=true
+```
+
+```bash
+docker compose up -d aries-app
+```
+
+To switch off one of the opt-out workers (reaper, kanban-gc, reconciler), set its gate to a falsy value, for example `ARIES_RECONCILER_ENABLED=0`, then recreate `aries-app`.
+
+Expected result: start-runtime forks (or skips) the matching worker on the next boot. The hermes-reconciler auto-respawns on crash, with a crash-loop guard that stops restarting after 5 restarts within 60000ms.
+
+### 4. Dry-run the draft-expiry sweep
+
+Before letting the sweep delete anything, run it read-only. `ARIES_DRAFT_EXPIRY_DRY_RUN=1` makes every tick issue only count queries through `runDraftExpirySweep(pool, { dryRun, ageDays })` in `backend/marketing/draft-expiry-sweep.ts`; it writes nothing. The sweep talks directly to Postgres, so it needs no app round-trip.
+
+To run one read-only cycle and exit, combine dry-run with one-shot mode:
+
+```bash
+docker compose run --rm \
+  -e ARIES_DRAFT_EXPIRY_ENABLED=1 \
+  -e ARIES_DRAFT_EXPIRY_DRY_RUN=1 \
+  -e ARIES_DRAFT_EXPIRY_RUN_ONCE=1 \
+  aries-draft-expiry-sweep-worker
+```
+
+Expected result: a startup line, then a summary line, then the process exits. The summary reports `dry_run`, `age_days`, `cutoff`, `candidates`, `expired`, `batches`, `truncated`, and `top_tenants`:
+
+```
+[draft-expiry-sweep-worker] starting; interval=...ms age_days=14 dry_run=true
+[draft-expiry-sweep-worker] summary {"dry_run":true,"age_days":14,"cutoff":"...","candidates":N,"expired":0,...}
+```
+
+In dry-run, `candidates` shows how many drafts would expire and `expired` stays `0`. Tune the age window with `ARIES_DRAFT_EXPIRY_AGE_DAYS` (default `14`). When you are satisfied, set `ARIES_DRAFT_EXPIRY_DRY_RUN=0` and `ARIES_DRAFT_EXPIRY_ENABLED=1` and recreate the long-running service to commit deletions on the 6h interval (`ARIES_DRAFT_EXPIRY_INTERVAL_MS`, default `21600000`).
+
+Other workers expose the same one-shot escape hatch: `ARIES_SCHEDULED_POSTS_RUN_ONCE=1`, `ARIES_WEEKLY_TRIGGER_RUN_ONCE=1`, `ARIES_HONCHO_PERF_RUN_ONCE=1`.
+
+## Verification
+
+Confirm a worker is doing work, not just running.
+
+### Check startup vs idle log lines
+
+Each sidecar logs one line at startup. An enabled worker logs `starting;`; a gated-off worker logs `idling`.
+
+```bash
+docker compose logs --tail=50 aries-scheduled-posts-worker
+docker compose logs --tail=50 aries-weekly-trigger-worker
+docker compose logs --tail=50 aries-draft-expiry-sweep-worker
+```
+
+Enabled examples:
+
+```
+[scheduled-posts-worker] starting; interval=60000ms batch=50
+[weekly-trigger-worker] starting; interval=900000ms
+[draft-expiry-sweep-worker] starting; interval=21600000ms age_days=14 dry_run=false
+```
+
+Idle examples (gate off):
+
+```
+[weekly-trigger-worker] ARIES_WEEKLY_TRIGGER_ENABLED is off; idling (no work). Set the flag and restart to enable.
+[draft-expiry-sweep-worker] ARIES_DRAFT_EXPIRY_ENABLED is off; idling (no work). Set the flag and restart to enable.
+```
+
+### Check per-tick summary lines
+
+Workers log a summary only when a tick did something, so an empty queue produces no summary line. Watch the logs live:
+
+```bash
+docker compose logs -f aries-scheduled-posts-worker
+```
+
+- `aries-scheduled-posts-worker`: `summary {processed,dispatched,failed,skipped}` when `processed` or `failed` > 0.
+- `aries-weekly-trigger-worker`: `summary {scanned,due,claimed,started,skipped,failed}` when `claimed` or `failed` > 0.
+- `aries-draft-expiry-sweep-worker`: `summary {dry_run,age_days,cutoff,candidates,expired,batches,truncated,top_tenants}` when there are candidates, expirations, or truncation.
+- `aries-honcho-performance-worker`: `summary {tenantsScanned,due,written,...,failed}` when `due` or `failed` > 0.
+- `aries-insights-sync-worker`: emits newline-delimited JSON events every tick, for example `{"event":"insights_sync_start",...}`, `insights_sync_account`, `insights_sync_done`, and `insights_sync_noop` when no accounts are connected.
+
+### Check the database for evidence of work
+
+```bash
+docker compose exec aries-app sh -c \
+  'PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+  -c "SELECT dispatch_status, count(*) FROM scheduled_posts GROUP BY 1;"'
+```
+
+Expected result: as the scheduled-posts worker runs, rows move through the `dispatch_status` enum `pending -> in_flight -> dispatched` (or `failed`). Insights runs are recorded in `insights_sync_runs`.
+
+## Troubleshooting
+
+**Sidecars never start.** They wait on `aries-app` being healthy (`depends_on ... condition: service_healthy`). Run `docker compose ps`; if `aries-app` is `starting` or `unhealthy`, fix it first. Check `docker compose logs aries-app`.
+
+**`aries-app` exits at boot with an init-db error.** start-runtime runs `scripts/init-db.js` before forking workers; on a non-zero exit it logs `[runtime] init-db.js exited with code=...; refusing to start workers` and exits 1. Read the init-db output, fix the database (connectivity, permissions, migrations), and restart. To boot without the schema step (for example when init already ran), set `ARIES_SKIP_DB_INIT=1`.
+
+**`aries-app` refuses to start with an `ARIES_PROCESS_MANAGER` error.** The value must be `cluster` (default, `:-cluster`) or `node`. Any other value makes start-runtime log `Invalid ARIES_PROCESS_MANAGER value ...` and exit 1.
+
+**You enabled a gate but nothing changed.** Gates are read once at process start. Editing `.env` is not enough; you must recreate the service (`docker compose up -d <service>`). For in-process workers, recreate `aries-app`. Also confirm the value is a recognized truthy token (`1/true/yes/on`); unrecognized values fall back to the gate's default.
+
+**A worker that calls the app logs auth or 401 errors.** `aries-scheduled-posts-worker` and `aries-weekly-trigger-worker` POST to internal routes (`/api/internal/publishing/scheduled-dispatch`, `/api/internal/marketing/weekly-trigger`) with `Authorization: Bearer ${INTERNAL_API_SECRET}`. Make sure `INTERNAL_API_SECRET` matches the value the app expects, and that `APP_BASE_URL` resolves to `http://aries-app:${PORT:-3000}`.
+
+**The honcho-performance worker runs but writes nothing.** The worker still ticks regardless; `recordPerformanceEvent` self-gates and skips the ledger when writes are off. To actually write, you need `HONCHO_WRITE_PUBLISH_ENABLED=true` (the service default) and `HONCHO_ENABLED=true`, plus `HONCHO_BASE_URL`, both Honcho JWTs (`HONCHO_CONTROL_PLANE_JWT`, `HONCHO_DATA_PLANE_JWT`), and `ARIES_TENANT_PSEUDONYM_SALT`. If any are missing, writes silently no-op.
+
+**Insights-sync logs `insights_sync_noop`.** That means no connected accounts for the tenants scanned. Per-provider syncs (X, YouTube, Reddit, LinkedIn) are sub-gated by their own `ARIES_*_ENABLED` plus `COMPOSIO_ENABLED`; if a provider is off, that adapter stays dormant.
+
+**The reconciler keeps restarting, then stops.** The hermes-reconciler auto-respawns on crash but gives up after 5 restarts within 60000ms, logging `crashed Nx within ...ms; not restarting (crash loop). Restart the container after fixing.` Fix the underlying error (often an import or config failure visible just above), then recreate `aries-app`.
+
+## Related
+
+- [Background workers reference](../reference/background-workers.md)
+- [Production deployment](../DEPLOYMENT.md)

--- a/docs/reference/api-jobs-and-callbacks.md
+++ b/docs/reference/api-jobs-and-callbacks.md
@@ -1,0 +1,492 @@
+# API reference: social-content jobs and callbacks
+
+This is the consumer/integrator reference for the Aries AI core API: creating a weekly social-content job, polling its status, approving (or denying) a gated stage, receiving inbound Hermes run callbacks, and the health probes.
+
+Five route groups are documented here in full:
+
+- `POST /api/social-content/jobs` and the legacy `POST /api/marketing/jobs` alias
+- `GET /api/social-content/jobs/{jobId}` (status)
+- `POST /api/social-content/jobs/{jobId}/approve`
+- `POST /api/internal/hermes/runs` (inbound Hermes callback)
+- `GET /api/health/db` and `GET /api/health/hermes`
+
+For the exhaustive inventory of UI-facing and operator routes, see [../../ROUTE_MANIFEST.md](../../ROUTE_MANIFEST.md) and [../SYSTEM-REFERENCE.md](../SYSTEM-REFERENCE.md). The route manifest is marketing-dialect-centric: it lists the legacy `/api/marketing/jobs*` routes and does not list the `/api/social-content/*`, `/api/internal/hermes/runs`, or `/api/health/*` routes. This page is the reference for those.
+
+This page describes *what* the surface is. It does not explain *why*. For task walkthroughs, see [Related](#related).
+
+## The two dialects: social-content and marketing
+
+The social-content routes and the legacy marketing routes share the same handlers. The only difference is the `responseDialect` option, which changes a few response field names and the `jobStatusUrl` path.
+
+| | social-content | marketing (legacy) |
+|---|---|---|
+| Create | `POST /api/social-content/jobs` | `POST /api/marketing/jobs` |
+| Status | `GET /api/social-content/jobs/{jobId}` | `GET /api/marketing/jobs/:jobId` |
+| Approve | `POST /api/social-content/jobs/{jobId}/approve` | `POST /api/marketing/jobs/:jobId/approve` |
+| Job types accepted | `weekly_social_content` only (any requested type is ignored) | `weekly_social_content`, `one_off_post`, `one_off_campaign` |
+| Shared handler | `app/api/marketing/jobs/handler.ts` (`handlePostMarketingJobs`) | same |
+
+Prefer the `/api/social-content/*` routes for new integrations. The `/api/marketing/*` routes are the legacy alias.
+
+Authentication and tenant resolution are the same for create, status, and approve: the request resolves a tenant context through `loadTenantContextOrResponse` (session + tenant membership). When the caller has no tenant membership, the response is:
+
+```json
+{
+  "status": 409,
+  "reason": "onboarding_required",
+  "message": "Complete tenant onboarding before starting a marketing job."
+}
+```
+
+(The approve handler uses the same shape with the message `Complete tenant onboarding before approving brand campaigns.`)
+
+---
+
+## POST /api/social-content/jobs
+
+Create a weekly social-content job. Source: `app/api/social-content/jobs/route.ts` -> `handlePostMarketingJobs(req, loader, { responseDialect: 'social-content' })` in `app/api/marketing/jobs/handler.ts`.
+
+The social-content dialect always forces the job type to `weekly_social_content`. Any `jobType` you send is ignored (`resolveRequestedJobType`). Use the legacy `/api/marketing/jobs` route if you need `one_off_post` or `one_off_campaign`.
+
+### Request
+
+You can send either `application/json` or `multipart/form-data`.
+
+JSON body shape:
+
+```json
+{
+  "jobType": "weekly_social_content",
+  "payload": { }
+}
+```
+
+For `multipart/form-data`, the handler reads fields explicitly (see `parseCreateJobRequest`) and reads file uploads from the `brandAssets` field. Use FormData when you upload brand assets.
+
+The `payload` object carries the brief and the weekly scope. For `weekly_social_content` it runs through `normalizeWeeklySocialContentPayload` (`backend/social-content/payload.ts`), which fills defaults, clamps counts, and redacts tokens.
+
+#### Weekly scope fields
+
+| Field | Alias | Type | Default | Constraint |
+|---|---|---|---|---|
+| `postWindowDays` | `windowDays` | integer | 7 | clamped 1..14 |
+| `staticPostCount` | `staticPostsCount` | integer | 7 | floored at 0 (no upper cap) |
+| `storyCount` | `storiesCount` | integer | 1 | floored at 0 (no upper cap) |
+| `imageCreativeCount` | `imageCreativesCount` | integer | 6 | clamped 0..6 |
+| `videoScriptCount` | `videoScriptsCount` | integer | 1 | floored at 0 (no upper cap) |
+| `videoRenderCount` | `renderVideoAfterApproval` (boolean) | integer | 0 | clamped 0..1 |
+| `channels` | | string[] | `["meta","instagram"]` | empty falls back to default |
+| `forbiddenVisualPatterns` | | string[] | 6-pattern default list | empty falls back to default |
+
+Notes on normalization:
+
+- `postWindowDays` falls back to `windowDays`. Unparseable values become `7`. The clamp bounds (default min 1, max 14) are overridable with the env vars `ARIES_SOCIAL_CONTENT_WINDOW_DAYS_MIN` and `ARIES_SOCIAL_CONTENT_WINDOW_DAYS_MAX`. The handler writes the clamped value to both `postWindowDays` and `windowDays`.
+- Only `imageCreativeCount` (max 6) and `videoRenderCount` (max 1) have an upper cap. `staticPostCount`, `storyCount`, and `videoScriptCount` are only floored at 0.
+- `videoRenderCount` can be derived from the boolean `renderVideoAfterApproval` when the count is absent: `true` -> 1, `false` -> 0.
+- The default `forbiddenVisualPatterns` are: `split-screen`, `before/after`, `side-by-side comparison`, `two-panel layout`, `old way vs new way`, `generic stock office`.
+- The handler also writes back-compat snake/plural fields (`staticPostsCount`, `storiesCount`, `imageCreativesCount`, `videoScriptsCount`, `renderVideoAfterApproval`).
+
+#### Brief fields
+
+The create handler also normalizes brief fields such as `brandUrl`/`websiteUrl`, `competitorUrl`, `competitorBrand`, `facebookPageUrl`/`competitorFacebookUrl`, `adLibraryUrl`, `metaPageId`, `primaryGoal`/`goal`, `launchApproverName`/`approverName`, `businessName`, `businessType`, `brandVoice`, `styleVibe`, `offer`, `audience`, `notes`, `visualReferences`, `mustUseCopy`, and `mustAvoidAesthetics`. Missing brief fields are backfilled from the tenant business profile. See `app/api/marketing/jobs/handler.ts` for the exact field list.
+
+#### Token redaction
+
+Before normalization, the payload is sanitized by `sanitizeWeeklySocialContentPayload`:
+
+- Keys whose name looks sensitive (segments matching `token`, `secret`, `auth`, `authorization`, `oauth`, or `apikey`/`api`+`key`) are dropped entirely.
+- Token-like string values are rewritten to `[redacted]`: Bearer tokens, OpenAI `sk-` keys, and common provider tokens (`ya29.`, `xox*-`, `gh*_`).
+- Sensitive URL query params are stripped: `access_token`, `refresh_token`, `id_token`, `client_secret`, `api_key`, `token`, `key`, `signature`, `sig`.
+
+### Response
+
+Success is `202 Accepted`. social-content dialect body:
+
+| Field | Description |
+|---|---|
+| `social_content_job_status` | job status (`result.status`) |
+| `social_content_stage` | current stage (`result.currentStage`) |
+| `jobId` | created job id |
+| `jobType` | always `weekly_social_content` |
+| `approvalRequired` | boolean |
+| `approval` | approval descriptor (or null) |
+| `reason` | status reason |
+| `message` | human-readable message |
+| `jobStatusUrl` | `/social-content/status?jobId=<encoded>` |
+
+The marketing dialect returns the same data with `marketing_job_status`, `marketing_stage`, and a `jobStatusUrl` of `/marketing/job-status?jobId=<encoded>`.
+
+### Status codes
+
+| Code | When | Body |
+|---|---|---|
+| 202 | created | create response above |
+| 400 | unsupported job type | `{ "error": "unsupported_job_type:<value>" }` |
+| 400 | missing required fields | `{ "error": "missing_required_fields:<...>" }` |
+| 400 | bad competitor URL | `{ "error": "<COMPETITOR_URL_SOCIAL_ERROR \| COMPETITOR_URL_INVALID_ERROR>" }` |
+| 409 | no tenant membership | onboarding_required (see above) |
+| 422 | one-off brief invalid (marketing dialect only) | `{ "error": "one_off_brief_invalid", "fieldErrors": { } }` |
+| 422 | brand kit error | `{ "error": "brand_kit_<...>" }` |
+| 501 | no workflow for route | `{ "error": "workflow_missing_for_route:<...>", "reason": "workflow_missing_for_route" }` |
+| 500 | unhandled | `{ "error": "<message>" }` |
+
+Errors from the orchestrator may also be remapped by `mapAriesExecutionError`.
+
+### Example: create a weekly job (JSON)
+
+```bash
+curl -X POST https://your-host/api/social-content/jobs \
+  -H "Content-Type: application/json" \
+  -H "Cookie: <your session cookie>" \
+  -d '{
+    "jobType": "weekly_social_content",
+    "payload": {
+      "brandUrl": "https://example.com",
+      "primaryGoal": "Drive bookings",
+      "postWindowDays": 7,
+      "staticPostCount": 7,
+      "storyCount": 1,
+      "imageCreativeCount": 6,
+      "videoScriptCount": 1,
+      "videoRenderCount": 0,
+      "channels": ["meta", "instagram"]
+    }
+  }'
+```
+
+### Example: create with brand asset uploads (FormData)
+
+```bash
+curl -X POST https://your-host/api/social-content/jobs \
+  -H "Cookie: <your session cookie>" \
+  -F "brandUrl=https://example.com" \
+  -F "primaryGoal=Drive bookings" \
+  -F "postWindowDays=7" \
+  -F "channels=meta" \
+  -F "channels=instagram" \
+  -F "brandAssets=@./logo.png" \
+  -F "brandAssets=@./brand-guide.pdf"
+```
+
+---
+
+## GET /api/social-content/jobs/{jobId}
+
+Read a job's status. Source: `app/api/social-content/jobs/[jobId]/route.ts` -> `handleGetMarketingJobStatus(jobId, undefined, { responseDialect: 'social-content' })` in `app/api/marketing/jobs/[jobId]/handler.ts`.
+
+### Response
+
+Success is `200 OK` with header `x-cache: <cacheStatus>`. The body is large and built by `buildResponsePayload`. The social-content dialect key fields:
+
+| Field | Notes |
+|---|---|
+| `jobId` | |
+| `jobType` | `weekly_social_content` |
+| `social_content_job_state` | |
+| `social_content_job_status` | |
+| `social_content_stage` | |
+| `social_content_stage_status` | |
+| `approvalRequired`, `approval` | gate state |
+| `summary`, `stageCards`, `timeline`, `statusHistory` | progress views |
+| `artifacts`, `contentBrief`, `dashboard`, `calendarEvents` | content views |
+| `workflowState`, `publishConfig`, `nextStep`, `needs_attention` | control views |
+| `postWindow`, `durationDays`, `plannedPostCount`, `createdPostCount` | scope counts |
+| `reason`, `message` | |
+
+The marketing dialect uses `marketing_job_state`, `marketing_job_status`, `marketing_stage`, and `marketing_stage_status` instead of the `social_content_*` names. For the full shape, read `app/api/marketing/jobs/[jobId]/handler.ts`.
+
+### Status codes
+
+| Code | When | Body |
+|---|---|---|
+| 200 | found | status payload (header `x-cache`) |
+| 404 | not found | `{ "error": "Marketing job not found.", "reason": "marketing_job_not_found" }` |
+| 409 | no tenant membership | onboarding_required |
+| 500 | unhandled | error body |
+
+### Example
+
+```bash
+curl https://your-host/api/social-content/jobs/<jobId> \
+  -H "Cookie: <your session cookie>"
+```
+
+---
+
+## POST /api/social-content/jobs/{jobId}/approve
+
+Approve or deny a gated stage and resume the job. Source: `app/api/social-content/jobs/[jobId]/approve/route.ts` -> `handleApproveMarketingJob(jobId, req, undefined, { responseDialect: 'social-content' })` in `app/api/marketing/jobs/[jobId]/approve/handler.ts`.
+
+### Request
+
+JSON body fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `approvedBy` | string | required for approve/deny (server enforces) |
+| `approved` | boolean | defaults to `true` when omitted or non-boolean |
+| `approvalStep` | string | one of the approval steps below |
+| `approvedStages` | string[] | subset of `research`, `strategy`, `production`, `publish` |
+| `approvalId` | string | targets a specific checkpoint |
+| `resumePublishIfNeeded` | boolean | |
+| `denialReasonCode` | string | used when `approved: false` |
+| `denialNote` / `note` | string | denial note (`denialNote` preferred) |
+| `publishConfig` | object | `{ platforms, livePublishPlatforms, videoRenderPlatforms }` |
+
+Actor identity beyond `approvedBy` (user id, role, tenant slug) is derived server-side from tenant context and is never read from the request body.
+
+`publishConfig` uses camelCase in the request. The handler maps it to snake_case before the orchestrator: `livePublishPlatforms` -> `live_publish_platforms`, `videoRenderPlatforms` -> `video_render_platforms`. `platforms` is passed through.
+
+Valid `approvalStep` values (`SocialContentApprovalStep`) and the stage each maps to:
+
+| `approvalStep` | Stage |
+|---|---|
+| `approve_weekly_plan` | strategy |
+| `approve_post_copy` | production |
+| `approve_image_creatives` | production |
+| `approve_video_script` | production |
+| `approve_video_render` | production |
+| `approve_publish` | publish |
+
+`approved: true` calls `approveSocialContentJob`; `approved: false` calls `denySocialContentJob`.
+
+### Response
+
+Built by `buildApproveResponse`. Base fields:
+
+| Field | Notes |
+|---|---|
+| `approval_status` | for social-content, `resumed`/`denied` are normalized to `submitted` |
+| `jobId` | |
+| `resumedStage` | stage resumed (or null) |
+| `completed` | boolean |
+| `approvalId` | |
+| `reason` | defaults to `unknown` |
+| `jobStatusUrl` | `/social-content/status?jobId=<encoded>` |
+
+The social-content dialect adds `social_content_approval_status` (same value as `approval_status`) and `jobType: "weekly_social_content"`.
+
+### Status codes
+
+| Code | When | Body / reason |
+|---|---|---|
+| 202 | social-content, status `resumed` or `denied` | approve response |
+| 200 | marketing, status `resumed` / `already_resolved` / `denied` | approve response |
+| 400 | other / `missing_approved_by` | `missing_approved_by` -> `{ "error": "approvedBy is required.", "reason": "missing_approved_by" }` |
+| 404 | not found / tenant mismatch | `{ "error": "...", "reason": "marketing_job_not_found" }` |
+| 409 | no active checkpoint | `reason: "approval_not_available"` |
+| 409 | checkpoint stage not selected | `reason: "approval_stage_not_selected"` |
+| 409 | no tenant membership | onboarding_required |
+| 501 | no workflow for route | `reason: "workflow_missing_for_route"` |
+| 500 | unhandled | error body |
+
+### Example: approve the weekly plan
+
+```bash
+curl -X POST https://your-host/api/social-content/jobs/<jobId>/approve \
+  -H "Content-Type: application/json" \
+  -H "Cookie: <your session cookie>" \
+  -d '{
+    "approvedBy": "operator@example.com",
+    "approved": true,
+    "approvalStep": "approve_weekly_plan"
+  }'
+```
+
+### Example: deny with a reason
+
+```bash
+curl -X POST https://your-host/api/social-content/jobs/<jobId>/approve \
+  -H "Content-Type: application/json" \
+  -H "Cookie: <your session cookie>" \
+  -d '{
+    "approvedBy": "operator@example.com",
+    "approved": false,
+    "approvalStep": "approve_post_copy",
+    "denialReasonCode": "off_brand",
+    "denialNote": "Tone is too casual; revise captions."
+  }'
+```
+
+---
+
+## POST /api/internal/hermes/runs
+
+Inbound callback from Hermes when a run advances, pauses for approval, or completes. Source: `app/api/internal/hermes/runs/route.ts`. This is a server-to-server endpoint, not a browser route.
+
+### Authentication (two layers)
+
+Layer 1, `verifyInternalCallbackRequest` (`lib/internal-callback-auth.ts`): a shared bearer secret.
+
+```
+Authorization: Bearer <INTERNAL_API_SECRET>
+```
+
+| Condition | Code | reason |
+|---|---|---|
+| `INTERNAL_API_SECRET` env unset | 503 | `internal_api_secret_not_configured` |
+| no/invalid `Authorization: Bearer` header | 401 | `missing_internal_callback_secret` |
+| wrong secret | 403 | `invalid_internal_callback_secret` |
+
+The secret comparison uses `timingSafeEqual`.
+
+Layer 2, `verifyCallbackToken`: a per-run token sent in the JSON body field `callback_token` (not a header). The token is SHA-256 hashed (`hashCallbackToken`, hex digest) and looked up in the `oauth_callback_tokens` table by `token_hash`, then the row's `aries_run_id` must match the payload's `aries_run_id`.
+
+| Condition | Code | reason |
+|---|---|---|
+| `callback_token` missing/empty | 403 | `missing_callback_token` |
+| token not found, hash mismatch, or run-id mismatch | 403 | `invalid_callback_token` |
+
+### Flow
+
+1. `verifyInternalCallbackRequest` (bearer secret).
+2. Parse JSON. On failure: `400 { "status": "error", "reason": "invalid_json" }`.
+3. `parseHermesRunCallbackPayload`. On null: `400 { "status": "error", "reason": "invalid_hermes_callback_payload" }`. This returns null when `aries_run_id` is missing or malformed, when the Zod schema fails, or when `protocol_version` is present and its major version does not match.
+4. `verifyCallbackToken` (per-run token).
+5. `handleHermesRunCallback`.
+
+### Payload
+
+Schema: `HermesRunCallbackPayloadSchema` (`packages/aries-hermes-protocol/src/schemas.ts`).
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `event_id` | string | yes | idempotency key; non-empty, must contain a non-whitespace char |
+| `aries_run_id` | string | yes | `arun_<uuid>`; pre-validated before Zod |
+| `callback_token` | string | yes | per-run auth token (read from body) |
+| `status` | enum | yes | see CallbackStatus below |
+| `hermes_run_id` | string | no | |
+| `stage` | enum | no | granular Hermes step (CallbackStage) |
+| `output` | object or array of objects | no | stage outputs |
+| `artifacts` | array | no | |
+| `approval` | object | no | present when `status === "requires_approval"` |
+| `error` | object | no | `{ code?, message, retryable? }` |
+| `protocol_version` | semver string | no | major-version mismatch rejected (parse returns null). Current `PROTOCOL_VERSION` is `1.1.1`. |
+
+`CallbackStatus` enum: `running`, `requires_approval`, `completed`, `failed`, `cancelled`, `stopped`.
+
+The `approval` object (`CallbackApprovalSchema`):
+
+| Field | Type | Required |
+|---|---|---|
+| `stage` | ApprovalStage enum | yes |
+| `workflow_step_id` | string | yes |
+| `prompt` | string | yes |
+| `approval_step` | ApprovalStep enum | no |
+| `resume_token` | string | no |
+
+`ApprovalStage` enum: `strategy`, `production`, `publish` (plus legacy `plan`, `creative`, `video`).
+
+`ApprovalStep` enum: `approve_weekly_plan`, `approve_post_copy`, `approve_image_creatives`, `approve_video_script`, `approve_video_render`, `approve_publish`.
+
+### Response
+
+Success:
+
+```json
+{
+  "status": "<result.status>",
+  "ariesRunId": "<aries_run_id>",
+  "duplicate": false
+}
+```
+
+Errors are shaped `{ "status": "error", "reason": "<reason>" }`. The `errorStatus` mapping:
+
+| reason | Code |
+|---|---|
+| `execution_run_not_found` | 404 |
+| `execution_run_locked` | 409 |
+| anything else | 400 |
+
+### Example
+
+```bash
+curl -X POST https://your-host/api/internal/hermes/runs \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $INTERNAL_API_SECRET" \
+  -d '{
+    "event_id": "evt_01HZX...",
+    "aries_run_id": "arun_3f9b2c10-...",
+    "callback_token": "<per-run token>",
+    "status": "requires_approval",
+    "stage": "plan_review",
+    "protocol_version": "1.1.1",
+    "approval": {
+      "stage": "strategy",
+      "approval_step": "approve_weekly_plan",
+      "workflow_step_id": "step_plan_review",
+      "prompt": "Review the weekly plan."
+    }
+  }'
+```
+
+---
+
+## Health endpoints
+
+### GET /api/health/db
+
+Source: `app/api/health/db/route.ts`. Probes `SELECT 1` with a 1-second cache (`HEALTH_CACHE_TTL_MS = 1000`).
+
+Success `200`:
+
+```json
+{
+  "status": "ok",
+  "poolStats": { },
+  "roundTripMs": 3,
+  "cacheAgeMs": 0,
+  "cached": false
+}
+```
+
+On failure `503`:
+
+```json
+{
+  "status": "error",
+  "error": "<message>",
+  "poolStats": { }
+}
+```
+
+### GET /api/health/hermes
+
+Source: `app/api/health/hermes/route.ts`. Calls `probeHermesSocialContentRuntime(process.env)` and returns the report. Status is `200` when `report.ok` is true, otherwise `503`.
+
+```bash
+curl https://your-host/api/health/db
+curl https://your-host/api/health/hermes
+```
+
+---
+
+## Defaults and limits quick reference
+
+| Constant | Value | Source |
+|---|---|---|
+| `postWindowDays` default | 7 | `backend/social-content/types.ts` (`DEFAULT_SOCIAL_CONTENT_COUNTS`) |
+| `postWindowDays` clamp | 1..14 | `backend/social-content/payload.ts` |
+| `staticPostCount` default | 7 | `backend/social-content/types.ts` (`DEFAULT_SOCIAL_CONTENT_COUNTS`) |
+| `storyCount` default | 1 | `backend/social-content/types.ts` (`DEFAULT_SOCIAL_CONTENT_COUNTS`) |
+| `imageCreativeCount` default / max | 6 / 6 | default `backend/social-content/types.ts`; max `backend/social-content/defaults.ts` |
+| `videoScriptCount` default | 1 | `backend/social-content/types.ts` (`DEFAULT_SOCIAL_CONTENT_COUNTS`) |
+| `videoRenderCount` default / max | 0 / 1 | default `backend/social-content/types.ts`; max `backend/social-content/defaults.ts` |
+| `channels` default | `["meta","instagram"]` | `backend/social-content/types.ts` |
+| `PROTOCOL_VERSION` | `1.1.1` | `packages/aries-hermes-protocol/src/schemas.ts` |
+| Redaction value | `[redacted]` | `backend/social-content/payload.ts` |
+
+Environment variables: `INTERNAL_API_SECRET`, `ARIES_SOCIAL_CONTENT_WINDOW_DAYS_MIN`, `ARIES_SOCIAL_CONTENT_WINDOW_DAYS_MAX`.
+
+To run the create/approve flow tests (covers `tests/marketing-job-route.smoke.test.ts` and `tests/social-content-approve-route.test.ts`):
+
+```bash
+npm run validate:social-content
+```
+
+## Related
+
+- [How to generate and approve a week of social content](../how-to/generate-and-approve-a-week.md)
+- [How to connect Aries to a Hermes execution endpoint](../how-to/integrate-hermes.md)
+- [System reference](../SYSTEM-REFERENCE.md)

--- a/docs/reference/background-workers.md
+++ b/docs/reference/background-workers.md
@@ -1,0 +1,170 @@
+# Background workers reference
+
+Aries AI runs ten background workers. Six are sidecar Compose services. Four are in-process workers spawned by the runtime launcher. This page lists every one: its name, entry file, job, cadence, gating and config env vars, and whether it is on by default.
+
+All ten share one image (`${ARIES_APP_IMAGE:-aries-app:local}`). The sidecars are defined in `docker-compose.yml`. The in-process workers are spawned by `scripts/start-runtime.mjs`, the container entrypoint that also boots the Next.js cluster.
+
+## Quick map
+
+| Worker | Type | Entry | Cadence (default) | Gate env var | On by default |
+| --- | --- | --- | --- | --- | --- |
+| `aries-scheduled-posts-worker` | sidecar | `scripts/automations/scheduled-posts-worker.mjs` | 60s | none | yes |
+| `aries-weekly-trigger-worker` | sidecar | `scripts/automations/weekly-job-trigger-worker.ts` | 15m | `ARIES_WEEKLY_TRIGGER_ENABLED` | no |
+| `aries-draft-expiry-sweep-worker` | sidecar | `scripts/automations/draft-expiry-sweep-worker.ts` | 6h | `ARIES_DRAFT_EXPIRY_ENABLED` | no |
+| `aries-hermes-gc-worker` | sidecar | `scripts/automations/gc-missing-hermes-assets-worker.ts` | 6h | `ARIES_HERMES_GC_ENABLED` | no |
+| `aries-insights-sync-worker` | sidecar | `scripts/automations/insights-sync-worker.ts` | 30m | none | yes |
+| `aries-honcho-performance-worker` | sidecar | `scripts/automations/honcho-performance-worker.ts` | 30m | `HONCHO_WRITE_PUBLISH_ENABLED` | yes |
+| stale-run reaper | in-process | `scripts/stale-run-reaper-worker.ts` | 5m | `ARIES_REAPER_ENABLED` | yes |
+| hermes kanban GC | in-process | `scripts/hermes-kanban-gc-worker.ts` | 24h | `ARIES_KANBAN_GC_ENABLED` | yes |
+| hermes reconciler | in-process | `scripts/hermes-reconciler-worker.ts` | 60s | `ARIES_RECONCILER_ENABLED` | yes |
+| partner attribution outbox | in-process | `scripts/partner-attribution-outbox-worker.ts` | 30s | `PARTNER_ATTRIBUTION_ENABLED` | no |
+
+"On by default" reflects the value `docker-compose.yml` ships. The reaper, kanban GC, and reconciler gates default differently in code when unset (see [In-process workers](#in-process-workers)); Compose pins each to an explicit value, so the shipped default is what the table shows.
+
+## Sidecar services
+
+Each sidecar is a separate `docker-compose.yml` service. All depend on `aries-app` being healthy (`condition: service_healthy`), set `restart: unless-stopped`, run on the external `docker-stack` network, and use `DB_POOL_MAX: 3`. Each worker self-schedules with `setInterval` and stays up as a long-lived process.
+
+### aries-scheduled-posts-worker
+
+- Command: `node scripts/automations/scheduled-posts-worker.mjs`
+- What it does: Drains the `scheduled_posts` table and POSTs due rows to `/api/internal/publishing/scheduled-dispatch` on the in-network app. One replica avoids racing the SQL claim-lock.
+- Cadence: 60s. `INTERVAL_MS = 60 * 1000` is hardcoded in the worker (no env override).
+- Config env: `ARIES_SCHEDULED_POSTS_RUN_ONCE=1` runs a single tick then exits (skips the interval).
+- Default: on. No gate.
+
+### aries-weekly-trigger-worker
+
+- Command: `node_modules/.bin/tsx scripts/automations/weekly-job-trigger-worker.ts`
+- What it does: Starts a `weekly_social_content` job for each opted-in tenant (a `marketing_schedule` row with `enabled=true`) on its configured day/hour/timezone. POSTs to `/api/internal/marketing/weekly-trigger`.
+- Cadence: 15m. `DEFAULT_INTERVAL_MS = 15 * 60 * 1000`, overridable by `ARIES_WEEKLY_TRIGGER_INTERVAL_MS` (Compose default `900000`).
+- Gate: `ARIES_WEEKLY_TRIGGER_ENABLED` (Compose default `0`). When off, the worker idles instead of exiting.
+- Config env: `ARIES_WEEKLY_TRIGGER_RUN_ONCE=1` runs one tick then exits.
+- Default: off.
+
+### aries-draft-expiry-sweep-worker
+
+- Command: `node_modules/.bin/tsx scripts/automations/draft-expiry-sweep-worker.ts`
+- What it does: Expires stranded pre-publish posts (no `scheduled_posts` row, never published, older than the age window) so the unscheduled-approved backlog stops growing. Talks only to Postgres.
+- Cadence: 6h. `ARIES_DRAFT_EXPIRY_INTERVAL_MS` (Compose default `21600000`).
+- Gate: `ARIES_DRAFT_EXPIRY_ENABLED` (Compose default `0`). When off, the worker idles.
+- Config env:
+  - `ARIES_DRAFT_EXPIRY_AGE_DAYS` (Compose default `14`) - age threshold for a stranded draft.
+  - `ARIES_DRAFT_EXPIRY_DRY_RUN` (Compose default `0`) - when `1`, counts candidates read-only without expiring them.
+  - `ARIES_DRAFT_EXPIRY_RUN_ONCE=1` runs one tick then exits.
+- Default: off.
+
+### aries-hermes-gc-worker
+
+- Command: `node_modules/.bin/tsx scripts/automations/gc-missing-hermes-assets-worker.ts`
+- What it does: Marks `creative_assets` rows orphaned once their Hermes image-cache file is evicted, so the dashboard stops emitting dead `/api/internal/hermes/media/<id>` URLs. Mounts the Hermes image cache read-only to tell "evicted" from "unreadable".
+- Cadence: 6h. `ARIES_HERMES_GC_INTERVAL_MS` (Compose default `21600000`).
+- Gate: `ARIES_HERMES_GC_ENABLED` (Compose default `0`). When off, the worker idles.
+- Config env:
+  - `ARIES_HERMES_GC_MAX_AGE_DAYS` (Compose default `7`).
+  - `ARIES_HERMES_GC_DRY_RUN` (Compose default `0`).
+  - `HERMES_IMAGE_CACHE_MOUNT` (default `/hermes-media`) - read-only mount the worker inspects.
+  - `ARIES_HERMES_GC_RUN_ONCE=1` runs one tick then exits.
+- Default: off.
+
+### aries-insights-sync-worker
+
+- Command: `node_modules/.bin/tsx scripts/automations/insights-sync-worker.ts`
+- What it does: Syncs platform analytics (YouTube, Instagram, Facebook, and others) for every tenant with a connected `insights_account`. One replica avoids duplicate API calls.
+- Cadence: 30m. `INTERVAL_MS = 30 * 60 * 1000` is hardcoded (no env override). First tick runs immediately on startup.
+- Config env:
+  - `ARIES_INSIGHTS_SWEEP_GRACE_MINUTES` (Compose default `60`) - grace window before a stranded `running` `insights_sync_runs` row is failed out.
+  - `HONCHO_WRITE_PUBLISH_ENABLED` (Compose default `false` on this service) - gates Honcho performance writes inside the sync.
+  - Per-platform insights gates, each requiring `COMPOSIO_ENABLED=true` plus the platform flag: `ARIES_X_ENABLED`, `ARIES_YOUTUBE_ENABLED`, `ARIES_REDDIT_ENABLED`, `ARIES_LINKEDIN_ENABLED` (all Compose default `false`), and `ANALYTICS_PROVIDER` (default `composio`) for the Facebook path.
+- Default: on. No gate on the worker itself.
+
+### aries-honcho-performance-worker
+
+- Command: `npx tsx scripts/automations/honcho-performance-worker.ts`
+- What it does: Reads stored `insights_post_metrics_daily` snapshots (never fetches Meta) and writes a `research_conclusion` to Honcho via `recordPerformanceEvent`. Until the #513 tables are populated, the due-posts query returns `[]` and each tick is a no-op.
+- Cadence: 30m. `INTERVAL_MS = 30 * 60 * 1000` is hardcoded (no env override).
+- Gate: `HONCHO_WRITE_PUBLISH_ENABLED` (Compose default `true` on this service). `recordPerformanceEvent` self-gates on this flag, so the worker stays up but writes nothing when off.
+- Config env:
+  - `ARIES_INSIGHTS_513_TABLES_PRESENT` (Compose default empty) - flip to `1` once `insights_post_metrics_daily` is populated.
+  - `ARIES_HONCHO_PERF_RUN_ONCE=1` runs one tick then exits.
+  - `HONCHO_ENABLED`, `HONCHO_BASE_URL`, `HONCHO_CONTROL_PLANE_JWT`, `HONCHO_DATA_PLANE_JWT`, `ARIES_TENANT_PSEUDONYM_SALT` configure the Honcho client.
+- Default: on (the service runs; whether it writes depends on `HONCHO_WRITE_PUBLISH_ENABLED` and the #513 data).
+
+## In-process workers
+
+`scripts/start-runtime.mjs` spawns these four as child processes alongside the Next.js cluster, in both the `cluster` and `node` process managers. They share the runtime env. The launcher reads each gate before spawning; a worker that is not enabled is never spawned.
+
+The launcher's gate parser (`workerGateEnabled`) treats `1`/`true`/`yes`/`on` as true and `0`/`false`/`no`/`off` as false. The two gate styles differ only in what an unset value means:
+
+- Opt-in gates default to off when unset: `ARIES_REAPER_ENABLED`, `PARTNER_ATTRIBUTION_ENABLED`.
+- Opt-out kill switches default to on when unset: `ARIES_KANBAN_GC_ENABLED`, `ARIES_RECONCILER_ENABLED`.
+
+`docker-compose.yml` pins all four to explicit values, so the shipped defaults are as listed below.
+
+### stale-run reaper
+
+- Entry: `scripts/stale-run-reaper-worker.ts`
+- What it does: Sweeps marketing-job runtime docs and marks stalled jobs failed. A job sitting at an approval gate is not stalled; it is reaped only after `ARIES_REAPER_AWAITING_APPROVAL_THRESHOLD_MS` (Compose default `604800000`, 7 days).
+- Cadence: 5m. `DEFAULT_INTERVAL_MS = 5 * 60 * 1000`, overridable by `ARIES_REAPER_INTERVAL_MS` (Compose default `300000`).
+- Gate: `ARIES_REAPER_ENABLED`. Code default when unset is off; Compose ships `1`.
+- Default: on (via Compose).
+
+### hermes kanban GC
+
+- Entry: `scripts/hermes-kanban-gc-worker.ts`
+- What it does: Archives completed kanban tasks older than the retention window, then runs downstream cleanup.
+- Cadence: 24h. `DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000`, overridable by `ARIES_KANBAN_GC_INTERVAL_MS` (Compose default `86400000`).
+- Gate: `ARIES_KANBAN_GC_ENABLED` (opt-out; on unless disabled). Compose ships `1`.
+- Config env:
+  - `ARIES_KANBAN_GC_RETENTION_DAYS` (Compose default `7`).
+  - `ARIES_KANBAN_GC_RUN_ONCE=1` runs one tick then exits.
+- Default: on.
+
+### hermes reconciler
+
+- Entry: `scripts/hermes-reconciler-worker.ts`
+- What it does: The durable replacement for the in-process Hermes poll-bridge. Each interval it re-discovers in-flight marketing execution runs and ingests any Hermes has finished, via the same idempotent callback path. Runs with `APP_INSTANCE_ID=hermes-reconciler` and `DB_POOL_MAX=5`. The launcher auto-respawns it if it crashes, unless it crash-loops (5 restarts within 60s).
+- Cadence: 60s. `DEFAULT_INTERVAL_MS = 60 * 1000`, overridable by `ARIES_RECONCILER_INTERVAL_MS` (Compose default `60000`). The 60s default beats the reaper's tightest stage threshold (strategy, 5 min).
+- Gate: `ARIES_RECONCILER_ENABLED` (opt-out; on unless disabled). Compose ships `1`. Set to `0` to fall back to bridge-only delivery.
+- Config env: `ARIES_RECONCILER_RUN_ONCE=1` runs one tick then exits.
+- Default: on.
+
+### partner attribution outbox
+
+- Entry: `scripts/partner-attribution-outbox-worker.ts`
+- What it does: Drains the partner-attribution outbox.
+- Cadence: 30s. `INTERVAL_MS = 30_000` is hardcoded (no env override).
+- Gate: `PARTNER_ATTRIBUTION_ENABLED` (opt-in; off unless enabled). Compose ships `false`. When off the worker is never spawned (and if launched directly, it logs and exits).
+- Default: off.
+
+## Examples
+
+Run the scheduled-posts worker once against your configured database, then exit:
+
+```bash
+ARIES_SCHEDULED_POSTS_RUN_ONCE=1 node scripts/automations/scheduled-posts-worker.mjs
+```
+
+Dry-run the draft-expiry sweep with a 30-day age window (counts candidates, expires nothing):
+
+```bash
+ARIES_DRAFT_EXPIRY_ENABLED=1 \
+ARIES_DRAFT_EXPIRY_DRY_RUN=1 \
+ARIES_DRAFT_EXPIRY_AGE_DAYS=30 \
+ARIES_DRAFT_EXPIRY_RUN_ONCE=1 \
+node_modules/.bin/tsx scripts/automations/draft-expiry-sweep-worker.ts
+```
+
+Bring up only the always-on sidecars with Docker Compose:
+
+```bash
+docker compose up -d \
+  aries-scheduled-posts-worker \
+  aries-insights-sync-worker \
+  aries-honcho-performance-worker
+```
+
+## Related
+
+- [How to run and operate the background workers](../how-to/run-background-workers.md)
+- [Production deployment](../DEPLOYMENT.md)

--- a/docs/tutorials/first-week-of-content.md
+++ b/docs/tutorials/first-week-of-content.md
@@ -1,0 +1,165 @@
+# Tutorial: generate and approve your first week of content
+
+By the end of this tutorial you will have a running Aries AI instance, a tenant you onboarded yourself, and a week of social posts that you generated, reviewed, approved, and scheduled. You will see a real result in the browser within the first few steps.
+
+Aries hands the run to Hermes, the separate execution service, so you need a reachable Hermes endpoint to finish. The weekly run plans the week and writes the copy, and with the default scope it also requests image creatives. You stop at scheduled, so you never publish to a live social account in this tutorial.
+
+What you will build:
+
+- A local Aries AI app at `http://localhost:3000`.
+- An onboarded tenant with a goal, business, website, brand, and channels.
+- A weekly social-content job created from a brand brief.
+- A reviewed and approved week of posts, scheduled for publish.
+
+This is a learning path. For day-to-day repeat work, follow the how-to guides linked at the end. For full environment setup and architecture, see [../SELF_HOSTING.md](../SELF_HOSTING.md) and [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
+## Before you start
+
+You need:
+
+- Node.js and npm.
+- A reachable Postgres database (host, port, user, password, database name).
+- The repo checked out. This tutorial uses the repo at `/home/node/docker-stack/aries-app`.
+
+Hermes is the separate execution service that runs the workflow and owns provider auth, including media generation. You need a reachable Hermes endpoint for any run: set `HERMES_GATEWAY_URL`, `HERMES_API_SERVER_KEY`, and `HERMES_SESSION_KEY` in your `.env`. With the default weekly scope the run also requests image creatives, so the endpoint needs media generation configured. If you want a planning-only run that calls no media provider, see "What the weekly run requests" in Step 3.
+
+## Step 1: Start the app and see it load
+
+Install dependencies, create your env file, initialize the database, and start the dev server.
+
+```bash
+cd /home/node/docker-stack/aries-app
+NODE_ENV=development npm ci
+cp .env.example .env
+npm run db:init
+npm run dev
+```
+
+Open `http://localhost:3000`. You should see the Aries AI app load.
+
+`npm run dev` uses Turbopack, which is required for Tailwind v4. If styles look unstyled or the build complains about Tailwind, you started Next without Turbopack. Stop the server and run `npm run dev` again, which is already wired for Turbopack in this repo.
+
+Fill in your `.env` before `npm run db:init`. At minimum you need the database vars (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`) and the app/auth vars (`APP_BASE_URL`, `NEXTAUTH_URL`, `AUTH_URL`, `NEXTAUTH_SECRET`, `AUTH_TRUST_HOST`, `OAUTH_TOKEN_ENCRYPTION_KEY`, `INTERNAL_API_SECRET`, `CODE_ROOT`, `DATA_ROOT`). For the Hermes handoff you also set `HERMES_GATEWAY_URL`, `HERMES_API_SERVER_KEY`, and `HERMES_SESSION_KEY` (usually `main`). The full list and meaning of each var lives in [../SELF_HOSTING.md](../SELF_HOSTING.md).
+
+If `npm run db:init` fails to connect, your `DB_*` values are wrong or Postgres is not running. Fix the values in `.env`, confirm Postgres accepts connections, then run `npm run db:init` again.
+
+## Step 2: Onboard your tenant
+
+Sign in, then open the onboarding flow.
+
+```text
+http://localhost:3000/onboarding/start
+```
+
+The page checks your session and tenant. A brand-new tenant has no onboarding decision yet, so the page renders the onboarding flow (`AriesOnboardingFlow`). An already-onboarded tenant is redirected straight to `/dashboard`. If you land on `/dashboard` instead of the flow, your tenant is already onboarded and you can skip to Step 3.
+
+Work through the five steps in order. The flow starts with the goal on purpose, so every later step is built around a real objective:
+
+1. **Goal** - pick a goal. The options include a social-visibility goal and a custom business outcome.
+2. **Business** - describe the business.
+3. **Website** - enter the website.
+4. **Brand identity** - capture the brand.
+5. **Channels** - choose where content goes. Options include Meta, Instagram (Organic), YouTube, and Google Business.
+
+When you finish, you land in the dashboard. You now have an onboarded tenant. That is your first visible result.
+
+## Step 3: Create a weekly social-content job
+
+Open the create screen.
+
+```text
+http://localhost:3000/dashboard/social-content/new
+```
+
+This is the New Social Content form. Leave the content type on **Weekly social content** (the default). This maps to the job type `weekly_social_content`.
+
+Fill in the form:
+
+- **Website URL** (required). Must look like `https://example.com`. The form normalizes a bare domain to `https://`, but it must validate as a real URL or the submit button stays disabled.
+- Optional brand inputs you can add now or leave blank: **Brand voice**, **Style / vibe**, **Visual references** (one per line), **Logo uploads / brand assets**, **Must-use copy**, **Must-avoid aesthetics**, **Extra notes / instructions**, **Competitor website URL**.
+
+Click **Start social content**.
+
+On submit, the form builds a `FormData` request (with `jobType`, `brandUrl`, `websiteUrl`, and any optional fields you filled) and posts it to:
+
+```text
+POST /api/social-content/jobs
+```
+
+A successful create returns HTTP 202 (Accepted) with a body containing `jobId` and `jobStatusUrl`. The 202 means Aries accepted the request and handed the run to Hermes; the week is now being planned. The screen then routes you straight into the campaign workspace at the Brand Review view:
+
+```text
+/dashboard/social-content/<jobId>?view=brand
+```
+
+Seeing the Brand Review workspace open is your sign the job was created. That is your third visible result.
+
+If the submit button is disabled, your Website URL is not valid yet. Enter a URL like `https://example.com` and the button enables.
+
+If the request comes back with an error instead of routing you, the status code tells you what to fix:
+
+- **400** - bad request, for example an unsupported job type. Make sure the content type is Weekly social content.
+- **422** - validation failed. Check the required fields; inline red errors point at the offending field.
+- **501** - `workflow_missing_for_route`. The weekly workflow is not registered in your environment. Confirm your Hermes config (`HERMES_GATEWAY_URL`, `HERMES_API_SERVER_KEY`, `HERMES_SESSION_KEY`).
+
+### What the weekly run requests
+
+The create form does not expose media-count inputs, so a job created here runs with the default scope. From `backend/social-content/defaults.ts`, `SOCIAL_CONTENT_DEFAULT_SCOPE` is:
+
+- `window_days: 7`
+- `static_post_count: 7`
+- `story_count: 1`
+- `image_creative_count: 6`
+- `video_script_count: 1`
+- `video_render_count: 0`
+- `channels: ['meta', 'instagram']`
+
+So a run created from this form asks Hermes for image creatives and one story; `video_render_count` is `0`, so there is no video render step. The planning, strategy, and copy stages run on Hermes regardless.
+
+If you want a planning-only run that calls no media provider, submit the job through the API with the media counts set to `0` instead of using this form. The payload layer floors every count at `0` with `Math.max(0, count)` and caps the image-creative and video-render counts with `Math.min(MAX, Math.max(0, count))` (see `backend/social-content/payload.ts`), so zero counts disable media generation, and `renderVideoAfterApproval` is true only when the clamped video render count is greater than `0`. See [../how-to/generate-and-approve-a-week.md](../how-to/generate-and-approve-a-week.md) and [../reference/api-jobs-and-callbacks.md](../reference/api-jobs-and-callbacks.md) for the request shape.
+
+## Step 4: Review the staged week
+
+You are already in the campaign workspace at `/dashboard/social-content/<jobId>?view=brand`. This single workspace page renders every review stage; the `?view=` query param chooses which stage you see:
+
+- `?view=brand` - Brand Review.
+- `?view=strategy` - Strategy Review.
+- `?view=creative` - Creative Review.
+- `?view=publish` - Publish Status.
+- no `view` (or any other value) - the Campaign overview.
+
+Walk the stages in order. Start at Brand Review, then move to Strategy Review and Creative Review. Each stage shows the staged output for that part of the week and holds its own approval state. Read the proposed week: the static posts, the copy, and the plan. Publish stays blocked until the workflow is explicitly approved.
+
+The week does not appear instantly. Aries submitted the run to Hermes, and Hermes posts authenticated callbacks to `/api/internal/hermes/runs` as the run progresses. Aries updates its runtime state and the read-model status from those callbacks. If a stage still looks empty, the run has not reported that stage yet. Give it time and refresh.
+
+## Step 5: Approve and see posts scheduled
+
+When the staged week looks right, approve it. Work through the review stages and approve each one, then move to Publish Status:
+
+```text
+/dashboard/social-content/<jobId>?view=publish
+```
+
+Approving releases the publish step. The default weekly scope sets `video_render_count: 0`, so there is no video render step to approve. Once publish is approved, the posts move to scheduled. Watch the Publish Status view show the week's posts as scheduled. That is the result you set out to build: a generated, reviewed, approved week of content, scheduled.
+
+## What you built
+
+You now have:
+
+- A running Aries AI instance at `http://localhost:3000`.
+- An onboarded tenant with a goal, business, website, brand, and channels.
+- A weekly social-content job created at `/dashboard/social-content/new`, posted to `POST /api/social-content/jobs`, returned as HTTP 202.
+- A week of posts reviewed across the Brand, Strategy, and Creative stages in the campaign workspace.
+- An approved week with posts scheduled.
+
+Next steps:
+
+- Repeat this as a fast routine with the how-to guide: [../how-to/generate-and-approve-a-week.md](../how-to/generate-and-approve-a-week.md).
+- Connect a platform so approved posts publish to a live account: [../how-to/connect-a-social-platform.md](../how-to/connect-a-social-platform.md).
+- Understand the full environment and the Aries-to-Hermes execution model: [../SELF_HOSTING.md](../SELF_HOSTING.md) and [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
+## Related
+
+- [How to generate and approve a week of social content](../how-to/generate-and-approve-a-week.md)
+- [How to connect a social platform](../how-to/connect-a-social-platform.md)
+- [Self-hosting Aries AI](../SELF_HOSTING.md)


### PR DESCRIPTION
## Documentation Generated

Fills the Diátaxis gaps in the existing `docs/` tree (which already had architecture, security, self-hosting, deployment, and OAuth reference). Generated by `/document-generate`; every doc went through a write → adversarial-verify pass that re-read the implementation and corrected drift.

| File | Quadrant | Description |
|------|----------|-------------|
| docs/tutorials/first-week-of-content.md | Tutorial | Onboard a tenant, create a weekly job, review the staged stages, approve, and see posts scheduled |
| docs/how-to/generate-and-approve-a-week.md | How-to | Submit a weekly job and walk the strategy → production → publish approvals (UI and API paths) |
| docs/how-to/connect-a-social-platform.md | How-to | Connect a channel (Composio screen + direct broker API), token encryption, reconnecting |
| docs/how-to/integrate-hermes.md | How-to | Point Aries at a Hermes endpoint; the two-layer authenticated callback contract |
| docs/how-to/run-background-workers.md | How-to | Enable, dry-run, and verify the sidecar and in-process workers |
| docs/reference/api-jobs-and-callbacks.md | Reference | The social-content jobs API, approve route, Hermes callback, health endpoints |
| docs/reference/background-workers.md | Reference | Every worker: command, cadence, env gates, on/off defaults (6 sidecar + 4 in-process) |

Plus a `docs/README.md` index that maps the whole `docs/` tree by quadrant, and an updated Documentation table in the top-level `README.md`.

### Notes for reviewers
- Docs only. Verified against the source on this branch's `master` base.
- The verify pass surfaced two upstream inaccuracies worth a separate fix (not changed here): `.env.example` comments for `HERMES_POLL_INTERVAL_MS` say the default is `1000ms` but the code default is `2000ms`; and the create form cannot produce a fully text-only run (the tutorial documents the API-only path for that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)