### PR TITLE
S1-3/AA-82: data-freshness stamp on /insights (uncached path)

### DIFF
--- a/app/api/insights/freshness/route.ts
+++ b/app/api/insights/freshness/route.ts
@@ -1,0 +1,8 @@
+import { handleGetInsightsFreshness } from '@/backend/insights/freshness/handler';
+
+// Uncached freshness stamp — see backend/insights/freshness/handler.ts.
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  return handleGetInsightsFreshness(req);
+}

--- a/backend/insights/freshness/freshness-logic.ts
+++ b/backend/insights/freshness/freshness-logic.ts
@@ -1,0 +1,90 @@
+/**
+ * backend/insights/freshness/freshness-logic.ts
+ *
+ * Pure status logic for the /insights data-freshness stamp (S1-3 / AA-82).
+ * No DB, no I/O — testable in isolation.
+ *
+ * The stamp must let a user tell "the sync broke / data is stale" apart from
+ * "my engagement is genuinely flat". So it is derived from insights_sync_runs
+ * STATUS + finished_at (NOT insights_accounts.last_sync_at alone, which is set
+ * on both ok AND partial runs and is not updated on a failed run — it can't
+ * distinguish fresh from partial/failed).
+ *
+ * Multi-account rule: the stamp reflects the LEAST-fresh connected account
+ * (oldest successful sync), so it never implies everything is fresh when one
+ * channel is stale or has never synced.
+ *
+ * Precedence (worst wins): never_synced → stale → partial → fresh.
+ */
+
+export type FreshnessStatus = 'fresh' | 'partial' | 'stale' | 'never_synced';
+
+/** Per-account sync state (one row per connected insights_account). */
+export interface AccountSyncRow {
+  platform:      string;
+  displayName:   string | null;
+  /** Status of the account's most recent TERMINAL run (ok|partial|failed), or null if none. */
+  latestStatus:  'ok' | 'partial' | 'failed' | null;
+  /** finished_at of the account's most recent ok|partial run (the "data as of"), or null. */
+  lastSuccessAt: string | Date | null;
+}
+
+export interface FreshnessAccount {
+  platform:      string;
+  displayName:   string | null;
+  lastSuccessAt: string | null;
+  latestStatus:  string | null;
+}
+
+export interface FreshnessResult {
+  status:                FreshnessStatus;
+  /** ISO timestamp of the least-fresh successful sync across accounts; null if never synced. */
+  dataAsOf:              string | null;
+  staleThresholdMinutes: number;
+  accounts:              FreshnessAccount[];
+}
+
+function toIso(value: string | Date | null): string | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+export function computeFreshness(rows: AccountSyncRow[], now: Date, staleMs: number): FreshnessResult {
+  const staleThresholdMinutes = Math.round(staleMs / 60000);
+
+  const accounts: FreshnessAccount[] = rows.map((r) => ({
+    platform:      r.platform,
+    displayName:   r.displayName,
+    lastSuccessAt: toIso(r.lastSuccessAt),
+    latestStatus:  r.latestStatus,
+  }));
+
+  const successMs = accounts
+    .map((a) => (a.lastSuccessAt ? new Date(a.lastSuccessAt).getTime() : null))
+    .filter((n): n is number => n !== null);
+
+  // No connected accounts, or none has ever completed an ok|partial run.
+  if (accounts.length === 0 || successMs.length === 0) {
+    return { status: 'never_synced', dataAsOf: null, staleThresholdMinutes, accounts };
+  }
+
+  // Least-fresh successful sync = the stamp's "data as of".
+  const oldestSuccessMs = Math.min(...successMs);
+  const dataAsOf = new Date(oldestSuccessMs).toISOString();
+
+  const anyFailed      = accounts.some((a) => a.latestStatus === 'failed');
+  const anyNeverSynced = accounts.some((a) => a.lastSuccessAt === null); // a connected account with no success yet
+  const ageExceeded    = now.getTime() - oldestSuccessMs > staleMs;
+
+  // stale = the "sync broke / data is old" signal — a visible warning, never a
+  // silent fresh-looking stamp.
+  if (ageExceeded || anyFailed || anyNeverSynced) {
+    return { status: 'stale', dataAsOf, staleThresholdMinutes, accounts };
+  }
+
+  // partial = fresh enough, but some legs of the latest run failed — must not
+  // claim fully-fresh data.
+  const anyPartial = accounts.some((a) => a.latestStatus === 'partial');
+  return { status: anyPartial ? 'partial' : 'fresh', dataAsOf, staleThresholdMinutes, accounts };
+}

--- a/backend/insights/freshness/handler.ts
+++ b/backend/insights/freshness/handler.ts
@@ -1,0 +1,80 @@
+/**
+ * backend/insights/freshness/handler.ts
+ *
+ * GET /api/insights/freshness — the data-freshness stamp for the /insights
+ * header (S1-3 / AA-82).
+ *
+ * UNCACHED BY DESIGN. Reads ONLY insights_accounts + insights_sync_runs. It does
+ * NOT touch insights_narratives, has NO TEMPLATE_VERSION, and returns
+ * Cache-Control: no-store — a cached freshness stamp would defeat its purpose.
+ *
+ * The single stamp reflects the least-fresh connected account and is derived
+ * from run STATUS (ok|partial|failed), so "sync broke / data is stale" is
+ * distinguishable from "engagement is genuinely flat". See freshness-logic.ts.
+ */
+
+import { NextResponse } from 'next/server';
+import pool from '@/lib/db';
+import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
+import { computeFreshness, type AccountSyncRow } from './freshness-logic';
+
+// Stale after ~2 sync ticks (the worker runs every 30 min). Env-tunable.
+function staleMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env.ARIES_INSIGHTS_STALE_MINUTES);
+  const minutes = Number.isFinite(raw) && raw > 0 ? raw : 60;
+  return minutes * 60_000;
+}
+
+async function queryAccountSyncState(tenantId: number): Promise<AccountSyncRow[]> {
+  const res = await pool.query<{
+    platform:        string;
+    display_name:    string | null;
+    latest_status:   'ok' | 'partial' | 'failed' | null;
+    last_success_at: Date | null;
+  }>(
+    `WITH latest_run AS (
+       SELECT DISTINCT ON (account_id) account_id, status
+       FROM insights_sync_runs
+       WHERE tenant_id = $1 AND status IN ('ok','partial','failed')
+       ORDER BY account_id, COALESCE(finished_at, started_at) DESC
+     ),
+     last_success AS (
+       SELECT account_id, MAX(finished_at) AS last_success_at
+       FROM insights_sync_runs
+       WHERE tenant_id = $1 AND status IN ('ok','partial') AND finished_at IS NOT NULL
+       GROUP BY account_id
+     )
+     SELECT a.platform,
+            a.display_name,
+            lr.status          AS latest_status,
+            ls.last_success_at
+     FROM insights_accounts a
+     LEFT JOIN latest_run   lr ON lr.account_id = a.id
+     LEFT JOIN last_success ls ON ls.account_id = a.id
+     WHERE a.tenant_id = $1
+     ORDER BY a.platform`,
+    [tenantId],
+  );
+
+  return res.rows.map((r) => ({
+    platform:      r.platform,
+    displayName:   r.display_name,
+    latestStatus:  r.latest_status,
+    lastSuccessAt: r.last_success_at,
+  }));
+}
+
+export async function handleGetInsightsFreshness(
+  req: Request,
+  tenantContextLoader?: TenantContextLoader,
+): Promise<Response> {
+  const tenantResult = await loadTenantContextOrResponse(tenantContextLoader);
+  if ('response' in tenantResult) return tenantResult.response;
+
+  const tenantId = Number(tenantResult.tenantContext.tenantId);
+  const rows     = await queryAccountSyncState(tenantId);
+  const freshness = computeFreshness(rows, new Date(), staleMs());
+
+  // no-store: the freshness stamp must never be served stale.
+  return NextResponse.json(freshness, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/frontend/insights/FreshnessStamp.tsx
+++ b/frontend/insights/FreshnessStamp.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FreshnessStamp.tsx
+// "Data as of <timestamp>" indicator for the /insights header, with a stale
+// warning state (S1-3 / AA-82). Fetches the UNCACHED /api/insights/freshness
+// endpoint on mount and polls every 60s, so a recovering sync clears the stale
+// warning without a manual reload. Independent of the cached narrative.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { useEffect, useState } from "react";
+import { C } from "@/frontend/insights/tokens";
+import { Icon } from "@/frontend/insights/ui";
+
+type FreshnessStatus = "fresh" | "partial" | "stale" | "never_synced";
+
+interface FreshnessData {
+  status:   FreshnessStatus;
+  dataAsOf: string | null;
+}
+
+const POLL_MS = 60_000;
+
+function relativeTime(iso: string, nowMs: number): string {
+  const min = Math.max(0, Math.round((nowMs - new Date(iso).getTime()) / 60_000));
+  if (min < 1)  return "just now";
+  if (min < 60) return `${min} min ago`;
+  const hrs = Math.round(min / 60);
+  if (hrs < 24) return `${hrs} ${hrs === 1 ? "hour" : "hours"} ago`;
+  const days = Math.round(hrs / 24);
+  return `${days} ${days === 1 ? "day" : "days"} ago`;
+}
+
+interface Display {
+  color:  string;
+  label:  string;
+  title?: string;
+  warn:   boolean;
+}
+
+function toDisplay(data: FreshnessData, nowMs: number): Display {
+  const rel  = data.dataAsOf ? relativeTime(data.dataAsOf, nowMs) : null;
+  const abs  = data.dataAsOf ? new Date(data.dataAsOf).toLocaleString() : undefined;
+  switch (data.status) {
+    case "fresh":
+      return { color: C.t3, label: `Data as of ${rel}`, title: abs, warn: false };
+    case "partial":
+      return {
+        color: C.amber,
+        label: `Data as of ${rel} · partial sync`,
+        title: "Some metrics may be incomplete — not all sources synced successfully.",
+        warn:  true,
+      };
+    case "stale":
+      return {
+        color: C.amber,
+        label: rel ? `Data may be stale — last updated ${rel}` : "Data may be stale",
+        title: abs ? `Last successful sync: ${abs}` : undefined,
+        warn:  true,
+      };
+    case "never_synced":
+    default:
+      return { color: C.t3, label: "Waiting for first sync…", warn: false };
+  }
+}
+
+export function FreshnessStamp() {
+  const [data, setData] = useState<FreshnessData | null>(null);
+  const [nowMs, setNowMs] = useState<number>(() => 0); // 0 until first client tick (SSR-safe)
+
+  useEffect(() => {
+    let alive = true;
+    const load = async () => {
+      try {
+        const res = await fetch("/api/insights/freshness", { cache: "no-store" });
+        if (!res.ok) return;
+        const json = (await res.json()) as FreshnessData;
+        if (alive) { setData(json); setNowMs(Date.now()); }
+      } catch {
+        /* transient — keep the last good stamp, retry next poll */
+      }
+    };
+    load();
+    const id = setInterval(load, POLL_MS);
+    return () => { alive = false; clearInterval(id); };
+  }, []);
+
+  if (!data || nowMs === 0) return null; // nothing until the first successful fetch
+
+  const d = toDisplay(data, nowMs);
+  return (
+    <span
+      title={d.title}
+      style={{
+        display: "inline-flex", alignItems: "center", gap: 6,
+        fontSize: 11.5, color: d.color, whiteSpace: "nowrap",
+        border: `1px solid ${d.warn ? `${C.amber}55` : C.border}`,
+        background: d.warn ? `${C.amber}14` : "transparent",
+        borderRadius: 99, padding: "4px 10px",
+      }}
+    >
+      <Icon name={d.warn ? "info" : "clock"} size={12} color={d.color} />
+      {d.label}
+    </span>
+  );
+}

--- a/frontend/insights/InsightsDashboard.tsx
+++ b/frontend/insights/InsightsDashboard.tsx
@@ -6,6 +6,7 @@ import { C } from "@/frontend/insights/tokens";
 import type { Period, Platform } from "@/frontend/insights/types";
 
 import { InsightsFilters }      from "@/frontend/insights/InsightsFilters";
+import { FreshnessStamp }        from "@/frontend/insights/FreshnessStamp";
 import { HeroSection }          from "@/frontend/insights/HeroSection";
 import { GoalSection }          from "@/frontend/insights/GoalSection";
 import { AttentionSection }     from "@/frontend/insights/AttentionSection";
@@ -42,13 +43,17 @@ export function InsightsDashboard() {
           {/* 1 — Hero band */}
           <HeroSection period={period} platform={platform} />
 
-          {/* Filters sit directly UNDER the hero (matches the mock) */}
-          <InsightsFilters
-            period={period}
-            platform={platform}
-            onPeriodChange={setPeriod}
-            onPlatformChange={setPlatform}
-          />
+          {/* Filters sit directly UNDER the hero (matches the mock); the
+              data-freshness stamp is right-aligned on the same control row. */}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+            <InsightsFilters
+              period={period}
+              platform={platform}
+              onPeriodChange={setPeriod}
+              onPlatformChange={setPlatform}
+            />
+            <FreshnessStamp />
+          </div>
 
           {/* 2 — Goal */}
           <GoalSection period={period} platform={platform} />

--- a/tests/insights-freshness.test.ts
+++ b/tests/insights-freshness.test.ts
@@ -1,0 +1,96 @@
+/**
+ * tests/insights-freshness.test.ts
+ *
+ * S1-3 / AA-82 — data-freshness stamp. Covers the pure status logic
+ * (computeFreshness) against the acceptance-criteria fixtures, plus the handler
+ * contract: Cache-Control: no-store and NO insights_narratives access.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeFreshness, type AccountSyncRow } from '../backend/insights/freshness/freshness-logic';
+import { handleGetInsightsFreshness } from '../backend/insights/freshness/handler';
+import pool from '../lib/db';
+
+const NOW = new Date('2026-07-07T12:00:00.000Z');
+const MIN = 60_000;
+const STALE_MS = 60 * MIN; // 2 ticks
+const ago = (mins: number) => new Date(NOW.getTime() - mins * MIN);
+
+const row = (over: Partial<AccountSyncRow>): AccountSyncRow => ({
+  platform: 'facebook', displayName: 'FB', latestStatus: 'ok', lastSuccessAt: ago(10), ...over,
+});
+
+test('fresh: recent ok sync → status fresh, dataAsOf = that sync', () => {
+  const r = computeFreshness([row({ lastSuccessAt: ago(10), latestStatus: 'ok' })], NOW, STALE_MS);
+  assert.equal(r.status, 'fresh');
+  assert.equal(r.dataAsOf, ago(10).toISOString());
+});
+
+test('least-fresh account wins: FB 5m + IG 3h → stale, dataAsOf = the OLDER (IG)', () => {
+  const r = computeFreshness([
+    row({ platform: 'facebook',  lastSuccessAt: ago(5),   latestStatus: 'ok' }),
+    row({ platform: 'instagram', lastSuccessAt: ago(180), latestStatus: 'ok' }),
+  ], NOW, STALE_MS);
+  assert.equal(r.status, 'stale');
+  assert.equal(r.dataAsOf, ago(180).toISOString()); // reflects the least-fresh channel
+});
+
+test('failed latest run is NOT a silent fresh stamp → stale (even with an older success)', () => {
+  const r = computeFreshness([
+    row({ lastSuccessAt: ago(20), latestStatus: 'failed' }), // synced 20m ago, but the LATEST run failed
+  ], NOW, STALE_MS);
+  assert.equal(r.status, 'stale');
+});
+
+test('partial latest run, recent → partial (does not overclaim fresh)', () => {
+  const r = computeFreshness([row({ lastSuccessAt: ago(10), latestStatus: 'partial' })], NOW, STALE_MS);
+  assert.equal(r.status, 'partial');
+  assert.ok(r.dataAsOf);
+});
+
+test('a connected account that never synced forces least-fresh → stale', () => {
+  const r = computeFreshness([
+    row({ platform: 'facebook',  lastSuccessAt: ago(5),  latestStatus: 'ok' }),
+    row({ platform: 'instagram', lastSuccessAt: null,     latestStatus: null }),
+  ], NOW, STALE_MS);
+  assert.equal(r.status, 'stale');
+});
+
+test('never_synced: no runs at all → never_synced, no timestamp', () => {
+  const r = computeFreshness([row({ lastSuccessAt: null, latestStatus: null })], NOW, STALE_MS);
+  assert.equal(r.status, 'never_synced');
+  assert.equal(r.dataAsOf, null);
+});
+
+test('no connected accounts → never_synced', () => {
+  const r = computeFreshness([], NOW, STALE_MS);
+  assert.equal(r.status, 'never_synced');
+});
+
+test('handler sets Cache-Control: no-store and never queries insights_narratives', async () => {
+  const original = pool.query;
+  const seenSql: string[] = [];
+  // Timestamp relative to the REAL clock — the handler uses new Date(), not the fixture NOW.
+  const tenMinAgo = new Date(Date.now() - 10 * MIN);
+  (pool as any).query = async (sql: string) => {
+    seenSql.push(String(sql));
+    return { rows: [{ platform: 'facebook', display_name: 'FB', latest_status: 'ok', last_success_at: tenMinAgo }] };
+  };
+  try {
+    const loader = async () => ({ tenantId: '1', tenantSlug: 't', role: 'tenant_admin', userId: '1' }) as any;
+    const res = await handleGetInsightsFreshness(
+      new Request('https://x.test/api/insights/freshness'), loader as any,
+    );
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    const body: any = await res.json();
+    assert.equal(body.status, 'fresh');
+    // The uncached contract: it must read sync tables only, never the cache table.
+    assert.ok(seenSql.length > 0, 'expected a query');
+    for (const sql of seenSql) {
+      assert.doesNotMatch(sql, /insights_narratives/i, 'freshness must not touch the narrative cache');
+      assert.match(sql, /insights_sync_runs|insights_accounts/i);
+    }
+  } finally {
+    (pool as any).query = original;
+  }
+});


### PR DESCRIPTION
Closes S1-3 / AA-82. (Gap A2b, docs/plans/2026-07-07-analytics-page-roadmap.md, PR #789.) Effort M — this ADDS a feature.

## Goal
Show a "Data as of <timestamp>" indicator on the /insights header, with a **warning state when data is stale** (last successful sync older than ~2 sync ticks, >60 min) — so an operator can tell **"the sync broke / data is stale"** apart from **"my engagement is genuinely flat."**

## ✅ Uncached — the critical constraint
Nothing here rides a `TEMPLATE_VERSION`'d cache row. A new **`GET /api/insights/freshness`**:
- reads **only** `insights_accounts` + `insights_sync_runs`,
- touches **no** `insights_narratives`, has **no** `TEMPLATE_VERSION`,
- returns **`Cache-Control: no-store`** (+ `export const dynamic = 'force-dynamic'`).

A handler test asserts both the `no-store` header **and** that the query never references `insights_narratives`.

## Derivation (status, not just last_sync_at)
Uses run **STATUS + `finished_at`** from `insights_sync_runs`, **not** `insights_accounts.last_sync_at` alone — I verified `last_sync_at` is written on both `ok` AND `partial` runs and is not updated on a failed run, so it can't distinguish fresh from partial/failed (that's the whole point of the ticket).

**Multi-account rule:** the single stamp reflects the **least-fresh** connected account (oldest successful sync) — never implies everything is fresh when one channel is stale or never synced.

**Status precedence (worst wins) + non-overclaiming copy:**
| Status | When | Copy |
|---|---|---|
| never_synced | no ok/partial run anywhere | "Waiting for first sync…" |
| **stale** (warning) | oldest success >60m **or** latest run `failed` **or** a connected account never synced | "Data may be stale — last updated {t}" |
| partial | fresh enough, latest run `partial` | "Data as of {t} · partial sync" (some metrics may be incomplete) |
| fresh | recent, all ok | "Data as of {t}" |

## Frontend
`<FreshnessStamp />`, right-aligned in the `InsightsDashboard` filters row. Fetches the uncached endpoint on mount and **polls every 60s**, so a recovering sync clears the stale warning without a reload. Independent of the cached narrative. Threshold env-tunable via `ARIES_INSIGHTS_STALE_MINUTES` (default 60).

## Acceptance criteria / tests
`tests/insights-freshness.test.ts`: stamp reflects the most-recent successful/partial sync; a **stale or failed** sync surfaces the warning (**not** a silent fresh-looking stamp); a **partial** run's copy doesn't overclaim; least-fresh-account-wins; never-synced; + the handler `no-store` / no-`insights_narratives` contract. Verified meaningful via a fails-before check against a naive (status-ignoring) implementation — the least-fresh / failed / partial / never-synced assertions all fail without the real logic. `npm run verify` passes.

_Please review + merge — not self-merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)