### PR TITLE
fix(shell): push content aside when the sidebar rail expands (AA-78)

### DIFF
--- a/components/redesign/layout/app-shell-client.tsx
+++ b/components/redesign/layout/app-shell-client.tsx
@@ -580,8 +580,12 @@ export default function AppShellClient({
         {/* Desktop sidebar */}
         <aside
           className={[
-            'group/sidebar fixed left-4 top-4 bottom-4 z-[70] hidden flex-col overflow-visible rounded-[2rem] border border-white/10 bg-white/[0.06] shadow-[0_28px_90px_rgba(0,0,0,0.38)] backdrop-blur-xl lg:flex',
-            keepSidebarExpanded ? 'w-[280px]' : 'w-[72px] hover:w-[280px]',
+            'group/sidebar peer/sidebar fixed left-4 top-4 bottom-4 z-[70] hidden flex-col overflow-visible rounded-[2rem] border border-white/10 bg-white/[0.06] shadow-[0_28px_90px_rgba(0,0,0,0.38)] backdrop-blur-xl lg:flex',
+            // hover:delay-150 = hover intent: an incidental pointer graze never
+            // starts the expand (nothing moves until 150ms of sustained hover);
+            // collapse keeps delay 0. Must stay mirrored with <main>'s
+            // peer-hover delay below or rail and content desync.
+            keepSidebarExpanded ? 'w-[280px]' : 'w-[72px] hover:w-[280px] hover:delay-150',
             'transition-[width] duration-[420ms] ease-[cubic-bezier(0.22,1,0.36,1)]',
           ].join(' ')}
         >
@@ -987,7 +991,21 @@ export default function AppShellClient({
           ) : null}
         </AnimatePresence>
 
-        <main className="relative flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden lg:min-h-screen lg:pl-[104px]">
+        {/* Rail is position:fixed, so "expanded" must be compensated here: the
+            collapsed rail gets 104px (16 edge + 72 rail + 16 gap); an expanded
+            rail (hover via peer/sidebar, or pinned while a menu is open) pushes
+            content to 312px (16 + 280 + 16) instead of overlaying it (AA-78).
+            The padding transition mirrors the rail's own width transition so
+            the two animate as one. */}
+        <main
+          className={[
+            'relative flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden lg:min-h-screen',
+            'lg:transition-[padding-left] lg:duration-[420ms] lg:ease-[cubic-bezier(0.22,1,0.36,1)] lg:motion-reduce:transition-none',
+            keepSidebarExpanded
+              ? 'lg:pl-[312px]'
+              : 'lg:pl-[104px] lg:peer-hover/sidebar:pl-[312px] lg:peer-hover/sidebar:delay-150',
+          ].join(' ')}
+        >
           {/* Single per-route page heading (visually hidden): satisfies WCAG 2.4.2/1.3.1
               so every dashboard route exposes exactly one descriptive <h1> from its
               route-config title. Visible section headings inside screens are <h2>+. */}

--- a/tests/app-shell-sidebar-push.regression-aa78.test.ts
+++ b/tests/app-shell-sidebar-push.regression-aa78.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+// AA-78: the desktop rail is position:fixed and expands 72px -> 280px on hover
+// (or while a rail menu pins it open). It used to OVERLAY the page content,
+// clipping the left edge of every heading/card. The contract under test: an
+// expanded rail PUSHES the content aside — <main> left padding grows in sync —
+// instead of sliding over it.
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const shell = readFileSync(
+  path.join(PROJECT_ROOT, 'components', 'redesign', 'layout', 'app-shell-client.tsx'),
+  'utf8',
+);
+
+test('rail aside is a named peer so <main> can react to its hover (AA-78)', () => {
+  // group/sidebar drives the rail's own internals; peer/sidebar is what lets a
+  // SIBLING (<main>) restyle on rail hover. Both must be on the same aside.
+  assert.match(shell, /group\/sidebar peer\/sidebar/);
+});
+
+test('main pushes aside on rail hover instead of being overlaid (AA-78)', () => {
+  // Collapsed baseline: 16px edge + 72px rail + 16px gap.
+  assert.match(shell, /lg:pl-\[104px\]/);
+  // Hover-expanded: 16px edge + 280px rail + 16px gap — driven by the peer.
+  assert.match(shell, /lg:peer-hover\/sidebar:pl-\[312px\]/);
+});
+
+test('pinned-expanded rail (menu open) also pushes main (AA-78)', () => {
+  // keepSidebarExpanded pins the rail at 280px; main must take the pushed
+  // padding unconditionally in that branch, not depend on hover.
+  assert.match(shell, /keepSidebarExpanded\s*\n?\s*\?\s*'lg:pl-\[312px\]'/);
+});
+
+test('push geometry and timing mirror the rail itself (AA-78)', () => {
+  // 104 = left-4 (16) + collapsed w-[72px] + 16 gap; 312 = 16 + expanded
+  // w-[280px] + 16. Pin BOTH rail widths (collapsed, and the hover-expansion
+  // token specifically) so any rail resize forces this math to be revisited —
+  // the pinned-expanded w-[280px] alone would mask a hover:w change.
+  assert.match(shell, /w-\[72px\] hover:w-\[280px\]/);
+  assert.match(shell, /left-4 top-4 bottom-4/);
+  // The padding transition must match the rail width transition (420ms, same
+  // easing) so rail and content move as one surface, not two.
+  assert.match(shell, /transition-\[width\] duration-\[420ms\]/);
+  assert.match(shell, /lg:transition-\[padding-left\] lg:duration-\[420ms\]/);
+});
+
+test('hover-intent delay is mirrored on rail and main (AA-78)', () => {
+  // 150ms expansion delay: an incidental pointer graze over the rail moves
+  // nothing. The delay must exist on BOTH the rail width (hover:) and the main
+  // padding (peer-hover/sidebar:) or the two surfaces desync for 150ms.
+  assert.match(shell, /hover:w-\[280px\] hover:delay-150/);
+  assert.match(shell, /lg:peer-hover\/sidebar:pl-\[312px\] lg:peer-hover\/sidebar:delay-150/);
+  // Reduced-motion users get the pushed layout without the 208px slide.
+  assert.match(shell, /lg:motion-reduce:transition-none/);
+});


### PR DESCRIPTION
## Summary
**AA-78** (P2, Hammad): "The sidebar nav bar is overlapping the main content instead of pushing it aside… the left edge of every element is cut off."

**Root cause:** the desktop rail is `position:fixed`, 72px collapsed, expanding to 280px on hover (or while a rail menu pins it open via `keepSidebarExpanded`). `<main>` only ever padded `104px` for the *collapsed* rail, so the expanded rail overlaid the content — reproduced on live prod at 1536×746 (Hammad's viewport): "POSTS", stat cards, and post titles all left-clipped on hover.

## Fix
An expanded rail now **pushes** the content instead of overlaying it:
- `aside` gains `peer/sidebar`; `<main>` animates `pl 104px → 312px` (16 edge + 280 rail + 16 gap) via `lg:peer-hover/sidebar:pl-[312px]` (hover) and the `keepSidebarExpanded` branch (pinned), with a `padding-left` transition mirroring the rail's 420ms width transition — the two move as one surface.
- **150ms hover-intent delay, mirrored on both surfaces** (`hover:delay-150` + `lg:peer-hover/sidebar:delay-150`): an incidental pointer graze over the rail moves nothing; collapse stays immediate. (Adversarial-review finding.)
- `lg:motion-reduce:transition-none`: reduced-motion users get the pushed layout without the 208px slide.

## Verification
- Reproduced pre-fix + previewed post-fix **rendered on live prod** via the headless QA sandbox (injected equivalent CSS → hover → everything visible, nothing clipped).
- **Compiled-CSS proof**: ran the real Tailwind v4 pipeline over the repo — all new utilities generate; the peer-hover rule is `:is(:where(.peer\/sidebar):hover ~ *)` under `lg` and cascades **after** `pl-[104px]` (order verified, aside precedes main as sibling).
- New string-golden regression test, **mutation-verified** (4/4 fail without the component change); pins both rail widths behind the 104/312 math, the mirrored delays, and the transition pairing.
- `npm run verify` green, typecheck green, adjacent sidebar regression tests green.
- 3-lens adversarial review (UX interaction / CSS-Tailwind / conventions): 3× approve; both should-fix findings addressed in-PR (hover-intent delay, test geometry gap).

## Known follow-up (not in scope)
Closing a pinned rail menu fires on `mousedown`, so content starts sliding before `mouseup` — a click straddling the collapse can miss its target. Reviewer judged it non-blocking (the overlay bug was strictly worse); fixing it means changing menu outside-close semantics, which deserves its own test pass.

Jira: AA-78

🤖 Generated with [Claude Code](https://claude.com/claude-code)