### PR TITLE
feat(marketing): auto-provision marketing_schedule at onboarding materialization

### DIFF
--- a/app/onboarding/resume/page.tsx
+++ b/app/onboarding/resume/page.tsx
@@ -17,9 +17,11 @@ import {
   updateOnboardingDraft,
 } from '@/backend/onboarding/draft-store';
 import {
+  loadTenantTimezoneOrFallback,
   tenantHasStoredBusinessProfileState,
   updateBusinessProfileWithDiagnostics,
 } from '@/backend/tenant/business-profile';
+import { provisionDefaultMarketingSchedule } from '@/backend/marketing/schedule-store';
 import { listSocialContentJobIdsForTenant } from '@/backend/marketing/runtime-state';
 import { listMarketingReviewItemsForTenant } from '@/backend/marketing/runtime-views';
 import { startSocialContentJob } from '@/backend/marketing/orchestrator';
@@ -232,6 +234,25 @@ export default async function OnboardingResumePage(
         competitorUrl: claim.draft.competitorUrl || null,
         channels: claim.draft.channels,
       });
+
+      // Multi-brand workspaces Phase 1a: seed a default weekly cadence row for
+      // every newly-materialized tenant so a cadence-settings card (1b) and the
+      // weekly trigger worker have something to read/pick up. Best-effort and
+      // NEVER blocks onboarding — flag-independent (runs for all onboarding
+      // completions; the multi-workspace flag split lives upstream in
+      // resolveTenantForDraft, not here). ON CONFLICT DO NOTHING makes this
+      // safe to call unconditionally, including for a reused tenant.
+      try {
+        await provisionDefaultMarketingSchedule(client, {
+          tenantId: Number(tenantId),
+          timezone: loadTenantTimezoneOrFallback(tenantId),
+        });
+      } catch (scheduleError) {
+        console.warn(
+          `[onboarding-resume] provisionDefaultMarketingSchedule failed for tenant ${tenantId}:`,
+          scheduleError,
+        );
+      }
     } finally {
       client.release();
     }

--- a/backend/marketing/schedule-store.ts
+++ b/backend/marketing/schedule-store.ts
@@ -1,0 +1,195 @@
+/**
+ * `marketing_schedule` — single writer.
+ *
+ * Historically the only writer of this table was the operator CLI
+ * (`scripts/marketing/upsert-marketing-schedule.ts`), which validates
+ * day/hour/timezone/enabled before writing so a typo can't silently misfire a
+ * tenant's whole cadence (the CEO review's "6-month ops regret"). This module
+ * lifts those validators + the exact upsert SQL out of the CLI so a second
+ * caller — onboarding auto-provisioning (multi-brand workspaces Phase 1a) —
+ * can reuse them verbatim instead of re-deriving the SQL/validation and
+ * risking drift.
+ *
+ * `db` is a structural type (`.query(text, params)`), so both `pg.Pool` and
+ * `pg.PoolClient` satisfy it. This module NEVER opens its own connection —
+ * callers own connection lifecycle (a borrowed onboarding client, the CLI's
+ * own pool, a future route handler's tenant-scoped client, etc).
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ScheduleQueryable = {
+  query: (sql: string, params: unknown[]) => Promise<{ rows: any[]; rowCount?: number | null }>;
+};
+
+export type MarketingScheduleRow = {
+  tenant_id: number;
+  cadence: string;
+  day_of_week: number;
+  hour: number;
+  timezone: string | null;
+  enabled: boolean;
+  last_triggered_at?: unknown;
+  last_attempt_at?: unknown;
+  last_success_at?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// Validators — moved verbatim from scripts/marketing/upsert-marketing-schedule.ts
+// ---------------------------------------------------------------------------
+
+const DAY_NAMES: Readonly<Record<string, number>> = {
+  sun: 0, sunday: 0,
+  mon: 1, monday: 1,
+  tue: 2, tues: 2, tuesday: 2,
+  wed: 3, weds: 3, wednesday: 3,
+  thu: 4, thur: 4, thurs: 4, thursday: 4,
+  fri: 5, friday: 5,
+  sat: 6, saturday: 6,
+};
+
+export function parseScheduleDay(raw: string | boolean | undefined): number | null {
+  if (typeof raw !== 'string') return null;
+  const t = raw.trim().toLowerCase();
+  if (/^[0-6]$/.test(t)) return Number.parseInt(t, 10);
+  return DAY_NAMES[t] ?? null;
+}
+
+export function parseScheduleHour(raw: string | boolean | undefined): number | null {
+  if (typeof raw !== 'string') return null;
+  if (!/^\d{1,2}$/.test(raw.trim())) return null;
+  const h = Number.parseInt(raw.trim(), 10);
+  return h >= 0 && h <= 23 ? h : null;
+}
+
+export function isValidScheduleTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseScheduleEnabled(raw: string | boolean | undefined): boolean | null {
+  if (raw === undefined) return null;
+  if (typeof raw === 'boolean') return raw;
+  const t = raw.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(t)) return true;
+  if (['0', 'false', 'no', 'off'].includes(t)) return false;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Writers
+// ---------------------------------------------------------------------------
+
+export type UpsertMarketingScheduleInput = {
+  tenantId: number;
+  /** null = omitted (preserve existing value / table default on insert). */
+  dayOfWeek: number | null;
+  /** null = omitted (preserve existing value / table default on insert). */
+  hour: number | null;
+  /** null = omitted (preserve existing value) OR an explicit clear when timezoneProvided is true. */
+  timezone: string | null;
+  /**
+   * Distinguishes "timezone omitted, preserve existing" from "timezone
+   * explicitly provided (possibly null, to clear it)" — a plain `timezone:
+   * null` is ambiguous on its own, exactly why the CLI carries a separate
+   * `tzProvided` flag over the wire as $6.
+   */
+  timezoneProvided: boolean;
+  /** null = omitted (preserve existing value / table default on insert). */
+  enabled: boolean | null;
+};
+
+/**
+ * The exact COALESCE-preserve upsert from
+ * scripts/marketing/upsert-marketing-schedule.ts: an omitted arg (null
+ * param) preserves the stored value on UPDATE; table defaults apply only to
+ * brand-new INSERTs. Used by both the CLI and the (future) settings PATCH
+ * route (1b) so both share one behavior-pinned SQL statement.
+ */
+export async function upsertMarketingSchedule(
+  db: ScheduleQueryable,
+  input: UpsertMarketingScheduleInput,
+): Promise<MarketingScheduleRow> {
+  const res = await db.query(
+    `INSERT INTO marketing_schedule (tenant_id, cadence, day_of_week, hour, timezone, enabled)
+     VALUES ($1, 'weekly', COALESCE($2, 1), COALESCE($3, 9), $4, COALESCE($5, false))
+     ON CONFLICT (tenant_id) DO UPDATE
+       SET day_of_week = COALESCE($2, marketing_schedule.day_of_week),
+           hour        = COALESCE($3, marketing_schedule.hour),
+           timezone    = CASE WHEN $6 THEN $4 ELSE marketing_schedule.timezone END,
+           enabled     = COALESCE($5, marketing_schedule.enabled),
+           updated_at  = now()
+     RETURNING tenant_id, day_of_week, hour, timezone, enabled`,
+    [input.tenantId, input.dayOfWeek, input.hour, input.timezone, input.enabled, input.timezoneProvided],
+  );
+  return res.rows[0] as MarketingScheduleRow;
+}
+
+export type ProvisionDefaultMarketingScheduleInput = {
+  tenantId: number;
+  timezone: string | null;
+  dayOfWeek?: number;
+  hour?: number;
+  enabled?: boolean;
+};
+
+/**
+ * Onboarding auto-provision (multi-brand workspaces Phase 1a): seed a
+ * default weekly cadence row for a newly-materialized tenant so a
+ * cadence-settings card (1b) has something to render and the weekly trigger
+ * worker (when enabled) has a row to pick up. `ON CONFLICT DO NOTHING` — this
+ * NEVER clobbers an existing row (e.g. a re-materialized/reused tenant, or a
+ * re-run of onboarding), so it is safe to call unconditionally and
+ * repeatedly. Returns whether a row was actually created.
+ */
+export async function provisionDefaultMarketingSchedule(
+  db: ScheduleQueryable,
+  input: ProvisionDefaultMarketingScheduleInput,
+): Promise<{ created: boolean }> {
+  const dayOfWeek = input.dayOfWeek ?? 1;
+  const hour = input.hour ?? 9;
+  const enabled = input.enabled ?? true;
+
+  const res = await db.query(
+    `INSERT INTO marketing_schedule (tenant_id, cadence, day_of_week, hour, timezone, enabled)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (tenant_id) DO NOTHING`,
+    [input.tenantId, 'weekly', dayOfWeek, hour, input.timezone, enabled],
+  );
+  return { created: (res.rowCount ?? 0) > 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Readers
+// ---------------------------------------------------------------------------
+
+export async function getMarketingScheduleForTenant(
+  db: ScheduleQueryable,
+  tenantId: number,
+): Promise<MarketingScheduleRow | null> {
+  const res = await db.query(
+    `SELECT tenant_id, cadence, day_of_week, hour, timezone, enabled,
+            last_triggered_at, last_attempt_at, last_success_at
+       FROM marketing_schedule
+      WHERE tenant_id = $1
+      LIMIT 1`,
+    [tenantId],
+  );
+  return (res.rows[0] as MarketingScheduleRow | undefined) ?? null;
+}
+
+export async function listMarketingSchedules(db: ScheduleQueryable): Promise<MarketingScheduleRow[]> {
+  const res = await db.query(
+    `SELECT tenant_id, cadence, day_of_week, hour, timezone, enabled,
+            last_triggered_at, last_success_at
+       FROM marketing_schedule
+      ORDER BY tenant_id`,
+    [],
+  );
+  return res.rows as MarketingScheduleRow[];
+}

--- a/scripts/marketing/upsert-marketing-schedule.ts
+++ b/scripts/marketing/upsert-marketing-schedule.ts
@@ -18,20 +18,24 @@
  *
  * --day accepts 0-6 (0=Sun) or sun/mon/tue/wed/thu/fri/sat.
  * --hour accepts 0-23 (tenant-local). --tz is an IANA name (validated).
+ *
+ * This is a thin CLI wrapper — argv parsing, its own pool, and process-exit
+ * handling live here. Validation + the actual upsert SQL live in
+ * backend/marketing/schedule-store.ts (the single writer), shared with the
+ * onboarding auto-provision hook and the (future) settings PATCH route.
  */
 import 'dotenv/config';
 
 import pg from 'pg';
 
-const DAY_NAMES: Readonly<Record<string, number>> = {
-  sun: 0, sunday: 0,
-  mon: 1, monday: 1,
-  tue: 2, tues: 2, tuesday: 2,
-  wed: 3, weds: 3, wednesday: 3,
-  thu: 4, thur: 4, thurs: 4, thursday: 4,
-  fri: 5, friday: 5,
-  sat: 6, saturday: 6,
-};
+import {
+  isValidScheduleTimezone,
+  listMarketingSchedules,
+  parseScheduleDay,
+  parseScheduleEnabled,
+  parseScheduleHour,
+  upsertMarketingSchedule,
+} from '@/backend/marketing/schedule-store';
 
 function parseArgs(argv: string[]): Record<string, string | boolean> {
   const out: Record<string, string | boolean> = {};
@@ -50,38 +54,6 @@ function parseArgs(argv: string[]): Record<string, string | boolean> {
   return out;
 }
 
-function parseDay(raw: string | boolean | undefined): number | null {
-  if (typeof raw !== 'string') return null;
-  const t = raw.trim().toLowerCase();
-  if (/^[0-6]$/.test(t)) return Number.parseInt(t, 10);
-  return DAY_NAMES[t] ?? null;
-}
-
-function parseHour(raw: string | boolean | undefined): number | null {
-  if (typeof raw !== 'string') return null;
-  if (!/^\d{1,2}$/.test(raw.trim())) return null;
-  const h = Number.parseInt(raw.trim(), 10);
-  return h >= 0 && h <= 23 ? h : null;
-}
-
-function isValidTimezone(tz: string): boolean {
-  try {
-    new Intl.DateTimeFormat('en-US', { timeZone: tz });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function parseEnabled(raw: string | boolean | undefined): boolean | null {
-  if (raw === undefined) return null;
-  if (typeof raw === 'boolean') return raw;
-  const t = raw.trim().toLowerCase();
-  if (['1', 'true', 'yes', 'on'].includes(t)) return true;
-  if (['0', 'false', 'no', 'off'].includes(t)) return false;
-  return null;
-}
-
 function buildPool(): pg.Pool {
   return new pg.Pool({
     host: process.env.DB_HOST || 'localhost',
@@ -94,17 +66,12 @@ function buildPool(): pg.Pool {
 }
 
 async function list(pool: pg.Pool): Promise<void> {
-  const res = await pool.query(
-    `SELECT tenant_id, cadence, day_of_week, hour, timezone, enabled,
-            last_triggered_at, last_success_at
-       FROM marketing_schedule
-      ORDER BY tenant_id`,
-  );
-  if (res.rowCount === 0) {
+  const rows = await listMarketingSchedules(pool);
+  if (rows.length === 0) {
     console.log('(no marketing_schedule rows)');
     return;
   }
-  console.table(res.rows);
+  console.table(rows);
 }
 
 async function main(): Promise<void> {
@@ -129,38 +96,34 @@ async function main(): Promise<void> {
     // true` (no --day/--hour/--tz) would silently reset its whole cadence to
     // Mon/09:00/null. So omitted args map to NULL params and the UPDATE COALESCEs
     // them against the existing row; table defaults apply only to brand-new INSERTs.
-    const day = args.day !== undefined ? parseDay(args.day) : null;
+    const day = args.day !== undefined ? parseScheduleDay(args.day) : null;
     if (args.day !== undefined && day === null) throw new Error(`invalid --day: ${String(args.day)} (use 0-6 or sun..sat)`);
 
-    const hour = args.hour !== undefined ? parseHour(args.hour) : null;
+    const hour = args.hour !== undefined ? parseScheduleHour(args.hour) : null;
     if (args.hour !== undefined && hour === null) throw new Error(`invalid --hour: ${String(args.hour)} (use 0-23)`);
 
     // timezone NULL is itself meaningful (clear → use tenant business tz), so a
     // separate "provided" flag distinguishes "omit, preserve" from "set".
     const tzProvided = typeof args.tz === 'string';
     const tz = tzProvided ? (args.tz as string).trim() : null;
-    if (tzProvided && tz && !isValidTimezone(tz)) {
+    if (tzProvided && tz && !isValidScheduleTimezone(tz)) {
       throw new Error(`invalid --tz: ${tz} (use an IANA name like America/New_York)`);
     }
 
-    const enabled = parseEnabled(args.enabled); // null when omitted → preserved
+    const enabled = parseScheduleEnabled(args.enabled); // null when omitted → preserved
     if (args.enabled !== undefined && enabled === null) {
       throw new Error(`invalid --enabled: ${String(args.enabled)} (use true/false)`);
     }
 
-    const res = await pool.query(
-      `INSERT INTO marketing_schedule (tenant_id, cadence, day_of_week, hour, timezone, enabled)
-       VALUES ($1, 'weekly', COALESCE($2, 1), COALESCE($3, 9), $4, COALESCE($5, false))
-       ON CONFLICT (tenant_id) DO UPDATE
-         SET day_of_week = COALESCE($2, marketing_schedule.day_of_week),
-             hour        = COALESCE($3, marketing_schedule.hour),
-             timezone    = CASE WHEN $6 THEN $4 ELSE marketing_schedule.timezone END,
-             enabled     = COALESCE($5, marketing_schedule.enabled),
-             updated_at  = now()
-       RETURNING tenant_id, day_of_week, hour, timezone, enabled`,
-      [tenantId, day, hour, tz, enabled, tzProvided],
-    );
-    console.log('upserted marketing_schedule:', res.rows[0]);
+    const row = await upsertMarketingSchedule(pool, {
+      tenantId,
+      dayOfWeek: day,
+      hour,
+      timezone: tz,
+      timezoneProvided: tzProvided,
+      enabled,
+    });
+    console.log('upserted marketing_schedule:', row);
   } finally {
     await pool.end().catch(() => {});
   }

--- a/tests/marketing/schedule-store.test.ts
+++ b/tests/marketing/schedule-store.test.ts
@@ -1,0 +1,259 @@
+/**
+ * backend/marketing/schedule-store.ts — self-contained unit tests (no live
+ * DB). Recording-fake queryable idiom mirrors
+ * tests/auth/tenant-resolution-flag-off-golden.test.ts /
+ * tests/tenant/business-profile.test.ts.
+ *
+ * Covers:
+ *   - provisionDefaultMarketingSchedule: exact ON CONFLICT DO NOTHING SQL +
+ *     params, created:true on rowCount 1, created:false on rowCount 0 with
+ *     no second (update) statement ever issued;
+ *   - upsertMarketingSchedule: byte-identical to the CLI's original
+ *     COALESCE-preserve SQL, omitted-arg preservation, and the
+ *     timezoneProvided clear-vs-omit distinction;
+ *   - the four validators reject invalid input (return null) and accept the
+ *     documented formats.
+ *
+ * Run:
+ *   APP_BASE_URL=https://aries.example.com ./node_modules/.bin/tsx --test tests/marketing/schedule-store.test.ts
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getMarketingScheduleForTenant,
+  isValidScheduleTimezone,
+  listMarketingSchedules,
+  parseScheduleDay,
+  parseScheduleEnabled,
+  parseScheduleHour,
+  provisionDefaultMarketingSchedule,
+  upsertMarketingSchedule,
+  type ScheduleQueryable,
+} from '../../backend/marketing/schedule-store';
+
+// ---------------------------------------------------------------------------
+// Recording fixture
+// ---------------------------------------------------------------------------
+
+type Call = { sql: string; params: unknown[] };
+
+function recordingQueryable(
+  respond: (sql: string, params: unknown[]) => { rowCount: number | null; rows: Array<Record<string, unknown>> },
+): { calls: Call[]; queryable: ScheduleQueryable } {
+  const calls: Call[] = [];
+  return {
+    calls,
+    queryable: {
+      async query(sql: string, params: unknown[] = []) {
+        calls.push({ sql, params });
+        return respond(sql, params);
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// provisionDefaultMarketingSchedule
+// ---------------------------------------------------------------------------
+
+test('provisionDefaultMarketingSchedule: emits ON CONFLICT DO NOTHING with the default day/hour/enabled params', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 1, rows: [] }));
+
+  const result = await provisionDefaultMarketingSchedule(queryable, {
+    tenantId: 42,
+    timezone: 'America/New_York',
+  });
+
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].sql, /INSERT INTO marketing_schedule/);
+  assert.match(calls[0].sql, /ON CONFLICT \(tenant_id\) DO NOTHING/);
+  assert.doesNotMatch(calls[0].sql, /DO UPDATE/);
+  assert.deepEqual(calls[0].params, [42, 'weekly', 1, 9, 'America/New_York', true]);
+  assert.deepEqual(result, { created: true });
+});
+
+test('provisionDefaultMarketingSchedule: created:false on rowCount 0 (conflict), and issues NO update statement', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 0, rows: [] }));
+
+  const result = await provisionDefaultMarketingSchedule(queryable, {
+    tenantId: 42,
+    timezone: null,
+  });
+
+  assert.equal(calls.length, 1, 'DO NOTHING must never be followed by a second (update) query');
+  assert.deepEqual(result, { created: false });
+});
+
+test('provisionDefaultMarketingSchedule: null rowCount (driver quirk) is treated as created:false, not thrown', async () => {
+  const { queryable } = recordingQueryable(() => ({ rowCount: null, rows: [] }));
+  const result = await provisionDefaultMarketingSchedule(queryable, { tenantId: 1, timezone: null });
+  assert.deepEqual(result, { created: false });
+});
+
+test('provisionDefaultMarketingSchedule: overrides for dayOfWeek/hour/enabled are honored', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 1, rows: [] }));
+
+  await provisionDefaultMarketingSchedule(queryable, {
+    tenantId: 7,
+    timezone: 'UTC',
+    dayOfWeek: 3,
+    hour: 14,
+    enabled: false,
+  });
+
+  assert.deepEqual(calls[0].params, [7, 'weekly', 3, 14, 'UTC', false]);
+});
+
+// ---------------------------------------------------------------------------
+// upsertMarketingSchedule — CLI-parity COALESCE-preserve SQL
+// ---------------------------------------------------------------------------
+
+const CLI_UPSERT_SQL =
+  `INSERT INTO marketing_schedule (tenant_id, cadence, day_of_week, hour, timezone, enabled)\n     VALUES ($1, 'weekly', COALESCE($2, 1), COALESCE($3, 9), $4, COALESCE($5, false))\n     ON CONFLICT (tenant_id) DO UPDATE\n       SET day_of_week = COALESCE($2, marketing_schedule.day_of_week),\n           hour        = COALESCE($3, marketing_schedule.hour),\n           timezone    = CASE WHEN $6 THEN $4 ELSE marketing_schedule.timezone END,\n           enabled     = COALESCE($5, marketing_schedule.enabled),\n           updated_at  = now()\n     RETURNING tenant_id, day_of_week, hour, timezone, enabled`;
+
+test('upsertMarketingSchedule: emits the exact CLI COALESCE-preserve SQL text', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({
+    rowCount: 1,
+    rows: [{ tenant_id: 15, day_of_week: 1, hour: 9, timezone: 'America/New_York', enabled: true }],
+  }));
+
+  await upsertMarketingSchedule(queryable, {
+    tenantId: 15,
+    dayOfWeek: 1,
+    hour: 9,
+    timezone: 'America/New_York',
+    timezoneProvided: true,
+    enabled: true,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].sql, CLI_UPSERT_SQL);
+});
+
+test('upsertMarketingSchedule: full explicit write sends every param verbatim', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 1, rows: [{}] }));
+
+  await upsertMarketingSchedule(queryable, {
+    tenantId: 15,
+    dayOfWeek: 5,
+    hour: 18,
+    timezone: 'America/Los_Angeles',
+    timezoneProvided: true,
+    enabled: false,
+  });
+
+  assert.deepEqual(calls[0].params, [15, 5, 18, 'America/Los_Angeles', false, true]);
+});
+
+test('upsertMarketingSchedule: omitted day/hour/timezone/enabled map to NULL params (COALESCE preserves on update)', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 1, rows: [{}] }));
+
+  await upsertMarketingSchedule(queryable, {
+    tenantId: 15,
+    dayOfWeek: null,
+    hour: null,
+    timezone: null,
+    timezoneProvided: false,
+    enabled: null,
+  });
+
+  assert.deepEqual(calls[0].params, [15, null, null, null, null, false]);
+});
+
+test('upsertMarketingSchedule: timezoneProvided:true + timezone:null explicitly CLEARS the stored timezone (not preserved)', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 1, rows: [{}] }));
+
+  await upsertMarketingSchedule(queryable, {
+    tenantId: 15,
+    dayOfWeek: null,
+    hour: null,
+    timezone: null,
+    timezoneProvided: true,
+    enabled: null,
+  });
+
+  // $4 (timezone) is null AND $6 (timezoneProvided) is true → the CASE WHEN
+  // branch writes $4 (null) instead of preserving marketing_schedule.timezone.
+  assert.deepEqual(calls[0].params, [15, null, null, null, null, true]);
+});
+
+// ---------------------------------------------------------------------------
+// Readers
+// ---------------------------------------------------------------------------
+
+test('getMarketingScheduleForTenant: scoped SELECT by tenant_id, returns null on zero rows', async () => {
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 0, rows: [] }));
+  const row = await getMarketingScheduleForTenant(queryable, 99);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].sql, /WHERE tenant_id = \$1/);
+  assert.deepEqual(calls[0].params, [99]);
+  assert.equal(row, null);
+});
+
+test('getMarketingScheduleForTenant: returns the row when present', async () => {
+  const fixture = { tenant_id: 99, cadence: 'weekly', day_of_week: 2, hour: 10, timezone: 'UTC', enabled: true };
+  const { queryable } = recordingQueryable(() => ({ rowCount: 1, rows: [fixture] }));
+  const row = await getMarketingScheduleForTenant(queryable, 99);
+  assert.deepEqual(row, fixture);
+});
+
+test('listMarketingSchedules: returns all rows ordered by tenant_id (no WHERE clause)', async () => {
+  const fixtures = [
+    { tenant_id: 1, day_of_week: 1, hour: 9, timezone: null, enabled: true },
+    { tenant_id: 2, day_of_week: 3, hour: 14, timezone: 'UTC', enabled: false },
+  ];
+  const { calls, queryable } = recordingQueryable(() => ({ rowCount: 2, rows: fixtures }));
+  const rows = await listMarketingSchedules(queryable);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].sql, /ORDER BY tenant_id/);
+  assert.doesNotMatch(calls[0].sql, /WHERE/);
+  assert.deepEqual(rows, fixtures);
+});
+
+// ---------------------------------------------------------------------------
+// Validators
+// ---------------------------------------------------------------------------
+
+test('parseScheduleDay: accepts 0-6 and day names/abbreviations, rejects everything else', () => {
+  assert.equal(parseScheduleDay('0'), 0);
+  assert.equal(parseScheduleDay('6'), 6);
+  assert.equal(parseScheduleDay('mon'), 1);
+  assert.equal(parseScheduleDay('Monday'), 1);
+  assert.equal(parseScheduleDay('  fri '), 5);
+  assert.equal(parseScheduleDay('7'), null);
+  assert.equal(parseScheduleDay('funday'), null);
+  assert.equal(parseScheduleDay(undefined), null);
+  assert.equal(parseScheduleDay(true), null);
+});
+
+test('parseScheduleHour: accepts 0-23, rejects out-of-range and non-numeric', () => {
+  assert.equal(parseScheduleHour('0'), 0);
+  assert.equal(parseScheduleHour('23'), 23);
+  assert.equal(parseScheduleHour('9'), 9);
+  assert.equal(parseScheduleHour('24'), null);
+  assert.equal(parseScheduleHour('-1'), null);
+  assert.equal(parseScheduleHour('nine'), null);
+  assert.equal(parseScheduleHour(undefined), null);
+});
+
+test('isValidScheduleTimezone: accepts IANA names, rejects garbage', () => {
+  assert.equal(isValidScheduleTimezone('America/New_York'), true);
+  assert.equal(isValidScheduleTimezone('UTC'), true);
+  assert.equal(isValidScheduleTimezone('Not/AZone'), false);
+});
+
+test('parseScheduleEnabled: accepts common truthy/falsy strings and booleans; rejects garbage', () => {
+  assert.equal(parseScheduleEnabled('true'), true);
+  assert.equal(parseScheduleEnabled('YES'), true);
+  assert.equal(parseScheduleEnabled('1'), true);
+  assert.equal(parseScheduleEnabled('on'), true);
+  assert.equal(parseScheduleEnabled('false'), false);
+  assert.equal(parseScheduleEnabled('no'), false);
+  assert.equal(parseScheduleEnabled('0'), false);
+  assert.equal(parseScheduleEnabled('off'), false);
+  assert.equal(parseScheduleEnabled(true), true);
+  assert.equal(parseScheduleEnabled(false), false);
+  assert.equal(parseScheduleEnabled(undefined), null);
+  assert.equal(parseScheduleEnabled('maybe'), null);
+});

--- a/tests/onboarding-resume.test.ts
+++ b/tests/onboarding-resume.test.ts
@@ -31,3 +31,16 @@ test('onboarding resume claims materialization once and falls back to a pending 
   assert.doesNotMatch(source, /updateOnboardingDraft\(draftId, \{ status: 'materializing' \}\)/);
   assert.doesNotMatch(source, /const draft = await requireOnboardingDraft/);
 });
+
+test('onboarding resume auto-provisions a default marketing_schedule row, flag-independently (multi-brand workspaces Phase 1a)', () => {
+  assert.match(source, /provisionDefaultMarketingSchedule/);
+
+  // Must NOT be gated behind isMultiWorkspaceEnabled(): the schedule hook is
+  // common to both the flag-ON and flag-OFF tenant-resolution branches, so it
+  // must not be nested inside an `if (isMultiWorkspaceEnabled())` block.
+  const multiWorkspaceBlockMatch = source.match(
+    /if \(isMultiWorkspaceEnabled\(\)\) \{([\s\S]*?)\n\s*\}/,
+  );
+  assert.ok(multiWorkspaceBlockMatch, 'expected to find the isMultiWorkspaceEnabled() branch');
+  assert.doesNotMatch(multiWorkspaceBlockMatch![1], /provisionDefaultMarketingSchedule/);
+});


### PR DESCRIPTION
Part of #803 (multi-brand workspaces build, Phase 1a — gap G1; contract: docs/plans/2026-07-08-multi-brand-workspaces.md §1a).

## Problem
A newly-materialized tenant never got a `marketing_schedule` row until an operator shelled in and ran the CLI by hand. Every new brand workspace silently never posted on a cadence — the exact gap the multi-brand build has to close before three isolated workspaces can go live.

## Change (5 files, +517/-66)
- **NEW `backend/marketing/schedule-store.ts`** — the single writer for `marketing_schedule`. Lifts the CLI's four validators (day/hour/tz/enabled) and its exact COALESCE-preserve upsert SQL out of the script verbatim, and adds `provisionDefaultMarketingSchedule` (`ON CONFLICT (tenant_id) DO NOTHING`, returns `{created}` from rowCount) plus get/list readers. Structural `ScheduleQueryable` type — the module never opens its own connection; callers own the lifecycle (borrowed onboarding client, CLI pool, future route client).
- **`scripts/marketing/upsert-marketing-schedule.ts`** — refactored to a thin wrapper (argv parsing + its own pool + process-exit handling) around the shared helper. **Byte-equivalent behavior**: identical upsert SQL, identical validators, identical `--list` output, identical exit handling (diffed against pre-refactor).
- **`app/onboarding/resume/page.tsx`** — calls `provisionDefaultMarketingSchedule` on the already-borrowed client right after `updateBusinessProfileWithDiagnostics`, in its own try/catch (warn + swallow, never blocks the render/redirect), sequential (no new `pool.connect`, no `Promise.all`), before `client.release()`. Seeds `[tenantId,'weekly',1,9,tz,true]` using the tenant's timezone via the synchronous file-only `loadTenantTimezoneOrFallback` (no DB round-trip). **Flag-independent** — the multi-workspace fork lives upstream in `resolveTenantForDraft`, not here.
- **NEW `tests/marketing/schedule-store.test.ts`** (15 tests) — recording-fake queryable; guards exact provision params + `DO NOTHING` (never `DO UPDATE`), byte-identical CLI upsert SQL, COALESCE omit-preserve vs. `timezoneProvided` clear semantics, readers, and all four validators at their boundaries.
- **`tests/onboarding-resume.test.ts`** (+1) — source-text guard: provision call present AND not nested inside the `if (isMultiWorkspaceEnabled())` branch.

## Safety
- Best-effort onboarding hook: any throw (including a synchronous throw from the timezone loader) is caught and logged; onboarding never blocks. No BEGIN/COMMIT on the borrowed client, so a failed provision cannot poison it.
- `ON CONFLICT DO NOTHING` never clobbers an existing row (re-materialized/reused tenant safe).
- No schema change — columns (`cadence`,`day_of_week`,`hour`,`timezone`,`enabled`) match `scripts/init-db.js`. The seeded `enabled=true` row is still globally gated by `ARIES_WEEKLY_TRIGGER_ENABLED` (default OFF).
- Tenant-scoped write (resolved onboarding `tenantId` only); no secrets read/logged; no Hermes browser exposure; no DB-pool fan-out.

## Gate evidence (run in the worktree, post-rebase onto origin/master @ 201ccbc0)
- `npm run verify` — green (42/42, "Verification suite passed")
- `npm run validate:social-content` — green (90/90)
- `npm run validate:banned-patterns` — ok
- `npm run guardrails:agent` — passed (1 ahead / 0 behind, unique diff)
- Focused: schedule-store 15/15, onboarding-resume 3/3

Rebased cleanly onto current master; `tests/auth/tenant-resolution-flag-off-golden.test.ts` untouched.