### PR TITLE
fix(marketing): schedule all crosspost platforms + terminal reddit publish errors

### DIFF
--- a/app/api/internal/publishing/scheduled-dispatch/route.ts
+++ b/app/api/internal/publishing/scheduled-dispatch/route.ts
@@ -168,6 +168,29 @@ export function planPostStatusUpdate(
   return anyRetryable ? null : 'failed';
 }
 
+// Derive the per-platform `retryable` flag from a caught publish error.
+//   - A MetaPublishError carries its own retryable flag (outcome-unknown video
+//     timeouts, auth, etc.).
+//   - Any other error that EXPLICITLY carries `retryable === false` (the
+//     IntegrationError family: a permanent Composio broker verdict such as a
+//     Reddit SUBREDDIT_NOEXIST, or a capability/guard error) is honored as
+//     terminal, so it self-terminates instead of the worker re-claiming and
+//     re-failing it every tick.
+//   - Everything else (a raw network throw, an unrecognized error) DEFAULTS TO
+//     RETRYABLE (fail-safe): only an explicit `false` buries a failure.
+export function deriveDispatchRetryable(error: unknown): boolean {
+  if (error instanceof MetaPublishError) return error.retryable;
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'retryable' in error &&
+    (error as { retryable?: unknown }).retryable === false
+  ) {
+    return false;
+  }
+  return true;
+}
+
 export async function POST(req: Request): Promise<Response> {
   const authResult = verifyInternalCallbackRequest(req);
   if (!authResult.ok) {
@@ -306,9 +329,7 @@ export async function POST(req: Request): Promise<Response> {
       const errMsg = error instanceof MetaPublishError
         ? `${error.code}: ${error.message}`
         : String((error as Error).message || error);
-      // A non-Meta error (e.g. a transient network throw) is treated as
-      // retryable; a MetaPublishError carries its own retryable flag.
-      const retryable = error instanceof MetaPublishError ? error.retryable : true;
+      const retryable = deriveDispatchRetryable(error);
       // Derive the failure taxonomy for surfacing only. A raw non-Meta throw is
       // 'permanent' per the classifier, but the route still treats it as
       // retryable above (network blips re-claim) — the two are independent.

--- a/backend/integrations/composio/composio-publisher-provider.ts
+++ b/backend/integrations/composio/composio-publisher-provider.ts
@@ -91,6 +91,30 @@ function redditTitleFromContent(content: string): string {
   return `${collapsed.slice(0, REDDIT_TITLE_MAX - 1)}…`;
 }
 
+/**
+ * Stable, permanent Reddit broker-error code tokens. A `successful:false`
+ * verdict whose error string contains one of these can ONLY ever fail the same
+ * way on a retry (the community does not exist / is not allowed / the post kind
+ * is forbidden), so the failure must self-terminate rather than have the standing
+ * worker re-claim and re-fail it every tick forever. Anything NOT matched here
+ * DEFAULTS TO RETRYABLE (fail-safe: an unrecognized/transient error is retried,
+ * never wrongly buried). Matched case-insensitively as a substring so the exact
+ * Reddit tuple wrapping (`[['SUBREDDIT_NOEXIST', "...", 'sr']]`) still classifies.
+ */
+const PERMANENT_REDDIT_ERROR_TOKENS = [
+  'SUBREDDIT_NOEXIST',
+  'SUBREDDIT_NOTALLOWED',
+  'SUBREDDIT_REQUIRED',
+  'NO_SELFS',
+  'NO_LINKS',
+] as const;
+
+function isPermanentBrokerError(error: string | null | undefined): boolean {
+  if (!error) return false;
+  const upper = error.toUpperCase();
+  return PERMANENT_REDDIT_ERROR_TOKENS.some((token) => upper.includes(token));
+}
+
 const LINKEDIN_COMMENTARY_MAX = 3000;
 
 /**
@@ -420,18 +444,22 @@ export class ComposioPublisherProvider implements PublisherProvider {
       // never-posted and the standing worker re-claims the row.
       //
       // Subreddit target (never guessed): an explicit
-      // COMPOSIO_REDDIT_TARGET_SUBREDDIT, else the connected user's own profile
-      // (`u_<username>` self-post), else refuse with a capability error.
-      let subreddit = redditTargetSubreddit();
-      if (!subreddit && conn.externalAccountName) {
-        subreddit = `u_${conn.externalAccountName}`;
-      }
-      if (!subreddit) {
+      // COMPOSIO_REDDIT_TARGET_SUBREDDIT is REQUIRED. There is NO `u_<username>`
+      // profile fallback — Reddit's `sr` field resolves COMMUNITY names only, so
+      // a user-profile target (`u_<name>` in any prefix form) is not addressable
+      // this way and deterministically fails with SUBREDDIT_NOEXIST. When the env
+      // is unset, refuse up-front with a capability error (never-posted AND
+      // non-retryable → fails terminal + clean, no retry-spam). Normalize the env
+      // value: strip a leading `r/` or `/r/` so the bare community name is sent
+      // (Reddit's `sr` wants the bare name, not the `r/` display prefix).
+      const rawSubreddit = redditTargetSubreddit();
+      if (!rawSubreddit) {
         throw new ComposioCapabilityMissingError(
           'reddit',
-          'configure a target subreddit (COMPOSIO_REDDIT_TARGET_SUBREDDIT) or reconnect Reddit',
+          'publish requires a target subreddit — set COMPOSIO_REDDIT_TARGET_SUBREDDIT to a community name',
         );
       }
+      const subreddit = rawSubreddit.replace(/^\/?r\//i, '');
 
       slug = this.requireSlug(input.platform, 'publish_post', 'publish posts');
       // Reddit returns a fullname id (`t3_<base36>`) at data.json.data.name — NOT
@@ -679,7 +707,16 @@ export class ComposioPublisherProvider implements PublisherProvider {
     });
 
     if (!result.successful) {
-      throw new ComposioToolError(slug, result.error ?? 'tool reported unsuccessful');
+      // Classify the broker verdict: a PERMANENT Reddit error code (e.g.
+      // SUBREDDIT_NOEXIST/NOTALLOWED) can only ever fail the same way, so mark it
+      // terminal (non-retryable) — the row fails clean instead of the worker
+      // re-claiming and re-failing it every tick. Scoped to reddit: the token
+      // list is Reddit's API vocabulary, and a generic-looking token appearing in
+      // another broker's error text must not bury a retryable post. Anything
+      // unrecognized defaults to retryable (fail-safe).
+      throw new ComposioToolError(slug, result.error ?? 'tool reported unsuccessful', {
+        terminal: input.platform === 'reddit' && isPermanentBrokerError(result.error),
+      });
     }
 
     return {

--- a/backend/integrations/composio/errors.ts
+++ b/backend/integrations/composio/errors.ts
@@ -51,10 +51,22 @@ export class ComposioCapabilityMissingError extends ComposioError {
   }
 }
 
-/** A Composio tool execution returned an error / unsuccessful result. */
+/**
+ * A Composio tool execution returned an error / unsuccessful result.
+ *
+ * Retryable by default (the standing worker re-claims the row): most broker
+ * `successful:false` verdicts are transient (rate-limit, gateway blip). Pass
+ * `{ terminal: true }` for a PERMANENT broker verdict (e.g. a Reddit
+ * `SUBREDDIT_NOEXIST` — the target community does not exist, so a retry can only
+ * ever fail the same way) so the failure self-terminates instead of the worker
+ * re-failing every tick forever. Still `publishNeverReachedPlatform` either way.
+ */
 export class ComposioToolError extends ComposioError {
-  constructor(slug: string, message: string) {
-    super('composio_tool_error', `Composio tool ${slug} failed: ${message}`, { status: 502, retryable: true });
+  constructor(slug: string, message: string, options?: { terminal?: boolean }) {
+    super('composio_tool_error', `Composio tool ${slug} failed: ${message}`, {
+      status: 502,
+      retryable: options?.terminal ? false : true,
+    });
     this.name = 'ComposioToolError';
   }
 }

--- a/backend/marketing/auto-schedule.ts
+++ b/backend/marketing/auto-schedule.ts
@@ -386,11 +386,17 @@ function formatTenantWallTime(
 //       ensures piece 1 always lands "today at the platform hour" even if now is
 //       a few minutes before that hour — never silently pushed ~7 days out.
 //
-// Layout: baseDate = max(now + 10min, campaignStart), then advanced by 1 day
-// if the earliest platform default hour on baseDate's calendar day is already
-// past (utc < now). piece k → baseDate + (k-1)d.
-// IG+FB of the same ordinal land on the same calendar day (different hours per
-// PLATFORM_POSTING_DEFAULTS). Pieces beyond campaignEnd are skipped + logged.
+// Layout: baseDate = max(now + 10min, campaignStart). Each (platform, surface)
+// pair gets a day shift of 0 or 1 decided ONCE from that pair's own platform
+// hour on baseDate's calendar day — 1 when the hour has already passed (utc <
+// windowStart), else 0 — and piece k → baseDate + (k-1+shift)d @ the pair's
+// hour. Deciding per pair (not globally from the earliest hour) means a run
+// whose `now` sits between two platform hours no longer drops the past-hour
+// platforms; applying the SAME shift to every ordinal of the pair preserves the
+// one-piece-per-day ladder (a per-row roll would land ordinal 1 and ordinal 2 on
+// the same instant). IG+FB of the same ordinal land on the same calendar day
+// (different hours per PLATFORM_POSTING_DEFAULTS). Pieces beyond campaignEnd
+// are skipped + logged.
 
 /**
  * One row for the default-cadence scheduler. Same shape as AutoScheduleInputRow
@@ -422,9 +428,13 @@ export interface ComputeDefaultCadenceSlotsInput {
  * `weekly_schedule[]`. Distributes posts one content-piece per day by ABSOLUTE
  * day offset — ordinal 1 always lands first regardless of the start weekday.
  *
- *   baseDate = max(now + 10min, campaignStart), advanced +1 day when the
- *             earliest platform default hour on that calendar day is already past
- *   piece k  → baseDate + (k - 1) calendar days @ platform default hour
+ *   baseDate = max(now + 10min, campaignStart)
+ *   shift    = per (platform, surface): 1 when that pair's platform hour on
+ *              baseDate's calendar day has already passed (utc < windowStart),
+ *              else 0 — earlier-hour platforms that can still post today stay
+ *              today; only the past-hour pairs advance, and every ordinal of a
+ *              pair shifts together so the one-piece-per-day ladder holds.
+ *   piece k  → baseDate + (k - 1 + shift) calendar days @ the pair's hour.
  *
  * Slots outside [campaignStart, campaignEnd] are collected into `skipped` with
  * `reason: overflow_beyond_window:<ordinal>`. Pure: no DB, no clock-as-side-
@@ -438,44 +448,23 @@ export function computeDefaultCadenceSlots(
   const windowEnd = input.campaignEnd;
 
   // baseDate: at least 10 minutes from now so the near-miss "platform hour is
-  // in a few minutes" case doesn't strand piece 1. Then check whether the
-  // earliest platform default hour across ALL input rows — at baseDate's
-  // calendar day — is already past (utc < windowStart). If so, advance
-  // baseDate by exactly 1 full day so piece 1 lands tomorrow instead of being
-  // silently dropped. One advance always suffices: tomorrow's platform hour is
-  // guaranteed to be in the future since platform hours are fixed within [0,24h)
-  // and tomorrow is always more than 24h from now-by-definition impossible to
-  // have already passed.
+  // in a few minutes" case doesn't strand piece 1. Each (platform, surface) pair
+  // then decides its day shift ONCE (below) from ITS OWN platform hour on
+  // baseDate's calendar day — not from a single global-min pre-scan. The old
+  // global pre-scan advanced the shared baseDate only when the EARLIEST platform
+  // hour was past — so when `windowStart` fell between two platform hours, the
+  // later-hour platforms whose hour had already passed on baseDate's day were
+  // left before `windowStart` and silently dropped as
+  // `derived_timestamp_outside_window` (live: a ~19:55Z run scheduled only
+  // facebook(13:00)/reddit(14:30) and dropped linkedin(9:30)/instagram(11:00)/
+  // x(12:30)). The shift is per PAIR, not per row: a per-row roll would land a
+  // rolled ordinal 1 and an unrolled ordinal 2 on the SAME instant (double-
+  // booking the platform); shifting every ordinal of the pair together keeps
+  // the one-piece-per-day ladder intact.
   const windowStart = input.campaignStart > now ? input.campaignStart : now;
 
   const tenMinutes = 10 * 60 * 1000;
-  let baseDate = new Date(Math.max(now.getTime() + tenMinutes, input.campaignStart.getTime()));
-
-  // Determine the minimum UTC slot time for ordinal-1 across all unique
-  // (platform, surface) combinations. If the earliest slot is before
-  // windowStart, advance baseDate by 1 day so piece 1 lands tomorrow.
-  {
-    const seenPairs = new Set<string>();
-    let minOrdinal1Utc: Date | null = null;
-    for (const row of input.rows) {
-      const pairKey = `${row.platform}:${row.surface ?? 'feed'}`;
-      if (seenPairs.has(pairKey)) continue;
-      seenPairs.add(pairKey);
-      const platformKey = row.platform.trim().toLowerCase() as AutoSchedulePlatform;
-      const surface: AutoScheduleSurface = row.surface ?? 'feed';
-      const defaults = pickSlotDefault(platformKey, surface);
-      if (!defaults) continue;
-      const wallIso = formatTenantWallTime(baseDate, tz, defaults);
-      const utc = wallTimeToUtc(wallIso, tz);
-      if (!utc) continue;
-      if (minOrdinal1Utc === null || utc < minOrdinal1Utc) {
-        minOrdinal1Utc = utc;
-      }
-    }
-    if (minOrdinal1Utc !== null && minOrdinal1Utc < windowStart) {
-      baseDate = new Date(baseDate.getTime() + 24 * 60 * 60 * 1000);
-    }
-  }
+  const baseDate = new Date(Math.max(now.getTime() + tenMinutes, input.campaignStart.getTime()));
 
   if (!(windowEnd > windowStart)) {
     return {
@@ -485,6 +474,27 @@ export function computeDefaultCadenceSlots(
         reason: 'campaign_window_closed_or_empty',
       })),
     };
+  }
+
+  // Per-(platform, surface) day shift: 1 when the pair's slot at baseDate's
+  // calendar day has already passed (utc < windowStart), else 0. One day always
+  // suffices — tomorrow's fixed platform hour is guaranteed to be ahead of
+  // windowStart. Pairs whose wall-time conversion fails here fall back to shift
+  // 0; the per-row conversion below hits the same failure and skips the row
+  // with a `wall_time_to_utc_failed` reason.
+  const pairShiftMs = new Map<string, number>();
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  for (const row of input.rows) {
+    const platformKey = row.platform.trim().toLowerCase() as AutoSchedulePlatform;
+    const surface: AutoScheduleSurface = row.surface ?? 'feed';
+    const pairKey = `${platformKey}:${surface}`;
+    if (pairShiftMs.has(pairKey)) continue;
+    const defaults = pickSlotDefault(platformKey, surface);
+    if (!defaults) continue;
+    const wallIso = formatTenantWallTime(baseDate, tz, defaults);
+    const utc = wallTimeToUtc(wallIso, tz);
+    if (!utc) continue;
+    pairShiftMs.set(pairKey, utc < windowStart ? oneDayMs : 0);
   }
 
   const slots: AutoScheduleSlot[] = [];
@@ -500,12 +510,20 @@ export function computeDefaultCadenceSlots(
       continue;
     }
 
-    // Piece k → baseDate + (k-1) calendar days. baseDate is already in UTC;
-    // formatTenantWallTime converts the UTC instant to the correct tenant-local
-    // calendar date so DST boundaries are handled correctly.
-    const dayOffset = (row.ordinal - 1) * 24 * 60 * 60 * 1000;
+    // Piece k → baseDate + (k-1) calendar days + the pair's shift. baseDate is
+    // already in UTC; formatTenantWallTime converts the UTC instant to the
+    // correct tenant-local calendar date so DST boundaries are handled correctly.
+    const dayOffset = (row.ordinal - 1) * oneDayMs + (pairShiftMs.get(`${platformKey}:${surface}`) ?? 0);
     const dayInstant = new Date(baseDate.getTime() + dayOffset);
 
+    const wallTimeIso = formatTenantWallTime(dayInstant, tz, defaults);
+    const utc = wallTimeToUtc(wallTimeIso, tz);
+    if (!utc) {
+      skipped.push({ row: { ...row, recommendedDay: null }, reason: `wall_time_to_utc_failed:${wallTimeIso}` });
+      continue;
+    }
+
+    // Overflow guard runs against the FINAL (shift-applied) instant.
     if (dayInstant > windowEnd) {
       skipped.push({
         row: { ...row, recommendedDay: null },
@@ -520,12 +538,9 @@ export function computeDefaultCadenceSlots(
       continue;
     }
 
-    const wallTimeIso = formatTenantWallTime(dayInstant, tz, defaults);
-    const utc = wallTimeToUtc(wallTimeIso, tz);
-    if (!utc) {
-      skipped.push({ row: { ...row, recommendedDay: null }, reason: `wall_time_to_utc_failed:${wallTimeIso}` });
-      continue;
-    }
+    // A row still before windowStart after the pair shift (or past windowEnd)
+    // is a genuine dead window — skip it (never emit a past-or-out-of-window
+    // slot).
     if (utc < windowStart || utc > windowEnd) {
       skipped.push({ row: { ...row, recommendedDay: null }, reason: `derived_timestamp_outside_window:${utc.toISOString()}` });
       continue;

--- a/tests/composio-reddit-publisher.test.ts
+++ b/tests/composio-reddit-publisher.test.ts
@@ -7,13 +7,18 @@
  *     with {subreddit, title, kind:'link', url}; externalPostId = t3_ name from
  *     nested json.data.name.
  *  2. Text-only post: kind='self', text=content (no url field).
- *  3. Subreddit resolution: env set → that subreddit; env unset + externalAccountName
- *     → u_<name>; both unset → ComposioCapabilityMissingError (never-posted).
+ *  3. Subreddit resolution: env REQUIRED (r//​/r/ prefix stripped to the bare
+ *     community name). Env unset → ComposioCapabilityMissingError (never-posted,
+ *     non-retryable); the old u_<username> profile fallback is REMOVED (#786 —
+ *     Reddit `sr` resolves community names only, so a profile target always
+ *     SUBREDDIT_NOEXISTs).
  *  4. Title derivation: multi-line → first non-empty line; >300 chars → truncated
  *     with ellipsis; empty content → 'New post'.
  *  5. Slug unset → ComposioCapabilityMissingError. Dry-run → no gateway calls.
  *     Not-approved → PublishGuardError. executeTool successful:false →
- *     ComposioToolError (never-posted).
+ *     ComposioToolError (never-posted); an unrecognized error stays retryable, a
+ *     PERMANENT Reddit token (SUBREDDIT_NOEXIST/NOTALLOWED/REQUIRED/NO_SELFS/
+ *     NO_LINKS) is non-retryable so it self-terminates (#786, no retry spam).
  *  6. normalizeTargetPlatforms: flag OFF → ['reddit'] returns null; flag ON →
  *     ['reddit'] accepted.
  *  7. Dispatch-guard predicate: isMetaProvider('reddit') false; combined guard
@@ -181,7 +186,7 @@ test('#641 Reddit image post: single REDDIT_CREATE_REDDIT_POST call with {subred
       assert.equal(call.slug, 'REDDIT_CREATE_REDDIT_POST', 'must call the reddit publish action slug');
 
       const args = call.options.arguments as Record<string, unknown>;
-      assert.equal(args.subreddit, 'r/testcommunity', 'subreddit must come from COMPOSIO_REDDIT_TARGET_SUBREDDIT');
+      assert.equal(args.subreddit, 'testcommunity', 'subreddit must come from COMPOSIO_REDDIT_TARGET_SUBREDDIT (r/ prefix stripped)');
       assert.equal(args.title, 'Hello', 'title must be the first non-empty line of content');
       assert.equal(args.kind, 'link', 'image post must use kind=link');
       assert.equal(args.url, 'https://img.example.com/photo.png', 'url must be the first mediaUrl');
@@ -233,7 +238,7 @@ test('#641 Reddit text-only post: kind=self, text=content, no url field', async 
       assert.equal(args.kind, 'self', 'text-only post must use kind=self');
       assert.equal(args.text, 'Just text, no image at all', 'text must be the full content');
       assert.equal(args.url, undefined, 'url must NOT be present for a text (self-kind) post');
-      assert.equal(args.subreddit, 'r/testcommunity');
+      assert.equal(args.subreddit, 'testcommunity');
       assert.equal(args.title, 'Just text, no image at all', 'title should be the first line');
 
       assert.equal(result.status, 'published');
@@ -268,12 +273,17 @@ test('#641 subreddit: env set → uses COMPOSIO_REDDIT_TARGET_SUBREDDIT', async 
       });
 
       const args = gateway.calls[0].options.arguments as Record<string, unknown>;
-      assert.equal(args.subreddit, 'r/mysubreddit', 'env value must take precedence over username fallback');
+      assert.equal(args.subreddit, 'mysubreddit', 'env value must take precedence (r/ prefix stripped)');
     },
   );
 });
 
-test('#641 subreddit: env unset + externalAccountName → u_<name>', async () => {
+test('#641 subreddit: env UNSET must throw ComposioCapabilityMissingError (no u_<name> fallback)', async () => {
+  // INVERTED: the old `u_<username>` profile fallback is REMOVED — Reddit's `sr`
+  // field resolves community names only, so a user-profile target is not
+  // addressable and deterministically fails SUBREDDIT_NOEXIST. Env-unset must now
+  // refuse up-front with a never-posted, non-retryable capability error — even
+  // when a connected externalAccountName is present.
   await withEnv(
     { COMPOSIO_REDDIT_TARGET_SUBREDDIT: undefined, ARIES_REDDIT_ENABLED: '1' },
     async () => {
@@ -286,25 +296,40 @@ test('#641 subreddit: env unset + externalAccountName → u_<name>', async () =>
         redditDb({ externalAccountName: 'someuser' }),
       );
 
-      await provider.publishPost({
-        tenantId,
-        platform: 'reddit',
-        content: 'profile post',
-        mediaUrls: [],
-        approved: true,
-      });
+      let caught: unknown;
+      try {
+        await provider.publishPost({
+          tenantId,
+          platform: 'reddit',
+          content: 'profile post',
+          mediaUrls: [],
+          approved: true,
+        });
+        assert.fail('expected rejection');
+      } catch (e) {
+        caught = e;
+      }
 
-      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
-      assert.equal(
-        args.subreddit,
-        'u_someuser',
-        'should fall back to u_<externalAccountName> when env is unset',
+      assert.ok(
+        caught instanceof ComposioCapabilityMissingError,
+        'env-unset subreddit must throw ComposioCapabilityMissingError (no u_<name> fallback)',
       );
+      assert.equal(
+        publishNeverReachedPlatform(caught),
+        true,
+        'subreddit-missing error must be classified as definitely-never-posted (safe rollback)',
+      );
+      assert.ok(
+        !(caught as { retryable?: boolean }).retryable,
+        'capability-missing must be non-retryable (terminal, no worker re-claim spam)',
+      );
+      // No executeTool call, and NO u_<name> was ever sent.
+      assert.equal(gateway.calls.length, 0, 'executeTool must not be called when subreddit is missing');
     },
   );
 });
 
-test('#641 subreddit: both unset → ComposioCapabilityMissingError AND publishNeverReachedPlatform=true', async () => {
+test('#641 subreddit: both env AND externalAccountName unset → ComposioCapabilityMissingError, never-posted, non-retryable', async () => {
   await withEnv(
     { COMPOSIO_REDDIT_TARGET_SUBREDDIT: undefined, ARIES_REDDIT_ENABLED: '1' },
     async () => {
@@ -338,8 +363,93 @@ test('#641 subreddit: both unset → ComposioCapabilityMissingError AND publishN
         true,
         'subreddit-missing error must be classified as definitely-never-posted (safe rollback)',
       );
+      assert.ok(
+        !(caught as { retryable?: boolean }).retryable,
+        'capability-missing must be non-retryable',
+      );
       // No executeTool call was made
       assert.equal(gateway.calls.length, 0, 'executeTool must not be called when subreddit is missing');
+    },
+  );
+});
+
+test('#641 subreddit: r/-prefixed env value is normalized to the bare community name', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/testcommunity', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_norm' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'normalize prefix',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(args.subreddit, 'testcommunity', 'leading r/ must be stripped before sending');
+    },
+  );
+});
+
+test('#641 subreddit: /r/-prefixed env value is normalized to the bare community name', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: '/r/testcommunity', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_norm2' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'normalize prefix 2',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(args.subreddit, 'testcommunity', 'leading /r/ must be stripped before sending');
+    },
+  );
+});
+
+test('#641 subreddit: a bare community name passes through unchanged', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'testcommunity', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      const gateway = makeRedditGateway({
+        defaultResult: { data: { json: { data: { name: 't3_bare' } } }, successful: true, error: null },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      await provider.publishPost({
+        tenantId,
+        platform: 'reddit',
+        content: 'bare name',
+        mediaUrls: [],
+        approved: true,
+      });
+
+      const args = gateway.calls[0].options.arguments as Record<string, unknown>;
+      assert.equal(args.subreddit, 'testcommunity', 'a bare name must not be altered');
     },
   );
 });
@@ -529,8 +639,9 @@ test('#641 Reddit executeTool successful:false → ComposioToolError (never-post
   await withEnv(
     { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
     async () => {
+      // A generic (unrecognized) failure string must stay RETRYABLE (fail-safe).
       const gateway = makeRedditGateway({
-        defaultResult: { data: null, successful: false, error: 'SUBREDDIT_NOEXIST' },
+        defaultResult: { data: null, successful: false, error: 'RATELIMIT: try again later' },
       });
       const provider = new ComposioPublisherProvider(
         gateway,
@@ -558,8 +669,100 @@ test('#641 Reddit executeTool successful:false → ComposioToolError (never-post
         true,
         'tool-unsuccessful must be classified as definitely-never-posted (safe to roll back)',
       );
+      assert.equal(
+        (caught as { retryable?: boolean }).retryable,
+        true,
+        'an unrecognized broker error must stay retryable (fail-safe: retried, never wrongly buried)',
+      );
     },
   );
+});
+
+test('#786 Reddit SUBREDDIT_NOEXIST verdict → ComposioToolError non-retryable + never-posted (self-terminates, no retry spam)', async () => {
+  await withEnv(
+    { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+    async () => {
+      // The exact wire shape Reddit returns through Composio: a nested tuple.
+      const gateway = makeRedditGateway({
+        defaultResult: {
+          data: null,
+          successful: false,
+          error: 'Reddit API error: [[\'SUBREDDIT_NOEXIST\', "Hmm, that community doesn\'t exist...", \'sr\']]',
+        },
+      });
+      const provider = new ComposioPublisherProvider(
+        gateway,
+        fakeConfig({ actions: REDDIT_ACTIONS }),
+        redditDb(),
+      );
+
+      let caught: unknown;
+      try {
+        await provider.publishPost({
+          tenantId,
+          platform: 'reddit',
+          content: 'fail permanently',
+          mediaUrls: [],
+          approved: true,
+        });
+        assert.fail('expected rejection');
+      } catch (e) {
+        caught = e;
+      }
+
+      assert.ok(caught instanceof ComposioToolError, 'permanent verdict must still be a ComposioToolError');
+      assert.equal(
+        (caught as { retryable?: boolean }).retryable,
+        false,
+        'a permanent Reddit error token must be classified non-retryable (terminal, no worker re-claim)',
+      );
+      assert.equal(
+        publishNeverReachedPlatform(caught),
+        true,
+        'a permanent broker verdict is still definitely-never-posted (safe rollback)',
+      );
+    },
+  );
+});
+
+test('#786 Reddit permanent tokens (NOTALLOWED/REQUIRED/NO_SELFS/NO_LINKS) all classify non-retryable', async () => {
+  const tokens = ['SUBREDDIT_NOTALLOWED', 'SUBREDDIT_REQUIRED', 'NO_SELFS', 'NO_LINKS'];
+  for (const token of tokens) {
+    await withEnv(
+      { COMPOSIO_REDDIT_TARGET_SUBREDDIT: 'r/test', ARIES_REDDIT_ENABLED: '1' },
+      async () => {
+        const gateway = makeRedditGateway({
+          defaultResult: { data: null, successful: false, error: `Reddit API error: [['${token}', 'msg', 'sr']]` },
+        });
+        const provider = new ComposioPublisherProvider(
+          gateway,
+          fakeConfig({ actions: REDDIT_ACTIONS }),
+          redditDb(),
+        );
+
+        let caught: unknown;
+        try {
+          await provider.publishPost({
+            tenantId,
+            platform: 'reddit',
+            content: 'fail',
+            mediaUrls: [],
+            approved: true,
+          });
+          assert.fail('expected rejection');
+        } catch (e) {
+          caught = e;
+        }
+
+        assert.ok(caught instanceof ComposioToolError, `${token} must throw ComposioToolError`);
+        assert.equal(
+          (caught as { retryable?: boolean }).retryable,
+          false,
+          `${token} must be non-retryable`,
+        );
+      },
+    );
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/marketing-auto-schedule.test.ts
+++ b/tests/marketing-auto-schedule.test.ts
@@ -85,6 +85,205 @@ for (const platform of ['x', 'linkedin', 'reddit'] as const) {
   });
 }
 
+// --- Default-cadence per-row roll-forward -------------------------------------
+// The default-cadence scheduler decided its "+1 day" advance from a global
+// pre-scan of only the MINIMUM ordinal-1 slot, then materialized each row at ITS
+// OWN platform hour. When `now`/windowStart fell BETWEEN two platform hours, the
+// later-hour platforms whose hour was already past were dropped as
+// `derived_timestamp_outside_window` (live: a ~19:55Z run scheduled only
+// facebook+reddit and dropped linkedin/instagram/x). The fix rolls each past-hour
+// row forward one day on its own; earlier-hour rows that can still post today stay.
+
+test('default-cadence: run past ALL platform hours schedules every platform (no drop)', () => {
+  // 2026-07-06 is EDT (UTC-4). Local feed hours in UTC on that day:
+  //   linkedin 9:30→13:30Z, instagram 11:00→15:00Z, x 12:30→16:30Z,
+  //   facebook 13:05→17:05Z, reddit 14:30→18:30Z.
+  // With now at 19:55Z, ALL five have already passed → every row must roll
+  // forward exactly one day, and none may be dropped.
+  const now = new Date('2026-07-06T19:55:00.000Z');
+  const campaignStart = new Date('2026-07-06T19:58:00.000Z'); // a few min in the future
+  const campaignEnd = new Date('2026-07-13T19:58:00.000Z'); // +7d
+  const platforms = ['facebook', 'instagram', 'x', 'linkedin', 'reddit'] as const;
+
+  const result = computeDefaultCadenceSlots({
+    rows: platforms.map((platform, i) => ({ postId: i + 1, platform, ordinal: 1 })),
+    tenantTimezone: TZ_NY,
+    campaignStart,
+    campaignEnd,
+    now,
+  });
+
+  assert.equal(result.skipped.length, 0, `skipped: ${JSON.stringify(result.skipped)}`);
+  assert.equal(result.slots.length, 5, 'all five platforms must be scheduled');
+  for (const platform of platforms) {
+    assert.ok(
+      result.slots.some((s) => s.platform === platform),
+      `platform ${platform} must be present (was silently dropped before the fix)`,
+    );
+  }
+  // Every rolled slot lands the next day and inside the window.
+  for (const slot of result.slots) {
+    assert.ok(slot.scheduledFor >= campaignStart, `${slot.platform} must be >= campaignStart`);
+    assert.ok(slot.scheduledFor <= campaignEnd, `${slot.platform} must be <= campaignEnd`);
+    // Rolled to 2026-07-07 (all July-6 platform hours were in the past).
+    assert.equal(
+      slot.scheduledFor.toISOString().slice(0, 10),
+      '2026-07-07',
+      `${slot.platform} must roll forward one day to 2026-07-07`,
+    );
+  }
+});
+
+test('default-cadence: run BEFORE all platform hours keeps every platform on the same day (no over-advance)', () => {
+  // now at 09:00Z (05:00 EDT) is before EVERY platform's local hour on 2026-07-06,
+  // so no row should be advanced — all land the SAME day, hour ordering preserved.
+  const now = new Date('2026-07-06T09:00:00.000Z');
+  const campaignStart = new Date('2026-07-06T00:00:00.000Z');
+  const campaignEnd = new Date('2026-07-13T23:59:59.000Z');
+  const platforms = ['facebook', 'instagram', 'x', 'linkedin', 'reddit'] as const;
+
+  const result = computeDefaultCadenceSlots({
+    rows: platforms.map((platform, i) => ({ postId: i + 1, platform, ordinal: 1 })),
+    tenantTimezone: TZ_NY,
+    campaignStart,
+    campaignEnd,
+    now,
+  });
+
+  assert.equal(result.skipped.length, 0, `skipped: ${JSON.stringify(result.skipped)}`);
+  assert.equal(result.slots.length, 5);
+  const dayOf = (d: Date) => d.toISOString().slice(0, 10);
+  for (const slot of result.slots) {
+    // No over-advancing: each slot stays on 2026-07-06 and is < 24h from now.
+    assert.equal(dayOf(slot.scheduledFor), '2026-07-06', `${slot.platform} must stay on today (no over-advance)`);
+    assert.ok(
+      slot.scheduledFor.getTime() - now.getTime() < 24 * 60 * 60 * 1000,
+      `${slot.platform} must be < 24h from now`,
+    );
+  }
+  // Per-platform hour ordering preserved: linkedin(9:30) < instagram(11:00) <
+  // x(12:30) < facebook(13:05) < reddit(14:30).
+  const byPlatform = new Map(result.slots.map((s) => [s.platform, s.scheduledFor.getTime()]));
+  assert.ok((byPlatform.get('linkedin') ?? 0) < (byPlatform.get('instagram') ?? 0), 'linkedin before instagram');
+  assert.ok((byPlatform.get('instagram') ?? 0) < (byPlatform.get('x') ?? 0), 'instagram before x');
+  assert.ok((byPlatform.get('x') ?? 0) < (byPlatform.get('facebook') ?? 0), 'x before facebook');
+  assert.ok((byPlatform.get('facebook') ?? 0) < (byPlatform.get('reddit') ?? 0), 'facebook before reddit');
+});
+
+test('default-cadence: a high-ordinal row beyond campaignEnd still skips with overflow_beyond_window', () => {
+  // ordinal 30 → baseDate + 29 days, well beyond a 7-day window → overflow skip.
+  const now = new Date('2026-07-06T09:00:00.000Z');
+  const campaignStart = new Date('2026-07-06T00:00:00.000Z');
+  const campaignEnd = new Date('2026-07-13T23:59:59.000Z');
+
+  const result = computeDefaultCadenceSlots({
+    rows: [{ postId: 1, platform: 'instagram', ordinal: 30 }],
+    tenantTimezone: TZ_NY,
+    campaignStart,
+    campaignEnd,
+    now,
+  });
+
+  assert.equal(result.slots.length, 0, 'the overflowing row must not be scheduled');
+  assert.equal(result.skipped.length, 1);
+  assert.match(
+    result.skipped[0].reason,
+    /^overflow_beyond_window:30$/,
+    `expected overflow_beyond_window:30, got ${result.skipped[0].reason}`,
+  );
+});
+
+test('default-cadence: multi-ordinal run past all hours keeps the one-per-day ladder (no same-instant collision)', () => {
+  // The roll-forward must shift EVERY ordinal of a (platform, surface) pair
+  // together. A per-row roll would advance only ordinal 1 (its slot passed) and
+  // leave ordinal 2 (tomorrow, still future) where it is — landing both on the
+  // SAME instant and double-booking the platform on day 1.
+  const now = new Date('2026-07-06T19:55:00.000Z'); // past all five platform hours
+  const campaignStart = new Date('2026-07-06T19:58:00.000Z');
+  const campaignEnd = new Date('2026-07-16T19:58:00.000Z'); // +10d
+  const platforms = ['facebook', 'instagram', 'x', 'linkedin', 'reddit'] as const;
+  const ordinals = [1, 2, 3] as const;
+
+  const result = computeDefaultCadenceSlots({
+    rows: platforms.flatMap((platform, p) =>
+      ordinals.map((ordinal) => ({ postId: p * 10 + ordinal, platform, ordinal })),
+    ),
+    tenantTimezone: TZ_NY,
+    campaignStart,
+    campaignEnd,
+    now,
+  });
+
+  assert.equal(result.skipped.length, 0, `skipped: ${JSON.stringify(result.skipped)}`);
+  assert.equal(result.slots.length, platforms.length * ordinals.length);
+  for (const platform of platforms) {
+    const times = result.slots
+      .filter((s) => s.platform === platform)
+      .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime())
+      .map((s) => s.scheduledFor);
+    assert.equal(times.length, ordinals.length, `${platform} must schedule every ordinal`);
+    assert.equal(
+      new Set(times.map((t) => t.getTime())).size,
+      ordinals.length,
+      `${platform} ordinals must not collide on the same instant`,
+    );
+    // All ordinals shifted together: day 1, 2, 3 (2026-07-07..09), exactly 24h apart.
+    for (let i = 0; i < times.length; i += 1) {
+      assert.equal(
+        times[i].toISOString().slice(0, 10),
+        `2026-07-0${7 + i}`,
+        `${platform} ordinal ${i + 1} must land on day ${i + 1} of the shifted ladder`,
+      );
+    }
+  }
+});
+
+test('default-cadence: run BETWEEN platform hours shifts only past-hour pairs, whole ladder per pair', () => {
+  // 15:30Z on 2026-07-06 is 11:30 EDT: linkedin(9:30) + instagram(11:00) have
+  // passed → their whole ladders shift +1 day; x(12:30)/facebook(13:05)/
+  // reddit(14:30) are still ahead → their ladders stay. Nothing is dropped
+  // (the live bug), and no pair double-books a day (the per-row-roll bug).
+  const now = new Date('2026-07-06T15:30:00.000Z');
+  const campaignStart = new Date('2026-07-06T00:00:00.000Z');
+  const campaignEnd = new Date('2026-07-16T23:59:59.000Z');
+  const platforms = ['facebook', 'instagram', 'x', 'linkedin', 'reddit'] as const;
+  const ordinals = [1, 2] as const;
+
+  const result = computeDefaultCadenceSlots({
+    rows: platforms.flatMap((platform, p) =>
+      ordinals.map((ordinal) => ({ postId: p * 10 + ordinal, platform, ordinal })),
+    ),
+    tenantTimezone: TZ_NY,
+    campaignStart,
+    campaignEnd,
+    now,
+  });
+
+  assert.equal(result.skipped.length, 0, `skipped: ${JSON.stringify(result.skipped)}`);
+  assert.equal(result.slots.length, platforms.length * ordinals.length);
+  const firstDay = (platform: string) =>
+    result.slots
+      .filter((s) => s.platform === platform)
+      .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime())[0]
+      .scheduledFor.toISOString()
+      .slice(0, 10);
+  // Past-hour pairs start tomorrow; still-ahead pairs start today.
+  assert.equal(firstDay('linkedin'), '2026-07-07', 'linkedin (9:30, passed) starts tomorrow');
+  assert.equal(firstDay('instagram'), '2026-07-07', 'instagram (11:00, passed) starts tomorrow');
+  assert.equal(firstDay('x'), '2026-07-06', 'x (12:30, ahead) stays today');
+  assert.equal(firstDay('facebook'), '2026-07-06', 'facebook (13:05, ahead) stays today');
+  assert.equal(firstDay('reddit'), '2026-07-06', 'reddit (14:30, ahead) stays today');
+  // Every pair keeps one-per-day spacing with no collisions.
+  for (const platform of platforms) {
+    const times = result.slots
+      .filter((s) => s.platform === platform)
+      .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime())
+      .map((s) => s.scheduledFor.getTime());
+    assert.equal(new Set(times).size, times.length, `${platform} must not double-book an instant`);
+    assert.equal(times[1] - times[0], 24 * 60 * 60 * 1000, `${platform} ordinals must sit exactly one day apart`);
+  }
+});
+
 // --- Per-platform timing ------------------------------------------------------
 
 test('Instagram post on Monday lands at 11:00 tenant-local', () => {

--- a/tests/scheduled-dispatch-post-status.test.ts
+++ b/tests/scheduled-dispatch-post-status.test.ts
@@ -1,7 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { planPostStatusUpdate } from '../app/api/internal/publishing/scheduled-dispatch/route';
+import {
+  planPostStatusUpdate,
+  deriveDispatchRetryable,
+} from '../app/api/internal/publishing/scheduled-dispatch/route';
+import { MetaPublishError } from '../backend/integrations/meta-publishing';
+import {
+  ComposioToolError,
+  ComposioCapabilityMissingError,
+} from '../backend/integrations/composio/errors';
 
 // F3 regression: a cross-post dispatches to several platforms independently.
 // The route used to write posts.published_status per-platform, so a
@@ -59,4 +67,82 @@ test('single-platform success => published', () => {
 
 test('single-platform terminal failure => failed', () => {
   assert.equal(planPostStatusUpdate([{ ok: false, retryable: false }]), 'failed');
+});
+
+// --- deriveDispatchRetryable ---------------------------------------------------
+// The route used to hardcode `retryable = true` for every non-Meta throw, so a
+// permanent Composio broker verdict (Reddit SUBREDDIT_NOEXIST with no target
+// subreddit configured) kept dispatch_status='pending' and the standing worker
+// re-claimed + re-failed the row every 60s tick forever. The derivation honors
+// an EXPLICIT `retryable === false` on any error (the IntegrationError family)
+// as terminal; everything unrecognized stays retryable (fail-safe).
+
+test('deriveDispatchRetryable: MetaPublishError carries its own retryable flag', () => {
+  assert.equal(
+    deriveDispatchRetryable(new MetaPublishError('rate_limited', 'try later', { retryable: true })),
+    true,
+  );
+  assert.equal(
+    deriveDispatchRetryable(new MetaPublishError('bad_media', 'unsupported image', { retryable: false })),
+    false,
+  );
+});
+
+test('deriveDispatchRetryable: outcome-unknown MetaPublishError is never retried (duplicate-post guard)', () => {
+  const outcomeUnknown = new MetaPublishError('publish_unconfirmed', 'accepted but no post id', {
+    retryable: false,
+    outcomeUnknown: true,
+  });
+  assert.equal(
+    deriveDispatchRetryable(outcomeUnknown),
+    false,
+    'a publish that MAY be live must not auto-retry — a retry of a secret success is a duplicate post',
+  );
+});
+
+test('deriveDispatchRetryable: default ComposioToolError (transient broker verdict) stays retryable', () => {
+  assert.equal(
+    deriveDispatchRetryable(new ComposioToolError('REDDIT_CREATE_REDDIT_POST', 'gateway blip')),
+    true,
+    'a non-terminal broker verdict is re-claimed by the worker next tick',
+  );
+});
+
+test('deriveDispatchRetryable: terminal ComposioToolError (SUBREDDIT_NOEXIST) self-terminates', () => {
+  const terminal = new ComposioToolError(
+    'REDDIT_CREATE_REDDIT_POST',
+    "[['SUBREDDIT_NOEXIST', 'that community does not exist', 'sr']]",
+    { terminal: true },
+  );
+  assert.equal(
+    deriveDispatchRetryable(terminal),
+    false,
+    'a permanent broker verdict must fail terminal — not retry-spam every worker tick',
+  );
+});
+
+test('deriveDispatchRetryable: ComposioCapabilityMissingError (no target subreddit) is terminal', () => {
+  assert.equal(
+    deriveDispatchRetryable(new ComposioCapabilityMissingError('reddit', 'publish without a target subreddit')),
+    false,
+    'capability-missing inherits retryable=false — retrying without config can only fail the same way',
+  );
+});
+
+test('deriveDispatchRetryable: unrecognized errors default to retryable (fail-safe)', () => {
+  assert.equal(deriveDispatchRetryable(new Error('ECONNRESET')), true, 'a raw network throw is retried');
+  assert.equal(deriveDispatchRetryable('string throw'), true);
+  assert.equal(deriveDispatchRetryable(null), true);
+  assert.equal(deriveDispatchRetryable(undefined), true);
+});
+
+test('deriveDispatchRetryable: only an explicit boolean false buries a failure', () => {
+  assert.equal(
+    deriveDispatchRetryable({ retryable: 'false' }),
+    true,
+    'a non-boolean retryable value must NOT be honored as terminal',
+  );
+  assert.equal(deriveDispatchRetryable({ retryable: undefined }), true);
+  assert.equal(deriveDispatchRetryable({ retryable: 0 }), true);
+  assert.equal(deriveDispatchRetryable({ retryable: false }), false, 'an explicit false is honored');
 });


### PR DESCRIPTION
## Summary

Fixes the two delivery bugs that forced `ARIES_WEEKLY_CROSSPOST_ENABLED` back to `0` in prod after live verification of the crosspost fan-out (#769, #786). Synthesis was proven correct for all 5 platforms; delivery broke in two independent places.

### 1. Scheduler dropped every platform whose posting hour had already passed

`computeDefaultCadenceSlots` advanced its shared `baseDate` by one day only when the **earliest** platform default hour was already past, but materialized each row at its **own** platform hour. A run landing between two platform hours left the later past-hour platforms before `windowStart`, silently skipped as `derived_timestamp_outside_window`.

**Live evidence:** a ~19:55Z run scheduled only facebook + reddit; instagram/linkedin/x got no `scheduled_posts` rows at all.

**Fix:** each `(platform, surface)` pair decides a 0/1-day shift **once** from its own hour on baseDate's calendar day and applies it to every ordinal of the pair. Past-hour platforms start tomorrow, still-ahead platforms stay today, and the one-piece-per-day ladder is preserved. (A naive per-row roll was rejected in adversarial review: it lands a rolled ordinal 1 on ordinal 2's exact instant, double-booking the platform — regression-tested.)

### 2. Reddit publish failure retry-spammed the worker every 60s

With no `COMPOSIO_REDDIT_TARGET_SUBREDDIT`, the publisher fell back to a `u_<username>` profile target, which Reddit's `sr` field cannot resolve → deterministic `SUBREDDIT_NOEXIST`. The dispatch route hardcoded every non-Meta throw as retryable, so `dispatch_status` stayed `pending` and the standing worker re-claimed + re-failed the row every tick forever.

**Fix:**
- The `u_` fallback is removed: env-unset refuses up-front with a terminal `ComposioCapabilityMissingError` (never-posted, no Graph/broker call, no retry).
- The env value is normalized (leading `r/` / `/r/` stripped).
- Permanent Reddit broker verdicts (`SUBREDDIT_NOEXIST`/`NOTALLOWED`/`REQUIRED`/`NO_SELFS`/`NO_LINKS`) throw a terminal `ComposioToolError` — scoped to reddit so a generic-looking token in another broker's error can't bury a retryable post.
- New `deriveDispatchRetryable` in the dispatch route honors an explicit `retryable === false` from any error family (only a boolean `false` counts); everything unrecognized stays retryable (fail-safe), and the Meta outcome-unknown duplicate-post guard is untouched.

## Tests

- `tests/marketing-auto-schedule.test.ts`: all-hours-passed (no drop), before-all-hours (no over-advance), **multi-ordinal ladder with no same-instant collision**, mixed between-hours shift, ordinal overflow.
- `tests/composio-reddit-publisher.test.ts`: env-unset → terminal capability error (never-posted, non-retryable), `r/`-prefix normalization, `SUBREDDIT_NOEXIST` → terminal + never-posted, all permanent tokens, unrecognized broker error stays retryable.
- `tests/scheduled-dispatch-post-status.test.ts`: full `deriveDispatchRetryable` matrix (Meta flags, outcome-unknown, Composio default/terminal, capability-missing, fail-safe defaults, boolean-false-only).

## Gates

- `npm run verify` ✓
- `npm run validate:social-content` ✓ (90/90)
- `npm run test:concurrent` ✓ (exit 0)
- `npm run lint` (typecheck + banned patterns) ✓
- `npm run guardrails:agent` ✓

## Rollout

Code-only; no schema or env-var changes. Re-enabling `ARIES_WEEKLY_CROSSPOST_ENABLED=1` in prod stays a separate manual step and **requires a real `COMPOSIO_REDDIT_TARGET_SUBREDDIT` first** (reddit publish now refuses cleanly without it instead of retry-spamming), followed by the bounded one-off live re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)