### PR TITLE
S1-1/AA-80: fix Attention CTA /conversations 404 → /dashboard/comments

### DIFF
--- a/backend/insights/attention/attention-card-builder.ts
+++ b/backend/insights/attention/attention-card-builder.ts
@@ -73,7 +73,7 @@ function buildUnrepliedCard(snap: AttentionSnapshot): AttentionCard {
     icon:   'message-circle',
     title:  `<em>${unreplied} comment${unreplied === 1 ? '' : 's'}</em> waiting for your reply`,
     body,
-    ctaPrimary:   { label: 'Open Conversations', href: '/conversations' },
+    ctaPrimary:   { label: 'Open Conversations', href: '/dashboard/comments' },
     ctaSecondary: { label: 'Mark as read', toast: 'Marked as read' },
   };
 }

--- a/backend/insights/attention/handler.ts
+++ b/backend/insights/attention/handler.ts
@@ -16,7 +16,9 @@ import { buildAttentionCards } from './attention-card-builder';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 import crypto from 'crypto';
 
-const TEMPLATE_VERSION = 'attention-v1';
+// v2: fix the unreplied-card CTA link (/conversations 404 → /dashboard/comments,
+// S1-1/AA-80). Bump regenerates cached attention snapshots holding the bad link.
+const TEMPLATE_VERSION = 'attention-v2';
 const CACHE_TTL_MS     = 15 * 60 * 1000; // 15 minutes
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/tests/insights-attention-cta-link.test.ts
+++ b/tests/insights-attention-cta-link.test.ts
@@ -1,0 +1,29 @@
+/**
+ * tests/insights-attention-cta-link.test.ts
+ *
+ * Regression for S1-1 / AA-80: the Attention "NEEDS REPLY" card's primary CTA
+ * must link to the real comments workspace (/dashboard/comments), NOT the
+ * non-existent /conversations route (which 404s). Pure builder assertion — no DB.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAttentionCards } from '../backend/insights/attention/attention-card-builder';
+import type { AttentionSnapshot } from '../backend/insights/attention/attention-snapshot-builder';
+
+const unrepliedSnapshot: AttentionSnapshot = {
+  unreplied: 3,
+  unrepliedLeads: 1,
+  unrepliedQuestions: 1,
+  highPerformer: null,
+  pattern: null,
+  milestone: null,
+  postCount: 5,
+};
+
+test('unreplied card CTA links to /dashboard/comments, not the 404 /conversations (S1-1/AA-80)', () => {
+  const cards = buildAttentionCards(unrepliedSnapshot, 'all', '90day');
+  const card = cards.find((c) => c.type === 'unreplied');
+  assert.ok(card, 'expected an unreplied attention card when unreplied > 0');
+  assert.equal(card.ctaPrimary?.href, '/dashboard/comments');
+  assert.notEqual(card.ctaPrimary?.href, '/conversations');
+});


### PR DESCRIPTION
Closes S1-1 / AA-80. (Gap A3 in docs/plans/2026-07-07-analytics-page-roadmap.md, PR #789.)

## Problem
The Attention section's "NEEDS REPLY" card had a primary CTA "Open Conversations" linking to **`/conversations`** — a route that does not exist, so clicking it **404s**. The real comments workspace is `/dashboard/comments` (`app/dashboard/comments/page.tsx`).

## Acceptance criteria
- **(a) No 404 from the attention card** — CTA now links to `/dashboard/comments` (an existing route). ✅
- **(b) TEMPLATE_VERSION bump so the cached Attention snapshot regenerates** — the card is cached in `insights_narratives` (validated against `TEMPLATE_VERSION`), so **`attention-v1` → `attention-v2`**; without it the corrected link wouldn't surface until the cache TTL expired. ✅

## Fix
- `attention-card-builder.ts`: `href: '/conversations'` → `href: '/dashboard/comments'`.
- `attention/handler.ts`: `TEMPLATE_VERSION 'attention-v1' → 'attention-v2'`.

## Scope check — nothing else links to the 404
Grepped `backend/ frontend/ app/ components/`. The only navigation link to `/conversations` was this card. Other matches are the `/api/insights/conversations` **API endpoint** (exists) and narrative prose ("Head to Conversations to respond") — neither is a broken link.

## Testing (fails-before / passes-after)
New `tests/insights-attention-cta-link.test.ts` asserts the unreplied card's `ctaPrimary.href === '/dashboard/comments'` (and `!== '/conversations'`). Verified it **fails against the old `/conversations` link** and **passes with the fix**. `npm run verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)