### PR TITLE
fix(insights): blank goal label/narrative + "@unknown" comment authors

### DIFF
--- a/backend/insights/conversations/conversations-builder.ts
+++ b/backend/insights/conversations/conversations-builder.ts
@@ -194,11 +194,18 @@ export async function buildConversationsSnapshot(
 
     const conversations: ConversationItem[] = feedRes.rows.map((row) => {
       const tagResult = deriveTag(row.is_lead, row.category, row.sentiment);
-      const handle    = row.author_handle || 'unknown';
+      // Facebook's Graph API withholds the commenter identity (`from`) on public
+      // Page comments unless advanced permissions are held, so author_handle is
+      // often null. Show a platform-appropriate label instead of "@unknown".
+      const rawHandle  = row.author_handle?.trim() || null;
+      const platformName = row.platform.charAt(0).toUpperCase() + row.platform.slice(1);
+      const author     = rawHandle
+        ? (rawHandle.startsWith('@') ? rawHandle : `@${rawHandle}`)
+        : `${platformName} user`;
       return {
         id:         row.id,
-        author:     handle.startsWith('@') ? handle : `@${handle}`,
-        avatar:     avatarInitials(handle),
+        author,
+        avatar:     avatarInitials(rawHandle || row.platform),
         text:       row.body_text,
         postRef:    row.post_title || 'a post',
         platform:   row.platform,

--- a/backend/insights/goal/goal-snapshot-builder.ts
+++ b/backend/insights/goal/goal-snapshot-builder.ts
@@ -58,6 +58,30 @@ function categoryLabel(contentType: string): string {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
+// `business_profiles.primary_goal` is a FREE-FORM string (set at onboarding /
+// written by Hermes brand-enrichment as natural language like "Generate more
+// leads"), NOT one of the four canonical GoalType keys. A blind
+// `rawGoal as GoalType` therefore produced an unmapped goal → empty goalLabel,
+// empty metricLabel and an empty Aries narrative, while the metric silently fell
+// through to brand awareness. Normalise any stored vocabulary to a canonical
+// goal by keyword, defaulting to brand_awareness (the most universal metric) so
+// the label + narrative are never blank.
+function normalizeGoal(raw: string): GoalType {
+  const s = raw.trim().toLowerCase();
+  if (!s) return 'brand_awareness';
+  // Exact canonical match wins.
+  if (s === 'lead_generation') return 'lead_generation';
+  if (s === 'content_growth')  return 'content_growth';
+  if (s === 'product_sales')   return 'product_sales';
+  if (s === 'brand_awareness') return 'brand_awareness';
+  // Keyword match on free-form text (most specific intent first).
+  if (/\blead|inquir|enquir|contact|sign[- ]?up|booking|appointment\b/.test(s)) return 'lead_generation';
+  if (/\bsale|sell|revenue|purchase|buy|checkout|conversion|order|product|shop|ecommerce\b/.test(s)) return 'product_sales';
+  if (/\bfollow|grow|audience|subscriber|community|reach more|build.*following\b/.test(s)) return 'content_growth';
+  if (/\baware|reach|visib|impression|discover|exposure|brand\b/.test(s)) return 'brand_awareness';
+  return 'brand_awareness';
+}
+
 function goalLabel(goal: GoalType): string {
   const labels: Record<GoalType, string> = {
     lead_generation: 'Lead Generation',
@@ -391,7 +415,7 @@ export async function buildGoalSnapshot(
     const rawGoal = profileRes.rows[0]?.primary_goal ?? null;
     if (!rawGoal) return null;
 
-    const goal = rawGoal as GoalType;
+    const goal = normalizeGoal(rawGoal);
 
     // Fetch metric for current + previous period
     let current: number;

--- a/backend/insights/goal/handler.ts
+++ b/backend/insights/goal/handler.ts
@@ -20,7 +20,10 @@ import { buildGoalText } from './goal-template-builder';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 import crypto from 'crypto';
 
-const TEMPLATE_VERSION = 'goal-template-v2';
+// v3: normalize free-form primary_goal → canonical GoalType, so the goal label
+// and Aries narrative are no longer blank when onboarding stored natural-language
+// goal text. Bump invalidates stale v2 rows that cached the empty label.
+const TEMPLATE_VERSION = 'goal-template-v3';
 const CACHE_TTL_MS     = 60 * 60 * 1000;
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);


### PR DESCRIPTION
## Summary
Two display-correctness fixes on the live Insights dashboard.

### 1. Goal section — blank label + empty narrative
"YOUR GOAL ·" rendered with no label and the "Aries:" narrative was empty. The goal builder cast `business_profiles.primary_goal` straight to the 4-value `GoalType`, but that column is **free-form text** (onboarding / Hermes brand-enrichment writes natural language like "Generate more leads"). An unmapped value → `undefined` label + empty narrative, while the metric silently fell through to brand awareness.

**Fix:** `normalizeGoal()` maps any stored vocabulary to a canonical goal by keyword (default `brand_awareness`), so label, metric, and narrative always resolve. Bumped the goal cache `TEMPLATE_VERSION` v2→v3 to invalidate stale rows that cached the empty label.

### 2. Conversations — "@unknown" authors
Every Facebook commenter showed as "@unknown". Graph withholds the commenter identity (`from`) on public Page comments without advanced permissions, so `author_handle` is null. Now falls back to a platform-appropriate label ("Facebook user").

## Verification
- Verified via the goal handler: canonical `lead_generation` and free-form "Generate more leads" both → "Lead Generation" + populated narrative; "brand visibility" → "Brand Awareness".
- `npm run lint` green; all 23 insights endpoint tests pass.

## Note
This does **not** address the empty sentiment / "What people are asking" panel — that's a separate, larger piece: there is currently **no comment-classification pipeline** in production (only the demo seed writes sentiment labels). A Hermes-agent classifier is planned as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)