### PR TITLE
test(feedback): close SC-70 dialog + attach-fail coverage gaps

### DIFF
--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -75,6 +75,7 @@ const steps = [
       'tests/feedback-report-submit.test.ts',
       'tests/feedback-report-sweep.test.ts',
       'tests/feedback-report-form.test.ts',
+      'tests/feedback-report-dialog.test.ts',
     ],
   },
   {

--- a/tests/feedback-report-dialog.test.ts
+++ b/tests/feedback-report-dialog.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+
+/**
+ * Component-level coverage for ReportModal (frontend/feedback/report-dialog.tsx)
+ * closing two gaps left by the pure-function tests in feedback-report-form.test.ts:
+ *
+ *   1. The double-submit guard (`if (submitting || phase === 'success') return;`
+ *      + `disabled={submitting}` on the submit button) — proven here as "exactly
+ *      one POST" when the form's onSubmit fires twice in quick succession.
+ *   2. The 429 branch keeps the dialog open with the typed values intact and
+ *      shows the server's rate-limit message (report-dialog.tsx's own comment:
+ *      "429 / errors: dialog stays open, values intact, retry works").
+ *
+ * ReportModal itself is NOT wrapped in createPortal (the widget does that), so
+ * react-test-renderer can mount it directly — same pattern as the existing
+ * feedback-widget-render.test.ts smoke test. The repo has no jsdom, so this
+ * file stubs only the minimal window/document surface the component's effects
+ * touch (focus-trap keydown listener, activeElement read on mount/unmount) and
+ * a fetch stub, all removed in `finally` so no other test observes them.
+ */
+
+interface Harness {
+  root: import('react-test-renderer').ReactTestRenderer;
+  onCloseCalls: number;
+  fetchCalls: number;
+  fillValidForm: () => Promise<void>;
+  submitOnce: () => Promise<void>;
+  titleValue: () => string;
+  hasDialog: () => boolean;
+  hasSubmitButton: () => boolean;
+  alertMessages: () => string[];
+}
+
+async function withReportDialog(
+  fetchImpl: (input: unknown, init?: unknown) => Promise<unknown>,
+  run: (h: Harness) => Promise<void>,
+): Promise<void> {
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
+  (globalThis as Record<string, unknown>).window = {
+    addEventListener: (type: string, fn: (event: unknown) => void) => {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(fn);
+    },
+    removeEventListener: (type: string, fn: (event: unknown) => void) => {
+      listeners.get(type)?.delete(fn);
+    },
+    setTimeout: (...args: Parameters<typeof setTimeout>) => setTimeout(...args),
+    clearTimeout: (id: ReturnType<typeof setTimeout>) => clearTimeout(id),
+  };
+  (globalThis as Record<string, unknown>).document = {
+    activeElement: null,
+  };
+
+  let fetchCalls = 0;
+  (globalThis as Record<string, unknown>).fetch = async (input: unknown, init?: unknown) => {
+    fetchCalls += 1;
+    return fetchImpl(input, init);
+  };
+
+  try {
+    const { act, create } = await import('react-test-renderer');
+    const ReportModal = (await import('../frontend/feedback/report-dialog')).default;
+
+    let onCloseCalls = 0;
+    let root!: import('react-test-renderer').ReactTestRenderer;
+    await act(async () => {
+      root = create(
+        React.createElement(ReportModal, {
+          onClose: () => {
+            onCloseCalls += 1;
+          },
+        }),
+      );
+    });
+
+    const findTitleInput = () =>
+      root.root.find(
+        (node) => node.type === 'input' && (node.props as { type?: string }).type === 'text',
+      );
+
+    const harness: Harness = {
+      root,
+      get onCloseCalls() {
+        return onCloseCalls;
+      },
+      get fetchCalls() {
+        return fetchCalls;
+      },
+      fillValidForm: async () => {
+        const radios = root.root.findAllByProps({ name: 'report-impact' });
+        await act(async () => {
+          radios[0].props.onChange({ target: { value: radios[0].props.value } });
+        });
+        const titleInput = findTitleInput();
+        await act(async () => {
+          titleInput.props.onChange({ target: { value: 'Broken publish button' } });
+        });
+        const textarea = root.root.findByType('textarea');
+        await act(async () => {
+          textarea.props.onChange({ target: { value: 'Clicking Publish does nothing.' } });
+        });
+      },
+      submitOnce: async () => {
+        const form = root.root.findByType('form');
+        await act(async () => {
+          form.props.onSubmit({ preventDefault() {} });
+        });
+      },
+      titleValue: () => findTitleInput().props.value as string,
+      hasDialog: () => root.root.findAllByProps({ role: 'dialog' }).length > 0,
+      hasSubmitButton: () => root.root.findAllByProps({ 'data-testid': 'report-submit' }).length > 0,
+      alertMessages: () =>
+        root.root
+          .findAllByProps({ role: 'alert' })
+          .map((node) => String((node.props as { children?: unknown }).children)),
+    };
+
+    await run(harness);
+
+    await act(async () => {
+      root.unmount();
+    });
+  } finally {
+    delete (globalThis as Record<string, unknown>).window;
+    delete (globalThis as Record<string, unknown>).document;
+    delete (globalThis as Record<string, unknown>).fetch;
+  }
+}
+
+test('INVARIANT double-submit guard: firing onSubmit twice sends exactly one POST', async () => {
+  await withReportDialog(
+    () => new Promise(() => {}), // never resolves — the request is still "in flight"
+    async (h) => {
+      await h.fillValidForm();
+      await h.submitOnce();
+      await h.submitOnce();
+      assert.equal(h.fetchCalls, 1, 'a second onSubmit while the first request is in flight must be a no-op');
+      // The submit button itself must reflect the guard (disabled while submitting).
+      const button = h.root.root.findByProps({ 'data-testid': 'report-submit' });
+      assert.equal(button.props.disabled, true);
+    },
+  );
+});
+
+test('INVARIANT 429 keeps values and keeps the dialog open', async () => {
+  await withReportDialog(
+    async () => ({
+      status: 429,
+      ok: false,
+      json: async () => ({ error: 'Too many reports.' }),
+    }),
+    async (h) => {
+      await h.fillValidForm();
+      await h.submitOnce();
+      // Let the fetch/json promise chain (and the state updates it drives) settle.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      assert.equal(h.fetchCalls, 1);
+      assert.equal(h.onCloseCalls, 0, 'a 429 must never close the dialog');
+      assert.ok(h.hasDialog(), 'the dialog must still be rendered after a 429');
+      assert.ok(h.hasSubmitButton(), 'the form (and its submit control) must still be present');
+      assert.equal(h.titleValue(), 'Broken publish button', 'typed values must survive a 429');
+
+      const alerts = h.alertMessages();
+      assert.equal(alerts.length, 1);
+      assert.equal(alerts[0], 'Too many reports.');
+
+      // Retry must be possible: the submit button is re-enabled (phase back to idle).
+      const button = h.root.root.findByProps({ 'data-testid': 'report-submit' });
+      assert.equal(button.props.disabled, false);
+    },
+  );
+});

--- a/tests/feedback-reports-store.requires-infra.test.ts
+++ b/tests/feedback-reports-store.requires-infra.test.ts
@@ -164,6 +164,40 @@ test('feedback_reports store: limits, claim, boundary, and sync against real Pos
     assert.equal(synced.rows[0].screenshot_bytes, null);
     assert.equal(synced.rows[0].screenshot_mime, null);
     assert.equal(synced.rows[0].last_error, null);
+
+    // --- attach-fail keeps screenshot bytes (the sweep re-attaches from these
+    // columns): a row with a stored ticket key + screenshot bytes that then
+    // fails (the attach step, specifically) must retain BOTH columns — the
+    // recordReportFailure UPDATE only ever touches status/attempts/last_error,
+    // never screenshot_bytes/screenshot_mime. ---
+    await insertReportWithLimits(
+      pool,
+      record('r7', {
+        submitterId: 'u3', // fresh bucket — u1/u2 are already at/near the test's rate-limit cap
+        screenshot: { bytes: Buffer.from('attach-me-bytes'), mime: 'image/jpeg' },
+      }),
+      limits,
+    );
+    await markReportTicketKey(pool, 'r7', 'AA-456');
+    await recordReportFailure(pool, 'r7', {
+      error: 'jira attach failed (HTTP 500)',
+      bumpAttempts: true,
+      maxAttempts: 5,
+    });
+    const attachFailed = await pool.query(
+      `SELECT status, attempts, jira_ticket_key, screenshot_bytes, screenshot_mime, last_error
+         FROM feedback_reports WHERE id = 'r7'`,
+    );
+    assert.equal(attachFailed.rows[0].status, 'pending_retry');
+    assert.equal(attachFailed.rows[0].attempts, 1);
+    assert.equal(attachFailed.rows[0].jira_ticket_key, 'AA-456');
+    assert.deepEqual(
+      Buffer.from(attachFailed.rows[0].screenshot_bytes),
+      Buffer.from('attach-me-bytes'),
+      'screenshot bytes must survive an attach failure so the sweep can retry the attach',
+    );
+    assert.equal(attachFailed.rows[0].screenshot_mime, 'image/jpeg');
+    assert.equal(attachFailed.rows[0].last_error, 'jira attach failed (HTTP 500)');
   } finally {
     resetFeedbackReportsEnsuredForTests();
     await pool.end().catch(() => {});


### PR DESCRIPTION
Test-only follow-up to the customer incident report feature (SC-70 port, AA-51; feature merged as #757). Closes three coverage gaps left by the pure-function tests, with no product-code change (`git diff origin/master...HEAD` is 3 files: 2 tests + the SC-70 verify-group registration).

## Gaps closed

1. **Double-submit guard (component-level)** — `tests/feedback-report-dialog.test.ts`: mounts `ReportModal` via `react-test-renderer` and fires the form `onSubmit` twice while the request is in flight (never-resolving fetch). Asserts exactly one POST and that the submit button is `disabled` while submitting. Guards `if (submitting || phase === 'success') return;` + `disabled={submitting || phase === 'success'}` in `report-dialog.tsx`.
2. **429 keeps the dialog open + values intact** — same file: mocks a 429 with the server's rate-limit message and asserts the dialog stays rendered, `onClose` is never called, the typed title survives, exactly one `role="alert"` shows the server message, and the submit button is re-enabled (phase back to idle) so retry works. The alert text is bound to the server's own `error` field via `outcomeFromResponse(429, …)`, not a hardcoded literal.
3. **Attach-failure preserves screenshot bytes** — `tests/feedback-reports-store.requires-infra.test.ts` (+34): against real Postgres in the existing throwaway `search_path`-pinned schema, a row with a stored Jira key + screenshot bytes that then hits `recordReportFailure` retains `screenshot_bytes`/`screenshot_mime` (only `status`/`attempts`/`last_error` change), so the retry sweep can re-attach. This is the inverse of the `markReportSynced` NULL-ing already covered.

## Verification

- Both dialog tests are **mutation-verified**: removing the double-submit guard fails test 1; making the 429 branch close/clear the dialog fails test 2. Product file restored byte-identical each time (empty `git diff --stat`).
- The requires-infra assertion is non-vacuous: `insertReportWithLimits` genuinely persists the screenshot bytes, and `recordReportFailure`'s UPDATE never touches those columns. Uses a fresh submitter bucket so it does not perturb the existing rate-limit assertions; still self-skips without live Postgres.
- Stubs (`window`/`document`/`fetch`) are set on `globalThis` and deleted in `finally`; no leak across tests.
- `npm run verify` → "Verification suite passed" (SC-70 group 80/80; embedded `guardrails:agent` passed). Focused dialog file 2/2. `npm run guardrails:agent` standalone: real unique diff, ahead 1 / behind 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)