### PR TITLE
fix(feedback): capture the current page in-app instead of getDisplayMedia (AA-77)

### DIFF
--- a/docs/plans/2026-07-03-customer-incident-button.md
+++ b/docs/plans/2026-07-03-customer-incident-button.md
@@ -27,7 +27,9 @@ the operator runbook.
   parity test green). Default ON, inherently dormant without `JIRA_*` config.
 - Dialog: the existing floating Feedback button now probes
   `/api/auth/session` once per page load — signed-in users get the impact-first
-  report dialog (screen capture via `getDisplayMedia` + file picker, 2 MB
+  report dialog (in-page "Capture page" rasterization via `html-to-image`,
+  excluding the feedback UI — replaced the original `getDisplayMedia`
+  screen-share per AA-77 — plus a file picker, 2 MB
   client cap computed from base64 length, pinned
   `https://sugarandleather.atlassian.net/browse/<key>` success link); everyone
   else keeps the legacy public feedback form unchanged.

--- a/frontend/feedback/capture-screenshot.ts
+++ b/frontend/feedback/capture-screenshot.ts
@@ -1,0 +1,101 @@
+/**
+ * In-page screenshot capture for the customer incident report dialog (AA-77).
+ *
+ * The original "Capture screen" used navigator.mediaDevices.getDisplayMedia() —
+ * the screen-SHARE API. That inherently (1) pops the browser's window/tab/entire-
+ * screen picker, (2) captures the whole shared surface rather than the page
+ * behind the widget, and (3) is unsupported on mobile — so in practice it never
+ * captured the actual error (AA-77: "captures incorrect portion of the screen").
+ *
+ * This replaces it with a DOM rasterization of the current page via html-to-image
+ * (the browser's own SVG <foreignObject> renderer, so Tailwind v4 `oklch()`
+ * colors and backdrop-blur render as the browser draws them): no picker, works
+ * on mobile, and captures exactly "the page you're on". The feedback UI itself
+ * (the modal, its backdrop, and the floating button) is excluded via the
+ * `data-feedback-capture-ignore` marker so the shot shows the page BEHIND the
+ * dialog, not our own chrome.
+ *
+ * Best-effort: any failure resolves null so the dialog degrades silently to the
+ * file picker — the same contract the old getDisplayMedia path had on denial.
+ */
+
+/** Nodes carrying this attribute (and their subtrees) are omitted from the capture. */
+export const CAPTURE_IGNORE_ATTR = 'data-feedback-capture-ignore';
+
+/**
+ * JPEG (not PNG) at viewport resolution keeps a full-page capture comfortably
+ * under the report dialog's 2 MB screenshot cap even for tall pages; JPEG is in
+ * the accepted MIME whitelist (image/jpeg).
+ */
+export const CAPTURE_JPEG_QUALITY = 0.82;
+
+/** Opaque fallback fill when the page background can't be read (JPEG has no alpha). */
+const CAPTURE_BG_FALLBACK = '#050505';
+
+/**
+ * html-to-image `filter` predicate: drop the feedback UI (the modal, its
+ * backdrop, and the floating button) so the screenshot shows the page behind
+ * it. Any node that IS — or is nested inside — a `[data-feedback-capture-ignore]`
+ * element is excluded; everything else is kept. Non-element nodes (text) and
+ * nodes without `closest` are kept.
+ */
+export function shouldCaptureNode(node: unknown): boolean {
+  if (!node || typeof node !== 'object') return true;
+  const el = node as { nodeType?: number; closest?: (selector: string) => unknown };
+  // Only Element nodes (nodeType 1) can carry the marker; text/comment nodes stay.
+  if (el.nodeType !== 1 || typeof el.closest !== 'function') return true;
+  return el.closest(`[${CAPTURE_IGNORE_ATTR}]`) == null;
+}
+
+type ToJpeg = (node: HTMLElement, options: Record<string, unknown>) => Promise<string>;
+
+export interface PageCaptureDeps {
+  /** Injectable for tests; defaults to a lazy html-to-image import (off the main bundle). */
+  toJpeg?: ToJpeg;
+}
+
+/**
+ * Rasterize the current page to a JPEG data URL, excluding the feedback UI.
+ * Resolves null when there is no DOM, the capture throws, or the output is not a
+ * JPEG data URL — the caller degrades to the file picker on null.
+ */
+export async function capturePageScreenshot(deps: PageCaptureDeps = {}): Promise<string | null> {
+  if (typeof document === 'undefined' || !document.body) return null;
+  try {
+    const toJpeg: ToJpeg = deps.toJpeg ?? (await import('html-to-image')).toJpeg;
+    const dataUrl = await toJpeg(document.body, {
+      quality: CAPTURE_JPEG_QUALITY,
+      // CSS-pixel resolution: plenty for a bug screenshot and keeps the encoded
+      // size under the 2 MB cap even on tall pages and HiDPI displays.
+      pixelRatio: 1,
+      cacheBust: true,
+      backgroundColor: getCaptureBackgroundColor(),
+      filter: shouldCaptureNode,
+    });
+    return typeof dataUrl === 'string' && dataUrl.startsWith('data:image/jpeg') ? dataUrl : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True whenever an in-page capture is possible (any client DOM). */
+export function pageCaptureSupported(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+/** The page's own background so JPEG's opaque fill matches the app, not black. */
+function getCaptureBackgroundColor(): string {
+  try {
+    if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+      return CAPTURE_BG_FALLBACK;
+    }
+    for (const el of [document.body, document.documentElement]) {
+      if (!el) continue;
+      const bg = window.getComputedStyle(el).backgroundColor;
+      if (bg && bg !== 'transparent' && bg !== 'rgba(0, 0, 0, 0)') return bg;
+    }
+  } catch {
+    /* fall through to the fallback */
+  }
+  return CAPTURE_BG_FALLBACK;
+}

--- a/frontend/feedback/feedback-widget.tsx
+++ b/frontend/feedback/feedback-widget.tsx
@@ -23,6 +23,7 @@ import {
   type FeedbackCategory,
 } from '@/lib/feedback/options';
 import { cn } from '../donor/lib/utils';
+import { CAPTURE_IGNORE_ATTR } from './capture-screenshot';
 import { getRecentConsoleErrors, installConsoleCapture } from './console-capture';
 import ReportModal from './report-dialog';
 
@@ -131,6 +132,9 @@ export default function FeedbackWidget(): React.ReactElement | null {
         aria-hidden={open}
         tabIndex={open ? -1 : 0}
         data-testid="feedback-button"
+        // Kept out of an in-page "Capture page" shot (it's still in the DOM,
+        // just visually hidden, while the report modal is open).
+        {...{ [CAPTURE_IGNORE_ATTR]: '' }}
         className={cn(
           'fixed bottom-4 right-4 z-[120] flex items-center gap-2 rounded-full',
           'bg-aries-crimson px-4 py-3 text-sm font-semibold text-white shadow-lg',

--- a/frontend/feedback/report-dialog.tsx
+++ b/frontend/feedback/report-dialog.tsx
@@ -3,8 +3,9 @@
 /**
  * Customer incident report dialog (SC-70 port) — the authenticated variant of
  * the feedback modal. Impact is asked FIRST (required, no default), then
- * category, title, description, and an optional screenshot via screen capture
- * (getDisplayMedia, when the browser exposes it) or a file picker.
+ * category, title, description, and an optional screenshot via an in-page
+ * capture of the current page (see capture-screenshot.ts — AA-77) or a file
+ * picker.
  *
  * Outcome UX (SC-70): 201 → success with the Jira ticket link (plus
  * "attachment still syncing" / screenshot-discarded notes); 202 → "received —
@@ -32,6 +33,7 @@ import {
   type ReportOutcome,
   type ReportScreenshotPayload,
 } from './report-form';
+import { CAPTURE_IGNORE_ATTR, capturePageScreenshot, pageCaptureSupported } from './capture-screenshot';
 import { cn } from '../donor/lib/utils';
 
 type Phase = 'idle' | 'submitting' | 'success';
@@ -49,43 +51,6 @@ function readFileAsDataUrl(file: File): Promise<string> {
     reader.onerror = () => reject(reader.error ?? new Error('read_failed'));
     reader.readAsDataURL(file);
   });
-}
-
-/** True when the screen-capture path can be offered at all. */
-function displayCaptureAvailable(): boolean {
-  return (
-    typeof navigator !== 'undefined' &&
-    typeof navigator.mediaDevices?.getDisplayMedia === 'function'
-  );
-}
-
-/**
- * Grab one frame of the user's screen as a PNG data URL. Tracks are stopped in
- * `finally`; a denial (or any failure) resolves null so the caller degrades to
- * the file picker without an error.
- */
-async function captureScreenDataUrl(): Promise<string | null> {
-  if (!displayCaptureAvailable()) return null;
-  let stream: MediaStream | null = null;
-  try {
-    stream = await navigator.mediaDevices.getDisplayMedia({ video: true });
-    const video = document.createElement('video');
-    video.srcObject = stream;
-    video.muted = true;
-    await video.play();
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    const canvas = document.createElement('canvas');
-    canvas.width = video.videoWidth || 1280;
-    canvas.height = video.videoHeight || 720;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return null;
-    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-    return canvas.toDataURL('image/png');
-  } catch {
-    return null;
-  } finally {
-    stream?.getTracks().forEach((track) => track.stop());
-  }
 }
 
 interface ScreenshotState {
@@ -183,10 +148,16 @@ export default function ReportModal({ onClose }: { onClose: () => void }): React
 
   const onCaptureScreen = useCallback(async () => {
     setCapturing(true);
+    setScreenshotError(null);
     try {
-      const dataUrl = await captureScreenDataUrl();
-      // Denial/failure degrades silently to the file-picker path.
-      if (dataUrl) attachDataUrl(dataUrl, 'Screen capture');
+      const dataUrl = await capturePageScreenshot();
+      if (dataUrl) {
+        attachDataUrl(dataUrl, 'Page capture');
+      } else {
+        // No picker/denial anymore, so a null is a genuine failure — point the
+        // user at the always-available file picker rather than failing silently.
+        setScreenshotError("We couldn't capture the page automatically — attach an image instead.");
+      }
     } finally {
       setCapturing(false);
     }
@@ -254,6 +225,9 @@ export default function ReportModal({ onClose }: { onClose: () => void }): React
   return (
     <div
       role="presentation"
+      // Exclude the whole modal (backdrop + dialog) from an in-page capture so a
+      // "Capture page" shot shows the page behind the dialog, not our own UI.
+      {...{ [CAPTURE_IGNORE_ATTR]: '' }}
       className="fixed inset-0 z-[200] flex items-end justify-center overflow-y-auto p-4 sm:items-center"
     >
       <motion.div
@@ -422,7 +396,7 @@ export default function ReportModal({ onClose }: { onClose: () => void }): React
               </div>
             ) : (
               <div className="flex flex-col gap-2 sm:flex-row">
-                {displayCaptureAvailable() ? (
+                {pageCaptureSupported() ? (
                   <button
                     type="button"
                     onClick={() => void onCaptureScreen()}
@@ -438,7 +412,7 @@ export default function ReportModal({ onClose }: { onClose: () => void }): React
                     ) : (
                       <Camera className="h-4 w-4" aria-hidden="true" />
                     )}
-                    Capture screen
+                    {capturing ? 'Capturing…' : 'Capture page'}
                   </button>
                 ) : null}
                 <label

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
         "dotenv": "^17.3.1",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^1.22.0",
         "motion": "^12.42.0",
         "next": "16.2.9",
@@ -2787,6 +2788,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.3.1",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^1.22.0",
     "motion": "^12.42.0",
     "next": "16.2.9",

--- a/tests/feedback-report-capture.test.ts
+++ b/tests/feedback-report-capture.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import React from 'react';
+
+/**
+ * Regression coverage for AA-77 ("Capture Screen feedback button captures
+ * incorrect portion of the screen"). The fix replaced the getDisplayMedia
+ * screen-SHARE path (picker friction, whole-surface capture, no mobile support)
+ * with an in-page DOM rasterization that excludes the feedback UI. These tests
+ * pin:
+ *   1. the node filter that keeps the page but drops the feedback chrome,
+ *   2. the capture helper's contract (JPEG data URL, fail-open to null),
+ *   3. that the rendered dialog offers the capture button and marks the modal
+ *      root as capture-ignored — and that the dialog no longer touches
+ *      getDisplayMedia at all.
+ */
+
+import {
+  CAPTURE_IGNORE_ATTR,
+  CAPTURE_JPEG_QUALITY,
+  capturePageScreenshot,
+  pageCaptureSupported,
+  shouldCaptureNode,
+} from '../frontend/feedback/capture-screenshot';
+
+// ── shouldCaptureNode (pure) ───────────────────────────────────────────────
+
+test('shouldCaptureNode keeps a normal element (not inside the feedback UI)', () => {
+  const el = { nodeType: 1, closest: (_sel: string) => null };
+  assert.equal(shouldCaptureNode(el), true);
+});
+
+test('shouldCaptureNode drops a tagged element and any descendant of one', () => {
+  const tagged = { nodeType: 1 };
+  // closest() returns the marked ancestor (or self) → excluded.
+  const self = { nodeType: 1, closest: (sel: string) => (sel === `[${CAPTURE_IGNORE_ATTR}]` ? tagged : null) };
+  const descendant = { nodeType: 1, closest: (sel: string) => (sel === `[${CAPTURE_IGNORE_ATTR}]` ? tagged : null) };
+  assert.equal(shouldCaptureNode(self), false);
+  assert.equal(shouldCaptureNode(descendant), false);
+});
+
+test('shouldCaptureNode keeps text/comment nodes and non-elements', () => {
+  assert.equal(shouldCaptureNode({ nodeType: 3 }), true); // text node, no closest
+  assert.equal(shouldCaptureNode(null), true);
+  assert.equal(shouldCaptureNode(undefined), true);
+  assert.equal(shouldCaptureNode('nope'), true);
+});
+
+// ── capturePageScreenshot (encoder injected) ───────────────────────────────
+
+function withDom<T>(run: () => Promise<T>): Promise<T> {
+  const g = globalThis as Record<string, unknown>;
+  const hadWindow = 'window' in g;
+  const hadDocument = 'document' in g;
+  g.window = {}; // no getComputedStyle → capture uses the dark fallback bg
+  g.document = { body: { nodeType: 1 }, documentElement: { nodeType: 1 } };
+  return run().finally(() => {
+    if (!hadWindow) delete g.window;
+    if (!hadDocument) delete g.document;
+  });
+}
+
+test('capturePageScreenshot returns the JPEG data URL and passes the right options', async () => {
+  await withDom(async () => {
+    let capturedNode: unknown;
+    let capturedOptions: Record<string, unknown> | undefined;
+    const dataUrl = await capturePageScreenshot({
+      toJpeg: async (node, options) => {
+        capturedNode = node;
+        capturedOptions = options;
+        return 'data:image/jpeg;base64,AAAA';
+      },
+    });
+    assert.equal(dataUrl, 'data:image/jpeg;base64,AAAA');
+    assert.ok(capturedOptions, 'toJpeg was called');
+    const options = capturedOptions as Record<string, unknown>;
+    const expectedBody = (globalThis as unknown as { document: { body: unknown } }).document.body;
+    assert.equal(capturedNode, expectedBody, 'captures document.body');
+    assert.equal(options.quality, CAPTURE_JPEG_QUALITY);
+    assert.equal(options.pixelRatio, 1);
+    assert.equal(options.cacheBust, true);
+    assert.equal(options.filter, shouldCaptureNode, 'the feedback-UI filter is wired in');
+    assert.equal(typeof options.backgroundColor, 'string');
+  });
+});
+
+test('capturePageScreenshot fails open to null on a throwing encoder', async () => {
+  await withDom(async () => {
+    const dataUrl = await capturePageScreenshot({
+      toJpeg: async () => {
+        throw new Error('rasterize failed');
+      },
+    });
+    assert.equal(dataUrl, null);
+  });
+});
+
+test('capturePageScreenshot returns null when the encoder yields a non-JPEG result', async () => {
+  await withDom(async () => {
+    const dataUrl = await capturePageScreenshot({ toJpeg: async () => 'data:image/png;base64,AAAA' });
+    assert.equal(dataUrl, null);
+  });
+});
+
+test('capturePageScreenshot returns null with no DOM (never throws)', async () => {
+  const g = globalThis as Record<string, unknown>;
+  const hadDocument = 'document' in g;
+  if (hadDocument) delete g.document;
+  try {
+    let called = false;
+    const dataUrl = await capturePageScreenshot({
+      toJpeg: async () => {
+        called = true;
+        return 'data:image/jpeg;base64,AAAA';
+      },
+    });
+    assert.equal(dataUrl, null);
+    assert.equal(called, false, 'the encoder is never invoked without a DOM');
+  } finally {
+    if (hadDocument) g.document = {};
+  }
+});
+
+test('pageCaptureSupported reflects the presence of a client DOM', () => {
+  const g = globalThis as Record<string, unknown>;
+  const hadWindow = 'window' in g;
+  const hadDocument = 'document' in g;
+  try {
+    g.window = {};
+    g.document = {};
+    assert.equal(pageCaptureSupported(), true);
+    delete g.document;
+    assert.equal(pageCaptureSupported(), false);
+  } finally {
+    if (hadWindow) g.window = {}; else delete g.window;
+    if (hadDocument) g.document = {}; else delete g.document;
+  }
+});
+
+// ── rendered dialog wiring ─────────────────────────────────────────────────
+
+test('the report dialog offers the capture button and marks the modal capture-ignored', async () => {
+  const g = globalThis as Record<string, unknown>;
+  g.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    setTimeout: (...args: Parameters<typeof setTimeout>) => setTimeout(...args),
+    clearTimeout: (id: ReturnType<typeof setTimeout>) => clearTimeout(id),
+  };
+  g.document = { activeElement: null };
+  try {
+    const { act, create } = await import('react-test-renderer');
+    const ReportModal = (await import('../frontend/feedback/report-dialog')).default;
+
+    let root!: import('react-test-renderer').ReactTestRenderer;
+    await act(async () => {
+      root = create(React.createElement(ReportModal, { onClose: () => {} }));
+    });
+
+    assert.equal(
+      root.root.findAllByProps({ 'data-testid': 'report-capture-screen' }).length,
+      1,
+      'the "Capture page" button is offered',
+    );
+    assert.ok(
+      root.root.findAllByProps({ [CAPTURE_IGNORE_ATTR]: '' }).length >= 1,
+      'the modal root is marked so the capture excludes the feedback UI',
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  } finally {
+    delete g.window;
+    delete g.document;
+  }
+});
+
+test('the report dialog no longer uses the getDisplayMedia screen-share API (AA-77)', () => {
+  const dialogSrc = readFileSync(
+    fileURLToPath(new URL('../frontend/feedback/report-dialog.tsx', import.meta.url)),
+    'utf8',
+  );
+  assert.ok(
+    !dialogSrc.includes('getDisplayMedia'),
+    'report-dialog.tsx must not reference the getDisplayMedia screen-share picker',
+  );
+});


### PR DESCRIPTION
## What

Fixes **[AA-77](https://sugarandleather.atlassian.net/browse/AA-77)** — "Capture Screen feedback button captures incorrect portion of the screen."

The report dialog's **Capture screen** used `navigator.mediaDevices.getDisplayMedia()` — the screen-**share** API. That inherently:
1. pops the browser's window/tab/entire-screen picker,
2. grabs the whole shared surface rather than the page behind the widget, and
3. is unsupported on mobile.

So in practice it never captured the actual error (the reporter's exact complaint).

## How

Replaced it with an in-page DOM rasterization — **"Capture page"** — via `html-to-image`, which uses the browser's own SVG `<foreignObject>` renderer (so Tailwind v4 `oklch()` colors and `backdrop-blur` render correctly, unlike `html2canvas`).

- **No picker**, works on **mobile**, captures exactly "the page you're on."
- The feedback UI itself (modal + backdrop + floating button) is excluded from the shot via a `data-feedback-capture-ignore` marker, so the capture shows the page **behind** the dialog, not our own chrome.
- Output is **JPEG @ pixelRatio 1** to stay under the existing 2 MB screenshot cap; the data URL still goes through the existing MIME-whitelist + size validation.
- **Fail-open**: any capture failure degrades to the file picker with an inline hint (no silent dead-click).
- `html-to-image` is **dynamically imported**, so it stays off the every-page feedback-widget bundle.

## Tests

`tests/feedback-report-capture.test.ts` (new): the node filter, the capture helper contract (JPEG data URL / options), fail-open to null, rendered dialog wiring, and a regression guard that `report-dialog.tsx` no longer references `getDisplayMedia`.

`npm run typecheck`, `npm run lint`, and `npm run verify` all green locally. Existing `feedback-report-dialog` / `feedback-widget-render` tests unchanged and passing.

## Verification note

Only rendered output is a full PASS: after merge+deploy, screenshot-verify on a live tenant that **Capture page** attaches a shot of the page behind the dialog (desktop **and** mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)