### PR TITLE
fix(dashboard): normalize timezone display across surfaces

### DIFF
--- a/frontend/aries-v1/calendar-screen.tsx
+++ b/frontend/aries-v1/calendar-screen.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { createAriesV1Api, type ScheduledPostsResponse } from '@/lib/api/aries-v1';
 import { useRuntimePosts } from '@/hooks/use-runtime-social-content';
-import { useBusinessProfile } from '@/hooks/use-business-profile';
 import { useTenantTimezone } from '@/hooks/use-tenant-timezone';
 import CalendarPresenter from '@/frontend/aries-v1/presenters/calendar-presenter';
 import {
@@ -44,7 +43,6 @@ export default function AriesCalendarScreen({ allowedPublishPlatforms }: AriesCa
   const range = useMemo(() => defaultRange(), []);
 
   const campaigns = useRuntimePosts({ autoLoad: true });
-  const businessProfile = useBusinessProfile({ autoLoad: true });
 
   const [schedule, setSchedule] = useState<ScheduledPostsResponse | null>(null);
   const [scheduleError, setScheduleError] = useState<string | null>(null);

--- a/frontend/aries-v1/post-workspace.tsx
+++ b/frontend/aries-v1/post-workspace.tsx
@@ -35,7 +35,7 @@ import {
 import { customerSafeActionErrorMessage, customerSafeUiErrorMessage } from './customer-safe-copy';
 import { ActivityFeed, EmptyStatePanel, SectionLink, ShellPanel, StatusChip } from './components';
 import { useTenantTimezone } from '@/hooks/use-tenant-timezone';
-import { formatInTenantZone, tenantZoneAbbreviation } from '@/lib/format-timestamp';
+import { formatInTenantZone, formatTenantDateRangeLabel, tenantZoneAbbreviation } from '@/lib/format-timestamp';
 
 type DecisionActionKind = 'approve' | 'changes_requested' | 'reject';
 
@@ -233,6 +233,7 @@ export default function AriesPostWorkspace(props: { postId: string; initialView?
   const searchParams = useSearchParams();
   const viewParam = searchParams?.get('view') ?? null;
   const activeView = resolveWorkspaceView(viewParam, props.initialView || 'brand');
+  const tz = useTenantTimezone();
 
   const progressActive = !!(status && deriveGenerationProgressState(status)?.isComplete === false);
 
@@ -299,6 +300,7 @@ export default function AriesPostWorkspace(props: { postId: string; initialView?
   const creativeFallback = deriveGateFallbackState(status, 'creative', props.postId, publishBlockedReason);
   const publishState = derivePublishSurfaceState(status, props.postId, publishBlockedReason);
   const generationProgress = deriveGenerationProgressState(status);
+  const postWindowLabel = formatTenantDateRangeLabel(status.postWindow?.start, status.postWindow?.end, tz);
 
   async function submitReviewDecision(
     reviewId: string,
@@ -372,7 +374,7 @@ export default function AriesPostWorkspace(props: { postId: string; initialView?
               </span>
             ) : null}
             <span className="rounded-full border border-white/10 px-3 py-1.5 text-xs font-medium text-white/70">
-              {status.postWindow?.start && status.postWindow?.end ? `${status.postWindow.start} - ${status.postWindow.end}` : 'Dates not scheduled yet'}
+              {postWindowLabel}
             </span>
             <span className="rounded-full border border-white/10 px-3 py-1.5 text-xs font-medium text-white/70">
               {stageReadyLabel(activeView)}

--- a/frontend/insights/AudienceSection.tsx
+++ b/frontend/insights/AudienceSection.tsx
@@ -11,6 +11,7 @@ import type {
   AudienceScheduleItem,
 } from "@/frontend/insights/types";
 import { useInsight } from "@/frontend/insights/useInsight";
+import { useTenantTimezone } from "@/hooks/use-tenant-timezone";
 import { C, platformLabel } from "@/frontend/insights/tokens";
 import {
   SectionHeader,
@@ -244,6 +245,12 @@ function HeatLegend() {
 export function AudienceSection({ period, platform }: AudienceSectionProps) {
   const { data, loading, error, refetch } =
     useInsight<AudienceData>("audience", period, platform);
+  const tenantTimeZone = useTenantTimezone();
+  const activeTimesZone = data?.activeTimes.timezone || tenantTimeZone;
+  const activeTimesSubtitle =
+    activeTimesZone === tenantTimeZone
+      ? `Activity by day & hour · times in ${tenantTimeZone}`
+      : `Activity by day & hour · audience data in ${activeTimesZone}; business timezone is ${tenantTimeZone}`;
 
   return (
     <section>
@@ -324,7 +331,7 @@ export function AudienceSection({ period, platform }: AudienceSectionProps) {
                 <BlockHeader
                   icon="clock"
                   title="When they're listening"
-                  subtitle={`Activity by day & hour${data?.activeTimes.timezone ? ` · times in ${data.activeTimes.timezone}` : ""}`}
+                  subtitle={activeTimesSubtitle}
                 />
                 {data?.activeTimes.hasData && data.activeTimes.peakWindow && (
                   <span

--- a/lib/format-timestamp.ts
+++ b/lib/format-timestamp.ts
@@ -145,6 +145,32 @@ export function formatTimeInTenantZone(
 }
 
 /**
+ * Renders a start/end UTC instant pair as an operator-facing publish window in
+ * the tenant business timezone. This keeps dashboard range copy aligned with
+ * the single tenant timezone source instead of exposing raw ISO/UTC strings.
+ */
+export function formatTenantDateRangeLabel(
+  start: string | number | Date | null | undefined,
+  end: string | number | Date | null | undefined,
+  timeZone: string = DEFAULT_TENANT_TIMEZONE,
+): string {
+  if (start === null || start === undefined || end === null || end === undefined) {
+    return 'Dates not scheduled yet';
+  }
+
+  const startDate = toDate(start);
+  const endDate = toDate(end);
+  if (!startDate || !endDate) {
+    return `${typeof start === 'string' ? start : String(start)} to ${typeof end === 'string' ? end : String(end)}`;
+  }
+
+  const zone = resolveTenantTimeZone(timeZone);
+  const startLabel = `${formatInTenantZone(startDate, zone)} ${tenantZoneAbbreviation(startDate, zone)}`;
+  const endLabel = `${formatInTenantZone(endDate, zone)} ${tenantZoneAbbreviation(endDate, zone)}`;
+  return `${startLabel} to ${endLabel}`;
+}
+
+/**
  * Converts a `datetime-local` wall-clock value (no zone) to a UTC instant,
  * interpreting the wall time in the tenant business zone. DST gaps/duplicates
  * are resolved per `DST_POLICY` (date-fns-tz `fromZonedTime` default).

--- a/tests/calendar-view-model.test.ts
+++ b/tests/calendar-view-model.test.ts
@@ -110,6 +110,9 @@ test('calendar view-model maps scheduled_posts rows into grid events', () => {
   );
   assert.equal(model.events[0].dispatchStatus, 'pending');
   assert.equal(model.events[1].dispatchStatus, 'dispatched');
+  assert.match(model.events[0].scheduledFor, /Apr 15/);
+  assert.match(model.events[0].scheduledFor, /10:00 AM EDT/);
+  assert.doesNotMatch(model.events[0].scheduledFor, /UTC/);
 });
 
 test('calendar view-model day key is tenant-zone aware (11pm post lands on the tenant day)', () => {

--- a/tests/format-timestamp.test.ts
+++ b/tests/format-timestamp.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   DEFAULT_TENANT_TIMEZONE,
   formatInTenantZone,
+  formatTenantDateRangeLabel,
   formatTimeInTenantZone,
   isTenantZoneToday,
   isValidTimeZone,
@@ -83,4 +84,21 @@ test('tenantZoneParts normalizes hour 24 to 0 at midnight', () => {
   const parts = tenantZoneParts('2026-01-16T05:00:00.000Z', 'America/New_York');
   assert.equal(parts?.hour, 0);
   assert.equal(parts?.day, 16);
+});
+
+test('formatTenantDateRangeLabel renders UTC publish windows in the tenant timezone', () => {
+  const label = formatTenantDateRangeLabel(
+    '2026-06-03T00:00:00.000Z',
+    '2026-06-09T23:59:59.999Z',
+    'America/New_York',
+  );
+
+  assert.equal(label, 'Jun 2, 8:00 PM EDT to Jun 9, 7:59 PM EDT');
+  assert.doesNotMatch(label, /2026-06-03T00:00:00\.000Z/);
+  assert.doesNotMatch(label, /UTC/);
+});
+
+test('formatTenantDateRangeLabel preserves invalid publish window fallback without inventing dates', () => {
+  assert.equal(formatTenantDateRangeLabel(null, '2026-06-09T23:59:59.999Z', 'America/New_York'), 'Dates not scheduled yet');
+  assert.equal(formatTenantDateRangeLabel('bad-start', 'bad-end', 'America/New_York'), 'bad-start to bad-end');
 });

--- a/tests/ui-timestamps-use-tenant-zone.test.ts
+++ b/tests/ui-timestamps-use-tenant-zone.test.ts
@@ -50,3 +50,19 @@ test('admin debug panel: formatTenantTime and formatUtcTime both present for sid
   assert.match(src, /formatTenantTime/, 'debug panel must have formatTenantTime for tenant-zone display');
   assert.match(src, /formatUtcTime/, 'debug panel must keep formatUtcTime for UTC display');
 });
+
+test('post workspace publish window uses tenant-zone range helper instead of raw ISO interpolation', () => {
+  const src = readRepoFile('frontend/aries-v1/post-workspace.tsx');
+  assert.match(src, /formatTenantDateRangeLabel/, 'workspace header must format publish windows in the tenant zone');
+  assert.doesNotMatch(
+    src,
+    /\$\{status\.postWindow\.start\}\s*-\s*\$\{status\.postWindow\.end\}/,
+    'workspace header must not expose raw ISO postWindow ranges',
+  );
+});
+
+test('insights active-times copy names the business timezone when audience timezone differs', () => {
+  const src = readRepoFile('frontend/insights/AudienceSection.tsx');
+  assert.match(src, /useTenantTimezone/, 'insights must read the same tenant timezone source as Calendar and Publish Status');
+  assert.match(src, /business timezone is/, 'insights must explain any audience-data timezone difference');
+});


### PR DESCRIPTION
## Summary
- Calendar scheduled post labels now assert tenant-local display with timezone abbreviations instead of UTC copy.
- Publish Status/workspace date windows use a shared tenant-zone range formatter, so operators see labels like `Jun 2, 8:00 PM EDT to Jun 9, 7:59 PM EDT` instead of raw ISO ranges.
- Insights active-times copy now reads the same tenant timezone source and explains when audience analytics use a different timezone.

## Test Plan
- `npm run guardrails:agent`
- `APP_BASE_URL=https://aries.example.com npx tsx --test tests/calendar-view-model.test.ts tests/e2e/calendar-smoke.test.ts tests/format-timestamp.test.ts tests/ui-timestamps-use-tenant-zone.test.ts`
- `npm run validate:repo-boundary`
- `npm run verify`

## Visual QA
- Ran `npm run dev -- -p 3010` with Turbopack and required local env values.
- Rendered a browser QA page using `CalendarPresenter` and the Publish Status date-range formatter; Chromium screenshot saved at `/home/node/timezone-display-qa.png`.
- Browser DOM confirmed the publish window rendered as `Jun 2, 8:00 PM EDT to Jun 9, 7:59 PM EDT`, the scheduled calendar post rendered, and raw `2026-06-03T00:00:00.000Z` / `UTC` labels were absent.
