### PR TITLE
S1-8/AA-87: currentFollowers = SUM of per-platform latest, not MAX

### DIFF
--- a/backend/insights/read-api.ts
+++ b/backend/insights/read-api.ts
@@ -32,6 +32,30 @@ function parseIntParam(value: string | null, fallback: number): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
+// S1-8 / AA-87: currentFollowers = SUM of each platform's LATEST follower count.
+// NOT MAX across platforms (which shows only the largest single platform — a
+// multi-platform tenant with FB 10k + IG 6k wrongly saw 10k) and NOT SUM across
+// dates (which multiplies by the number of daily snapshots). DISTINCT ON
+// (platform) ORDER BY platform, date DESC takes the most recent non-null
+// follower row per platform; the outer SUM adds those per-platform latest
+// values. Uncorrelated scalar subquery (uses only $1/$2/$3), so it composes
+// with the other SUM aggregates in the summary query. Exported standalone so
+// the requires-infra test proves the exact expression against the real schema.
+const LATEST_FOLLOWERS_PER_PLATFORM_SUBQUERY = `
+      SELECT COALESCE(SUM(latest.followers), 0)
+      FROM (
+        SELECT DISTINCT ON (platform) followers
+        FROM insights_account_metrics_daily
+        WHERE tenant_id = $1
+          AND date >= $2
+          AND ($3::text IS NULL OR platform = $3)
+          AND followers IS NOT NULL
+        ORDER BY platform, date DESC
+      ) latest`;
+
+export const CURRENT_FOLLOWERS_SUM_SQL =
+  `SELECT (${LATEST_FOLLOWERS_PER_PLATFORM_SUBQUERY}) AS current_followers`;
+
 // ── Summary ───────────────────────────────────────────────────────────────────
 
 /**
@@ -69,7 +93,7 @@ export async function handleGetInsightsSummary(
     }>(
       `SELECT
          COALESCE(SUM(views), 0)              AS total_views,
-         COALESCE(MAX(followers), 0)          AS current_followers,
+         (${LATEST_FOLLOWERS_PER_PLATFORM_SUBQUERY}) AS current_followers,
          COALESCE(SUM(followers_delta), 0)    AS followers_gained,
          COALESCE(SUM(likes), 0)              AS total_likes,
          COALESCE(SUM(comments_count), 0)     AS total_comments,

--- a/tests/REQUIRES_INFRA.md
+++ b/tests/REQUIRES_INFRA.md
@@ -36,6 +36,7 @@ All files below gate on the **superset** `DB_HOST` + `DB_PORT` + `DB_USER` + `DB
 | File | What it proves against real Postgres | Extra env |
 |---|---|---|
 | `tests/insights-sync-runs-sweep.requires-infra.test.ts` | the stranded-run sweep predicate flips only stale `'running'` rows, and the dispatcher's terminal-ok UPDATE overrides a mid-flight sweep + clears the abort message (rolled back) | — |
+| `tests/insights-summary-current-followers.requires-infra.test.ts` | `summary.currentFollowers` is the SUM of each platform's LATEST follower count (`CURRENT_FOLLOWERS_SUM_SQL`), not MAX across platforms and not SUM across dated snapshots — seeds older+latest FB/IG rows and asserts 16k, not 10k/29k (rolled back) | — |
 | `tests/publish-creative-asset-ids.test.ts` | `creative_asset_ids` round-trips through the real `posts` schema + `resolveMediaUrls` SQL (rolled back) | — |
 | `tests/scheduled-posts-worker-end-date.test.ts` | the `campaign_end_date` column exists and the claim filter plans correctly | — |
 | `tests/scheduled-posts-worker-live-db.test.ts` | the scheduled-posts worker drains/claims rows through the live schema (rolled back) | — |

--- a/tests/insights-summary-current-followers.requires-infra.test.ts
+++ b/tests/insights-summary-current-followers.requires-infra.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import pg from 'pg';
+
+import { requireDbEnvOrSkip } from './helpers/requires-infra';
+import { CURRENT_FOLLOWERS_SUM_SQL } from '../backend/insights/read-api';
+
+// S1-8 / AA-87 — live-schema proof that summary.currentFollowers is the SUM of
+// each platform's LATEST follower count, not MAX across platforms.
+//
+// This can only be proven against real Postgres: the fix lives entirely in SQL
+// (DISTINCT ON (platform) latest row, then SUM), so a mocked pool would prove
+// nothing. Runs the exact exported statement inside a rolled-back transaction.
+//
+// requires-infra: self-skips when DB env is absent (as in CI — see the S8-2
+// gap), so the green CI check does NOT mean this ran. Verified locally via the
+// fails-before/passes-after swap (MAX → returns the largest single platform).
+test('summary.currentFollowers = SUM of per-platform latest, not MAX', async (t) => {
+  if (!requireDbEnvOrSkip(t)) return;
+
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    max: 1,
+  });
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const org = (await client.query<{ id: number }>(
+      `INSERT INTO organizations (name) VALUES ('S1-8 followers-sum test') RETURNING id`,
+    )).rows[0].id;
+
+    const account = async (platform: string): Promise<number> => (
+      await client.query<{ id: number }>(
+        `INSERT INTO insights_accounts (tenant_id, platform, external_account_id)
+         VALUES ($1, $2, $3) RETURNING id`,
+        [org, platform, `${platform}-ext-1`],
+      )
+    ).rows[0].id;
+
+    const fb = await account('facebook');
+    const ig = await account('instagram');
+
+    // followers is a dated time-series. Older rows PLUS a latest row per platform.
+    const snap = async (accId: number, platform: string, daysAgo: number, followers: number) => {
+      await client.query(
+        `INSERT INTO insights_account_metrics_daily
+           (tenant_id, account_id, platform, date, followers, raw_source)
+         VALUES ($1, $2, $3, CURRENT_DATE - $4::int, $5, '{}'::jsonb)`,
+        [org, accId, platform, daysAgo, followers],
+      );
+    };
+    await snap(fb, 'facebook', 5, 8000);   // older FB
+    await snap(fb, 'facebook', 1, 10000);  // latest FB
+    await snap(ig, 'instagram', 5, 5000);  // older IG
+    await snap(ig, 'instagram', 1, 6000);  // latest IG
+
+    const fromDate = new Date();
+    fromDate.setDate(fromDate.getDate() - 30);
+
+    // All platforms: latest FB (10k) + latest IG (6k) = 16k.
+    // NOT 10000 (MAX across platforms) and NOT 29000 (8k+10k+5k+6k across dates).
+    const all = await client.query<{ current_followers: string }>(
+      CURRENT_FOLLOWERS_SUM_SQL, [org, fromDate, null],
+    );
+    assert.equal(Number(all.rows[0].current_followers), 16000,
+      'combined = sum of each platform\'s latest follower count');
+
+    // Single-platform filter still correct: FB latest = 10k.
+    const fbOnly = await client.query<{ current_followers: string }>(
+      CURRENT_FOLLOWERS_SUM_SQL, [org, fromDate, 'facebook'],
+    );
+    assert.equal(Number(fbOnly.rows[0].current_followers), 10000,
+      'single-platform tenant unaffected');
+  } finally {
+    await client.query('ROLLBACK').catch(() => {});
+    client.release();
+    await pool.end();
+  }
+});


### PR DESCRIPTION
Closes S1-8 / AA-87

## Bug
`summary.currentFollowers` used `COALESCE(MAX(followers), 0)` over the dated `insights_account_metrics_daily` time-series → a multi-platform tenant saw only their **single largest** platform's follower count. FB 10k + IG 6k showed **10k**, not **16k**.

## Fix
For **each** platform take its **latest** non-null follower snapshot (`DISTINCT ON (platform) … ORDER BY platform, date DESC`), then **SUM** those per-platform latest values:
```sql
SELECT COALESCE(SUM(latest.followers), 0)
FROM (
  SELECT DISTINCT ON (platform) followers
  FROM insights_account_metrics_daily
  WHERE tenant_id = $1 AND date >= $2 AND ($3::text IS NULL OR platform = $3)
    AND followers IS NOT NULL
  ORDER BY platform, date DESC
) latest
```
Not a blind MAX→SUM: the inner query returns **exactly one row per platform**, so it never sums across dates (which would inflate to 8k+10k+5k+6k = 29k). Uncorrelated scalar subquery (`$1/$2/$3`), so it composes with the summary query's other `SUM` aggregates. Exported as `CURRENT_FOLLOWERS_SUM_SQL` so the live-DB test exercises the exact expression.

## No TEMPLATE_VERSION bump
`handleGetInsightsSummary` reads the DB directly (no `insights_narratives`) — **uncached**.

## Sibling MAX spots — flagged, NOT fixed here (possible separate tickets)
- `read-api.ts:251` `MAX(followers)` — `GROUP BY date, platform`, so **not** the cross-platform bug (minor MAX-vs-SUM-across-accounts-per-platform-day nuance only).
- `attention-snapshot-builder.ts:271` `MAX(followers) AS end_followers` — in the **cached attention** builder; may share the cross-platform MAX issue for its growth figure.

## Acceptance criteria
- [x] Multi-platform (FB latest 10k, IG latest 6k, + older dated rows) → **16000** (sum of latest-per-platform).
- [x] Not 10000 (MAX) and not 29000 (sum-across-dates).
- [x] Single-platform tenant still correct (10000).

## Verification — ⚠️ requires-infra test, self-skips in CI
`tests/insights-summary-current-followers.requires-infra.test.ts` seeds one org + FB/IG accounts with older+latest dated rows and asserts the exported SQL against **real Postgres** (rolled-back txn). Because the fix is pure SQL, a mock proves nothing.

**This test self-skips when DB env is absent (as in CI — no DB per the S8-2 gap), so the green `full-suite` check does NOT mean it ran.** It was verified **locally**:

```
# passes-after (SUM fix)
ok 1 - summary.currentFollowers = SUM of per-platform latest, not MAX
# pass 1  # fail 0

# fails-before (swapped SUM → MAX)
not ok 1 - summary.currentFollowers = SUM of per-platform latest, not MAX
  expected: 16000
  actual: 10000
# pass 0  # fail 1
```
`npm run verify` green (42/42; this requires-infra file is not part of the fast suite). Also added to `tests/REQUIRES_INFRA.md`.

## Branch
Off `master`; no overlap with the other open S1 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)