### PR TITLE
fix(video): reel voiceover hung ffmpeg (bare apad) + 404 on empty voice id

### DIFF
--- a/backend/integrations/elevenlabs/tts.ts
+++ b/backend/integrations/elevenlabs/tts.ts
@@ -57,8 +57,11 @@ export async function synthesizeVoiceover(
     return null;
   }
 
+  // Use || (not ??) so an EMPTY ELEVENLABS_VOICE_ID — which docker-compose
+  // injects as '' via ${ELEVENLABS_VOICE_ID:-} — falls back to the default
+  // voice instead of building /text-to-speech/ (empty id) → HTTP 404.
   const voiceId =
-    args.voiceId ?? process.env.ELEVENLABS_VOICE_ID ?? DEFAULT_VOICE_ID;
+    args.voiceId?.trim() || process.env.ELEVENLABS_VOICE_ID?.trim() || DEFAULT_VOICE_ID;
   const modelId = args.modelId ?? DEFAULT_MODEL_ID;
 
   const controller = new AbortController();

--- a/backend/marketing/marketing-layer/compose-reel.ts
+++ b/backend/marketing/marketing-layer/compose-reel.ts
@@ -297,12 +297,16 @@ export async function composeReelMarketingLayer(args: ComposeReelArgs): Promise<
     if (music && audioInIdx >= 0) {
       // VO ────────────────────────────────────────┐
       // music ──(volume=0.18)──[mus_duck]────────┘ → amix → alimiter → [a]
+      // apad=whole_dur=<D> pads the mixed audio to EXACTLY the clip duration
+      // (finite). A bare apad pads forever, and -shortest cannot bound a
+      // filtered (vs input) stream, so ffmpeg never terminates — the VO-path
+      // hang. whole_dur makes the audio finite and = the video length.
       fc += `[${audioInIdx}:a]volume=0.18[mus_duck];`;
       fc += `[mus_duck][${voInIdx}:a]amix=inputs=2:duration=longest[mixed];`;
-      fc += `[mixed]alimiter=limit=0.99,apad[a]`;
+      fc += `[mixed]alimiter=limit=0.99,apad=whole_dur=${end}[a]`;
     } else {
-      // VO only (no music bed on disk)
-      fc += `[${voInIdx}:a]aresample=44100,apad[a]`;
+      // VO only (no music bed on disk) — same finite-pad to the clip duration.
+      fc += `[${voInIdx}:a]aresample=44100,apad=whole_dur=${end}[a]`;
     }
     map.push('-map', '[a]', '-c:a', 'aac', '-b:a', '160k');
   } else if (music && audioInIdx >= 0) {


### PR DESCRIPTION
Live verification of the voiceover (#740) found it **broken two ways**, both caught by a contained `composeReelMarketingLayer` run (VO-on vs VO-off audio md5 compare — identical = VO never muxed):

1. **HANG** — the VO audio graph used a bare `apad` (infinite trailing silence). `-shortest` can't bound a *filtered* stream, so ffmpeg never terminates → the compositor never returns → would stall the reel ingest. Fix: `apad=whole_dur=${D}` (finite pad to the clip duration). Reproduced: bare-apad **hangs** (timeout 124); `whole_dur` **terminates** (exit 0, correct 15s output).
2. **HTTP 404** — `voiceId` used `??`, so the empty string docker-compose injects for `ELEVENLABS_VOICE_ID` slipped through → `/v1/text-to-speech/` (empty id) → 404 → silent fallback to the music bed. Fix: `|| .trim()` → empty/whitespace falls back to the default voice.

Auth + raw TTS smoke tests passed (key valid) — the bug was in the integration, which is why the in-container compose check was the one that caught it. typecheck + verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)