### PR TITLE
S1-5/AA-84: surface inferred goal + fix dead Settings link (interim)

### DIFF
--- a/backend/insights/goal/goal-snapshot-builder.ts
+++ b/backend/insights/goal/goal-snapshot-builder.ts
@@ -49,6 +49,13 @@ export interface GoalSnapshot {
   contributors: GoalContributor[];   // top posts (used for the week view)
   categories: GoalCategory[];        // grouped by content type (used for 30/90-day)
   hasData: boolean;
+  /**
+   * True when `normalizeGoal` could not confidently map the stored free-text
+   * goal and fell back to the default bucket — i.e. Aries is GUESSING. The UI
+   * renders a "Goal inferred — confirm in Settings" chip so the user can fix a
+   * misclassification (S1-5 / AA-84).
+   */
+  goalInferred: boolean;
 }
 
 function categoryLabel(contentType: string): string {
@@ -66,20 +73,31 @@ function categoryLabel(contentType: string): string {
 // through to brand awareness. Normalise any stored vocabulary to a canonical
 // goal by keyword, defaulting to brand_awareness (the most universal metric) so
 // the label + narrative are never blank.
-function normalizeGoal(raw: string): GoalType {
+//
+// Returns { goal, inferred }. `inferred` is true ONLY on the terminal
+// fallthrough — when neither an exact canonical key nor any keyword matched, so
+// the default is a GUESS, not a confident mapping. Exact and keyword matches are
+// inferred:false. On a guess we also log the original free text so an unmatched
+// onboarding preset (e.g. "Increase social media presence") is visible to us,
+// instead of silently landing on brand_awareness (S1-5 / AA-84). Exported for
+// direct unit testing.
+export function normalizeGoal(raw: string): { goal: GoalType; inferred: boolean } {
   const s = raw.trim().toLowerCase();
-  if (!s) return 'brand_awareness';
+  if (!s) return { goal: 'brand_awareness', inferred: true };
   // Exact canonical match wins.
-  if (s === 'lead_generation') return 'lead_generation';
-  if (s === 'content_growth')  return 'content_growth';
-  if (s === 'product_sales')   return 'product_sales';
-  if (s === 'brand_awareness') return 'brand_awareness';
+  if (s === 'lead_generation') return { goal: 'lead_generation', inferred: false };
+  if (s === 'content_growth')  return { goal: 'content_growth',  inferred: false };
+  if (s === 'product_sales')   return { goal: 'product_sales',   inferred: false };
+  if (s === 'brand_awareness') return { goal: 'brand_awareness', inferred: false };
   // Keyword match on free-form text (most specific intent first).
-  if (/\blead|inquir|enquir|contact|sign[- ]?up|booking|appointment\b/.test(s)) return 'lead_generation';
-  if (/\bsale|sell|revenue|purchase|buy|checkout|conversion|order|product|shop|ecommerce\b/.test(s)) return 'product_sales';
-  if (/\bfollow|grow|audience|subscriber|community|reach more|build.*following\b/.test(s)) return 'content_growth';
-  if (/\baware|reach|visib|impression|discover|exposure|brand\b/.test(s)) return 'brand_awareness';
-  return 'brand_awareness';
+  if (/\blead|inquir|enquir|contact|sign[- ]?up|booking|appointment\b/.test(s)) return { goal: 'lead_generation', inferred: false };
+  if (/\bsale|sell|revenue|purchase|buy|checkout|conversion|order|product|shop|ecommerce\b/.test(s)) return { goal: 'product_sales', inferred: false };
+  if (/\bfollow|grow|audience|subscriber|community|reach more|build.*following\b/.test(s)) return { goal: 'content_growth', inferred: false };
+  if (/\baware|reach|visib|impression|discover|exposure|brand\b/.test(s)) return { goal: 'brand_awareness', inferred: false };
+  // No keyword matched — we are GUESSING. Log the original text for our
+  // visibility and mark the result inferred so the UI asks the user to confirm.
+  console.warn(`[insights.goal] unmatched primary_goal ${JSON.stringify(raw)} → defaulting to brand_awareness (inferred)`);
+  return { goal: 'brand_awareness', inferred: true };
 }
 
 function goalLabel(goal: GoalType): string {
@@ -415,7 +433,7 @@ export async function buildGoalSnapshot(
     const rawGoal = profileRes.rows[0]?.primary_goal ?? null;
     if (!rawGoal) return null;
 
-    const goal = normalizeGoal(rawGoal);
+    const { goal, inferred: goalInferred } = normalizeGoal(rawGoal);
 
     // Fetch metric for current + previous period
     let current: number;
@@ -449,6 +467,7 @@ export async function buildGoalSnapshot(
       contributors,
       categories,
       hasData:        current > 0 || prev > 0,
+      goalInferred,
     };
   } finally {
     client.release();

--- a/backend/insights/goal/handler.ts
+++ b/backend/insights/goal/handler.ts
@@ -23,7 +23,9 @@ import crypto from 'crypto';
 // v3: normalize free-form primary_goal → canonical GoalType, so the goal label
 // and Aries narrative are no longer blank when onboarding stored natural-language
 // goal text. Bump invalidates stale v2 rows that cached the empty label.
-const TEMPLATE_VERSION = 'goal-template-v3';
+// v4: cached body now carries `goalInferred` (S1-5 / AA-84) — the body shape
+// changed, so bump to invalidate v3 rows that lack the flag.
+const TEMPLATE_VERSION = 'goal-template-v4';
 const CACHE_TTL_MS     = 60 * 60 * 1000;
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);
@@ -152,6 +154,7 @@ export async function handleGetInsightsGoal(
       contributors:    snapshot.contributors,
       categories:      snapshot.categories,
       hasData:         snapshot.hasData,
+      goalInferred:    snapshot.goalInferred,
     };
 
     await upsert(client, tenantId, period, platform, body, hash);

--- a/frontend/insights/GoalSection.tsx
+++ b/frontend/insights/GoalSection.tsx
@@ -40,6 +40,10 @@ const GOAL_VERB: Record<string, string> = {
   brand_awareness: "Build awareness",
 };
 
+// Verified route: the goal (business_profiles.primary_goal) is edited on the
+// business-profile settings page (frontend/app-shell/routes.ts).
+const SETTINGS_GOAL_HREF = "/dashboard/settings/business-profile";
+
 function titleCase(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
@@ -99,7 +103,10 @@ export function GoalSection({ period, platform }: GoalSectionProps) {
         ) : error ? (
           <ErrorState message={error} onRetry={refetch} />
         ) : !data || data.status === "no_goal" ? (
-          <EmptyState message="No primary goal set. Go to Settings to configure your goal." />
+          <EmptyState
+            message="No primary goal set."
+            action={{ label: "Set your goal in Settings", href: SETTINGS_GOAL_HREF }}
+          />
         ) : (
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 28 }}>
             {/* ── LEFT: the headline metric ── */}
@@ -108,6 +115,20 @@ export function GoalSection({ period, platform }: GoalSectionProps) {
                 <span style={{ color: C.t3 }}>YOUR GOAL</span>
                 <span style={{ color: C.t3 }}>{"  ·  "}</span>
                 <span style={{ color: C.accentB, textTransform: "uppercase" }}>{goalVerb}</span>
+                {data.goalInferred && (
+                  <a
+                    href={SETTINGS_GOAL_HREF}
+                    title="Aries inferred this goal from your profile text. Click to confirm or change it in Settings."
+                    style={{
+                      marginLeft: 10, fontSize: 10.5, fontWeight: 600, color: C.amber,
+                      background: `${C.amber}1c`, border: `1px solid ${C.amber}55`,
+                      borderRadius: 99, padding: "2px 8px", textDecoration: "none",
+                      textTransform: "none", letterSpacing: "normal",
+                    }}
+                  >
+                    Goal inferred — confirm
+                  </a>
+                )}
               </div>
 
               <div style={{ display: "flex", alignItems: "baseline", gap: 12, flexWrap: "wrap" }}>

--- a/frontend/insights/types.ts
+++ b/frontend/insights/types.ts
@@ -83,6 +83,7 @@ export interface GoalData extends ApiBase {
   contributors:    GoalContributor[];   // top posts — used for the this-week view
   categories:      GoalCategory[];      // grouped by content type — used for 30/90-day
   hasData:         boolean;             // ← top-level for this section
+  goalInferred?:   boolean;             // Aries guessed the goal — show "confirm in Settings" chip (S1-5)
 }
 
 // § Attention — backend/insights/attention/handler.ts

--- a/frontend/insights/ui.tsx
+++ b/frontend/insights/ui.tsx
@@ -579,7 +579,14 @@ export function StatusBadge({
 
 // ── Empty state ───────────────────────────────────────────────────────────────
 
-export function EmptyState({ message }: { message: string }) {
+export function EmptyState({
+  message,
+  action,
+}: {
+  message: string;
+  /** Optional call-to-action link rendered under the message. */
+  action?: { label: string; href: string };
+}) {
   return (
     <div
       style={{
@@ -590,6 +597,21 @@ export function EmptyState({ message }: { message: string }) {
       }}
     >
       {message}
+      {action && (
+        <div style={{ marginTop: 12 }}>
+          <a
+            href={action.href}
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 6,
+              fontSize: 12.5, fontWeight: 600, color: C.accentB,
+              background: `${C.accentB}1c`, border: `1px solid ${C.accentB}55`,
+              borderRadius: 99, padding: "6px 14px", textDecoration: "none",
+            }}
+          >
+            {action.label}
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/tests/insights-goal-inferred.test.ts
+++ b/tests/insights-goal-inferred.test.ts
@@ -1,0 +1,74 @@
+/**
+ * tests/insights-goal-inferred.test.ts
+ *
+ * S1-5 / AA-84 — stop the silent goal misclassification.
+ *
+ * `normalizeGoal` maps free-text business_profiles.primary_goal to a canonical
+ * GoalType. When nothing matches it falls back to brand_awareness — but that is
+ * a GUESS, and previously it happened silently. It must now:
+ *   (a) return inferred:true ONLY on the terminal fallthrough, and
+ *   (b) console.warn the original free text.
+ * A confident match (exact key or keyword) must be inferred:false with no warn.
+ *
+ * Also asserts the goal section's no_goal empty state links to the real
+ * business-profile Settings route (the dead "Go to Settings" text is fixed).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { normalizeGoal } from '../backend/insights/goal/goal-snapshot-builder';
+
+/** Run fn with console.warn captured; returns the warn calls seen. */
+function captureWarn<T>(fn: () => T): { result: T; warnings: string[] } {
+  const original = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+  try {
+    return { result: fn(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+test('unmatched onboarding preset "Increase social media presence" → inferred:true + logged', () => {
+  const { result, warnings } = captureWarn(() => normalizeGoal('Increase social media presence'));
+  // The intent-agnostic default is brand_awareness, but it must be MARKED as a guess.
+  assert.equal(result.goal, 'brand_awareness');
+  assert.equal(result.inferred, true, 'unmatched free text must be flagged inferred');
+  assert.equal(warnings.length, 1, 'a guess must be logged for our visibility');
+  assert.match(warnings[0], /Increase social media presence/, 'the log must include the original free text');
+});
+
+test('empty goal string → inferred:true (still a guess)', () => {
+  const { result } = captureWarn(() => normalizeGoal('   '));
+  assert.equal(result.goal, 'brand_awareness');
+  assert.equal(result.inferred, true);
+});
+
+test('keyword match "Generate more leads and inquiries" → lead_generation, inferred:false, no warn', () => {
+  const { result, warnings } = captureWarn(() => normalizeGoal('Generate more leads and inquiries'));
+  assert.equal(result.goal, 'lead_generation');
+  assert.equal(result.inferred, false, 'a confident keyword match must NOT be inferred');
+  assert.equal(warnings.length, 0, 'a confident match must not warn');
+});
+
+test('exact canonical "brand_awareness" → inferred:false, no warn', () => {
+  const { result, warnings } = captureWarn(() => normalizeGoal('brand_awareness'));
+  assert.equal(result.goal, 'brand_awareness');
+  assert.equal(result.inferred, false);
+  assert.equal(warnings.length, 0);
+});
+
+test('keyword match "Drive product sales" → product_sales, inferred:false', () => {
+  const { result } = captureWarn(() => normalizeGoal('Drive product sales'));
+  assert.equal(result.goal, 'product_sales');
+  assert.equal(result.inferred, false);
+});
+
+test('goal section no_goal empty state links to the real business-profile Settings route', () => {
+  // Guard against a regression to the dead "Go to Settings" text with no href.
+  const src = fs.readFileSync(new URL('../frontend/insights/GoalSection.tsx', import.meta.url), 'utf8');
+  assert.match(src, /\/dashboard\/settings\/business-profile/, 'empty state must link to a real Settings route');
+  // The empty state must pass an action link, not bare "Go to Settings" prose.
+  assert.doesNotMatch(src, /Go to Settings to configure/, 'the dead prose CTA must be gone');
+});


### PR DESCRIPTION
Closes S1-5 / AA-84

**Interim fix** — the real goal-picker dropdown is **S6-1** (later). This ticket only stops the silent misclassification and fixes the dead link.

## Problem
- **A6a:** `business_profiles.primary_goal` is free text. `normalizeGoal` keyword-maps it to a canonical `GoalType` and, on **no match**, defaulted to `brand_awareness` **silently**. The shipped onboarding preset **"Increase social media presence"** matches no bucket (no `follow`/`grow`/`audience`/`social` in content_growth; no `aware`/`reach`/`visib`/`brand` in brand_awareness) → wrongly lands on `brand_awareness` with **no signal Aries guessed**.
- **A6b:** the `no_goal` empty state said "Go to Settings…" with **no actual link**.

## Change
- `normalizeGoal` now returns `{ goal, inferred }` (and is **exported** for direct unit testing). `inferred` is **true only on the terminal fallthrough** — exact-key and keyword matches stay `inferred:false`. On a guess it `console.warn`s the original free text for our visibility.
- Thread `goalInferred` through `GoalSnapshot` → handler `body` → `GoalData`.
- `GoalSection`: the `no_goal` empty state **and** the inferred chip both link to the **verified** `/dashboard/settings/business-profile` route (where `primary_goal` is edited — confirmed via `frontend/app-shell/routes.ts`). The **"Goal inferred — confirm"** chip renders only when `goalInferred` is true.
- `EmptyState` gains an optional `action` link (existing callers unaffected).

## TEMPLATE_VERSION bump (required)
`goal-template-v3` → **`goal-template-v4`**. The cached goal `body` shape changed (adds `goalInferred`), so v3 rows must be invalidated by the `model !== TEMPLATE_VERSION` check.

## Dependency (NOT built here)
A user **correcting** their goal in Settings won't reflect for up to 1h until the cache is invalidated on profile save — that is **S1-6 / AA-85**, which follows this. This PR only surfaces the guess + fixes the link.

## Acceptance criteria
- [x] Unmatched free text ("Increase social media presence") → `inferred:true` + logged (no silent `brand_awareness`).
- [x] Matched goal → `inferred:false`, no warn, no chip.
- [x] Empty goal → empty state with a **real** Settings link.
- [x] `goal-template-v3` → `v4` bump (cached body shape changed).

## Verification
- `tests/insights-goal-inferred.test.ts` — 6/6 pass. **Fails-before** verified against the old silent signature (the two `inferred` assertions fail). `npm run verify` green (42/42); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)