### PR TITLE
fix(dashboard): clarify Insights Aries-published scope

### DIFF
--- a/frontend/insights/ActivitySection.tsx
+++ b/frontend/insights/ActivitySection.tsx
@@ -89,13 +89,13 @@ export function ActivitySection({ period, platform }: ActivitySectionProps) {
       ) : error ? (
         <Panel><ErrorState message={error} onRetry={refetch} /></Panel>
       ) : !data?.meta?.hasData ? (
-        <Panel><EmptyState message="No posts published in this period." /></Panel>
+        <Panel><EmptyState message="No Aries-published posts in this period." /></Panel>
       ) : (
         <div style={{ display: "grid", gridTemplateColumns: "1.55fr 1fr", gap: 20, alignItems: "stretch" }}>
           {/* ── LEFT panel: metric cards + insight footer ── */}
           <Panel style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-              <MetricCard icon="post" value={data.strip.postsPublished.toLocaleString()} label="Posts published">
+              <MetricCard icon="post" value={data.strip.postsPublished.toLocaleString()} label="Aries-published posts">
                 <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2 }}>
                   <span style={{ display: "inline-flex", gap: 3 }}>
                     {platforms.map((p) => <ChannelIcon key={p} platform={p} size={13} />)}

--- a/frontend/insights/TopPostsSection.tsx
+++ b/frontend/insights/TopPostsSection.tsx
@@ -337,7 +337,7 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
     <section>
       {/* Header row: title on the left, sort select on the right */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
-        <SectionHeader title="Top performing content" />
+        <SectionHeader title="Top Aries-published content" />
         <select
           value={sort}
           onChange={(e) => setSort(e.target.value as SortKey)}
@@ -367,7 +367,7 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
         ) : error ? (
           <ErrorState message={error} onRetry={refetch} />
         ) : empty || !data ? (
-          <EmptyState message="No posts published in this period." />
+          <EmptyState message="No Aries-published posts in this period." />
         ) : (
           <>
             <div
@@ -389,7 +389,7 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
                     marginBottom:  6,
                   }}
                 >
-                  Your top 5 posts
+                  Your top 5 Aries-published posts
                 </div>
                 <div style={{ display: "flex", flexDirection: "column" }}>
                   {data.posts.map((post, i) => (

--- a/tests/insights-dashboard-ui.test.ts
+++ b/tests/insights-dashboard-ui.test.ts
@@ -22,6 +22,8 @@ const commentsHook = read('hooks', 'use-insights-comments.ts');
 const apiClient = read('lib', 'api', 'aries-v1.ts');
 const appShellClient = read('components', 'redesign', 'layout', 'app-shell-client.tsx');
 const readApi = read('backend', 'insights', 'read-api.ts');
+const insightsActivitySection = read('frontend', 'insights', 'ActivitySection.tsx');
+const insightsTopPostsSection = read('frontend', 'insights', 'TopPostsSection.tsx');
 
 test('analytics + comments nav routes are registered as reachable utility entries', () => {
   const analytics = getRouteById('analytics');
@@ -149,6 +151,14 @@ test('comments read-api exposes replied state so the inbox can render it', () =>
   assert.match(readApi, /c\.replied_at/);
   assert.match(readApi, /isReplied:/);
   assert.match(readApi, /repliedAt:/);
+});
+
+test('insights empty states label Aries-published scope so they do not contradict the hero account summary', () => {
+  assert.match(insightsActivitySection, /No Aries-published posts in this period\./);
+  assert.match(insightsTopPostsSection, /Top Aries-published content/);
+  assert.match(insightsTopPostsSection, /No Aries-published posts in this period\./);
+  assert.doesNotMatch(insightsActivitySection, /No posts published in this period\./);
+  assert.doesNotMatch(insightsTopPostsSection, /No posts published in this period\./);
 });
 
 // ─── #684 honest analytics "metric unavailable" states ───────────────────────


### PR DESCRIPTION
## Summary
- Clarifies that the lower Insights activity and top-content widgets are scoped to Aries-published posts.
- Replaces the generic no-data copy that made the operator see "No posts published" while the hero could show account-level published-post totals.
- Adds a regression assertion for the Activity and Top Content empty states.

## Test Plan
- APP_BASE_URL=https://aries.example.com npx tsx --test tests/insights-dashboard-ui.test.ts
- APP_BASE_URL=https://aries.example.com npx tsx --test tests/insights*.test.ts
- npm run guardrails:agent
- npm run validate:repo-boundary
- APP_BASE_URL=https://aries.example.com npx tsx scripts/verify-insights-data.ts (reports DB env errors in this workspace, exit 0)
- npm run verify

## Visual QA
- Started the dashboard with npm run dev -- -p 3003 through the repo script, preserving Turbopack. /insights compiled and returned the expected auth redirect, but this headless worker could not capture the authenticated Insights screen because /login compilation/browser navigation exceeded the tool timeout. The changed operator-facing copy is covered by the focused UI regression test above.
