### PR TITLE
S1-9/AA-88: interim provisional-totals disclosure (removed by S2-1)

### DIFF
--- a/frontend/aries-v1/analytics-screen.tsx
+++ b/frontend/aries-v1/analytics-screen.tsx
@@ -83,6 +83,16 @@ export default function AriesAnalyticsScreen({
   // column renders as it does today.
   const postsTable = (
     <ShellPanel eyebrow="Posts" title="Per-post performance">
+      {/* S1-9-PROVISIONAL-DISCLOSURE — REMOVE IN S2-1 (Gap A1 fix). Per-post
+          metrics are lifetime-cumulative snapshots currently SUMmed across daily
+          rows, so these Views/Likes/Comments/Shares totals over-count (~N× over N
+          days). S2-1 fixes the reader math and deletes this note. The /insights
+          Top Performing Content + Goal panels carry the matching disclosure. */}
+      {posts.length > 0 && (
+        <p className="mb-3 inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-400/10 px-3 py-1 text-[11px] text-amber-300">
+          Provisional totals — these per-post numbers currently over-count; a metrics fix is in progress.
+        </p>
+      )}
       {posts.length > 0 ? (
         <div className="overflow-x-auto">
           <table className="w-full min-w-[640px] border-collapse text-left text-sm">

--- a/frontend/insights/GoalSection.tsx
+++ b/frontend/insights/GoalSection.tsx
@@ -14,6 +14,8 @@ import { C, platformLabel } from "@/frontend/insights/tokens";
 import {
   SectionHeader, Panel, ChannelIcon, Icon, ErrorState, EmptyState, LoadingRows,
 } from "@/frontend/insights/ui";
+// S1-9-PROVISIONAL-DISCLOSURE — REMOVE IN S2-1 (Gap A1 fix).
+import { ProvisionalMetricNote } from "@/frontend/insights/ProvisionalMetricNote";
 
 interface GoalSectionProps {
   period:   Period;
@@ -150,8 +152,15 @@ export function GoalSection({ period, platform }: GoalSectionProps) {
 
             {/* ── RIGHT: what contributed ── */}
             <div style={{ borderLeft: `1px solid ${C.border}`, paddingLeft: 28 }}>
-              <div style={{ fontSize: 10.5, fontWeight: 700, color: C.t3, textTransform: "uppercase", letterSpacing: "0.07em", marginBottom: 14 }}>
-                What contributed
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, marginBottom: 14, flexWrap: "wrap" }}>
+                <span style={{ fontSize: 10.5, fontWeight: 700, color: C.t3, textTransform: "uppercase", letterSpacing: "0.07em" }}>
+                  What contributed
+                </span>
+                {/* S1-9-PROVISIONAL-DISCLOSURE — REMOVE IN S2-1 (Gap A1 fix):
+                    contributor/category values are per-post lifetime-SUM reach/
+                    saves (over-count). The goal headline metric is account-level
+                    and is NOT labelled here. */}
+                <ProvisionalMetricNote />
               </div>
 
               <div style={{ display: "flex", flexDirection: "column" }}>

--- a/frontend/insights/ProvisionalMetricNote.tsx
+++ b/frontend/insights/ProvisionalMetricNote.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// S1-9-PROVISIONAL-DISCLOSURE — REMOVE IN S2-1 (Gap A1 fix).
+//
+// INTERIM disclosure component. Per-post metrics come back from Meta as
+// lifetime-cumulative snapshots stamped with today's date, but every reader
+// currently SUMs them across daily rows as if each day's value were that day's
+// delta — so raw per-post totals over-count (~N× over N days of syncing).
+//
+// This is NOT the fix. S2-1 (AA-88's follow-up, Gap A1) changes every reader to
+// latest-snapshot / window-delta math and DELETES this disclosure. Its own
+// acceptance says "removes the S1-9 disclosure".
+//
+// To remove cleanly in S2-1:
+//   grep -rn "S1-9-PROVISIONAL-DISCLOSURE"
+//   → delete this file, its two <ProvisionalMetricNote/> usages
+//     (TopPostsSection, GoalSection), and the matching inline note on the
+//     legacy /dashboard/analytics screen (frontend/aries-v1/analytics-screen.tsx).
+//
+// Only RAW summed counts are labelled (reach, saves, shares, comments,
+// avg reach, goal contributor values). Ratios (engagement %, save rate,
+// multiplier), rankings, the high-performers count, and currentFollowers
+// (account-level, fixed in S1-8) are NOT affected and are NOT labelled.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { C } from "@/frontend/insights/tokens";
+import { Icon } from "@/frontend/insights/ui";
+
+export function ProvisionalMetricNote({ label = "Provisional totals" }: { label?: string }) {
+  return (
+    <span
+      title="These totals currently over-count — a metrics fix is in progress. Rankings are reliable; the absolute numbers will drop once corrected."
+      style={{
+        display: "inline-flex", alignItems: "center", gap: 5,
+        fontSize: 11, color: C.amber,
+        background: `${C.amber}14`, border: `1px solid ${C.amber}55`,
+        borderRadius: 99, padding: "3px 9px", whiteSpace: "nowrap",
+      }}
+    >
+      <Icon name="info" size={11} color={C.amber} />
+      {label} — correcting soon
+    </span>
+  );
+}

--- a/frontend/insights/TopPostsSection.tsx
+++ b/frontend/insights/TopPostsSection.tsx
@@ -23,6 +23,8 @@ import {
   EmptyState,
   LoadingRows,
 } from "@/frontend/insights/ui";
+// S1-9-PROVISIONAL-DISCLOSURE — REMOVE IN S2-1 (Gap A1 fix).
+import { ProvisionalMetricNote } from "@/frontend/insights/ProvisionalMetricNote";
 
 interface TopPostsSectionProps {
   period:   Period;
@@ -413,14 +415,24 @@ export function TopPostsSection({ period, platform }: TopPostsSectionProps) {
             {/* Footer line */}
             <div
               style={{
-                marginTop:  18,
-                paddingTop: 14,
-                borderTop:  `1px solid ${C.border}`,
-                fontSize:   12,
-                color:      C.t3,
+                marginTop:      18,
+                paddingTop:     14,
+                borderTop:      `1px solid ${C.border}`,
+                fontSize:       12,
+                color:          C.t3,
+                display:        "flex",
+                alignItems:     "center",
+                justifyContent: "space-between",
+                gap:            12,
+                flexWrap:       "wrap",
               }}
             >
-              {data.meta.postCount} posts · avg reach {data.meta.avgReach.toLocaleString()}
+              <span>{data.meta.postCount} posts · avg reach {data.meta.avgReach.toLocaleString()}</span>
+              {/* S1-9-PROVISIONAL-DISCLOSURE — REMOVE IN S2-1 (Gap A1 fix): reach/
+                  saves/shares/comments + avg reach are raw per-post lifetime SUMs
+                  (over-count). engagement %, save rate, multiplier are ratios and
+                  are NOT affected. */}
+              <ProvisionalMetricNote label="Reach / saves / shares / comments are provisional" />
             </div>
           </>
         )}

--- a/tests/insights-provisional-disclosure.test.ts
+++ b/tests/insights-provisional-disclosure.test.ts
@@ -1,0 +1,51 @@
+/**
+ * tests/insights-provisional-disclosure.test.ts
+ *
+ * S1-9 / AA-88 — interim inflated-totals disclosure (Gap A1 mitigation). Source
+ * scan (these are client components, so a source scan is the right surface):
+ *  - the shared ProvisionalMetricNote exists and carries the REMOVE IN S2-1
+ *    marker + the greppable removal token, so S2-1 can find and rip it out;
+ *  - both /insights sections that render raw per-post-summed totals (Top,
+ *    Goal) render the note;
+ *  - the legacy /dashboard/analytics screen carries the disclosure too (the bug
+ *    inflates BOTH surfaces; S2-1 acceptance requires both to agree post-fix);
+ *  - the grep token appears in >=3 sites so the S2-1 removal sweep finds them all.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const TOKEN = 'S1-9-PROVISIONAL-DISCLOSURE';
+const read = (rel: string) => fs.readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+
+test('ProvisionalMetricNote exists and is tagged for S2-1 removal', () => {
+  const src = read('../frontend/insights/ProvisionalMetricNote.tsx');
+  assert.match(src, /export function ProvisionalMetricNote/);
+  assert.match(src, /REMOVE IN S2-1/, 'must carry the S2-1 removal marker');
+  assert.match(src, new RegExp(TOKEN), 'must carry the greppable removal token');
+});
+
+test('/insights Top + Goal sections render the provisional note', () => {
+  for (const file of ['../frontend/insights/TopPostsSection.tsx', '../frontend/insights/GoalSection.tsx']) {
+    const src = read(file);
+    assert.match(src, /<ProvisionalMetricNote/, `${file} must render the disclosure`);
+  }
+});
+
+test('legacy /dashboard/analytics screen carries the disclosure', () => {
+  const src = read('../frontend/aries-v1/analytics-screen.tsx');
+  assert.match(src, new RegExp(TOKEN), 'legacy analytics screen must carry the removal token');
+  assert.match(src, /Provisional totals/, 'legacy screen must show a provisional disclaimer');
+});
+
+test('the removal token appears in >=3 sites so S2-1 can sweep them all', () => {
+  const files = [
+    '../frontend/insights/ProvisionalMetricNote.tsx',
+    '../frontend/insights/TopPostsSection.tsx',
+    '../frontend/insights/GoalSection.tsx',
+    '../frontend/aries-v1/analytics-screen.tsx',
+  ];
+  const sites = files.filter((f) => read(f).includes(TOKEN));
+  assert.ok(sites.length >= 3, `expected the token in >=3 sites, found ${sites.length}: ${sites.join(', ')}`);
+});


### PR DESCRIPTION
Closes S1-9 / AA-88

**TEMPORARY Gap-A1 mitigation — to be REMOVED by S2-1.** Per-post metrics come back from Meta as lifetime-cumulative snapshots stamped with today's date, but every reader `SUM`s them across daily rows as if each day's value were a daily delta → raw per-post totals over-count (~N× over N days of syncing). **This PR does NOT fix the math** (that's S2-1, a Sprint-2 L ticket); it ensures no *undisclosed*-wrong headline number renders during the gap.

## What gets labelled (only genuinely-inflated raw counts), on BOTH surfaces
| Surface | Figures labelled |
|---|---|
| `/insights` Top Performing Content | per-post **reach, saves, shares, comments** + **avg reach** |
| `/insights` Goal "what contributed" | contributor / category **values** |
| `/dashboard/analytics` (legacy) | per-post **views / likes / comments / shares** table |

The legacy screen is included because the bug inflates it too, and S2-1's acceptance requires `/insights` and `/dashboard/analytics` to render **agreeing totals** post-fix.

## Deliberately NOT labelled (verified correct)
Ratios — **engagement %, save rate, multiplier** (numerator & denominator inflate together → self-cancel); **rankings**; the **high-performers** threshold count; trends' top-post-title ordering; and **currentFollowers** (account-level, already fixed in S1-8). Labelling these would be wrong — they aren't inflated.

## Mechanism (single, frontend-only, trivial to rip out)
One shared component `frontend/insights/ProvisionalMetricNote.tsx` (used in Top + Goal) + one matching inline note on the legacy screen (different design system). **Frontend-only** — it annotates rendered output and does not touch any cached builder body, so **no `TEMPLATE_VERSION` bumps**.

## 🔴 REMOVE IN S2-1
Every site carries the grep token **`S1-9-PROVISIONAL-DISCLOSURE`** + a `REMOVE IN S2-1 (Gap A1 fix)` comment. The component header documents the recipe:
```
grep -rn "S1-9-PROVISIONAL-DISCLOSURE"
→ delete ProvisionalMetricNote.tsx + its 2 usages (Top, Goal)
  + the inline note on frontend/aries-v1/analytics-screen.tsx
```
S2-1's own acceptance already says "removes the S1-9 disclosure."

## Acceptance criteria
- [x] No undisclosed-wrong headline number renders in the Sprint-1→2 gap (both surfaces disclosed).
- [x] Only inflated raw counts labelled; ratios / rankings / counts / followers untouched.
- [x] Trivially removable by S2-1 (single grep token, documented recipe).
- [x] No cache churn (frontend-only, no `TEMPLATE_VERSION` bumps).

## Verification
`tests/insights-provisional-disclosure.test.ts` — 4/4 pass (source scan: component exists + carries the marker; Top + Goal render it; legacy screen carries the token; token in ≥3 sites so the S2-1 sweep finds them all). **Fails-before** verified by moving the component/edits aside (4/4 fail), restored → 4/4. `npm run verify` green (42/42); typecheck clean.

## Branch
Off `master`; no overlap with the other open S1 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)