### PR TITLE
fix(shell): close rail-pinning menus on click, not mousedown (AA-78 follow-up)

### DIFF
--- a/components/redesign/layout/app-shell-client.tsx
+++ b/components/redesign/layout/app-shell-client.tsx
@@ -175,10 +175,20 @@ export default function AppShellClient({
       }
     }
 
-    document.addEventListener('mousedown', handleClickOutside);
+    // 'click', not 'mousedown': closing the account menu un-pins the rail
+    // (keepSidebarExpanded) and slides <main> 312->104px. On mousedown that
+    // slide started BEFORE mouseup, so a click aimed at content could straddle
+    // the moving target and never fire (AA-78 follow-up). On click, the aimed
+    // click completes first; the collapse starts after. (The mobile-drawer leg
+    // moves no content; it shares the event type so there is one close model.)
+    // NOTE: the drawer's hamburger trigger sits OUTSIDE mobileMenuRef, so the
+    // opening click not self-closing relies on React 18+ deferring the discrete
+    // state flush past this native dispatch — the drawer isn't mounted (ref
+    // null) when this listener sees that click.
+    document.addEventListener('click', handleClickOutside);
     document.addEventListener('keydown', handleKeyDown);
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, []);

--- a/components/redesign/layout/workspace-switcher.tsx
+++ b/components/redesign/layout/workspace-switcher.tsx
@@ -177,16 +177,19 @@ export default function WorkspaceSwitcher({
     }
   }, [open]);
 
-  // Close on outside pointer down.
+  // Close on outside click — 'click', not 'mousedown': this menu pins the rail
+  // expanded (keepSidebarExpanded), and a mousedown-close starts the 312->104px
+  // content slide before mouseup, so the click the user aimed at content could
+  // straddle the moving target and never fire (AA-78 follow-up).
   useEffect(() => {
     if (!open) return;
-    function onPointerDown(event: MouseEvent) {
+    function onOutsideClick(event: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
         onOpenChange(false);
       }
     }
-    document.addEventListener('mousedown', onPointerDown);
-    return () => document.removeEventListener('mousedown', onPointerDown);
+    document.addEventListener('click', onOutsideClick);
+    return () => document.removeEventListener('click', onOutsideClick);
   }, [open, onOpenChange]);
 
   const announce = useCallback((message: string) => setAnnouncement(message), []);

--- a/tests/app-shell-sidebar-push.regression-aa78.test.ts
+++ b/tests/app-shell-sidebar-push.regression-aa78.test.ts
@@ -49,6 +49,22 @@ test('push geometry and timing mirror the rail itself (AA-78)', () => {
   assert.match(shell, /lg:transition-\[padding-left\] lg:duration-\[420ms\]/);
 });
 
+test('rail-pinning menus close on click, never mousedown (AA-78 follow-up)', () => {
+  // Closing the account menu or the workspace switcher un-pins the rail
+  // (keepSidebarExpanded) and slides <main> 312->104px. A mousedown-close
+  // starts that slide BEFORE mouseup, so the click the user aimed at content
+  // straddles a moving target and never fires. Both outside-close listeners
+  // must therefore be 'click' (fires after the aimed click completes).
+  const switcher = readFileSync(
+    path.join(PROJECT_ROOT, 'components', 'redesign', 'layout', 'workspace-switcher.tsx'),
+    'utf8',
+  );
+  assert.match(shell, /document\.addEventListener\('click', handleClickOutside\)/);
+  assert.match(switcher, /document\.addEventListener\('click', onOutsideClick\)/);
+  assert.doesNotMatch(shell, /addEventListener\('mousedown'/);
+  assert.doesNotMatch(switcher, /addEventListener\('mousedown'/);
+});
+
 test('hover-intent delay is mirrored on rail and main (AA-78)', () => {
   // 150ms expansion delay: an incidental pointer graze over the rail moves
   // nothing. The delay must exist on BOTH the rail width (hover:) and the main

--- a/tests/sidebar-account-menu-escape.regression-012.test.ts
+++ b/tests/sidebar-account-menu-escape.regression-012.test.ts
@@ -20,10 +20,13 @@ test('desktop sidebar account menu keeps click-outside close behavior', () => {
   assert.match(
     appShellSource,
     /if \(accountMenuRef\.current && !accountMenuRef\.current\.contains\(event\.target as Node\)\) \{\s*setIsAccountMenuOpen\(false\);\s*\}/,
-    'account menu should still close when a mousedown lands outside accountMenuRef',
+    'account menu should still close when a click lands outside accountMenuRef',
   );
-  assert.match(appShellSource, /document\.addEventListener\('mousedown', handleClickOutside\);/);
-  assert.match(appShellSource, /document\.removeEventListener\('mousedown', handleClickOutside\);/);
+  // 'click', NOT 'mousedown': closing un-pins the rail and slides the content,
+  // so a mousedown-close starts the slide before mouseup and swallows the click
+  // the user aimed at content (AA-78 follow-up).
+  assert.match(appShellSource, /document\.addEventListener\('click', handleClickOutside\);/);
+  assert.match(appShellSource, /document\.removeEventListener\('click', handleClickOutside\);/);
 });
 
 test('desktop sidebar account menu closes on Escape via a document keydown handler', () => {


### PR DESCRIPTION
## Summary
Follow-up flagged in #787's review: closing the account menu (or workspace switcher) un-pins the sidebar rail, which now slides `<main>` 312→104px. Both outside-close listeners fired on **`mousedown`**, so the slide started *before* `mouseup` — a click aimed at content could straddle the moving target, and the browser fires no click at all (the aimed button silently does nothing; user has to click twice).

## Fix
`document` outside-close listeners in `app-shell-client.tsx` (account menu + mobile drawer) and `workspace-switcher.tsx` moved from `mousedown` to **`click`**: the aimed click completes first (its action runs *and* the menu closes), then the collapse animates. Escape handling unchanged.

Accepted behavior deltas (called out in the commit): right-click no longer dismisses the menus; a drag gesture no longer dismisses at drag *start* — which is itself a win, since the old behavior slid the layout under the pointer mid-drag (same moving-target class as AA-78).

## Verification
- 2-skeptic adversarial review (event semantics / repo interactions): **both approve, zero blockers.** Key confirmations: the switcher cannot self-close on its opening click (listener attaches after dispatch); the mobile-drawer open path was verified against react-dom 19's deferred discrete flush and the timing dependency is now pinned in a comment; content `stopPropagation()` (post-workspace buttons) cannot suppress a same-node document listener, so menus can't get stuck open; no test or QA script anywhere dispatches raw `mousedown` to close these menus.
- New regression test bans `addEventListener('mousedown'` in both files and pins the `click` listeners; `sidebar-account-menu-escape.regression-012` re-pinned to the new contract.
- Focused tests 8/8, `npm run verify` green, typecheck green, guardrails passed.

Jira: AA-78 (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)