### PR TITLE
S1-2/AA-81: escape untrusted post title in insights HTML sinks (stored XSS)

### DIFF
--- a/backend/insights/attention/attention-card-builder.ts
+++ b/backend/insights/attention/attention-card-builder.ts
@@ -12,6 +12,7 @@
 
 import type { AttentionSnapshot, ContentPattern } from './attention-snapshot-builder';
 import { fmtMilestone } from './attention-snapshot-builder';
+import { escapeHtml } from '../escape-html';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 
 export type CardTone = 'urgent' | 'positive' | 'celebrate' | 'neutral';
@@ -89,7 +90,10 @@ function buildOpportunityCard(snap: AttentionSnapshot): AttentionCard {
     tone:   'positive',
     badge:  'OPPORTUNITY',
     icon:   'trending-up',
-    title:  `Your <em>"${hp.title}"</em> hit ${hp.multiplier}x your ${platLabel} average`,
+    // hp.title is insights_posts.title — an attacker-controllable platform post
+    // title. Escape before interpolating into this dangerouslySetInnerHTML
+    // string (stored XSS, S1-2/AA-81); the <em> emphasis still renders.
+    title:  `Your <em>"${escapeHtml(hp.title)}"</em> hit ${hp.multiplier}x your ${platLabel} average`,
     body:   'Aries can put $50–$200 behind it as a paid ad to extend reach to similar audiences.',
     ctaPrimary:   { label: 'Promote as ad', href: '/campaigns' },
     ctaSecondary: { label: 'View details',  toast: 'Post details available in Top Performing Content below' },

--- a/backend/insights/attention/handler.ts
+++ b/backend/insights/attention/handler.ts
@@ -18,7 +18,9 @@ import crypto from 'crypto';
 
 // v2: fix the unreplied-card CTA link (/conversations 404 → /dashboard/comments,
 // S1-1/AA-80). Bump regenerates cached attention snapshots holding the bad link.
-const TEMPLATE_VERSION = 'attention-v2';
+// v3: escape the untrusted post title in the opportunity-card HTML (stored XSS,
+// S1-2/AA-81). Bump flushes cached cards holding the unescaped title.
+const TEMPLATE_VERSION = 'attention-v3';
 const CACHE_TTL_MS     = 15 * 60 * 1000; // 15 minutes
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/escape-html.ts
+++ b/backend/insights/escape-html.ts
@@ -1,0 +1,21 @@
+/**
+ * backend/insights/escape-html.ts
+ *
+ * Escape a string for safe interpolation into an HTML string that is later
+ * rendered via `dangerouslySetInnerHTML` in the insights UI. The insights cards
+ * legitimately inject app-controlled markup (e.g. <em>, <strong>, <span
+ * class>), so those strings can't be plain-text-rendered — but any UNTRUSTED
+ * value interpolated into them (notably insights_posts.title, which can be an
+ * attacker-controlled platform post/video title) must be escaped first, or it
+ * becomes stored XSS (S1-2 / AA-81).
+ *
+ * Coerces null/undefined to '' so callers don't render the literal "null".
+ */
+export function escapeHtml(value: string | null | undefined): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/backend/insights/top/top-template-builder.ts
+++ b/backend/insights/top/top-template-builder.ts
@@ -7,6 +7,7 @@
 
 import type { TopPost, TopSnapshot } from './top-snapshot-builder';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
+import { escapeHtml } from '../escape-html';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -140,11 +141,11 @@ export function buildPatternCard(snap: TopSnapshot): PatternCard {
   if (leadCount >= Math.ceil(total * 0.6)) {
     const label = leadType.charAt(0).toUpperCase() + leadType.slice(1);
     title    = `${label} posts leading your top ${total}`;
-    takeaway = `<strong>${label}</strong> content dominates your top performers — Aries will keep leaning in.`;
+    takeaway = `<strong>${escapeHtml(label)}</strong> content dominates your top performers — Aries will keep leaning in.`;
   } else if (sorted.length === 1) {
     const label = leadType.charAt(0).toUpperCase() + leadType.slice(1);
     title    = `All top posts are ${label}`;
-    takeaway = `Your top posts are all <strong>${label.toLowerCase()}</strong> — typical for this channel.`;
+    takeaway = `Your top posts are all <strong>${escapeHtml(label.toLowerCase())}</strong> — typical for this channel.`;
   } else {
     title    = `Mixed top performers`;
     takeaway = `Your audience responds to several formats — Aries is rotating to find the highest-leverage mix.`;

--- a/tests/insights-xss-escaping.test.ts
+++ b/tests/insights-xss-escaping.test.ts
@@ -1,0 +1,66 @@
+/**
+ * tests/insights-xss-escaping.test.ts
+ *
+ * Regression for S1-2 / AA-81 (stored XSS). An untrusted post title
+ * (insights_posts.title — e.g. an attacker-controlled YouTube video title) that
+ * flows into an insights card rendered via dangerouslySetInnerHTML must be
+ * ESCAPED so injected markup is inert, while the card's intended app markup
+ * (<em>, <strong>) still renders.
+ *
+ * Acceptance criterion: an injected <img onerror=…> / <script> in a title
+ * renders inert / escaped in the built card output. Pure builder assertions.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildAttentionCards } from '../backend/insights/attention/attention-card-builder';
+import type { AttentionSnapshot } from '../backend/insights/attention/attention-snapshot-builder';
+import { buildPatternCard } from '../backend/insights/top/top-template-builder';
+import type { TopPost, TopSnapshot } from '../backend/insights/top/top-snapshot-builder';
+import { escapeHtml } from '../backend/insights/escape-html';
+
+const PAYLOADS = ['<img src=x onerror=alert(1)>', '<script>alert(1)</script>'];
+
+function attentionSnapshotWithTitle(title: string): AttentionSnapshot {
+  return {
+    unreplied: 0,
+    unrepliedLeads: 0,
+    unrepliedQuestions: 0,
+    highPerformer: { title, platform: 'youtube', multiplier: 4 } as any,
+    pattern: null,
+    milestone: null,
+    postCount: 10,
+  };
+}
+
+test('attention opportunity card escapes an injected post title (S1-2/AA-81)', () => {
+  for (const payload of PAYLOADS) {
+    const cards = buildAttentionCards(attentionSnapshotWithTitle(payload), 'all', '90day');
+    const card = cards.find((c) => c.type === 'opportunity');
+    assert.ok(card, 'expected an opportunity card when highPerformer is set');
+    // No live tag survives — the '<' is escaped, so no parseable element. (The
+    // literal text "onerror=" may remain; it is inert because the tag opener is
+    // escaped. Escaping neutralizes injection without stripping text.)
+    assert.doesNotMatch(card.title, /<img|<script/i);
+    // The escaped form IS present (payload rendered as inert text).
+    assert.match(card.title, /&lt;(img|script)/i);
+    // Intended app markup still renders.
+    assert.match(card.title, /<em>/);
+  }
+});
+
+test('top pattern takeaway escapes a malicious content-type label (defense-in-depth)', () => {
+  const posts = Array.from({ length: 3 }, (_, i) =>
+    ({ contentType: '<script>alert(1)</script>', title: `p${i}`, platform: 'youtube' }) as unknown as TopPost,
+  );
+  const snap = { posts, avgReach: 100, postCount: 3, sortBy: 'reach' } as unknown as TopSnapshot;
+  const card = buildPatternCard(snap);
+  assert.doesNotMatch(card.takeaway, /<script/i);
+  assert.match(card.takeaway, /&lt;script/i);
+});
+
+test('escapeHtml neutralizes the dangerous characters and coerces null', () => {
+  assert.equal(escapeHtml('<img src=x onerror=alert(1)>'), '&lt;img src=x onerror=alert(1)&gt;');
+  assert.equal(escapeHtml(`a & b "c" 'd'`), 'a &amp; b &quot;c&quot; &#39;d&#39;');
+  assert.equal(escapeHtml(null), '');
+  assert.equal(escapeHtml(undefined), '');
+});


### PR DESCRIPTION
Closes S1-2 / AA-81. (Gap A4, docs/plans/2026-07-07-analytics-page-roadmap.md, PR #789.)

> ⚠️ **Stacked on #792 (S1-1).** Base is `hammad/s1-1-attention-cta-404`, not master — the diff here is S1-2 only. **Merge #792 first**, then this. (GitHub will retarget this PR to master automatically once #792 merges.)

## Vulnerability (stored XSS)
The Attention "opportunity" card interpolated `insights_posts.title` — an **attacker-controllable** platform post/video title (e.g. a YouTube video title) — **unescaped** into an HTML string rendered via `dangerouslySetInnerHTML`:
```
attention-card-builder.ts:92  → title: `Your <em>"${hp.title}"</em> hit …`
AttentionSection.tsx:147      → dangerouslySetInnerHTML={{ __html: card.title }}
```
A title like `<img src=x onerror=alert(document.cookie)>` executes for every operator who views the dashboard.

## Acceptance criterion
> An injected `<img onerror=…>` / `<script>` in a title renders **inert / escaped** in the built output.

Met — asserted in `tests/insights-xss-escaping.test.ts`.

## Fix
Shared `escapeHtml()` helper (`backend/insights/escape-html.ts`); escape untrusted interpolations at the builder. Intended app markup (`<em>`, `<strong>`) still renders; injected markup becomes inert text.

## Per-sink decisions (all three `dangerouslySetInnerHTML` sinks)
- **Attention title `AttentionSection.tsx:147` — the live vector.** Escape `hp.title`. Cached section, so bump **`attention-v2 → v3`** to flush stale cards holding the unescaped title.
- **Top takeaway `TopPostsSection.tsx:307` — defense-in-depth.** Escape the content-type `label`. It's Aries-derived (never the untrusted title), so it wasn't exploitable and output is **byte-identical** for real labels → **no TEMPLATE_VERSION bump** (agreed).
- **Trends `supporting` `TrendsSection.tsx:135` — left as-is (audited safe).** It interpolates **only app-computed numbers/labels** — no untrusted input reaches it, so escaping would be pointless cache churn. The untrusted title only reaches the sibling `interpretation`, which is rendered as **auto-escaped JSX text** (`{metric.interpretation}`), not through a sink → **not XSS**.

## Out of scope (noted follow-up)
`interpretation` renders literal `<strong>` tags (cosmetic, pre-existing). Deliberately **not** touched to keep this PR security-focused. ⚠️ Whoever fixes that must **escape `topPostTitle` first** if they switch `interpretation` to a sink, or they reintroduce this XSS.

## Testing
`tests/insights-xss-escaping.test.ts`: injected `<img onerror>` / `<script>` in a title → asserts no live tag, escaped form present, `<em>` survives; plus the top-takeaway escape and an `escapeHtml` unit. **Fails against the unescaped builders, passes with the fix.** `npm run verify` passes.

_Please review + merge (after #792) — not self-merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)