### PR TITLE
fix(publishing): normalize reused runtime brand kit copy

### DIFF
--- a/backend/marketing/brand-kit-enrich.ts
+++ b/backend/marketing/brand-kit-enrich.ts
@@ -245,7 +245,7 @@ export type OperatorBrandKitOverrides = {
   palette?: string[] | null;
 };
 
-function stripLeadingDanglingArticleFragment(value: string | null | undefined): string | null {
+export function stripLeadingDanglingArticleFragment(value: string | null | undefined): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.replace(/\s+/g, ' ').trim();
   if (!trimmed) return null;

--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -7,6 +7,7 @@ import { normalizeMetaLocatorUrl, normalizeMetaPageId } from '@/lib/marketing-co
 import { describeSpecResolution, resolveDataPath } from '@/lib/runtime-paths';
 import { ingestRuntimeDocAssets } from './asset-ingest';
 import { loadTenantBrandKit, tenantBrandKitPath, type TenantBrandKit } from './brand-kit';
+import { stripLeadingDanglingArticleFragment } from './brand-kit-enrich';
 import { recordMarketingFailureRuntimeIncident } from './runtime-error-bridge';
 
 const REQUIRED_SCHEMA_FILES = [
@@ -431,11 +432,30 @@ function marketingRuntimeRoot(): string {
   return resolveDataPath('generated', 'draft', 'marketing-jobs');
 }
 
+function normalizeRuntimeBrandKitText(value: string | null | undefined): string | null {
+  return stripLeadingDanglingArticleFragment(value) ?? null;
+}
+
+export function normalizeMarketingBrandKitReference(
+  brandKit: MarketingBrandKitReference | null | undefined,
+): MarketingBrandKitReference | null {
+  if (!brandKit) return null;
+  return {
+    ...brandKit,
+    brand_voice_summary: normalizeRuntimeBrandKitText(brandKit.brand_voice_summary),
+    offer_summary: normalizeRuntimeBrandKitText(brandKit.offer_summary),
+    positioning: normalizeRuntimeBrandKitText(brandKit.positioning),
+    audience: normalizeRuntimeBrandKitText(brandKit.audience),
+    tone_of_voice: normalizeRuntimeBrandKitText(brandKit.tone_of_voice),
+    style_vibe: normalizeRuntimeBrandKitText(brandKit.style_vibe),
+  };
+}
+
 export function marketingBrandKitReferenceFromTenantBrandKit(
   brandKit: TenantBrandKit,
   filePath: string,
 ): MarketingBrandKitReference {
-  return {
+  return normalizeMarketingBrandKitReference({
     path: filePath,
     source_url: brandKit.source_url,
     canonical_url: brandKit.canonical_url,
@@ -459,7 +479,7 @@ export function marketingBrandKitReferenceFromTenantBrandKit(
     audience: brandKit.audience ?? null,
     tone_of_voice: brandKit.tone_of_voice ?? null,
     style_vibe: brandKit.style_vibe ?? null,
-  };
+  }) as MarketingBrandKitReference;
 }
 
 function runtimeBrandKitReferenceFromTenantBrandKit(
@@ -572,6 +592,8 @@ export async function loadSocialContentJobRuntime(jobId: string): Promise<Social
     }
     if (!doc.brand_kit) {
       doc.brand_kit = await recoverLegacyRuntimeBrandKit(doc);
+    } else {
+      doc.brand_kit = normalizeMarketingBrandKitReference(doc.brand_kit);
     }
     return doc;
   } catch (error) {

--- a/backend/social-content/brand-kit-payload.ts
+++ b/backend/social-content/brand-kit-payload.ts
@@ -1,4 +1,5 @@
 import { repairStaleMarketingOffer } from '@/backend/marketing/brand-kit';
+import { stripLeadingDanglingArticleFragment } from '@/backend/marketing/brand-kit-enrich';
 import type {
   MarketingBrandKitReference,
   SocialContentJobRuntimeDocument,
@@ -43,6 +44,11 @@ const NOTES_FALLBACK_BUDGET = 300;
 
 function stringValue(value: unknown): string {
   return typeof value === 'string' ? redactTokenLikeString(value).trim() : '';
+}
+
+function brandKitStringValue(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return stripLeadingDanglingArticleFragment(redactTokenLikeString(value)) ?? '';
 }
 
 function stringArray(value: unknown): string[] {
@@ -132,8 +138,8 @@ function brandKitFontFamilies(brandKit: MarketingBrandKitReference | null | unde
 }
 
 function resolveBrandVoice(req: UnknownRecord, brandKit: MarketingBrandKitReference | null | undefined): string {
-  const summary = stringValue(brandKit?.brand_voice_summary) || '';
-  const tone = stringValue(brandKit?.tone_of_voice) || '';
+  const summary = brandKitStringValue(brandKit?.brand_voice_summary);
+  const tone = brandKitStringValue(brandKit?.tone_of_voice);
   const operatorVoice = stringValue(req.brandVoice);
   const base = summary || operatorVoice;
   if (base && tone) return `${base} Tone: ${tone}.`;
@@ -154,7 +160,7 @@ function resolveNotes(req: UnknownRecord, brandKit: MarketingBrandKitReference |
   if (operatorNotes) return operatorNotes;
   const summary = brandKit?.brand_voice_summary;
   if (typeof summary !== 'string') return '';
-  const trimmed = stringValue(summary);
+  const trimmed = brandKitStringValue(summary);
   if (!trimmed) return '';
   if (trimmed.length <= NOTES_FALLBACK_BUDGET) return trimmed;
   return `${trimmed.slice(0, NOTES_FALLBACK_BUDGET)}…`;
@@ -163,25 +169,25 @@ function resolveNotes(req: UnknownRecord, brandKit: MarketingBrandKitReference |
 function resolveBrandOffer(req: UnknownRecord, brandKit: MarketingBrandKitReference | null | undefined): string {
   return (
     repairStaleMarketingOffer({
-      offer: stringValue(req.offer) || brandKit?.offer_summary || null,
+      offer: stringValue(req.offer) || brandKitStringValue(brandKit?.offer_summary) || null,
       brandName: stringValue(req.businessName) || brandKit?.brand_name || null,
       businessType: stringValue(req.businessType) || null,
       primaryGoal: stringValue(req.primaryGoal) || stringValue(req.goal) || null,
-      brandVoice: stringValue(req.brandVoice) || brandKit?.brand_voice_summary || null,
-      positioning: brandKit?.positioning || brandKit?.offer_summary || null,
-      brandKitOfferSummary: brandKit?.offer_summary || null,
+      brandVoice: stringValue(req.brandVoice) || brandKitStringValue(brandKit?.brand_voice_summary) || null,
+      positioning: brandKitStringValue(brandKit?.positioning) || brandKitStringValue(brandKit?.offer_summary) || null,
+      brandKitOfferSummary: brandKitStringValue(brandKit?.offer_summary) || null,
     }) || ''
   );
 }
 
 function resolveBrandStyleVibe(req: UnknownRecord, brandKit: MarketingBrandKitReference | null | undefined): string {
-  const enriched = stringValue(brandKit?.style_vibe);
+  const enriched = brandKitStringValue(brandKit?.style_vibe);
   if (enriched) return enriched;
   return stringValue(req.styleVibe) || '';
 }
 
 function resolveBrandAudience(req: UnknownRecord, brandKit: MarketingBrandKitReference | null | undefined): string {
-  return stringValue(req.audience) || stringValue(brandKit?.audience ?? '') || '';
+  return stringValue(req.audience) || brandKitStringValue(brandKit?.audience) || '';
 }
 
 function resolveMustAvoidAesthetics(req: UnknownRecord): string[] {

--- a/tests/marketing-runtime-brand-kit-normalization.test.ts
+++ b/tests/marketing-runtime-brand-kit-normalization.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+async function withEnv<T>(overrides: Record<string, string | undefined>, fn: () => Promise<T>): Promise<T> {
+  const original: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    original[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function makeRuntimeDoc(): Record<string, unknown> {
+  return {
+    schema_name: 'marketing_job_state_schema',
+    schema_version: '1.0.0',
+    job_id: 'mkt_runtime_brand_kit_normalization',
+    tenant_id: 'tenant_runtime_brand_kit_normalization',
+    job_type: 'weekly_social_content',
+    state: 'running',
+    status: 'running',
+    current_stage: 'strategy',
+    stage_order: ['research', 'strategy', 'production', 'publish'],
+    stages: {
+      research: { stage: 'research', status: 'completed', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      strategy: { stage: 'strategy', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      production: { stage: 'production', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+      publish: { stage: 'publish', status: 'not_started', started_at: null, completed_at: null, failed_at: null, run_id: null, summary: null, primary_output: null, outputs: {}, artifacts: [], errors: [] },
+    },
+    approvals: { current: null, history: [] },
+    publish_config: { platforms: [], live_publish_platforms: [], video_render_platforms: [] },
+    brand_kit: {
+      path: '/tmp/brand-kit.json',
+      source_url: 'https://aries.example.com',
+      canonical_url: 'https://aries.example.com',
+      brand_name: 'Aries',
+      logo_urls: [],
+      colors: { primary: null, secondary: null, accent: null, palette: [] },
+      font_families: [],
+      external_links: [],
+      extracted_at: '2026-05-19T00:00:00.000Z',
+      brand_voice_summary: 'A, approval-safe social content operating system for small businesses.',
+      offer_summary: 'An, automated weekly marketing workspace.',
+      positioning: 'The, safe publishing workflow for teams.',
+      audience: 'A, operators who need approval-safe content.',
+      tone_of_voice: 'An, crisp and direct tone.',
+      style_vibe: 'The, editorial dashboard feel.',
+    },
+    inputs: { request: {}, brand_url: 'https://aries.example.com' },
+    errors: [],
+    last_error: null,
+    history: [],
+    created_at: '2026-05-19T00:00:00.000Z',
+    updated_at: '2026-05-19T00:00:00.000Z',
+  };
+}
+
+test('loadSocialContentJobRuntime normalizes persisted runtime brand kit copy on read', async () => {
+  const { loadSocialContentJobRuntime } = await import('../backend/marketing/runtime-state.js');
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-runtime-brand-kit-'));
+  try {
+    const doc = makeRuntimeDoc();
+    const jobsDir = path.join(dataRoot, 'generated', 'draft', 'marketing-jobs');
+    await mkdir(jobsDir, { recursive: true });
+    await writeFile(path.join(jobsDir, `${doc.job_id}.json`), JSON.stringify(doc, null, 2));
+
+    await withEnv({ DATA_ROOT: dataRoot }, async () => {
+      const loaded = await loadSocialContentJobRuntime(String(doc.job_id));
+
+      assert.ok(loaded?.brand_kit, 'runtime doc should load a brand kit');
+      assert.equal(loaded.brand_kit.brand_voice_summary, 'Approval-safe social content operating system for small businesses.');
+      assert.equal(loaded.brand_kit.offer_summary, 'Automated weekly marketing workspace.');
+      assert.equal(loaded.brand_kit.positioning, 'Safe publishing workflow for teams.');
+      assert.equal(loaded.brand_kit.audience, 'Operators who need approval-safe content.');
+      assert.equal(loaded.brand_kit.tone_of_voice, 'Crisp and direct tone.');
+      assert.equal(loaded.brand_kit.style_vibe, 'Editorial dashboard feel.');
+    });
+  } finally {
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/social-content/brand-kit-payload.test.ts
+++ b/tests/social-content/brand-kit-payload.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import test from 'node:test';
 
 import { buildBrandKitPayload } from '../../backend/social-content/brand-kit-payload';
@@ -126,6 +128,20 @@ test('buildBrandKitPayload falls back to request data from the runtime doc when 
   assert.equal(payload.objective.primary_goal, 'Book more consulting calls');
   assert.equal(payload.objective.offer, 'Operator coaching intensives');
   assert.equal(payload.objective.audience, 'Operators building the next layer of systems');
+});
+
+test('buildBrandKitPayload normalizes persisted runtime brand kit voice fragments before reuse', () => {
+  const fixturePath = path.join(__dirname, '..', 'fixtures', 'marketing-runtime-primary-output.json');
+  const doc = JSON.parse(readFileSync(fixturePath, 'utf8')) as SocialContentJobRuntimeDocument;
+  const rawVoice = doc.brand_kit?.brand_voice_summary;
+  assert.equal(typeof rawVoice, 'string');
+  assert.match(rawVoice ?? '', /^A, approval-safe/i);
+
+  const payload = buildBrandKitPayload(doc, doc.brand_kit, null);
+
+  assert.match(payload.brand.voice, /^Approval-safe social content operating system/i);
+  assert.doesNotMatch(payload.brand.voice, /^A,\s/i);
+  assert.doesNotMatch(payload.brand.notes, /^A,\s/i);
 });
 
 test('buildBrandKitPayload carries helper-only defaults without mutating weekly constraints shape', () => {


### PR DESCRIPTION
## Summary
- Normalizes persisted runtime `brand_kit` text fields when `loadSocialContentJobRuntime()` reads existing social-content runtime docs, so old saved snapshots no longer carry leading dangling article/comma fragments into later stages.
- Reuses the existing brand-kit fragment sanitizer inside `buildBrandKitPayload()`, covering direct strategy/creative/publishing payload reuse even when callers pass an already-loaded runtime `doc.brand_kit`.
- Adds regression coverage for the exact `tests/fixtures/marketing-runtime-primary-output.json` fragment and a load-time normalization/backfill-path test for persisted runtime docs.

## Operator impact
Before this change, an operator could reuse an older saved brand snapshot and see `A, approval-safe...` leak into the weekly social-content payload even though the dashboard/profile sanitizer path passed. After this change, retries and stage resumes reuse the cleaned brand voice/offer/positioning/audience/tone/style copy, so generated strategy, creative, and publishing prompts stay grammatically clean.

## Test Plan
- RED first: `APP_BASE_URL=https://aries.example.com npx tsx --test tests/social-content/brand-kit-payload.test.ts` failed on `buildBrandKitPayload normalizes persisted runtime brand kit voice fragments before reuse` with `A, approval-safe...` still emitted.
- `APP_BASE_URL=https://aries.example.com npx tsx --test tests/social-content/brand-kit-payload.test.ts tests/marketing-runtime-brand-kit-normalization.test.ts` — 7/7 pass.
- `APP_BASE_URL=https://aries.example.com npx tsx --test tests/marketing-brand-kit-grammar.regression-004.test.ts tests/brand-kit-enrich-apply.test.ts tests/marketing-brand-kit-reference.test.ts tests/social-content-brand-kit-injection.test.ts tests/social-content/brand-kit-payload.test.ts tests/marketing-runtime-brand-kit-normalization.test.ts tests/business-profile-screen.test.ts tests/frontend-api-layer.test.ts` — 89/89 pass.
- `npm run validate:banned-patterns` — passed.
- `APP_BASE_URL=https://aries.example.com npm run verify` — Verification suite passed.
- `npm run guardrails:agent` — passed after commit.

## Security / correctness
No token, tenant, approval, or Graph API publish behavior changed. This is a load-time/payload normalization fix for persisted brand-kit copy only.
