### PR TITLE
feat(qa): headless QA sandbox — passwordless session mint for rendered-UI verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ npm run precheck
 - `npm run test:concurrent` runs the full TypeScript test set with `--test-concurrency=8`; use it before shipping work that changes routes, backend services, process management, or shared helpers.
 - `npm run validate:execution-provider` is the focused Hermes callback/execution-port gate.
 - `npm run validate:social-content` is the focused weekly social-content gate.
+- **Headless rendered-UI QA**: `scripts/qa/seed-qa-tenant.ts` + `scripts/qa/mint-qa-session.ts` mint a real Auth.js session for the passwordless `aries-qa-sandbox` bot (pinned identity, 12h TTL cap) so gstack `/browse` can screenshot/drive the live authenticated app from this host — see `docs/qa/headless-qa-sandbox.md`.
 
 ## Active operational guardrails
 

--- a/docs/qa/headless-qa-sandbox.md
+++ b/docs/qa/headless-qa-sandbox.md
@@ -1,0 +1,46 @@
+# Headless QA sandbox — rendered-UI verification without a human browser
+
+Purpose: let an agent on the prod host do **rendered** verification of the live
+app (screenshots, dialogs, real submissions) with a real authenticated session
+— no pairing, no cookie exports, no human browser online. First used to verify
+the SC-70 incident-report button end-to-end (AA-74, 2026-07-03).
+
+## Security model
+
+- One sandbox org (`aries-qa-sandbox`) + one QA user (`qa-bot@aries-qa.internal`).
+- The QA user has **no usable password** — its hash is over random bytes
+  discarded at seed time. Credentials login is impossible.
+- Sessions are minted by `scripts/qa/mint-qa-session.ts`, which encodes an
+  Auth.js session JWT with the app's own `NEXTAUTH_SECRET` (same
+  `next-auth/jwt` `encode`, same cookie-name salt). Host access to the app's
+  `.env` is the trust boundary — the same one that already protects every
+  session.
+- Fail-closed pinning: the mint script refuses any identity other than the QA
+  email on the sandbox tenant slug (`scripts/qa/qa-session-lib.ts`
+  `assertQaScoped`), TTL is clamped to 12h (default 2h), and every mint writes
+  an audit line to stderr. The token goes to a 0600 file, never stdout.
+
+## Usage (on the prod host)
+
+```bash
+# one-time (idempotent) — creates/repairs the sandbox org + user:
+cd /home/node/docker-stack/aries-app && npx tsx scripts/qa/seed-qa-tenant.ts
+
+# per QA session — mint a cookie file, import it into gstack /browse:
+npx tsx scripts/qa/mint-qa-session.ts --out /tmp/qa-cookies.json --ttl-minutes 120
+browse goto https://aries.sugarandleather.com   # visit site first (cookie domain check)
+browse cookie-import /tmp/qa-cookies.json
+browse goto https://aries.sugarandleather.com/dashboard
+# → authenticated as the QA bot; a fresh sandbox tenant lands on /onboarding/start
+```
+
+Notes:
+- Run the scripts from a checkout whose CWD has the prod `.env` (they use
+  `dotenv/config`), or export `DB_*`, `NEXTAUTH_SECRET`, `APP_BASE_URL`
+  explicitly. From outside the compose network use `DB_HOST=127.0.0.1`.
+- Anything the QA bot does is tenant-isolated to `aries-qa-sandbox` (tenant id
+  from the seed output). Feedback reports it files carry the
+  `customer-aries-qa-sandbox` Jira label — close them with a QA-artifact
+  comment when done.
+- Revocation: delete the QA user row, or rotate `NEXTAUTH_SECRET` (kills all
+  sessions app-wide), or just wait out the TTL.

--- a/scripts/qa/mint-qa-session.ts
+++ b/scripts/qa/mint-qa-session.ts
@@ -1,0 +1,115 @@
+/**
+ * Mint a short-lived Auth.js session for the pinned QA sandbox user, for
+ * headless rendered-UI verification (gstack /browse) against the live app.
+ *
+ * How: builds the same JWT claim shape auth.ts's jwt callback produces, and
+ * encodes it with the app's own `next-auth/jwt` `encode` (same NEXTAUTH_SECRET,
+ * same cookie-name salt) — so `auth()` accepts it exactly like a login-issued
+ * session. No password exists or is entered anywhere; possession of the host's
+ * NEXTAUTH_SECRET is the (pre-existing) trust boundary.
+ *
+ * Guards (fail closed): mints ONLY for qa-bot@aries-qa.internal on the
+ * aries-qa-sandbox tenant (see qa-session-lib.assertQaScoped), TTL clamped to
+ * 12h, and an audit line goes to stderr on every mint. The token itself is
+ * written to the output file (0600), never printed.
+ *
+ * Usage (from a checkout with .env available, e.g. the prod host):
+ *   npx tsx scripts/qa/mint-qa-session.ts --out /tmp/qa-cookies.json [--ttl-minutes 120]
+ * then:
+ *   browse cookie-import /tmp/qa-cookies.json
+ */
+import 'dotenv/config';
+
+import { writeFileSync } from 'node:fs';
+import pg from 'pg';
+import { encode } from 'next-auth/jwt';
+
+import {
+  assertQaScoped,
+  buildQaTokenClaims,
+  buildSessionCookieJson,
+  clampTtlMinutes,
+  sessionCookieNameForBaseUrl,
+  QA_USER_EMAIL,
+} from './qa-session-lib';
+
+function arg(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  return idx >= 0 ? process.argv[idx + 1] : undefined;
+}
+
+async function main(): Promise<void> {
+  const out = arg('--out');
+  if (!out) {
+    console.error('usage: mint-qa-session.ts --out <cookies.json> [--ttl-minutes N]');
+    process.exit(2);
+  }
+  const ttlMinutes = clampTtlMinutes(Number(arg('--ttl-minutes')));
+
+  const secret = process.env.NEXTAUTH_SECRET?.trim() || process.env.AUTH_SECRET?.trim();
+  const baseUrl = (process.env.APP_BASE_URL || process.env.NEXTAUTH_URL || '').trim();
+  if (!secret || !baseUrl) {
+    console.error('[mint-qa-session] NEXTAUTH_SECRET/AUTH_SECRET and APP_BASE_URL are required');
+    process.exit(2);
+  }
+
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST || 'localhost',
+    port: Number(process.env.DB_PORT) || 5432,
+    user: process.env.DB_USER || 'aries_user',
+    password: process.env.DB_PASSWORD || 'aries_pass',
+    database: process.env.DB_NAME || 'aries_dev',
+    max: 1,
+  });
+
+  try {
+    const result = await pool.query(
+      `SELECT u.id AS user_id, u.email, u.full_name, u.role,
+              o.id AS tenant_id,
+              COALESCE(NULLIF(o.slug, ''), 'org-' || o.id::text) AS tenant_slug
+         FROM users u
+         LEFT JOIN organizations o ON o.id = u.organization_id
+        WHERE u.email = $1
+        LIMIT 1`,
+      [QA_USER_EMAIL],
+    );
+    const row = result.rows[0];
+    if (!row) {
+      console.error(
+        `[mint-qa-session] QA user ${QA_USER_EMAIL} not found — run scripts/qa/seed-qa-tenant.ts first`,
+      );
+      process.exit(1);
+    }
+
+    const scoped = assertQaScoped(row);
+    if (!scoped.ok) {
+      console.error(`[mint-qa-session] ${scoped.reason}`);
+      process.exit(1);
+    }
+
+    const cookieName = sessionCookieNameForBaseUrl(baseUrl);
+    const token = await encode({
+      token: buildQaTokenClaims(row),
+      secret,
+      salt: cookieName,
+      maxAge: ttlMinutes * 60,
+    });
+
+    writeFileSync(out, JSON.stringify(buildSessionCookieJson(baseUrl, token, ttlMinutes, Date.now())), {
+      mode: 0o600,
+    });
+
+    // Audit trail — identity and lifetime only, never the token.
+    console.error(
+      `[mint-qa-session] minted session for ${QA_USER_EMAIL} (user ${row.user_id}, tenant ${row.tenant_id}/${row.tenant_slug}) ttl=${ttlMinutes}m -> ${out}`,
+    );
+    console.log(JSON.stringify({ ok: true, cookieName, ttlMinutes, out }));
+  } finally {
+    await pool.end().catch(() => {});
+  }
+}
+
+void main().catch((error) => {
+  console.error('[mint-qa-session] failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/qa/qa-session-lib.ts
+++ b/scripts/qa/qa-session-lib.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure helpers for the headless-QA session tooling (scripts/qa/*). Split from
+ * the CLIs so the guard logic is unit-testable without env or DB.
+ *
+ * Security model: there is NO password for the QA account (its hash is random
+ * bytes discarded at seed time). The ONLY way to authenticate as it is this
+ * mint path, which requires host access to the app's own NEXTAUTH_SECRET —
+ * the same trust boundary that already protects every session. The guards
+ * below pin minting to the sandbox identity so the tooling can never be
+ * pointed at a real tenant/user.
+ */
+
+/** The one identity the mint script will ever issue sessions for. */
+export const QA_USER_EMAIL = 'qa-bot@aries-qa.internal';
+export const QA_TENANT_SLUG = 'aries-qa-sandbox';
+export const QA_TENANT_NAME = 'Aries QA Sandbox';
+export const QA_USER_NAME = 'Aries QA Bot';
+
+/** Hard ceiling on minted-session lifetime (minutes). */
+export const QA_SESSION_MAX_TTL_MINUTES = 12 * 60;
+export const QA_SESSION_DEFAULT_TTL_MINUTES = 120;
+
+export interface QaClaimsRow {
+  user_id: string | number;
+  email: string;
+  full_name: string | null;
+  tenant_id: string | number | null;
+  tenant_slug: string | null;
+  role: string | null;
+}
+
+/**
+ * INVARIANT: sessions are minted ONLY for the pinned sandbox identity — the
+ * email must be the QA bot's and the tenant slug must be the sandbox's. A
+ * drifted row (renamed org, reassigned user) fails closed with a reason.
+ */
+export function assertQaScoped(row: QaClaimsRow): { ok: true } | { ok: false; reason: string } {
+  if (row.email !== QA_USER_EMAIL) {
+    return { ok: false, reason: `refusing to mint for non-QA email (${row.email})` };
+  }
+  if (row.tenant_slug !== QA_TENANT_SLUG) {
+    return {
+      ok: false,
+      reason: `refusing to mint: QA user is not on the sandbox tenant (slug=${String(row.tenant_slug)})`,
+    };
+  }
+  if (row.tenant_id === null || row.tenant_id === undefined) {
+    return { ok: false, reason: 'refusing to mint: QA user has no tenant id' };
+  }
+  return { ok: true };
+}
+
+export function clampTtlMinutes(requested: number | undefined): number {
+  if (!Number.isFinite(requested) || (requested as number) <= 0) {
+    return QA_SESSION_DEFAULT_TTL_MINUTES;
+  }
+  return Math.min(Math.floor(requested as number), QA_SESSION_MAX_TTL_MINUTES);
+}
+
+/**
+ * Auth.js v5 default session cookie name: __Secure- prefixed on https (the
+ * prefix is also the JWT encode/decode salt, so getting this wrong produces
+ * an undecodable token, never a privilege problem).
+ */
+export function sessionCookieNameForBaseUrl(baseUrl: string): string {
+  return baseUrl.startsWith('https://')
+    ? '__Secure-authjs.session-token'
+    : 'authjs.session-token';
+}
+
+/** JWT payload mirroring auth.ts's jwt-callback claim shape for the QA user. */
+export function buildQaTokenClaims(row: QaClaimsRow): Record<string, unknown> {
+  return {
+    sub: String(row.user_id),
+    userId: String(row.user_id),
+    email: row.email,
+    name: row.full_name ?? QA_USER_NAME,
+    tenantId: String(row.tenant_id),
+    tenantSlug: row.tenant_slug,
+    tenantRole: row.role ?? 'tenant_admin',
+  };
+}
+
+/** Playwright-format cookie for `browse cookie-import <file>`. */
+export function buildSessionCookieJson(
+  baseUrl: string,
+  tokenValue: string,
+  ttlMinutes: number,
+  nowMs: number,
+): Array<Record<string, unknown>> {
+  const url = new URL(baseUrl);
+  return [
+    {
+      name: sessionCookieNameForBaseUrl(baseUrl),
+      value: tokenValue,
+      domain: url.hostname,
+      path: '/',
+      expires: Math.floor(nowMs / 1000) + ttlMinutes * 60,
+      httpOnly: true,
+      secure: baseUrl.startsWith('https://'),
+      sameSite: 'Lax',
+    },
+  ];
+}

--- a/scripts/qa/seed-qa-tenant.ts
+++ b/scripts/qa/seed-qa-tenant.ts
@@ -1,0 +1,81 @@
+/**
+ * Seed the headless-QA sandbox: one organization (aries-qa-sandbox) and one
+ * QA user (qa-bot@aries-qa.internal) with an UNUSABLE password — the hash is
+ * over random bytes that are discarded immediately, so the account cannot be
+ * logged into with credentials at all. Sessions for it are minted exclusively
+ * by scripts/qa/mint-qa-session.ts (requires host access to NEXTAUTH_SECRET).
+ *
+ * Idempotent: re-running updates names/membership and re-randomizes the
+ * unusable hash; it never creates duplicates (org keyed by unique slug, user
+ * by unique email).
+ *
+ * Usage (from a checkout with the DB env available, e.g. the prod host):
+ *   npx tsx scripts/qa/seed-qa-tenant.ts
+ */
+import 'dotenv/config';
+
+import { randomBytes } from 'node:crypto';
+import bcrypt from 'bcryptjs';
+import pg from 'pg';
+
+import {
+  QA_TENANT_NAME,
+  QA_TENANT_SLUG,
+  QA_USER_EMAIL,
+  QA_USER_NAME,
+} from './qa-session-lib';
+
+async function main(): Promise<void> {
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST || 'localhost',
+    port: Number(process.env.DB_PORT) || 5432,
+    user: process.env.DB_USER || 'aries_user',
+    password: process.env.DB_PASSWORD || 'aries_pass',
+    database: process.env.DB_NAME || 'aries_dev',
+    max: 1,
+  });
+
+  try {
+    const org = await pool.query<{ id: number }>(
+      `INSERT INTO organizations (name, slug)
+       VALUES ($1, $2)
+       ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+       RETURNING id`,
+      [QA_TENANT_NAME, QA_TENANT_SLUG],
+    );
+    const tenantId = org.rows[0].id;
+
+    // Unusable credential: 48 random bytes hashed and immediately forgotten.
+    const unusable = await bcrypt.hash(randomBytes(48).toString('hex'), 10);
+    const user = await pool.query<{ id: number }>(
+      `INSERT INTO users (email, password_hash, full_name, organization_id, role, onboarding_required)
+       VALUES ($1, $2, $3, $4, 'tenant_admin', FALSE)
+       ON CONFLICT (email) DO UPDATE SET
+         password_hash = EXCLUDED.password_hash,
+         full_name = EXCLUDED.full_name,
+         organization_id = EXCLUDED.organization_id,
+         role = 'tenant_admin',
+         onboarding_required = FALSE
+       RETURNING id`,
+      [QA_USER_EMAIL, unusable, QA_USER_NAME, tenantId],
+    );
+
+    console.log(
+      JSON.stringify({
+        seeded: true,
+        tenantId,
+        tenantSlug: QA_TENANT_SLUG,
+        userId: user.rows[0].id,
+        email: QA_USER_EMAIL,
+        note: 'password is unusable by design; mint sessions via scripts/qa/mint-qa-session.ts',
+      }),
+    );
+  } finally {
+    await pool.end().catch(() => {});
+  }
+}
+
+void main().catch((error) => {
+  console.error('[seed-qa-tenant] failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -79,6 +79,10 @@ const steps = [
     ],
   },
   {
+    name: 'headless QA sandbox session tooling (pinned identity, TTL clamp, cookie shape)',
+    args: ['--test', 'tests/qa-session-lib.test.ts'],
+  },
+  {
     name: 'process-concurrent helper',
     args: ['--test', 'tests/process-concurrent.test.ts'],
   },

--- a/tests/qa-session-lib.test.ts
+++ b/tests/qa-session-lib.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  QA_SESSION_DEFAULT_TTL_MINUTES,
+  QA_SESSION_MAX_TTL_MINUTES,
+  QA_TENANT_SLUG,
+  QA_USER_EMAIL,
+  assertQaScoped,
+  buildQaTokenClaims,
+  buildSessionCookieJson,
+  clampTtlMinutes,
+  sessionCookieNameForBaseUrl,
+} from '../scripts/qa/qa-session-lib';
+
+const QA_ROW = {
+  user_id: 42,
+  email: QA_USER_EMAIL,
+  full_name: 'Aries QA Bot',
+  tenant_id: 99,
+  tenant_slug: QA_TENANT_SLUG,
+  role: 'tenant_admin',
+};
+
+test('INVARIANT: minting is pinned to the sandbox identity — everything else fails closed', () => {
+  assert.deepEqual(assertQaScoped(QA_ROW), { ok: true });
+  // A real user's email can never mint.
+  assert.equal(assertQaScoped({ ...QA_ROW, email: 'brendan3394@gmail.com' }).ok, false);
+  // The QA user reassigned onto a REAL tenant can never mint.
+  assert.equal(assertQaScoped({ ...QA_ROW, tenant_slug: 'sugar-leather' }).ok, false);
+  assert.equal(assertQaScoped({ ...QA_ROW, tenant_slug: null }).ok, false);
+  assert.equal(assertQaScoped({ ...QA_ROW, tenant_id: null }).ok, false);
+});
+
+test('TTL clamps: garbage/zero → default, oversize → 12h ceiling', () => {
+  assert.equal(clampTtlMinutes(undefined), QA_SESSION_DEFAULT_TTL_MINUTES);
+  assert.equal(clampTtlMinutes(Number.NaN), QA_SESSION_DEFAULT_TTL_MINUTES);
+  assert.equal(clampTtlMinutes(0), QA_SESSION_DEFAULT_TTL_MINUTES);
+  assert.equal(clampTtlMinutes(-5), QA_SESSION_DEFAULT_TTL_MINUTES);
+  assert.equal(clampTtlMinutes(45.9), 45);
+  assert.equal(clampTtlMinutes(10_000), QA_SESSION_MAX_TTL_MINUTES);
+});
+
+test('cookie name matches Auth.js defaults per scheme (name doubles as JWT salt)', () => {
+  assert.equal(
+    sessionCookieNameForBaseUrl('https://aries.sugarandleather.com'),
+    '__Secure-authjs.session-token',
+  );
+  assert.equal(sessionCookieNameForBaseUrl('http://localhost:3000'), 'authjs.session-token');
+});
+
+test('token claims mirror the auth.ts jwt-callback shape', () => {
+  const claims = buildQaTokenClaims(QA_ROW);
+  assert.deepEqual(claims, {
+    sub: '42',
+    userId: '42',
+    email: QA_USER_EMAIL,
+    name: 'Aries QA Bot',
+    tenantId: '99',
+    tenantSlug: QA_TENANT_SLUG,
+    tenantRole: 'tenant_admin',
+  });
+});
+
+test('cookie JSON targets the app host with secure/httpOnly and a real expiry', () => {
+  const nowMs = 1_800_000_000_000;
+  const [cookie] = buildSessionCookieJson('https://aries.sugarandleather.com', 'tok', 60, nowMs);
+  assert.equal(cookie.name, '__Secure-authjs.session-token');
+  assert.equal(cookie.value, 'tok');
+  assert.equal(cookie.domain, 'aries.sugarandleather.com');
+  assert.equal(cookie.path, '/');
+  assert.equal(cookie.secure, true);
+  assert.equal(cookie.httpOnly, true);
+  assert.equal(cookie.expires, nowMs / 1000 + 3600);
+});


### PR DESCRIPTION
Brendan-approved tooling so an agent on the prod host can do **rendered** UI verification of the live app (screenshots, dialogs, real submissions) with a real authenticated session — no pairing, no cookie export, no human browser online.

## What changed (scripts/tests/docs only — zero app-runtime code)
- `scripts/qa/qa-session-lib.ts` — pure, unit-tested guards: `assertQaScoped`, `clampTtlMinutes`, `buildQaTokenClaims`, cookie-name/JSON builders.
- `scripts/qa/seed-qa-tenant.ts` — idempotently seeds one sandbox org (`aries-qa-sandbox`) + one QA user (`qa-bot@aries-qa.internal`) with an **unusable password** (bcrypt over `randomBytes(48)`, discarded at seed time). `tenant_admin` on its own sandbox tenant only.
- `scripts/qa/mint-qa-session.ts` — mints a short-lived Auth.js session by encoding the same JWT claim shape auth.ts's jwt callback produces, via `next-auth/jwt` `encode` with the app's own `NEXTAUTH_SECRET` (cookie-name salt) — so `auth()` accepts it exactly like a login-issued session.
- `tests/qa-session-lib.test.ts` + `scripts/verify-regression-suite.mjs` registration (in `npm run verify`).
- `docs/qa/headless-qa-sandbox.md`, one CLAUDE.md pointer line.

## Security model
- **No password path.** The QA account cannot be logged into with credentials at all. The only way to authenticate as it is this mint path, which requires host access to the app's own `NEXTAUTH_SECRET` — the same pre-existing trust boundary that protects every session.
- **Fail-closed pinning.** `assertQaScoped` refuses to mint for any identity other than `qa-bot@aries-qa.internal` **on** the `aries-qa-sandbox` tenant slug. Crucially, the mint query derives the slug with the exact same `COALESCE(NULLIF(o.slug,''), 'org-'||o.id)` expression auth.ts's authoritative `findTenantClaimsByUserId` uses — so a drifted row (reassigned user, renamed org, null tenant) fails closed, and there is no gap between what the pin checks and what the app re-hydrates.
- **Never escalates.** auth.ts re-hydrates tenant claims from the DB by `token.userId` on every session read, so a wrong/incomplete claim shape can only decode to the QA user's real (sandbox) claims or fail to decode entirely (unauthenticated) — never another tenant.
- **Blast radius contained.** No app code special-cases the QA identity (grep-verified); the sandbox is a plain tenant. Diff touches `scripts/`, `tests/`, `docs/`, `CLAUDE.md` only.
- **Secret hygiene.** `NEXTAUTH_SECRET` read from env only; token written to a `0600` file, never printed. The audit line carries identity + TTL only.
- **TTL clamp** — 12h ceiling, 2h default; garbage/zero/negative falls back to default.
- **Revocation** — delete the QA user row, rotate `NEXTAUTH_SECRET`, or wait out the TTL.

## Test evidence
- `APP_BASE_URL=… tsx --test tests/qa-session-lib.test.ts` → 5/5 pass (pinning fails-closed, TTL clamp, cookie-name-per-scheme, claim-shape mirror, cookie JSON shape).
- `npm run verify` green (guardrails:agent first, then the full suite incl. the new step).
- `npm run guardrails:agent` → real unique diff vs origin/master (ahead 1, behind 0), not duplicate work.

## Live proof
Already proven against **prod**: this mint authenticated against the live `auth()` and drove the full SC-70 incident-report-button rendered verification end-to-end (Jira AA-74, now closed).

## Residual risk
Possession of the host `.env` remains the trust boundary (unchanged from every existing session). The pin + unusable-password + no-runtime-touch keep the surface to exactly "an operator with host secrets can mint a sandbox-only session," which is the intended capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)