### PR TITLE
fix(marketing): three feedback-reported dashboard bugs (AA-50, AA-73, AA-76)

### DIFF
--- a/backend/marketing/runtime-state.ts
+++ b/backend/marketing/runtime-state.ts
@@ -225,10 +225,19 @@ export function nowIso(): string {
 }
 
 export function defaultPublishConfig(input: Partial<MarketingPublishConfig> = {}): MarketingPublishConfig {
+  // Defaults must reflect what the weekly pipeline actually does for a job
+  // created without an explicit publish config: generate image posts for
+  // Facebook + Instagram, and render NO video (video is opt-in via
+  // videoRenderCount / renderVideoAfterApproval). The old `tiktok` defaults
+  // surfaced a platform the tenant never chose plus a phantom "Video render:
+  // tiktok" and a planned-video count on the dashboard (AA-76).
+  // `live_publish_platforms` stays meta-ads only — it is read by the real FB/IG
+  // publish handlers, so its default is deliberately conservative to avoid any
+  // auto-publish surprise.
   return {
-    platforms: normalizePlatformList(input.platforms, ['meta-ads', 'tiktok']),
+    platforms: normalizePlatformList(input.platforms, ['meta-ads', 'instagram']),
     live_publish_platforms: normalizePlatformList(input.live_publish_platforms, ['meta-ads']),
-    video_render_platforms: normalizePlatformList(input.video_render_platforms, ['tiktok']),
+    video_render_platforms: normalizePlatformList(input.video_render_platforms, []),
   };
 }
 

--- a/frontend/aries-v1/post-workspace.tsx
+++ b/frontend/aries-v1/post-workspace.tsx
@@ -324,7 +324,11 @@ export default function AriesPostWorkspace(props: { postId: string; initialView?
         throw new Error(payload.error || 'Failed to save review decision.');
       }
       setNotesByReviewId((current) => ({ ...current, [reviewId]: '' }));
-      await job.load(props.postId, { quiet: false });
+      // Quiet refetch: reconcile to server truth WITHOUT flipping job.isLoading,
+      // which would trip the top-level "Loading post…" gate and blank the entire
+      // workspace on every Authorize/Reject. Per-item feedback already comes from
+      // busyByReviewId, so this updates the review in place (AA-73).
+      await job.load(props.postId, { quiet: true });
     } catch (error) {
       window.alert(
         customerSafeActionErrorMessage(
@@ -354,7 +358,10 @@ export default function AriesPostWorkspace(props: { postId: string; initialView?
         );
       }
 
-      await job.load(props.postId, { quiet: false });
+      // Quiet refetch (same rationale as the review-decision path, AA-73): the
+      // BrandBriefCard already surfaces its own `saving` state, so update the
+      // brief in place instead of blanking the workspace via the loading gate.
+      await job.load(props.postId, { quiet: true });
     } finally {
       setBriefSaving(false);
     }
@@ -1430,7 +1437,11 @@ function RuntimeStatusSurface(props: {
             <div className="grid gap-1 text-sm text-white/70">
               <span>Platforms: {status.publishConfig.platforms.join(', ') || 'none selected'}</span>
               <span>Live draft publish: {status.publishConfig.livePublishPlatforms.join(', ') || 'not requested'}</span>
-              <span>Video render: {status.publishConfig.videoRenderPlatforms.join(', ') || 'not requested'}</span>
+              {/* Only surface video when it was actually requested — else the panel
+                  reads as if a (never-produced) video is planned (AA-76). */}
+              {status.publishConfig.videoRenderPlatforms.length > 0 ? (
+                <span>Video render: {status.publishConfig.videoRenderPlatforms.join(', ')}</span>
+              ) : null}
             </div>
           </div>
         ) : null}

--- a/frontend/aries-v1/settings-screen.tsx
+++ b/frontend/aries-v1/settings-screen.tsx
@@ -294,6 +294,8 @@ export default function AriesSettingsScreen() {
               </div>
               <p className="mt-3 text-xs leading-6 text-white/70">
                 Newly connected media portals update this Business Profile summary automatically.
+                Weekly content is currently generated and published to Facebook and Instagram — other
+                connected platforms aren&apos;t used for automatic weekly posts yet.
               </p>
             </div>
             <button type="button" onClick={() => void saveProfile()} disabled={business.save.isLoading} className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] disabled:opacity-60">

--- a/frontend/marketing/month-day-picker.tsx
+++ b/frontend/marketing/month-day-picker.tsx
@@ -42,10 +42,16 @@ function parseValue(value: string): { month: number; day: number; year: number }
   return { year, month, day };
 }
 
+// The <select> control is text-white, but the native <option> children must
+// also carry an opaque dark background + explicit text color — otherwise Chrome
+// paints the collapsed selected-value label and the option list near-white on
+// the translucent bg-white/5, so Month/Day/Year read as invisible until a hover
+// highlight restores contrast (AA-50). `[&>option]` styles them directly.
+const optionClassName = '[&>option]:bg-[#050505] [&>option]:text-white';
 const selectClassName =
-  'rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-primary/50';
+  `rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-primary/50 ${optionClassName}`;
 const selectInvalidClassName =
-  'rounded-2xl border border-red-500/50 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-red-500/70';
+  `rounded-2xl border border-red-500/50 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-red-500/70 ${optionClassName}`;
 
 export function MonthDayPicker({ value, onChange, ariaLabel, invalid, _today }: MonthDayPickerProps) {
   const today = _today ?? new Date();

--- a/tests/marketing-publish-config-defaults.test.ts
+++ b/tests/marketing-publish-config-defaults.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { defaultPublishConfig, publishConfigFromChannels } from '../backend/marketing/runtime-state';
+
+/**
+ * AA-76 regression: "Generate Weekly Content is not showing the correct
+ * requested information." A weekly job created without an explicit publish
+ * config fell back to `platforms: ['meta-ads','tiktok']` +
+ * `video_render_platforms: ['tiktok']`, so the dashboard showed a `tiktok`
+ * platform the tenant never chose and a phantom "Video render: tiktok" /
+ * planned-video count — even though the pipeline renders no video by default.
+ *
+ * The default must reflect what actually happens: image posts for
+ * Facebook + Instagram, no video. `live_publish_platforms` stays meta-ads only
+ * (it is read by the real FB/IG publish handlers). The explicit-input
+ * passthrough must be untouched — only the FALLBACK changed.
+ */
+
+test('AA-76: default publish config has no tiktok and no phantom video', () => {
+  const cfg = defaultPublishConfig();
+  assert.deepEqual(cfg.platforms, ['meta-ads', 'instagram'], 'default platforms should be FB + IG, not tiktok');
+  assert.deepEqual(cfg.video_render_platforms, [], 'default must render no video (video is opt-in)');
+  assert.deepEqual(cfg.live_publish_platforms, ['meta-ads'], 'live publish default stays conservative');
+  const serialized = JSON.stringify(cfg);
+  assert.ok(!serialized.includes('tiktok'), 'no tiktok anywhere in the default publish config');
+});
+
+test('AA-76: explicit publish-config input is still honored (only the fallback changed)', () => {
+  const cfg = defaultPublishConfig({
+    platforms: ['tiktok'],
+    live_publish_platforms: ['tiktok'],
+    video_render_platforms: ['tiktok'],
+  });
+  assert.deepEqual(cfg.platforms, ['tiktok']);
+  assert.deepEqual(cfg.live_publish_platforms, ['tiktok']);
+  assert.deepEqual(cfg.video_render_platforms, ['tiktok'], 'explicit video request must pass through unchanged');
+});
+
+test('AA-76: channel-derived config for meta/instagram renders no video', () => {
+  const cfg = publishConfigFromChannels(['meta', 'instagram']);
+  assert.deepEqual(cfg.platforms, ['meta-ads', 'instagram']);
+  assert.deepEqual(cfg.live_publish_platforms, ['meta-ads', 'instagram']);
+  assert.deepEqual(cfg.video_render_platforms, [], 'meta/instagram are image targets — no video render');
+});
+
+test('AA-76: a genuine video channel (youtube) still drives video_render_platforms', () => {
+  // Proves the fix only touched the fallback — real channel-driven video is intact.
+  const cfg = publishConfigFromChannels(['meta', 'youtube']);
+  assert.deepEqual(cfg.video_render_platforms, ['youtube']);
+});
+
+test('AA-76: empty/absent channels fall back to the no-video default', () => {
+  assert.deepEqual(publishConfigFromChannels([]).video_render_platforms, []);
+  assert.deepEqual(publishConfigFromChannels(null).video_render_platforms, []);
+  assert.deepEqual(publishConfigFromChannels(undefined).platforms, ['meta-ads', 'instagram']);
+});
+
+test('AA-76: the workspace panel only shows "Video render" when video was actually requested', () => {
+  const src = readFileSync(
+    fileURLToPath(new URL('../frontend/aries-v1/post-workspace.tsx', import.meta.url)),
+    'utf8',
+  );
+  assert.match(
+    src,
+    /videoRenderPlatforms\.length > 0/,
+    'the Video render line must be gated on a non-empty videoRenderPlatforms',
+  );
+  assert.ok(
+    !src.includes("Video render: {status.publishConfig.videoRenderPlatforms.join(', ') || 'not requested'}"),
+    'the always-on "Video render … not requested" line must be gone',
+  );
+});

--- a/tests/month-day-picker.test.ts
+++ b/tests/month-day-picker.test.ts
@@ -221,6 +221,48 @@ test('incoming value "2026-06-14" populates month=6 (June), day=14', async () =>
   assert.equal(daySelect!.props.value, 14, 'Day should be 14');
 });
 
+// --- AA-50 regression: option labels must be legible on the dark theme ---
+// The native <option> children need an opaque dark background + explicit text
+// color, else Chrome paints them near-white on the translucent bg-white/5 and
+// Month/Day/Year read as invisible until a hover highlight restores contrast.
+
+test('AA-50: every select styles its <option> children with an opaque dark bg + white text', async () => {
+  const { act, create } = await import('react-test-renderer');
+
+  for (const invalid of [false, true]) {
+    let root!: import('react-test-renderer').ReactTestRenderer;
+    await act(async () => {
+      root = create(
+        React.createElement(MonthDayPicker, {
+          value: '',
+          onChange: () => {},
+          ariaLabel: 'Test date',
+          invalid,
+          // Force the year selector to render too, so all three selects are covered.
+          _today: new Date(`${new Date().getFullYear()}-12-15T12:00:00`),
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    const selects = root.root.findAllByType('select');
+    assert.ok(selects.length >= 2, 'expected Month/Day (and Year) selects');
+    for (const select of selects) {
+      const className = String(select.props.className);
+      assert.match(
+        className,
+        /\[&>option\]:bg-\[#050505\]/,
+        `select (invalid=${invalid}) must give options an opaque dark background`,
+      );
+      assert.match(
+        className,
+        /\[&>option\]:text-white/,
+        `select (invalid=${invalid}) must give options explicit white text`,
+      );
+    }
+  }
+});
+
 test('emitted date string zero-pads month and day ("2026-06-04" not "2026-6-4")', async () => {
   const { act, create } = await import('react-test-renderer');
 

--- a/tests/post-workspace-review-decision-no-blank.regression-073.test.ts
+++ b/tests/post-workspace-review-decision-no-blank.regression-073.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+/**
+ * AA-73 regression: authorizing/rejecting a creative (and saving the brief) must
+ * NOT blank the whole post workspace.
+ *
+ * Root cause was `job.load(props.postId, { quiet: false })` after the mutation:
+ * `quiet: false` flips `job.isLoading`, which trips the top-level
+ * `if (job.isLoading) return <Loading post…>` gate and unmounts the entire
+ * workspace — indistinguishable from a full-page refresh. The fix makes the
+ * post-mutation refetch quiet (per-item busy state still gives feedback; the
+ * refetch still reconciles to server truth), so the review/brief updates in
+ * place.
+ *
+ * Source-assertion test mirroring the existing post-workspace-*.test.ts pattern
+ * (no jsdom; locks the load-bearing class/flag against regression).
+ */
+
+const SRC = readFileSync(
+  fileURLToPath(new URL('../frontend/aries-v1/post-workspace.tsx', import.meta.url)),
+  'utf8',
+);
+
+test('AA-73: no mutation refetch reloads the workspace non-quietly', () => {
+  assert.ok(
+    !SRC.includes('job.load(props.postId, { quiet: false })'),
+    'a non-quiet job.load after a mutation re-trips the loading gate and blanks the whole workspace',
+  );
+});
+
+test('AA-73: the review-decision handler still refetches (quietly) after a decision', () => {
+  const start = SRC.indexOf('async function submitReviewDecision');
+  assert.ok(start >= 0, 'submitReviewDecision handler not found');
+  const body = SRC.slice(start, SRC.indexOf('async function submitBriefUpdate', start));
+  assert.ok(
+    body.includes('job.load(props.postId, { quiet: true })'),
+    'submitReviewDecision must still refetch job status, but quietly (in place)',
+  );
+});
+
+test('AA-73: the top-level loading gate is still present (fix relies on not reaching it, not deleting it)', () => {
+  assert.match(
+    SRC,
+    /if \(job\.isLoading\)/,
+    'the job.isLoading gate must remain; the fix avoids tripping it rather than removing it',
+  );
+});


### PR DESCRIPTION
Fixes three bugs reported through the in-app feedback button.

## [AA-50](https://sugarandleather.atlassian.net/browse/AA-50) — one-off date picker labels invisible until hover
On `/dashboard/social-content/new`, the Month/Day/Year `<select>`s were `text-white` but their `<option>` children were uncolored, so on the translucent `bg-white/5` Chrome painted them near-white on near-white — labels only appeared on hover. Added `[&>option]:bg-[#050505] [&>option]:text-white` to both the valid and invalid select variants.

## [AA-73](https://sugarandleather.atlassian.net/browse/AA-73) — Authorize/Reject blanks the whole workspace
On the creative review page, approve/reject (and brief save) called `job.load(postId, { quiet: false })`, which flips `job.isLoading` → trips the top-level `if (job.isLoading) return <Loading>` gate → unmounts the entire workspace (reads as a full-page refresh, loses scroll/state). Switched both post-mutation reloads to `{ quiet: true }`: the per-item busy state (`busyByReviewId` / `briefSaving`) still shows feedback and the refetch still reconciles to server truth, so the review/brief updates **in place**.

## [AA-76](https://sugarandleather.atlassian.net/browse/AA-76) — Generate Weekly Content shows phantom tiktok/video
`defaultPublishConfig`'s fallback was `platforms:['meta-ads','tiktok']` / `video_render_platforms:['tiktok']`, so an image-only job created without an explicit config surfaced a `tiktok` platform the tenant never chose, a "Video render: tiktok" line, and a planned-video count — even though the pipeline renders no video by default. Changed the **fallback** to `platforms:['meta-ads','instagram']` / `video_render_platforms:[]` (explicit input still passes through; `live_publish_platforms` left unchanged because the real FB/IG publish handlers read it). Gated the workspace "Video render" panel line on a non-empty list, and added a Settings clarifier that weekly content currently targets Facebook + Instagram only.

**Out of scope (flagged as separate greenfield):** wiring connected X/LinkedIn/YouTube as weekly-generation targets, and FB/IG reels + FB stories — those are per-platform-flag / `ARIES_VIDEO_PUBLISH_ENABLED` rollout work, not display bugs.

## Verification
- Adversarially reviewed (Opus): every consumer of the changed `publish_config` fields traced — the changed defaults are **display-only** and alter no publishing decision (`live_publish_platforms`, which gates real FB/IG publishing, is untouched).
- New tests: month-day-picker option legibility; post-workspace quiet-refetch regression; publish-config defaults (no tiktok / no phantom video, explicit passthrough intact, channel-driven video still works).
- `typecheck`, `lint`, `validate:social-content` (90/90), and `verify` (42/42) all green.

Rendered-UI verification on a live tenant to follow after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)