### PR TITLE
fix(workspace): reframe upgrade screen copy for additional brand workspaces

### DIFF
--- a/app/workspace/upgrade/page.tsx
+++ b/app/workspace/upgrade/page.tsx
@@ -6,7 +6,7 @@ import { WORKSPACE_UPGRADE_PATH } from '@/backend/tenant/workspace-upgrade';
 import AuthLayout from '@/frontend/auth/auth-layout';
 
 export const metadata = {
-  title: 'Upgrade to add a workspace — Aries AI',
+  title: 'Add a brand workspace — Aries AI',
 };
 
 /**
@@ -33,21 +33,23 @@ export default async function WorkspaceUpgradePage() {
   return (
     <AuthLayout>
       <div className="mx-auto max-w-md rounded-2xl border border-white/10 bg-white/5 px-6 py-10 text-left text-white/80 space-y-4">
-        <p className="text-lg font-semibold text-white">Adding a workspace needs Aries Pro.</p>
+        <p className="text-lg font-semibold text-white">
+          Additional brand workspaces are a Pro feature.
+        </p>
         <div className="space-y-2 text-sm text-white/70">
           <p>
             {email ? (
               <>
                 Your account (<span className="font-semibold text-white">{email}</span>) is on the
-                free plan, which includes one workspace.
+                free plan, which includes one brand workspace.
               </>
             ) : (
-              <>Your account is on the free plan, which includes one workspace.</>
+              <>Your account is on the free plan, which includes one brand workspace.</>
             )}
           </p>
           <p>
-            Creating a second business for the same account needs Aries Pro. Contact the Aries team
-            about upgrading your account, then start onboarding your new business again.
+            Adding more brand workspaces needs Aries Pro. Contact the Aries team to upgrade your
+            account, then start onboarding your new brand again.
           </p>
         </div>
         <a


### PR DESCRIPTION
Part of #803

## Phase 1 task 1d — upgrade-screen copy

Copy-only reword of the create-second-workspace paywall screen (`app/workspace/upgrade/page.tsx`) toward the multi-brand framing from docs/plans/2026-07-08-multi-brand-workspaces.md §1d: "Additional brand workspaces are a Pro feature" instead of the old generic "add a workspace" / "second business" wording.

### What changed
- Page metadata title: "Upgrade to add a workspace" → "Add a brand workspace".
- Heading: "Adding a workspace needs Aries Pro." → "Additional brand workspaces are a Pro feature."
- Plan-includes line (both the with-email and no-email ternary branches): "one workspace" → "one brand workspace".
- CTA paragraph: reworded to "Adding more brand workspaces needs Aries Pro… start onboarding your new brand again."

### Scope / safety
- Exactly one file changed; strings only. JSX structure and all Tailwind classNames are unchanged.
- No enforcement-logic change: the `auth()` gate, `isMultiWorkspaceEnabled()` redirect, and the `/dashboard` fallback are untouched.
- Out-of-scope files (invite accept client, invite-join route, `backend/tenant/workspace-upgrade.ts`) are untouched.
- No banned patterns; no test pins the old strings.

### Test evidence
- `npm run verify` green (42/42) in the worktree.
- `npm run guardrails:agent` passed (real unique diff, no duplicate work).

### Residual risk
None — static server-component copy behind the (default-OFF) `ARIES_MULTI_WORKSPACE_ENABLED` flag; no runtime behavior change.

Part of the multi-brand workspaces build (tracker #803); this is one sub-task, so the tracker stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)