### PR TITLE
fix(marketing): schedule X/LinkedIn/Reddit crossposts (delivery gap in #769)

### DIFF
--- a/backend/marketing/auto-schedule.ts
+++ b/backend/marketing/auto-schedule.ts
@@ -107,6 +107,29 @@ export const PLATFORM_POSTING_DEFAULTS = {
     story: { hour: 10, minute: 0, staggerMinutes: 5 },
     reel: { hour: 14, minute: 0, staggerMinutes: 5 },
   },
+  // Weekly cross-post targets (ARIES_WEEKLY_CROSSPOST_ENABLED). Without posting
+  // defaults here, computeAutoScheduleSlots skips these platforms as
+  // `unsupported_platform`, so synthesized x/linkedin/reddit rows are never
+  // scheduled and never publish. They fan out the FEED image only; the
+  // story/reel slots exist to satisfy the surface map (never hit for
+  // crossposts). Distinct hours so a post crossposted to every platform does
+  // not land minute-for-minute across all of them. Actual publishing stays
+  // gated by ARIES_<PLATFORM>_ENABLED at the scheduled-dispatch admission gate.
+  linkedin: {
+    feed: { hour: 9, minute: 30, staggerMinutes: 10 },
+    story: { hour: 8, minute: 30, staggerMinutes: 10 },
+    reel: { hour: 10, minute: 30, staggerMinutes: 10 },
+  },
+  x: {
+    feed: { hour: 12, minute: 30, staggerMinutes: 15 },
+    story: { hour: 9, minute: 30, staggerMinutes: 15 },
+    reel: { hour: 13, minute: 30, staggerMinutes: 15 },
+  },
+  reddit: {
+    feed: { hour: 14, minute: 30, staggerMinutes: 20 },
+    story: { hour: 11, minute: 30, staggerMinutes: 20 },
+    reel: { hour: 15, minute: 30, staggerMinutes: 20 },
+  },
 } as const satisfies Record<string, Record<'feed' | 'story' | 'reel', SurfaceSlotDefault>>;
 
 export type AutoSchedulePlatform = keyof typeof PLATFORM_POSTING_DEFAULTS;

--- a/tests/marketing-auto-schedule.test.ts
+++ b/tests/marketing-auto-schedule.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   PLATFORM_POSTING_DEFAULTS,
   computeAutoScheduleSlots,
+  computeDefaultCadenceSlots,
   autoSchedulePosts,
   type AutoScheduleInputRow,
 } from '../backend/marketing/auto-schedule';
@@ -43,6 +44,46 @@ test('PLATFORM_POSTING_DEFAULTS pins Instagram 11:00 and Facebook 13:05 tenant-l
   // burst posting flagged by Meta's spam heuristics. Effective time = 13:05.
   assert.equal(PLATFORM_POSTING_DEFAULTS.facebook.feed.staggerMinutes, 5);
 });
+
+// --- Cross-post delivery regression -------------------------------------------
+// Weekly cross-post (ARIES_WEEKLY_CROSSPOST_ENABLED) synthesizes x/linkedin/
+// reddit `posts` rows, but the scheduler had posting defaults for FB/IG only —
+// so those rows were dropped as `unsupported_platform` and NEVER published
+// (found by live verification). Both scheduling paths (weekly-schedule and the
+// default-cadence path one-off campaigns use) must now schedule them.
+
+for (const platform of ['x', 'linkedin', 'reddit'] as const) {
+  test(`crosspost: ${platform} has a feed posting default`, () => {
+    assert.ok(PLATFORM_POSTING_DEFAULTS[platform]?.feed, `${platform} needs a feed window`);
+    assert.equal(typeof PLATFORM_POSTING_DEFAULTS[platform].feed.hour, 'number');
+  });
+
+  test(`crosspost: computeAutoScheduleSlots schedules a ${platform} row (not unsupported_platform)`, () => {
+    const result = computeAutoScheduleSlots({
+      rows: rowsForPlatform(1, platform, 'Monday'),
+      tenantTimezone: TZ_NY,
+      campaignStart: CAMPAIGN_START,
+      campaignEnd: CAMPAIGN_END,
+      now: NOW,
+    });
+    assert.equal(result.skipped.length, 0, `skipped: ${JSON.stringify(result.skipped)}`);
+    assert.equal(result.slots.length, 1);
+    assert.equal(result.slots[0].platform, platform);
+  });
+
+  test(`crosspost: computeDefaultCadenceSlots (one-off path) schedules a ${platform} row`, () => {
+    const result = computeDefaultCadenceSlots({
+      rows: [{ postId: 1, platform, ordinal: 1 }],
+      tenantTimezone: TZ_NY,
+      campaignStart: CAMPAIGN_START,
+      campaignEnd: CAMPAIGN_END,
+      now: NOW,
+    });
+    assert.equal(result.skipped.length, 0, `skipped: ${JSON.stringify(result.skipped)}`);
+    assert.equal(result.slots.length, 1);
+    assert.equal(result.slots[0].platform, platform);
+  });
+}
 
 // --- Per-platform timing ------------------------------------------------------
 
@@ -237,7 +278,10 @@ test('Closed-or-empty campaign window returns all rows as skipped', () => {
 test('Unsupported platform is skipped with a typed reason, NOT silently dropped', () => {
   const result = computeAutoScheduleSlots({
     rows: [
-      { postId: 1, platform: 'linkedin', recommendedDay: 'Monday' },
+      // pinterest is not an Aries publish target (no posting defaults) — a truly
+      // unsupported platform. (linkedin/x/reddit are now supported crosspost
+      // targets and would schedule.)
+      { postId: 1, platform: 'pinterest', recommendedDay: 'Monday' },
       { postId: 2, platform: 'instagram', recommendedDay: 'Monday' },
     ],
     tenantTimezone: TZ_NY,
@@ -247,7 +291,7 @@ test('Unsupported platform is skipped with a typed reason, NOT silently dropped'
   });
   assert.equal(result.slots.length, 1, 'instagram must still schedule');
   assert.equal(result.skipped.length, 1);
-  assert.match(result.skipped[0]!.reason, /^unsupported_platform:linkedin$/);
+  assert.match(result.skipped[0]!.reason, /^unsupported_platform:pinterest$/);
 });
 
 // --- DB writer (in-memory queryable stub) ------------------------------------


### PR DESCRIPTION
Follow-up to #769. The weekly cross-post feature **synthesizes** x/linkedin/reddit `posts` rows correctly, but they never publish — the auto-scheduler silently drops them.

## Root cause (found by live verification)

A live one-off on tenant 15 produced 5 posts (fb, ig, **x, linkedin, reddit**) with correctly adapted captions — but only FB/IG got `scheduled_posts` rows. `PLATFORM_POSTING_DEFAULTS` in `auto-schedule.ts` has windows for facebook/instagram only; `pickSlotDefault` returns `null` for anything else, so `computeAutoScheduleSlots` / `computeDefaultCadenceSlots` skip crosspost rows as `unsupported_platform`. They sit `approved` forever and never reach the (fully-working) publish back-half.

This slipped past #769's tests + review because the scheduler is pre-existing code outside that diff — exactly what live measurement is for.

## Fix

Add feed/story/reel posting defaults for **x, linkedin, reddit** (distinct hours so an all-platform crosspost doesn't burst at one minute). Both schedulers read the same map, so this fixes the weekly-schedule path and the default-cadence (one-off) path. Crossposts fan out the FEED image only. Actual publishing stays gated by `ARIES_<PLATFORM>_ENABLED` at the scheduled-dispatch admission gate.

**Blast radius:** `PLATFORM_POSTING_DEFAULTS` / `AutoSchedulePlatform` / `pickSlotDefault` are used only inside `auto-schedule.ts` (grep-confirmed). Updated the "unsupported platform is skipped" test to use `pinterest` (linkedin is now supported) and added regression tests asserting x/linkedin/reddit schedule in **both** scheduling paths.

## Verification

`typecheck`, `lint`, `validate:social-content` (90/90), `verify` all green. Live re-verification (a fresh bounded one-off confirming x/linkedin/reddit actually publish) follows after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)