### PR TITLE
S1-6/AA-85: invalidate goal cache on profile save (completes S1-5 loop)

### DIFF
--- a/backend/insights/goal/cache-invalidation.ts
+++ b/backend/insights/goal/cache-invalidation.ts
@@ -1,0 +1,32 @@
+import type { PoolClient } from 'pg';
+
+/**
+ * backend/insights/goal/cache-invalidation.ts
+ *
+ * Deletes the tenant's cached GOAL narrative rows (every period × platform combo)
+ * so the next GET /api/insights/goal rebuilds from the just-saved primary_goal —
+ * closing the S1-5 loop (a "Goal inferred — confirm in Settings" fix would
+ * otherwise appear to do nothing for up to the 1h goal cache TTL). S1-6 / AA-85.
+ *
+ * Scoped to section_key='goal' ONLY — no other cached section reads primary_goal,
+ * so their caches are intentionally left intact. Version-independent: keys on
+ * (tenant_id, section_key), not TEMPLATE_VERSION, so it clears rows regardless of
+ * which template version wrote them. Reuses the caller's PoolClient (no extra
+ * pool.connect). Resilient: NEVER throws — a cache-invalidation failure must not
+ * fail the profile save that triggered it (the save is the important operation).
+ */
+export async function invalidateGoalNarrativeCache(
+  client: PoolClient,
+  tenantId: string | number,
+): Promise<void> {
+  const numericId = Number(tenantId);
+  if (!Number.isFinite(numericId) || numericId <= 0) return;
+  try {
+    await client.query(
+      `DELETE FROM insights_narratives WHERE tenant_id = $1 AND section_key = 'goal'`,
+      [numericId],
+    );
+  } catch (err) {
+    console.error('[insights.goal] goal cache invalidation failed (save preserved):', err);
+  }
+}

--- a/backend/tenant/business-profile.ts
+++ b/backend/tenant/business-profile.ts
@@ -33,6 +33,7 @@ import {
   sanitizeLegacyCompetitorUrl,
   validateCanonicalCompetitorUrl,
 } from '@/lib/marketing-competitor';
+import { invalidateGoalNarrativeCache } from '@/backend/insights/goal/cache-invalidation';
 import { resolveDataPath } from '@/lib/runtime-paths';
 import { DEFAULT_TENANT_TIMEZONE, isValidTimeZone, resolveTenantTimeZone } from '@/lib/format-timestamp';
 import {
@@ -923,6 +924,13 @@ export async function updateBusinessProfileWithDiagnostics(
     reel_audio_mode: nextReelAudioMode,
     updated_at: nowIso(),
   });
+
+  // S1-6 / AA-85: drop the cached goal section so the next /insights load
+  // rebuilds from the just-saved primary_goal — completing the S1-5 "Goal
+  // inferred — confirm in Settings" loop (otherwise a goal edit appears to do
+  // nothing for up to the 1h goal cache TTL). Runs AFTER the save (already
+  // persisted) and never throws, so a cache miss can't fail the user's save.
+  await invalidateGoalNarrativeCache(client, input.tenantId);
 
   await persistBrandKitIfNeeded(input.tenantId, nextWebsiteUrl, current.profile.websiteUrl);
   return getBusinessProfileWithDiagnostics(client, input.tenantId);

--- a/tests/insights-goal-cache-invalidation.test.ts
+++ b/tests/insights-goal-cache-invalidation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * tests/insights-goal-cache-invalidation.test.ts
+ *
+ * S1-6 / AA-85 — invalidate the cached goal section on a business-profile save,
+ * so a goal edit (incl. confirming an S1-5 inferred goal) reflects on the next
+ * /insights load instead of waiting out the 1h goal cache TTL.
+ *
+ * Covers the helper's contract (scoped DELETE, resilience, id guards) and a
+ * source-level wiring guard that the authenticated save path actually calls it.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import type { PoolClient } from 'pg';
+import { invalidateGoalNarrativeCache } from '../backend/insights/goal/cache-invalidation';
+
+interface SeenQuery { sql: string; params: unknown[] }
+
+/** Fake PoolClient capturing queries; optionally rejects to simulate a DB error. */
+function fakeClient(opts: { reject?: boolean } = {}): { client: PoolClient; seen: SeenQuery[] } {
+  const seen: SeenQuery[] = [];
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      seen.push({ sql: String(sql), params });
+      if (opts.reject) throw new Error('simulated DB failure');
+      return { rows: [], rowCount: 0 };
+    },
+  } as unknown as PoolClient;
+  return { client, seen };
+}
+
+test('deletes ONLY the goal section rows, scoped to the tenant', async () => {
+  const { client, seen } = fakeClient();
+  await invalidateGoalNarrativeCache(client, 42);
+
+  assert.equal(seen.length, 1, 'expected exactly one query');
+  const { sql, params } = seen[0];
+  assert.match(sql, /DELETE\s+FROM\s+insights_narratives/i);
+  assert.match(sql, /section_key\s*=\s*'goal'/i, 'must be scoped to the goal section');
+  assert.match(sql, /tenant_id\s*=\s*\$1/i, 'must be scoped to the tenant');
+  assert.deepEqual(params, [42]);
+  // Must NOT wipe other sections' caches.
+  assert.doesNotMatch(sql, /'hero'|'attention'|'trends'|'top'|'activity'/i);
+});
+
+test('resilient: a rejecting client.query does NOT throw (save survives)', async () => {
+  const { client } = fakeClient({ reject: true });
+  await assert.doesNotReject(
+    () => invalidateGoalNarrativeCache(client, 7),
+    'a cache-invalidation failure must not propagate and fail the profile save',
+  );
+});
+
+test('guards a non-numeric or non-positive tenant id — issues no query', async () => {
+  for (const bad of [0, -1, NaN, 'abc', '', null as unknown as number]) {
+    const { client, seen } = fakeClient();
+    await invalidateGoalNarrativeCache(client, bad as string | number);
+    assert.equal(seen.length, 0, `expected no query for tenant id ${JSON.stringify(bad)}`);
+  }
+});
+
+test('accepts a string tenant id (route passes tenantId as a string)', async () => {
+  const { client, seen } = fakeClient();
+  await invalidateGoalNarrativeCache(client, '13');
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0].params, [13]);
+});
+
+test('wiring: the authenticated save path calls invalidateGoalNarrativeCache after the save', () => {
+  const src = fs.readFileSync(new URL('../backend/tenant/business-profile.ts', import.meta.url), 'utf8');
+  assert.match(src, /invalidateGoalNarrativeCache/, 'save path must invoke the invalidator');
+  // It must run AFTER the profile is persisted, not before.
+  const saveIdx = src.indexOf('saveBusinessProfileRecord({');
+  const callIdx = src.indexOf('await invalidateGoalNarrativeCache(client, input.tenantId)');
+  assert.ok(saveIdx >= 0, 'expected the save call in the update path');
+  assert.ok(callIdx > saveIdx, 'invalidation must be wired AFTER saveBusinessProfileRecord');
+});


### PR DESCRIPTION
Closes S1-6 / AA-85

**Completes the S1-5 loop** (#796, `hammad/s1-5-goal-inferred`).

## Problem
The goal section is cached in `insights_narratives` for ~1h. When a user edits `primary_goal` on the business-profile settings page and saves, **nothing invalidated that cache** — so the dashboard kept showing the **old** goal for up to an hour. This made the S1-5 **"Goal inferred — confirm in Settings"** chip incoherent: the page asks the user to fix their goal, they do, and it appears to do nothing.

## Fix
- **New `invalidateGoalNarrativeCache(client, tenantId)`** (`backend/insights/goal/cache-invalidation.ts`): `DELETE`s the tenant's cached goal rows (**all** period × platform combos) scoped to `section_key = 'goal'`. Version-independent (keys on `tenant_id` + `section_key`, not `TEMPLATE_VERSION`). Reuses the caller's `PoolClient` (no extra `pool.connect`). **Never throws** — a cache-invalidation failure must not fail the profile save.
- **Wired into `updateBusinessProfileWithDiagnostics` AFTER `saveBusinessProfileRecord`** (the authenticated settings save path only — not the anonymous/marketing paths). The save is already persisted before invalidation runs, so a cache miss can't lose the write.
- **Unconditional** on successful save: `primary_goal` drives the goal cache and the goal row is cheap to rebuild lazily; a change-gate against the *effective* (possibly-inferred) profile view could misfire versus the *stored* column the snapshot actually reads.

## Scope (verified)
`grep primary_goal backend/insights/` returns **only** `goal/*` — no other cached section reads `primary_goal`, so nothing else goes stale on a goal edit. Invalidation stays scoped to the goal rows; hero/attention/trends/top/activity caches are untouched.

## Acceptance criteria
- [x] After a profile save, the tenant's cached goal rows are deleted (scoped to `tenant_id` + `section_key='goal'`) → next `/insights` load rebuilds from the new goal.
- [x] The save still succeeds even if the invalidation errors (log-and-continue; helper never throws).
- [x] Works regardless of whether the goal was inferred or explicit (keys on section, not the goal value).
- [x] Scoped to the goal section only.

## Verification
- `tests/insights-goal-cache-invalidation.test.ts` — 5/5 pass: scoped DELETE (goal only, right tenant), resilient (save survives a rejecting `client.query`), guards NaN/0/non-numeric tenant ids, and a **wiring guard** that the save path calls the invalidator after the save. **Fails-before** verified (wiring guard fails without the call). `npm run verify` green (42/42); typecheck clean.

## Relationship to S1-5
S1-5 (#796) surfaces the inferred goal + fixes the dead Settings link; this PR makes the *correction* take effect immediately. No file overlap — branched off `master`, composes cleanly whichever merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)