### PR TITLE
fix(publishing): sanitize brand snapshot fragments

### DIFF
--- a/backend/marketing/brand-kit-enrich.ts
+++ b/backend/marketing/brand-kit-enrich.ts
@@ -245,6 +245,17 @@ export type OperatorBrandKitOverrides = {
   palette?: string[] | null;
 };
 
+function stripLeadingDanglingArticleFragment(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (!trimmed) return null;
+  const stripped = trimmed.replace(/^\s*(?:a|an|the)\s*,\s+/i, '');
+  if (stripped === trimmed || !stripped) {
+    return trimmed;
+  }
+  return stripped.charAt(0).toUpperCase() + stripped.slice(1);
+}
+
 /**
  * Merge LLM enrichment into the base brand kit.
  *
@@ -273,20 +284,20 @@ export function applyBrandKitEnrichment(
     : null;
 
   // style_vibe: operator > base (existing) > enrichment
-  const styleVibe = opStyleVibe ?? base.style_vibe ?? enrichment.styleVibe ?? null;
+  const styleVibe = stripLeadingDanglingArticleFragment(opStyleVibe ?? base.style_vibe ?? enrichment.styleVibe) ?? null;
 
   // tone_of_voice: operator brandVoice is authoritative for tone — if operator supplied it,
   // preserve the existing base value (or null) and never let enrichment fill it in.
   // The operator's brandVoice string is their explicit tone preference; we must not let
   // LLM-scraped adjectives contradict it.
   const toneOfVoice = opBrandVoice
-    ? (base.tone_of_voice ?? null)
-    : (enrichment.toneOfVoice ?? base.tone_of_voice ?? null);
+    ? (stripLeadingDanglingArticleFragment(base.tone_of_voice) ?? null)
+    : (stripLeadingDanglingArticleFragment(enrichment.toneOfVoice ?? base.tone_of_voice) ?? null);
 
   // brand_voice_summary: operator brandVoice is authoritative — preserve base, never let enrichment overwrite
   const brandVoiceSummary = opBrandVoice
-    ? base.brand_voice_summary
-    : (enrichment.brandVoiceSummary ?? base.brand_voice_summary);
+    ? stripLeadingDanglingArticleFragment(base.brand_voice_summary)
+    : stripLeadingDanglingArticleFragment(enrichment.brandVoiceSummary ?? base.brand_voice_summary);
 
   // Colors: if operator supplied a palette, preserve the base colors (which were set from the operator palette
   // upstream); do not allow enrichment to clobber palette with scraped values.
@@ -297,9 +308,9 @@ export function applyBrandKitEnrichment(
     ...base,
     colors,
     brand_voice_summary: brandVoiceSummary,
-    offer_summary: enrichment.offerSummary ?? base.offer_summary,
-    positioning: enrichment.positioning ?? base.positioning ?? null,
-    audience: enrichment.audience ?? base.audience ?? null,
+    offer_summary: stripLeadingDanglingArticleFragment(enrichment.offerSummary ?? base.offer_summary),
+    positioning: stripLeadingDanglingArticleFragment(enrichment.positioning ?? base.positioning) ?? null,
+    audience: stripLeadingDanglingArticleFragment(enrichment.audience ?? base.audience) ?? null,
     tone_of_voice: toneOfVoice,
     style_vibe: styleVibe,
   };

--- a/backend/marketing/brand-kit.ts
+++ b/backend/marketing/brand-kit.ts
@@ -559,8 +559,16 @@ function htmlToText(html: string): string {
   );
 }
 
+function stripLeadingDanglingArticleFragment(value: string): string {
+  const stripped = value.replace(/^\s*(?:a|an|the)\s*,\s+/i, '');
+  if (stripped === value || !stripped) {
+    return value;
+  }
+  return stripped.charAt(0).toUpperCase() + stripped.slice(1);
+}
+
 function cleanSentenceCandidate(value: string | null | undefined, maxLength = 220): string | null {
-  const normalized = normalizeWhitespace(
+  const normalized = stripLeadingDanglingArticleFragment(normalizeWhitespace(
     (value || '')
       .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, ' ')
       .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, ' ')
@@ -571,7 +579,7 @@ function cleanSentenceCandidate(value: string | null | undefined, maxLength = 22
       .replace(PREVIEW_UTILITY_TOKEN_PATTERN, ' ')
       .replace(PREVIEW_CSS_REMNANT_PATTERN, ' ')
       .replace(/[`*_#>{}[\]|]/g, ' '),
-  );
+  ));
   if (!normalized) {
     return null;
   }

--- a/tests/brand-kit-enrich-apply.test.ts
+++ b/tests/brand-kit-enrich-apply.test.ts
@@ -84,6 +84,27 @@ test('applyBrandKitEnrichment with full enrichment overwrites brand_voice_summar
   assert.equal(result.style_vibe, 'minimalist');
 });
 
+test('applyBrandKitEnrichment sanitizes leading dangling article-comma enrichment fragments', () => {
+  const base = baseKit({ brand_voice_summary: null, offer_summary: null, positioning: null });
+  const enrichment: BrandKitEnrichment = {
+    brandVoiceSummary: 'A, approval-safe social content operating system for teams that need reviews before publishing.',
+    offerSummary: 'An, automated content review workflow for small teams.',
+    positioning: 'The, safest way for teams to approve and publish weekly social posts.',
+    audience: null,
+    toneOfVoice: null,
+    styleVibe: null,
+  };
+
+  const result = applyBrandKitEnrichment(base, enrichment);
+
+  assert.equal(
+    result.brand_voice_summary,
+    'Approval-safe social content operating system for teams that need reviews before publishing.',
+  );
+  assert.equal(result.offer_summary, 'Automated content review workflow for small teams.');
+  assert.equal(result.positioning, 'Safest way for teams to approve and publish weekly social posts.');
+});
+
 test('applyBrandKitEnrichment returns a new object — mutating result does not mutate base', () => {
   const base = baseKit();
   const enrichment: BrandKitEnrichment = {

--- a/tests/marketing-brand-kit-grammar.regression-004.test.ts
+++ b/tests/marketing-brand-kit-grammar.regression-004.test.ts
@@ -92,3 +92,15 @@ test('normalizeWhitespace cleans inline-tag-strip grammar artifacts (unit)', asy
   const out5 = sanitizeBrandKitSummaryText('Wait... it works');
   assert.equal(out5, 'Wait... it works');
 });
+
+test('sanitizeBrandKitSummaryText removes leading dangling article-comma fragments', async () => {
+  const { sanitizeBrandKitSummaryText } = await import('../backend/marketing/brand-kit');
+
+  const out = sanitizeBrandKitSummaryText('A, approval-safe social content operating system for teams that need reviews before publishing.');
+
+  assert.equal(
+    out,
+    'Approval-safe social content operating system for teams that need reviews before publishing.',
+  );
+  assert.doesNotMatch(out || '', /^[Aa],\s/);
+});


### PR DESCRIPTION
## Summary
- Sanitizes Business Profile brand snapshot copy so a generated fragment like `A, approval-safe social content operating system...` displays as a complete customer-safe sentence: `Approval-safe social content operating system...`.
- Applies the same dangling article/comma cleanup when merging enriched brand-kit fields, preventing contaminated reusable brand identity text from reaching future social-content generation.
- Keeps cached/persisted brand-kit loading on the existing normalization path, so bad stored text is repaired when the kit is loaded/regenerated rather than surfaced again.

## Operator-visible behavior
Before: Business Profile > Brand snapshot could open with awkward truncated copy like `A, approval-safe...`, making the profile look broken and risking reuse in generated posts.

After: Brand snapshot and enriched brand-kit fields drop leading dangling article/comma fragments and start with a complete phrase before display/reuse.

## Test plan
- `npm run guardrails:agent`
- `APP_BASE_URL=https://aries.example.com npx tsx --test --test-concurrency=1 tests/brand-kit-enrich-apply.test.ts tests/marketing-brand-kit-grammar.regression-004.test.ts tests/marketing-brand-identity-parity.test.ts tests/marketing-validated-profile-source-leak.test.ts`
- `npm run validate:repo-boundary`
- `npm run verify` (captured to `/tmp/verify-brand-snapshot-postrebase.log`; `Verification suite passed.`, `VERIFY_EXIT_CODE=0`)

## Notes
No token, tenant, or approval-path behavior changed. This is a brand-kit text sanitation fix only.
