### PR TITLE
fix(insights): count all channel posts, not just Aries-attributed (Activity/Top)

### DIFF
--- a/backend/insights/activity/activity-snapshot-builder.ts
+++ b/backend/insights/activity/activity-snapshot-builder.ts
@@ -5,7 +5,7 @@
  * All queries are sequential (DB_POOL_MAX guardrail — no Promise.all on DB calls).
  *
  * Activity strip:
- *   - postsPublished   — Aries-generated posts published in the period
+ *   - postsPublished   — all posts published on connected channels in the period
  *   - commentsReceived — comments received on those posts
  *   - highPerformers   — posts that hit ≥2x the period average reach (same
  *                        baseline logic as the Section 3 opportunity card)
@@ -73,7 +73,6 @@ export async function buildActivitySnapshot(
   try {
 
     // ── Posts published + platform count ─────────────────────────────────────
-    // Only Aries-generated posts (aries_post_id IS NOT NULL).
     const postsRes = await client.query<{
       post_count:     string;
       platform_count: string;
@@ -86,7 +85,6 @@ export async function buildActivitySnapshot(
        FROM insights_posts
        WHERE tenant_id      = $1
          AND published_at   >= $2
-         AND aries_post_id  IS NOT NULL
          AND ($3::text IS NULL OR platform = $3)`,
       [tenantId, fromDate, platformFilter],
     );
@@ -104,7 +102,6 @@ export async function buildActivitySnapshot(
        JOIN insights_posts p ON p.id = c.post_id
        WHERE c.tenant_id     = $1
          AND c.received_at   >= $2
-         AND p.aries_post_id IS NOT NULL
          AND ($3::text IS NULL OR c.platform = $3)`,
       [tenantId, fromDate, platformFilter],
     );
@@ -128,7 +125,6 @@ export async function buildActivitySnapshot(
                   ON m.post_id = p.id AND m.tenant_id = p.tenant_id
            WHERE p.tenant_id    = $1
              AND p.published_at >= $2
-             AND p.aries_post_id IS NOT NULL
              AND ($3::text IS NULL OR p.platform = $3)
            GROUP BY p.id
          ),
@@ -155,7 +151,6 @@ export async function buildActivitySnapshot(
        FROM insights_posts
        WHERE tenant_id     = $1
          AND published_at  >= $2
-         AND aries_post_id IS NOT NULL
          AND ($3::text IS NULL OR platform = $3)
        GROUP BY COALESCE(content_type, 'uncategorized')
        ORDER BY cnt DESC`,
@@ -173,13 +168,12 @@ export async function buildActivitySnapshot(
       };
     });
 
-    // How many Aries posts are still awaiting classification
+    // How many posts are still awaiting content-type classification
     const pendingRes = await client.query<{ count: string }>(
       `SELECT COUNT(*) AS count
        FROM insights_posts
        WHERE tenant_id     = $1
          AND published_at  >= $2
-         AND aries_post_id IS NOT NULL
          AND content_type  IS NULL
          AND ($3::text IS NULL OR platform = $3)`,
       [tenantId, fromDate, platformFilter],

--- a/backend/insights/activity/handler.ts
+++ b/backend/insights/activity/handler.ts
@@ -20,7 +20,7 @@ import { buildActivitySnapshot } from './activity-snapshot-builder';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 import crypto from 'crypto';
 
-const TEMPLATE_VERSION = 'activity-v2';
+const TEMPLATE_VERSION = 'activity-v3';
 const CACHE_TTL_MS     = 60 * 60 * 1000; // 1 hour
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/top/handler.ts
+++ b/backend/insights/top/handler.ts
@@ -24,7 +24,7 @@ import crypto from 'crypto';
 
 // v2: builder output changed (numeric `id`, fixed sentiment Map lookup); bump
 // so any pre-existing top-v1 cache row is invalidated instead of served stale.
-const TEMPLATE_VERSION = 'top-v2';
+const TEMPLATE_VERSION = 'top-v3';
 const CACHE_TTL_MS     = 60 * 60 * 1000;
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/top/top-snapshot-builder.ts
+++ b/backend/insights/top/top-snapshot-builder.ts
@@ -134,7 +134,6 @@ export async function buildTopSnapshot(
                 ON m.post_id = p.id AND m.tenant_id = p.tenant_id
          WHERE p.tenant_id     = $1
            AND p.published_at  >= $2
-           AND p.aries_post_id IS NOT NULL
            AND ($3::text IS NULL OR p.platform = $3)
          GROUP BY p.id
        )
@@ -184,7 +183,6 @@ export async function buildTopSnapshot(
                 ON m.post_id = p.id AND m.tenant_id = p.tenant_id
          WHERE p.tenant_id     = $1
            AND p.published_at  >= $2
-           AND p.aries_post_id IS NOT NULL
            AND ($3::text IS NULL OR p.platform = $3)
          GROUP BY p.id, p.platform, p.title, p.caption, p.permalink,
                   p.published_at, p.content_type, p.media_type, p.platform_data

--- a/backend/insights/trends/handler.ts
+++ b/backend/insights/trends/handler.ts
@@ -25,7 +25,7 @@ import crypto from 'crypto';
 // v2: builder output changed (fixed ::date bucketing so the current-period
 // reach series populates); bump so a stale trends-v1 cache row showing reach=0
 // is invalidated instead of served for up to the TTL.
-const TEMPLATE_VERSION = 'trends-v2';
+const TEMPLATE_VERSION = 'trends-v3';
 const CACHE_TTL_MS     = 60 * 60 * 1000; // 1 hour
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/trends/trends-snapshot-builder.ts
+++ b/backend/insights/trends/trends-snapshot-builder.ts
@@ -378,7 +378,6 @@ export async function buildTrendsSnapshot(
        FROM insights_posts
        WHERE tenant_id     = $1
          AND published_at  >= $2
-         AND aries_post_id IS NOT NULL
          AND ($3::text IS NULL OR platform = $3)`,
       [tenantId, currentStart, platformFilter],
     );
@@ -427,7 +426,6 @@ export async function buildTrendsSnapshot(
               ON m.post_id = p.id AND m.tenant_id = p.tenant_id
        WHERE p.tenant_id     = $1
          AND p.published_at  >= $2
-         AND p.aries_post_id IS NOT NULL
          AND ($3::text IS NULL OR p.platform = $3)
        GROUP BY p.id, p.title
        ORDER BY SUM(COALESCE(m.reach, m.views, 0)) DESC

--- a/frontend/insights/ActivitySection.tsx
+++ b/frontend/insights/ActivitySection.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // ActivitySection.tsx
-// "What Aries did" — activity metrics (left panel) + content mix donut (right panel)
+// "Your activity" — channel activity metrics (left panel) + content mix donut (right panel)
 // API: GET /api/insights/activity?period=…&platform=…
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -18,9 +18,9 @@ interface ActivitySectionProps {
 }
 
 const PERIOD_TITLE: Record<Period, string> = {
-  week:    "What Aries did this week",
-  "30day": "What Aries did this month",
-  "90day": "What Aries did over 90 days",
+  week:    "Your activity this week",
+  "30day": "Your activity this month",
+  "90day": "Your activity over 90 days",
 };
 
 const PERIOD_DAYS: Record<Period, number> = { week: 7, "30day": 30, "90day": 90 };
@@ -89,13 +89,13 @@ export function ActivitySection({ period, platform }: ActivitySectionProps) {
       ) : error ? (
         <Panel><ErrorState message={error} onRetry={refetch} /></Panel>
       ) : !data?.meta?.hasData ? (
-        <Panel><EmptyState message="No Aries-published posts in this period." /></Panel>
+        <Panel><EmptyState message="No posts published on your channels in this period." /></Panel>
       ) : (
         <div style={{ display: "grid", gridTemplateColumns: "1.55fr 1fr", gap: 20, alignItems: "stretch" }}>
           {/* ── LEFT panel: metric cards + insight footer ── */}
           <Panel style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-              <MetricCard icon="post" value={data.strip.postsPublished.toLocaleString()} label="Aries-published posts">
+              <MetricCard icon="post" value={data.strip.postsPublished.toLocaleString()} label="Posts published">
                 <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2 }}>
                   <span style={{ display: "inline-flex", gap: 3 }}>
                     {platforms.map((p) => <ChannelIcon key={p} platform={p} size={13} />)}

--- a/frontend/insights/TopPostsSection.tsx
+++ b/frontend/insights/TopPostsSection.tsx
@@ -337,7 +337,7 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
     <section>
       {/* Header row: title on the left, sort select on the right */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
-        <SectionHeader title="Top Aries-published content" />
+        <SectionHeader title="Top performing content" />
         <select
           value={sort}
           onChange={(e) => setSort(e.target.value as SortKey)}
@@ -367,7 +367,7 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
         ) : error ? (
           <ErrorState message={error} onRetry={refetch} />
         ) : empty || !data ? (
-          <EmptyState message="No Aries-published posts in this period." />
+          <EmptyState message="No published posts in this period." />
         ) : (
           <>
             <div
@@ -389,7 +389,7 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
                     marginBottom:  6,
                   }}
                 >
-                  Your top 5 Aries-published posts
+                  Your top 5 posts
                 </div>
                 <div style={{ display: "flex", flexDirection: "column" }}>
                   {data.posts.map((post, i) => (

--- a/tests/insights-dashboard-ui.test.ts
+++ b/tests/insights-dashboard-ui.test.ts
@@ -153,12 +153,12 @@ test('comments read-api exposes replied state so the inbox can render it', () =>
   assert.match(readApi, /repliedAt:/);
 });
 
-test('insights empty states label Aries-published scope so they do not contradict the hero account summary', () => {
-  assert.match(insightsActivitySection, /No Aries-published posts in this period\./);
-  assert.match(insightsTopPostsSection, /Top Aries-published content/);
-  assert.match(insightsTopPostsSection, /No Aries-published posts in this period\./);
-  assert.doesNotMatch(insightsActivitySection, /No posts published in this period\./);
-  assert.doesNotMatch(insightsTopPostsSection, /No posts published in this period\./);
+test('insights sections use all-channel copy — no Aries-published misattribution (#785)', () => {
+  assert.match(insightsActivitySection, /No posts published on your channels in this period\./);
+  assert.match(insightsTopPostsSection, /Top performing content/);
+  assert.match(insightsTopPostsSection, /No published posts in this period\./);
+  assert.doesNotMatch(insightsActivitySection, /Aries-published/);
+  assert.doesNotMatch(insightsTopPostsSection, /Aries-published/);
 });
 
 // ─── #684 honest analytics "metric unavailable" states ───────────────────────


### PR DESCRIPTION
## Summary
"What Aries did" (Activity) and "Top performing content" were **empty for every real tenant** — even though posts, comments, and metrics are in the DB.

**Root cause:** both filtered on `aries_post_id IS NOT NULL`, but **no production code ever sets `aries_post_id`** — only the demo seed does (`backend/insights/sync/` has zero write sites for it). So in prod it's always NULL and the attribution filter hid every synced post. The demo looks full only because the seed links it.

## Fix (Option A — show all channel activity)
Drop the `aries_post_id` filter from the Activity, Top, and Trends builders so these sections count **all posts published on connected channels** — the data the tenant actually has. Reframe the copy so it doesn't misattribute externally-published posts to Aries:
- Activity: "What Aries did …" → **"Your activity …"**; "Aries-published posts" → "Posts published"; empty state updated.
- Top: "Top Aries-published content" → **"Top performing content"**; row header + empty state updated.

Bumped Activity/Top/Trends cache `TEMPLATE_VERSION` (v2→v3) so it shows on deploy, not after the 1h TTL.

## Verification
Ran the Activity + Top handlers against the seed with `aries_post_id` nulled (simulating externally-posted content): Activity → 10 posts / 140 comments / 6 content-mix slices; Top → 5 posts. Lint green; insights suite 23/23.

## Note
This is the "show what you have" fix. If you later want strict Aries attribution back (a "What Aries did" that only counts posts Aries published), that needs a **linker** that sets `aries_post_id` on sync by matching a fetched post to its Aries `posts` row (`platform_post_id`) — a separate follow-up (Option B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)