### PR TITLE
S1-4/AA-83: connect-gate returns retryable error state on DB failure instead of not_connected

### DIFF
--- a/backend/insights/narrative/handler.ts
+++ b/backend/insights/narrative/handler.ts
@@ -31,7 +31,9 @@ function isValidPeriod(p: string | null): p is NarrativePeriod {
   return p != null && VALID_PERIODS.has(p);
 }
 
-async function isPlatformConnected(platform: string, tenantId: string): Promise<boolean> {
+type PlatformConnectionState = 'connected' | 'not_connected' | 'error';
+
+async function checkPlatformConnection(platform: string, tenantId: string): Promise<PlatformConnectionState> {
   try {
     // A platform counts as "connected" for the hero when EITHER there is a live
     // connection for it (connected_accounts, the Composio source of truth) OR we
@@ -51,9 +53,15 @@ async function isPlatformConnected(platform: string, tenantId: string): Promise<
        ) AS connected`,
       [Number(tenantId), platform],
     );
-    return res.rows[0]?.connected === true;
-  } catch {
-    return false;
+    return res.rows[0]?.connected === true ? 'connected' : 'not_connected';
+  } catch (err) {
+    // A DB/query failure is NOT a "not connected" signal. Surfacing it as such
+    // makes the UI say "connect <platform>" during a backend outage (S1-4/AA-83).
+    // Return a distinct error state so the caller can respond retryably.
+    console.error('[insights/narrative] platform connection check failed', {
+      platform, tenantId, error: err instanceof Error ? err.message : String(err),
+    });
+    return 'error';
   }
 }
 
@@ -147,8 +155,16 @@ export async function handleGetInsightsNarrative(
 
   // ── Connection check (skip for 'all') ────────────────────────────────────
   if (platform !== 'all' && isSupportedPlatform(platform)) {
-    const connected = await isPlatformConnected(platform, tenantIdStr);
-    if (!connected) {
+    const connection = await checkPlatformConnection(platform, tenantIdStr);
+    if (connection === 'error') {
+      // Retryable backend error — NOT a connect prompt. 503 so the client shows
+      // its retry state instead of "connect <platform>" (S1-4/AA-83).
+      return NextResponse.json(
+        { status: 'error', error: 'connection_check_failed', retryable: true, platform },
+        { status: 503 },
+      );
+    }
+    if (connection === 'not_connected') {
       return NextResponse.json({
         status:      'not_connected',
         platform,

--- a/tests/insights-narrative-connection-error.test.ts
+++ b/tests/insights-narrative-connection-error.test.ts
@@ -1,0 +1,51 @@
+/**
+ * tests/insights-narrative-connection-error.test.ts
+ *
+ * Regression for S1-4 / AA-83: the narrative hero connect-gate must NOT report a
+ * DB/query failure as "not_connected" (which makes the UI say "connect
+ * <platform>" during a backend outage). A thrown connection-check query must
+ * surface a distinct, retryable error state (HTTP 503), while a genuine miss
+ * still returns not_connected (200).
+ *
+ * Drives the real handler with a stub tenant loader (no session) and monkey-
+ * patches the shared pg pool's `query` so no live DB is required.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import pool from '../lib/db';
+import { handleGetInsightsNarrative } from '../backend/insights/narrative/handler';
+
+const loader = async () =>
+  ({ tenantId: '1', tenantSlug: 'insights-demo', role: 'tenant_admin', userId: '1' }) as any;
+
+const req = (platform: string) =>
+  new Request(`https://x.test/api/insights/narrative?period=90day&platform=${platform}`);
+
+test('DB error during the connection check → 503 retryable error, NOT not_connected (S1-4/AA-83)', async () => {
+  const original = pool.query;
+  (pool as any).query = async () => { throw new Error('simulated DB outage'); };
+  try {
+    const res = await handleGetInsightsNarrative(req('facebook'), loader as any);
+    const body: any = await res.json();
+    assert.equal(res.status, 503, 'a backend/DB error must be a 503, not a 200');
+    assert.equal(body.status, 'error');
+    assert.equal(body.retryable, true);
+    assert.notEqual(body.status, 'not_connected', 'a DB error must not masquerade as not_connected');
+  } finally {
+    (pool as any).query = original;
+  }
+});
+
+test('genuinely unconnected platform still returns not_connected (200)', async () => {
+  const original = pool.query;
+  (pool as any).query = async () => ({ rows: [{ connected: false }] }) as any;
+  try {
+    const res = await handleGetInsightsNarrative(req('facebook'), loader as any);
+    const body: any = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.status, 'not_connected');
+    assert.equal(body.connect_url, '/integrations');
+  } finally {
+    (pool as any).query = original;
+  }
+});


### PR DESCRIPTION
Closes S1-4 / AA-83.

## Problem
The narrative hero connect-gate swallowed a thrown connection-check query as `not_connected` (`catch { return false }`). A DB/backend outage therefore rendered **"connect Facebook"** — a misleading connect prompt during a backend failure, even for an already-connected account.

## Acceptance criterion (from the ticket)
> A DB outage renders a **retryable error state** (not `not_connected`).

## Fix
Replace the boolean check with a tri-state `checkPlatformConnection()` distinguishing all three cases:
- **connected** → proceed to build the narrative
- **not_connected** → `200 { status: 'not_connected', connect_url }` (connect prompt — unchanged)
- **error** → `503 { status: 'error', retryable: true }` (the DB error is logged; a distinct, retryable state)

`useInsight` already turns any non-200 into a retryable `ErrorState` (Retry button), while a 200 `not_connected` renders the connect prompt — so a DB outage now surfaces **Retry**, not "connect". No frontend change required.

## Relationship to the earlier "connected account shows connect" fix
Same function, **different failure mode**. The earlier fix changed *what* the gate queries (legacy `oauthStatusAsync` → `connected_accounts` + insights-data `EXISTS`), fixing a false negative. It kept `catch → false`, so it never addressed error-swallowing. S1-4 is that remaining defect — now resolved.

## No TEMPLATE_VERSION bump needed
The gate runs **before** the cache read/write (`pool.connect()` / `getCachedNarrative`) and never touches the narrative body builder or template (`buildNarrativeSnapshot` / `buildNarrativeText`). Its `not_connected` / `error` responses are returned early and are never cached — so there is no stale cached body to invalidate. (Contrast the goal/activity/top tickets, where the body changed and versions were bumped.)

## Testing (fails-before / passes-after)
New `tests/insights-narrative-connection-error.test.ts` monkey-patches the pg pool's `query`:
- **DB throw → asserts 503 + `status:'error'` + `retryable:true`, and `≠ not_connected`.** Verified this **fails against the old `catch → false` code** (it returned `200 not_connected`) and **passes with the fix**.
- Genuine miss (`connected:false`) → still `200 not_connected`.

`npm run verify` passes; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)