### PR TITLE
S1-7/AA-86: replace alert() stub CTAs + honest empty-state copy

### DIFF
--- a/frontend/insights/AttentionSection.tsx
+++ b/frontend/insights/AttentionSection.tsx
@@ -59,14 +59,10 @@ function PrimaryCta({ cta }: { cta: AttentionCta }) {
       </a>
     );
   }
+  // No real destination yet — show it disabled (planned, not broken) rather
+  // than firing a placeholder popup. S5-* wires these for real.
   return (
-    <button
-      type="button"
-      style={baseStyle}
-      onClick={() => {
-        if (cta.toast) alert(cta.toast);
-      }}
-    >
+    <button type="button" disabled title="Coming soon" style={{ ...baseStyle, opacity: 0.5, cursor: "not-allowed" }}>
       {cta.label}
     </button>
   );
@@ -93,14 +89,9 @@ function SecondaryCta({ cta }: { cta: AttentionCta }) {
       </a>
     );
   }
+  // No real destination yet — disabled (planned, not broken), no placeholder popup.
   return (
-    <button
-      type="button"
-      style={baseStyle}
-      onClick={() => {
-        if (cta.toast) alert(cta.toast);
-      }}
-    >
+    <button type="button" disabled title="Coming soon" style={{ ...baseStyle, opacity: 0.5, cursor: "not-allowed" }}>
       {cta.label}
     </button>
   );
@@ -108,6 +99,16 @@ function SecondaryCta({ cta }: { cta: AttentionCta }) {
 
 function AttentionCardView({ card }: { card: AttentionCard }) {
   const tint = toneColor(card.tone);
+
+  // "View details" on the opportunity card points at the Top Performing Content
+  // section, which is rendered on this same page — so wire it as an in-page
+  // anchor rather than a placeholder. Keyed on card.type (structural), so no
+  // cached-builder change and no TEMPLATE_VERSION bump. Other no-href CTAs (e.g.
+  // "Mark as read") have no real target yet and fall through to disabled.
+  const secondaryCta =
+    card.ctaSecondary && !card.ctaSecondary.href && card.type === "opportunity"
+      ? { ...card.ctaSecondary, href: "#top-performing" }
+      : card.ctaSecondary;
 
   return (
     <div
@@ -156,7 +157,7 @@ function AttentionCardView({ card }: { card: AttentionCard }) {
       {(card.ctaPrimary || card.ctaSecondary) && (
         <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", marginTop: 12 }}>
           {card.ctaPrimary && <PrimaryCta cta={card.ctaPrimary} />}
-          {card.ctaSecondary && <SecondaryCta cta={card.ctaSecondary} />}
+          {secondaryCta && <SecondaryCta cta={secondaryCta} />}
         </div>
       )}
     </div>

--- a/frontend/insights/AudienceSection.tsx
+++ b/frontend/insights/AudienceSection.tsx
@@ -293,7 +293,7 @@ export function AudienceSection({ period, platform }: AudienceSectionProps) {
                     )}
                   </div>
                 ) : (
-                  <StubLine message="Demographics coming soon — connect Instagram/Facebook business accounts to unlock audience insights." />
+                  <StubLine message="Audience demographics coming soon — we're still building this insight." />
                 )}
               </div>
 

--- a/frontend/insights/ConversationsSection.tsx
+++ b/frontend/insights/ConversationsSection.tsx
@@ -40,8 +40,6 @@ function tagIcon(tag: string | null): IconName {
   }
 }
 
-const comingSoon = () => alert("Opens in the Conversations workspace (coming soon).");
-
 // Compact tag (smaller than the shared Pill).
 function MiniTag({ label, color }: { label: string; color: string }) {
   return (
@@ -57,14 +55,26 @@ function MiniTag({ label, color }: { label: string; color: string }) {
   );
 }
 
-function ActionButton({ icon, label, onClick }: { icon: IconName; label: string; onClick: () => void }) {
+function ActionButton({
+  icon, label, onClick, disabled, title,
+}: {
+  icon: IconName;
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  title?: string;
+}) {
   return (
     <button
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      title={title}
       style={{
         display: "inline-flex", alignItems: "center", gap: 5,
         background: "transparent", border: `1px solid ${C.border}`, color: C.t2,
-        borderRadius: 7, padding: "4px 10px", fontSize: 11.5, fontWeight: 500, cursor: "pointer",
+        borderRadius: 7, padding: "4px 10px", fontSize: 11.5, fontWeight: 500,
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
       }}
     >
       <Icon name={icon} size={12} color={C.t2} />
@@ -97,8 +107,12 @@ function ConversationRow({ item, last }: { item: ConversationItem; last: boolean
         <div style={{ fontSize: 13, color: C.t2, marginTop: 5, lineHeight: 1.5 }}>{item.text}</div>
         <div style={{ fontSize: 11, color: C.t3, marginTop: 6 }}>on “{item.postRef}”</div>
         <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 9 }}>
-          <ActionButton icon="reply" label="Reply" onClick={comingSoon} />
-          {item.tag === "lead" && <ActionButton icon="send" label="Send to Sequences" onClick={comingSoon} />}
+          {/* Reply is intentionally kept VISIBLE but disabled — S5-2 wires it
+              up for real (just flips `disabled` off). Do not remove. */}
+          <ActionButton icon="reply" label="Reply" disabled title="Reply ships soon" />
+          {item.tag === "lead" && (
+            <ActionButton icon="send" label="Send to Sequences" disabled title="Coming soon" />
+          )}
         </div>
       </div>
     </div>
@@ -161,8 +175,9 @@ export function ConversationsSection({ period, platform }: ConversationsSectionP
               {/* View all + channel hint */}
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, marginTop: 14, paddingTop: 14, borderTop: `1px solid ${C.border}` }}>
                 <button
-                  onClick={comingSoon}
-                  style={{ display: "inline-flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", fontSize: 12.5, fontWeight: 600, color: C.accentB, padding: 0 }}
+                  disabled
+                  title="Coming soon"
+                  style={{ display: "inline-flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "not-allowed", opacity: 0.5, fontSize: 12.5, fontWeight: 600, color: C.accentB, padding: 0 }}
                 >
                   View all {data.meta.needsReply} replies needed →
                 </button>

--- a/frontend/insights/TopPostsSection.tsx
+++ b/frontend/insights/TopPostsSection.tsx
@@ -235,21 +235,24 @@ function PostRow({
                 Open on {platformLabel[post.platform] ?? post.platform}
               </a>
             )}
-            <button
-              onClick={() => alert("Ad promotion coming soon")}
+            <a
+              href="/campaigns"
               style={{
-                background:   C.accent,
-                color:        "#fff",
-                border:       "none",
-                borderRadius: 8,
-                padding:      "6px 12px",
-                fontSize:     12,
-                fontWeight:   600,
-                cursor:       "pointer",
+                background:     C.accent,
+                color:          "#fff",
+                border:         "none",
+                borderRadius:   8,
+                padding:        "6px 12px",
+                fontSize:       12,
+                fontWeight:     600,
+                cursor:         "pointer",
+                textDecoration: "none",
+                display:        "inline-flex",
+                alignItems:     "center",
               }}
             >
               Promote as ad
-            </button>
+            </a>
           </div>
         </div>
       )}
@@ -334,7 +337,8 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
   const empty = !data?.meta?.hasData || !data?.posts?.length;
 
   return (
-    <section>
+    // Anchor target for the Attention "View details" CTA (in-page scroll).
+    <section id="top-performing">
       {/* Header row: title on the left, sort select on the right */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
         <SectionHeader title="Top performing content" />

--- a/tests/insights-no-placeholder-alerts.test.ts
+++ b/tests/insights-no-placeholder-alerts.test.ts
@@ -1,0 +1,56 @@
+/**
+ * tests/insights-no-placeholder-alerts.test.ts
+ *
+ * S1-7 / AA-86 — make the insights UI honest. Source-level scan (these are
+ * client .tsx components, so a source scan is the right surface):
+ *  - NO placeholder alert() anywhere under frontend/insights/.
+ *  - The Conversations Reply button is kept VISIBLE but disabled with a
+ *    "Reply ships soon" tooltip (S5-2 just flips disabled off) — NOT removed.
+ *  - The demographics empty-state copy no longer tells a (possibly connected)
+ *    tenant to "connect" anything.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const INSIGHTS_DIR = fileURLToPath(new URL('../frontend/insights/', import.meta.url));
+
+function tsxFiles(dir: string): string[] {
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith('.tsx'))
+    .map((f) => path.join(dir, f));
+}
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(INSIGHTS_DIR, rel), 'utf8');
+}
+
+test('no placeholder alert() remains anywhere under frontend/insights/', () => {
+  const offenders: string[] = [];
+  for (const file of tsxFiles(INSIGHTS_DIR)) {
+    const src = fs.readFileSync(file, 'utf8');
+    if (/\balert\s*\(/.test(src)) offenders.push(path.basename(file));
+  }
+  assert.deepEqual(offenders, [], `alert() must be gone; still present in: ${offenders.join(', ')}`);
+});
+
+test('Conversations Reply button is kept visible but disabled with a "ships soon" tooltip', () => {
+  const src = read('ConversationsSection.tsx');
+  // Still present (not deleted).
+  assert.match(src, /label="Reply"/, 'the Reply button must NOT be removed');
+  // Rendered disabled with the ships-soon tooltip.
+  assert.match(
+    src,
+    /label="Reply"\s+disabled\s+title="Reply ships soon"/,
+    'Reply must be disabled with a "Reply ships soon" tooltip',
+  );
+});
+
+test('demographics empty state no longer tells the user to connect', () => {
+  const src = read('AudienceSection.tsx');
+  const demoLine = src.split('\n').find((l) => l.includes('demographics coming soon') || l.includes('Audience demographics'));
+  assert.ok(demoLine, 'expected a demographics coming-soon stub line');
+  assert.doesNotMatch(demoLine!, /connect/i, 'demographics copy must not claim the user needs to connect');
+});


### PR DESCRIPTION
Closes S1-7 / AA-86

Make the insights UI honest: no placeholder `alert()` popups, and empty-state copy that doesn't tell an already-connected tenant to "connect".

## Per-button treatment
Every button stays **visible** unless a real destination exists; only genuinely-planned stubs are disabled, and the one CTA with a real target is wired.

| Button | Treatment | Why |
|---|---|---|
| Conversations **Reply** | **disabled + "Reply ships soon"**, kept visible | S5-2 wires it for real (just flips `disabled` off). **Not removed.** |
| Conversations **Send to Sequences** | disabled + "Coming soon" | Sequences CRM not built; no route |
| Conversations **View all replies needed** | disabled + "Coming soon" | no `/conversations` route yet |
| Attention **"Mark as read"** (no-href toast CTA) | disabled + "Coming soon" | genuine no-op — no attention read-state feature exists |
| Attention **"View details"** | **WIRED** → in-page anchor `#top-performing` | real target: the Top Performing Content section is on the same page |
| Top **"Promote as ad"** | **WIRED** → `/campaigns` | route exists; the Attention card's own "Promote as ad" already links there |

**"View details" wiring** is resolved in `AttentionCardView` keyed on `card.type === 'opportunity'` (structural, not string-matching) + an `id="top-performing"` anchor on the Top section — so **no cached-builder change and no TEMPLATE_VERSION bump**.

## Empty-state copy
- **Demographics**: dropped the misleading *"connect Instagram/Facebook business accounts"* line (it misled tenants who **are** connected — the real state is "not built yet") → *"Audience demographics coming soon — we're still building this insight."*
- **Active-times**: **verified already honest** (*"available after more tracking — check back soon"* — no "connect" claim) → **left unchanged**.

## No TEMPLATE_VERSION bump
All changes are frontend render-state / string-literal only. The cached attention builder's fields (incl. the `toast` strings) are untouched.

## Acceptance criteria
- [x] No `alert(` anywhere under `frontend/insights/`.
- [x] Reply button rendered **disabled with a "Reply ships soon" tooltip**, kept visible (not removed).
- [x] Demographics / active-times copy no longer implies the user must connect.

## Verification
- `tests/insights-no-placeholder-alerts.test.ts` — 3/3 pass: no-`alert()` source scan, Reply present+disabled with the ships-soon tooltip, demographics copy no longer says "connect". **Fails-before** verified against master sources (4 `alert()` calls → 3/3 fail). `npm run verify` green (42/42); typecheck clean.

## Branch
Off `master` — no file overlap with S1-5 (#796): extends the **local** `ActionButton` in ConversationsSection (not shared `ui.tsx`) and changes only a `StubLine` message string in AudienceSection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)