### PR TITLE
fix(marketing): carry hard DARK brand constraint on auto-advanced production runs

### DIFF
--- a/backend/marketing/ports/hermes.ts
+++ b/backend/marketing/ports/hermes.ts
@@ -1309,6 +1309,28 @@ export class HermesMarketingPort implements MarketingExecutionPort {
       if (startingStage) {
         promptLines.push(`Starting stage: ${startingStage}`);
       }
+      // BRAND-RENDER FIX: the auto-advanced production run (submitNextStage →
+      // action:'run' → buildSocialContentWeeklyRequest) must carry the SAME hard
+      // brand-rendering constraint (dark/near-black background, palette, logo,
+      // "NON-NEGOTIABLE: this brand is DARK") + rich per-image prompts that the
+      // approval-resume production path already injects (see the action:'resume'
+      // branch's `stage === 'production'` block). Without it the content-generator
+      // profile drafts "bright/soft white" visual_prompts and renders off-brand
+      // WHITE images — the per-stage-pipeline regression of the #553 hard
+      // constraint, which only patched the resume path. Reuses the exact same
+      // tested builder so the auto-advance and approval-resume production
+      // submissions stay byte-for-byte in lockstep. Scoped to the production
+      // stage and skipped for single-creative regenerate/image-edit (a
+      // stage:'research'-shaped run with its own per-image scope + edit contract).
+      if (input.stage === 'production' && input.doc && !input.regenerateCreative) {
+        const ctx = buildProductionResumeContext({
+          doc: input.doc,
+          researchOutput: (input.doc.stages.research?.primary_output ?? null) as Record<string, unknown> | null,
+          strategyOutput: (input.doc.stages.strategy?.primary_output ?? null) as Record<string, unknown> | null,
+          tasteProjection,
+        });
+        promptLines.push('', ctx.contextBlock);
+      }
       // IMAGE EDIT (image-to-image): when the regenerate context carries an edit
       // instruction, pin the content-generator profile to image_generate's edit
       // endpoint on the existing source image instead of a fresh generation. The

--- a/tests/marketing/production-autoadvance-dark-constraint.test.ts
+++ b/tests/marketing/production-autoadvance-dark-constraint.test.ts
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { HermesMarketingPort } from '../../backend/marketing/ports/hermes';
+import type { SocialContentJobRuntimeDocument } from '../../backend/marketing/runtime-state';
+
+/**
+ * Regression: the auto-advanced production run must carry the hard "this brand
+ * is DARK" constraint.
+ *
+ * Root cause (white-published-posts bug): the per-stage profile pipeline
+ * advances strategy -> production via submitNextStage (action:'run' ->
+ * buildSocialContentWeeklyRequest). The hard dark-background constraint shipped
+ * in #553 lived ONLY in buildProductionResumeContext (the action:'resume'
+ * path). So an auto-advanced production stage (no approval gate) reached the
+ * content-generator profile with no dark instruction, the agent drafted
+ * "bright/soft white" visual_prompts, and the rendered images published WHITE.
+ *
+ * The fix appends the same production context block (constraint + rich per-image
+ * prompts) on the action:'run' production submission. These tests pin the wire
+ * `input` so the run and resume production submissions stay in lockstep.
+ */
+
+type FetchCall = { url: string; init: RequestInit };
+
+function recordingFetch() {
+  const calls: FetchCall[] = [];
+  const fetchImpl = async (url: string | URL, init?: RequestInit): Promise<Response> => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return new Response(JSON.stringify({ run_id: 'hermes-run-1', status: 'started' }), {
+      status: 202,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  return { calls, fetchImpl };
+}
+
+const NO_SLEEP = async () => {};
+const NO_OP_BRAND_KIT_REFRESHER = async () => ({ refreshed: false, enriched: false });
+
+async function withDataRoot<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env.DATA_ROOT;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-prod-autoadvance-dark-'));
+  process.env.DATA_ROOT = dataRoot;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previous;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+const ENV = {
+  HERMES_GATEWAY_URL: 'http://127.0.0.1:8642',
+  HERMES_API_SERVER_KEY: 'default-key',
+  HERMES_CONTENT_GATEWAY_URL: 'http://host.docker.internal:8655',
+  HERMES_CONTENT_API_SERVER_KEY: 'content-key',
+  INTERNAL_API_SECRET: 'internal-secret',
+  APP_BASE_URL: 'https://aries.example.com',
+  HERMES_POLL_BRIDGE_ENABLED: '0',
+};
+
+function makePort(fetchImpl: typeof fetch) {
+  return new HermesMarketingPort(
+    ENV,
+    fetchImpl as unknown as (input: string | URL, init?: RequestInit) => Promise<Response>,
+    NO_SLEEP,
+    NO_OP_BRAND_KIT_REFRESHER,
+  );
+}
+
+/** A completed-research/strategy weekly doc whose brand theme is configurable. */
+function weeklyDoc(mode: 'dark' | 'light' | null): SocialContentJobRuntimeDocument {
+  const ts = new Date().toISOString();
+  const stageRecord = (stage: string, status: string, primaryOutput: Record<string, unknown> | null) => ({
+    stage,
+    status,
+    started_at: ts,
+    completed_at: status === 'completed' ? ts : null,
+    failed_at: null,
+    run_id: `run-${stage}`,
+    summary: null,
+    primary_output: primaryOutput,
+    outputs: {},
+    artifacts: [],
+    errors: [],
+  });
+  return {
+    schema_name: 'marketing_job_state_schema',
+    schema_version: '1.0.0',
+    job_id: 'job_dark_autoadvance',
+    tenant_id: 'tenant_test',
+    job_type: 'weekly_social_content',
+    state: 'running',
+    status: 'running',
+    current_stage: 'production',
+    stage_order: ['research', 'strategy', 'production', 'publish'],
+    stages: {
+      research: stageRecord('research', 'completed', { positioning: 'RESEARCH_MARKER' }),
+      strategy: stageRecord('strategy', 'completed', { strategySummary: 'STRATEGY_MARKER' }),
+      production: stageRecord('production', 'not_started', null),
+      publish: stageRecord('publish', 'not_started', null),
+    },
+    approvals: { current: null, history: [] },
+    publish_config: { platforms: [], live_publish_platforms: [], video_render_platforms: [] },
+    brand_kit: {
+      brand_name: 'Aries AI',
+      brand_voice_summary: 'Calm, premium, systemized.',
+      offer_summary: 'A weekly content operating system.',
+      positioning: null,
+      audience: null,
+      tone_of_voice: null,
+      style_vibe: null,
+      colors: {
+        primary: '#d8475f',
+        secondary: '#7c3aed',
+        accent: '#a855f7',
+        palette: ['#d8475f', '#7c3aed', '#a855f7', '#c084fc'],
+        background: mode === 'dark' ? '#050505' : mode === 'light' ? '#ffffff' : null,
+        mode,
+      },
+      logo_urls: [],
+      font_families: ['Inter', 'Manrope'],
+      external_links: [],
+      extracted_at: ts,
+      source_url: 'https://aries.sugarandleather.com/',
+      canonical_url: 'https://aries.sugarandleather.com/',
+    },
+    inputs: {
+      brand_url: 'https://aries.sugarandleather.com/',
+      request: {
+        jobType: 'weekly_social_content',
+        channels: ['instagram', 'meta'],
+        imageCreativeCount: 2,
+        windowDays: 7,
+        staticPostCount: 7,
+      },
+    },
+    created_at: ts,
+    updated_at: ts,
+    history: [],
+  } as unknown as SocialContentJobRuntimeDocument;
+}
+
+test('auto-advanced production run carries the hard DARK constraint + per-image context', async () => {
+  await withDataRoot(async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const port = makePort(fetchImpl as unknown as typeof fetch);
+    await port.submitNextStage({
+      jobId: 'job_dark_autoadvance',
+      tenantId: 'tenant_test',
+      doc: weeklyDoc('dark'),
+      stage: 'production',
+    });
+    assert.equal(calls.length, 1);
+    // production routes to the content-generator gateway (the auto-advance run path)
+    assert.equal(calls[0].url, 'http://host.docker.internal:8655/v1/runs');
+    const body = JSON.parse(calls[0].init.body as string) as Record<string, unknown>;
+    const callbackContext = body.callback_context as Record<string, unknown> | undefined;
+    assert.equal(callbackContext?.auto_advance, true, 'submitNextStage marks the run auto_advance');
+    const input = String(body.input);
+    assert.ok(
+      input.includes('NON-NEGOTIABLE: this brand is DARK'),
+      'production run input must carry the NON-NEGOTIABLE dark directive',
+    );
+    assert.ok(
+      input.includes('#050505'),
+      'production run input must name the dark background color',
+    );
+    assert.ok(
+      input.includes('Production context ('),
+      'production run input must carry the rich per-image prompt context block',
+    );
+  });
+});
+
+test('auto-advanced production run for a LIGHT brand does NOT emit the dark directive', async () => {
+  await withDataRoot(async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const port = makePort(fetchImpl as unknown as typeof fetch);
+    await port.submitNextStage({
+      jobId: 'job_dark_autoadvance',
+      tenantId: 'tenant_test',
+      doc: weeklyDoc('light'),
+      stage: 'production',
+    });
+    const body = JSON.parse(calls[0].init.body as string) as Record<string, unknown>;
+    const input = String(body.input);
+    assert.ok(
+      !input.includes('NON-NEGOTIABLE: this brand is DARK'),
+      'a light brand must not be forced dark',
+    );
+    // The per-image context block is still injected (it just lacks the dark line).
+    assert.ok(input.includes('Production context ('), 'production run still carries the context block');
+  });
+});
+
+test('auto-advanced NON-production stage does not get the production context block', async () => {
+  await withDataRoot(async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const port = makePort(fetchImpl as unknown as typeof fetch);
+    await port.submitNextStage({
+      jobId: 'job_dark_autoadvance',
+      tenantId: 'tenant_test',
+      doc: weeklyDoc('dark'),
+      stage: 'strategy',
+    });
+    const body = JSON.parse(calls[0].init.body as string) as Record<string, unknown>;
+    const input = String(body.input);
+    assert.ok(
+      !input.includes('Production context ('),
+      'only the production stage should inject the production context block',
+    );
+    assert.ok(
+      !input.includes('NON-NEGOTIABLE: this brand is DARK'),
+      'the strategy stage must not carry the production-only dark directive',
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Marketing posts for **dark-themed brands** (e.g. `aries.sugarandleather.com` — `#050505` + purple) were being **published WHITE**. Verified live: published IG/FB posts 219/223/224 (job `mkt_c8ee6236`, tenant 15) are white pastel; their stored `visual_prompt`s literally read *"Bright, clean… soft white background with pink and violet accents"*, and the entire dark-constraint vocabulary (`NON-NEGOTIABLE`, `this brand is DARK`, `#050505`) appears **zero times** in that job.

## Root cause

The per-stage profile pipeline (research/strategist/content-generator) auto-advances strategy → production via `submitNextStage` → `action:'run'` → `buildSocialContentWeeklyRequest`. The hard "this brand is DARK" constraint shipped in #553 lives **only** in `buildProductionResumeContext` (the `action:'resume'` path). So an auto-advanced production stage (no approval gate; `maybeAutoAdvanceNextStage` fires when a stage completes without an approval checkpoint) reaches the content-generator profile with **no dark instruction** — the agent drafts bright/white prompts and renders off-brand white images. This is the decomposition regression of the monolith → 3-profile pipeline ("monolith regresses").

## Fix

On the `action:'run'` production submission, append the **same** production context block (dark/light constraint + palette + logo + rich per-image prompts) the resume path already injects — reusing `buildProductionResumeContext` so the two production submissions stay in lockstep. Scoped to `stage==='production'`; single-creative regenerate/image-edit (a `stage:'research'`-shaped run with its own edit contract) is untouched. The resume path and light/no-mode brands are unchanged.

## Tests

- **Oracle**: `tests/marketing/production-autoadvance-dark-constraint.test.ts` — fails before the fix, passes after (dark run carries `NON-NEGOTIABLE: this brand is DARK` + `#050505` + the context block; light brand does not; non-production stages do not).
- typecheck ✓ · `npm run verify` ✓ · `validate:social-content` 92/92 ✓ · `validate:execution-provider` 52/52 ✓ · `three-profile-routing` (resume path) 17/17 ✓

## Note on already-affected posts

This prevents **future** white renders. White posts already published to IG/FB (219/223/224) are live history. Posts 227–230 (`img_5`/`img_6`, approved, not yet published) are still white — remediation (regenerate / replace via a fresh weekly job after deploy) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)