### PR TITLE
fix(integrations): env-managed status resolves per-tenant connected_accounts when Composio enabled

### DIFF
--- a/backend/integrations/status.ts
+++ b/backend/integrations/status.ts
@@ -1,7 +1,10 @@
 import { isAllowedProvider } from './connect';
 import { resolveTokenHealth } from './connection-schema';
+import { getConnectionRow } from './composio/connection-store';
 import { dbGetConnection } from './oauth-db';
 import { getProviderOAuthAvailability } from './oauth-provider-runtime';
+import { getAccountConnectionProvider } from './providers/provider-factory';
+import type { IntegrationPlatform } from './providers/types';
 
 type PlatformConnectionStatus =
   | 'disconnected'
@@ -174,6 +177,55 @@ export async function oauthStatusAsync(provider: string, tenantId?: string): Pro
     return buildMisconfiguredStatus(provider, normalizedTenantId, new Date().toISOString(), availability.message, availability.missingEnv);
   }
   if (!availability.connectable) {
+    // Env-managed providers (Instagram, via META_PAGE_ID/META_ACCESS_TOKEN) have
+    // no per-tenant OAuth record in oauth_connections by design. When Composio is
+    // the active account-connection provider, per-tenant state DOES exist
+    // (connected_accounts) and must be consulted — otherwise every tenant on a
+    // process with Meta env vars set reads as "connected" regardless of whether
+    // that specific tenant ever connected anything (#808). When Composio is
+    // disabled there is no per-tenant record to check at all, so the legacy
+    // unconditional "connected" behavior is preserved byte-identically.
+    //
+    // NOTE: the deprecated sync `oauthStatus` twin below intentionally keeps its
+    // legacy unconditional env-managed behavior even when Composio is enabled —
+    // a known limitation, not fixed here (out of scope; no remaining callers rely
+    // on it for env-managed correctness).
+    const now = new Date().toISOString();
+    const accountConnectionProvider = getAccountConnectionProvider(process.env);
+    if (accountConnectionProvider !== null) {
+      const row = await getConnectionRow(normalizedTenantId, provider as IntegrationPlatform);
+      if (row?.status === 'connected') {
+        return {
+          schema_name: 'platform_connection_status_schema',
+          schema_version: '1.0.0',
+          tenant_id: normalizedTenantId,
+          integration_id: undefined,
+          platform: provider,
+          connection_status: 'connected',
+          status_reason: 'env_managed',
+          health: 'unknown',
+          updated_at: now,
+          capabilities: [],
+          metadata: {},
+          external_account_id: row.externalAccountId ?? undefined,
+          external_account_name: row.externalAccountName ?? undefined,
+        };
+      }
+      return {
+        schema_name: 'platform_connection_status_schema',
+        schema_version: '1.0.0',
+        tenant_id: normalizedTenantId,
+        integration_id: undefined,
+        platform: provider,
+        connection_status: 'disconnected',
+        status_reason: 'connection_not_found',
+        health: 'unknown',
+        updated_at: now,
+        capabilities: [],
+        metadata: {},
+      };
+    }
+
     return {
       schema_name: 'platform_connection_status_schema',
       schema_version: '1.0.0',
@@ -183,7 +235,7 @@ export async function oauthStatusAsync(provider: string, tenantId?: string): Pro
       connection_status: 'connected',
       status_reason: 'env_managed',
       health: 'unknown',
-      updated_at: new Date().toISOString(),
+      updated_at: now,
       capabilities: [],
       metadata: {},
     };

--- a/tests/integrations-status-composio-env-managed.test.ts
+++ b/tests/integrations-status-composio-env-managed.test.ts
@@ -208,6 +208,62 @@ test('#808: Composio ON + a connected_accounts row with status=connected -> oaut
   });
 });
 
+test('#808: Composio ON + a connected_accounts row with status=pending -> oauthStatusAsync does NOT report connected (in-flight handshake)', async (t) => {
+  await withComposioEnabledEnv(async () => {
+    resetOauthStore();
+    const connRow: ConnectedAccountRowFixture = {
+      id: '502',
+      tenant_id: '21',
+      external_user_id: 'tenant-21',
+      platform: 'instagram',
+      provider: 'composio',
+      connected_account_id: 'ca_pending123',
+      auth_config_id: 'ac_xyz789',
+      external_account_id: null,
+      external_account_name: null,
+      status: 'pending',
+      capabilities_json: null,
+      last_capability_check_at: null,
+      created_at: '2026-07-09T00:00:00.000Z',
+      updated_at: '2026-07-09T00:00:00.000Z',
+    };
+    t.mock.method(pool, 'query', makeQueryMock({ connectedAccounts: [connRow] }) as typeof pool.query);
+
+    const status = await oauthStatusAsync('instagram', '21');
+    assert.ok(!('broker_status' in status), 'expected a status shape, not a broker error');
+    assert.equal(status.connection_status, 'disconnected');
+    assert.equal(status.status_reason, 'connection_not_found');
+  });
+});
+
+test('#808: Composio ON + a connected_accounts row with status=error -> oauthStatusAsync does NOT report connected (failed handshake)', async (t) => {
+  await withComposioEnabledEnv(async () => {
+    resetOauthStore();
+    const connRow: ConnectedAccountRowFixture = {
+      id: '503',
+      tenant_id: '22',
+      external_user_id: 'tenant-22',
+      platform: 'instagram',
+      provider: 'composio',
+      connected_account_id: 'ca_error123',
+      auth_config_id: 'ac_xyz789',
+      external_account_id: null,
+      external_account_name: null,
+      status: 'error',
+      capabilities_json: null,
+      last_capability_check_at: null,
+      created_at: '2026-07-09T00:00:00.000Z',
+      updated_at: '2026-07-09T00:00:00.000Z',
+    };
+    t.mock.method(pool, 'query', makeQueryMock({ connectedAccounts: [connRow] }) as typeof pool.query);
+
+    const status = await oauthStatusAsync('instagram', '22');
+    assert.ok(!('broker_status' in status), 'expected a status shape, not a broker error');
+    assert.equal(status.connection_status, 'disconnected');
+    assert.equal(status.status_reason, 'connection_not_found');
+  });
+});
+
 test('#808: Composio OFF -> Instagram env-managed branch stays unconditionally connected (legacy behavior unchanged)', async (t) => {
   await withComposioDisabledEnv(async () => {
     resetOauthStore();

--- a/tests/integrations-status-composio-env-managed.test.ts
+++ b/tests/integrations-status-composio-env-managed.test.ts
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { handleIntegrationsGet } from '../app/api/integrations/handlers';
+import { oauthStatusAsync } from '../backend/integrations/status';
+import { oauthStore } from '../backend/integrations/connect';
+import pool from '../lib/db';
+
+// #808: the env-managed branch of oauthStatusAsync (Instagram, connectionMode
+// 'env_managed' in oauth-provider-runtime.ts) must become per-tenant-aware when
+// Composio is the active account-connection provider, instead of reporting
+// EVERY tenant as "connected" whenever process-wide META_PAGE_ID/META_ACCESS_TOKEN
+// are set. When Composio is disabled the branch must stay byte-identical.
+
+const BASE64_KEY = Buffer.alloc(32, 7).toString('base64');
+
+const META_ENV_KEYS = [
+  'META_APP_ID',
+  'META_APP_SECRET',
+  'META_PAGE_ID',
+  'META_ACCESS_TOKEN',
+  'OAUTH_TOKEN_ENCRYPTION_KEY',
+] as const;
+
+const COMPOSIO_ENV_KEYS = ['COMPOSIO_ENABLED', 'COMPOSIO_API_KEY'] as const;
+
+const ALL_ENV_KEYS = [...META_ENV_KEYS, ...COMPOSIO_ENV_KEYS] as const;
+
+function withEnv(overrides: Partial<Record<(typeof ALL_ENV_KEYS)[number], string>>, fn: () => Promise<void>): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of ALL_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  // Instagram is env_managed — needs META_PAGE_ID + META_ACCESS_TOKEN to reach
+  // the env-managed branch (rather than 'misconfigured' for missing env).
+  process.env.META_APP_ID = 'test-app-id';
+  process.env.META_APP_SECRET = 'test-app-secret';
+  process.env.META_PAGE_ID = 'test-page-id';
+  process.env.META_ACCESS_TOKEN = 'test-access-token';
+  process.env.OAUTH_TOKEN_ENCRYPTION_KEY = BASE64_KEY;
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  return fn().finally(() => {
+    for (const key of ALL_ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+}
+
+function withComposioEnabledEnv(fn: () => Promise<void>): Promise<void> {
+  return withEnv({ COMPOSIO_ENABLED: 'true', COMPOSIO_API_KEY: 'test-composio-key' }, fn);
+}
+
+function withComposioDisabledEnv(fn: () => Promise<void>): Promise<void> {
+  return withEnv({}, fn);
+}
+
+function resetOauthStore(): void {
+  const store = oauthStore();
+  store.pendingByState.clear();
+  store.connectionsById.clear();
+  store.connectedByTenantProvider.clear();
+}
+
+interface ConnectedAccountRowFixture {
+  id: string;
+  tenant_id: string;
+  external_user_id: string;
+  platform: string;
+  provider: string;
+  connected_account_id: string | null;
+  auth_config_id: string | null;
+  external_account_id: string | null;
+  external_account_name: string | null;
+  status: string;
+  capabilities_json: unknown;
+  last_capability_check_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Build a pool.query mock that services both the legacy oauth_connections
+ * lookup (oauth-db.ts::dbGetConnection, used by oauth-mode platforms like
+ * Facebook) and the Composio connected_accounts lookup
+ * (composio/connection-store.ts::getConnectionRow, used by the fixed
+ * env-managed Instagram branch). Mirrors the makeQueryMock idiom in
+ * tests/integrations-status.test.ts.
+ */
+function makeQueryMock(options: {
+  connectedAccounts?: ConnectedAccountRowFixture[];
+  throwOnConnectedAccounts?: Error;
+}) {
+  const connectedAccounts = options.connectedAccounts ?? [];
+
+  return async (sql: string, params: unknown[] = []) => {
+    const text = String(sql);
+
+    // Composio per-tenant connection lookup (connection-store.ts::getConnectionRow)
+    if (text.includes('FROM connected_accounts') && text.includes('WHERE tenant_id = $1 AND platform = $2')) {
+      if (options.throwOnConnectedAccounts) {
+        throw options.throwOnConnectedAccounts;
+      }
+      const tenantId = String(params[0]);
+      const platform = String(params[1]);
+      const row = connectedAccounts.find((c) => c.tenant_id === tenantId && c.platform === platform);
+      return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+    }
+
+    // Legacy oauth_connections lookup (oauth-db.ts::dbGetConnection) — always
+    // "no row" in these tests, since only Instagram (env-managed) is exercised.
+    if (text.includes('FROM oauth_connections') && text.includes('WHERE tenant_id = $1 AND provider = $2')) {
+      return { rows: [], rowCount: 0 };
+    }
+    if (text.includes('FROM oauth_connections') && text.includes('WHERE id = $1')) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    // Writes — treat as no-ops.
+    if (
+      text.includes('INSERT INTO') ||
+      text.includes('DELETE FROM') ||
+      text.includes('UPDATE ')
+    ) {
+      return { rows: [], rowCount: 1 };
+    }
+
+    throw new Error(`Unhandled SQL in test mock: ${text}`);
+  };
+}
+
+test('#808: Composio ON + zero connected_accounts rows -> oauthStatusAsync reports Instagram disconnected, not env-managed connected', async (t) => {
+  await withComposioEnabledEnv(async () => {
+    resetOauthStore();
+    t.mock.method(pool, 'query', makeQueryMock({ connectedAccounts: [] }) as typeof pool.query);
+
+    const status = await oauthStatusAsync('instagram', '999');
+    assert.ok(!('broker_status' in status), 'expected a status shape, not a broker error');
+    assert.equal(status.connection_status, 'disconnected');
+    assert.equal(status.status_reason, 'connection_not_found');
+  });
+});
+
+test('#808: Composio ON + zero connected_accounts rows -> /api/integrations Instagram card is not_connected with no disconnect action', async (t) => {
+  await withComposioEnabledEnv(async () => {
+    resetOauthStore();
+    t.mock.method(pool, 'query', makeQueryMock({ connectedAccounts: [] }) as typeof pool.query);
+
+    const response = await handleIntegrationsGet(async () => ({
+      userId: 'user_999',
+      tenantId: '999',
+      tenantSlug: 'brand-new-workspace',
+      role: 'tenant_admin',
+    }));
+    const body = (await response.json()) as {
+      cards: Array<{ platform: string; connection_state: string; available_actions: string[] }>;
+    };
+
+    assert.equal(response.status, 200);
+    const instagram = body.cards.find((card) => card.platform === 'instagram');
+    assert.equal(instagram?.connection_state, 'not_connected');
+    assert.ok(
+      !instagram?.available_actions.includes('disconnect'),
+      'a tenant with zero connections must not see a Disconnect action',
+    );
+  });
+});
+
+test('#808: Composio ON + a connected_accounts row with status=connected -> oauthStatusAsync reports connected (tenant-15 preservation)', async (t) => {
+  await withComposioEnabledEnv(async () => {
+    resetOauthStore();
+    const connRow: ConnectedAccountRowFixture = {
+      id: '501',
+      tenant_id: '15',
+      external_user_id: 'tenant-15',
+      platform: 'instagram',
+      provider: 'composio',
+      connected_account_id: 'ca_abc123',
+      auth_config_id: 'ac_xyz789',
+      external_account_id: 'ig_17841400000000000',
+      external_account_name: 'Aries AI',
+      status: 'connected',
+      capabilities_json: null,
+      last_capability_check_at: null,
+      created_at: '2026-06-01T00:00:00.000Z',
+      updated_at: '2026-06-01T00:00:00.000Z',
+    };
+    t.mock.method(pool, 'query', makeQueryMock({ connectedAccounts: [connRow] }) as typeof pool.query);
+
+    const status = await oauthStatusAsync('instagram', '15');
+    assert.ok(!('broker_status' in status), 'expected a status shape, not a broker error');
+    assert.equal(status.connection_status, 'connected');
+    assert.equal(status.status_reason, 'env_managed');
+    assert.equal(status.external_account_id, 'ig_17841400000000000');
+    assert.equal(status.external_account_name, 'Aries AI');
+  });
+});
+
+test('#808: Composio OFF -> Instagram env-managed branch stays unconditionally connected (legacy behavior unchanged)', async (t) => {
+  await withComposioDisabledEnv(async () => {
+    resetOauthStore();
+    // No connected_accounts/oauth_connections row exists anywhere — if the fix
+    // regressed the Composio-disabled path, this proves it: the legacy branch
+    // must never touch the DB and must always report connected.
+    t.mock.method(pool, 'query', makeQueryMock({ connectedAccounts: [] }) as typeof pool.query);
+
+    const status = await oauthStatusAsync('instagram', '999');
+    assert.ok(!('broker_status' in status), 'expected a status shape, not a broker error');
+    assert.equal(status.connection_status, 'connected');
+    assert.equal(status.status_reason, 'env_managed');
+  });
+});
+
+test('#808: Composio ON + connected_accounts read throws -> oauthStatusAsync rejects (no confident false status)', async (t) => {
+  await withComposioEnabledEnv(async () => {
+    resetOauthStore();
+    t.mock.method(
+      pool,
+      'query',
+      makeQueryMock({ throwOnConnectedAccounts: new Error('simulated connection pool failure') }) as typeof pool.query,
+    );
+
+    await assert.rejects(
+      () => oauthStatusAsync('instagram', '999'),
+      /simulated connection pool failure/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #808
Part of #803

## Defect
On a Composio-enabled process with Meta env vars set (`META_PAGE_ID`/`META_ACCESS_TOKEN`), the env-managed branch of `oauthStatusAsync` reported **every** tenant's Instagram as `connected` / `env_managed` — regardless of whether that specific tenant ever connected anything. A brand-new workspace with zero connections showed a false "Instagram Connected" surface (and no Connect CTA), because the env-managed branch returned an unconditional `connected` and never consulted per-tenant state. This blocks the multi-brand goal, where each workspace must resolve its own connection independently.

## Root cause
Env-managed providers (Instagram via Meta env) have no per-tenant record in `oauth_connections` by design, so the env-managed branch short-circuited to `connected`. But when Composio is the active account-connection provider, per-tenant state DOES exist in `connected_accounts` and was simply never read on this path.

## Fix shape (one production file: `backend/integrations/status.ts`)
- In the `!availability.connectable` (env-managed) branch of `oauthStatusAsync`, gate on `getAccountConnectionProvider(process.env) !== null` (true iff Composio is the active provider).
- When Composio is active, load the tenant's row via `getConnectionRow(normalizedTenantId, provider)` (`WHERE tenant_id AND platform`, tenant-scoped) and report `connected`/`env_managed` **only** on a strict `row?.status === 'connected'`; every other state (missing row, `pending`, `error`, `reauthorization_required`) reports `disconnected`/`connection_not_found`. On the connected path the non-secret `external_account_id`/`external_account_name` are surfaced for the card label.
- No `try/catch` around the DB read — DB errors propagate (retryable posture, consistent with #790's connect-gate) rather than emitting a confident false status.
- When Composio is disabled, `getAccountConnectionProvider` returns `null`, so the legacy unconditional `connected` behavior is preserved **byte-identically** (no DB touch at all).

`connected_accounts` deliberately holds no access/refresh token (only the Composio connected-account pointer), so nothing secret is surfaced. No `Promise.all` added; no import cycle (`status.ts` → `provider-factory` + `connection-store`, neither imports back). Blast radius verified: the integrations card now shows Connect for unconnected tenants; disconnect/reconnect handlers already 404 for env-managed (undefined `integration_id`), so no new dead-end.

## Test evidence (all re-run locally, not from a report)
- New `tests/integrations-status-composio-env-managed.test.ts` — **7/7**: Composio-ON zero-rows → disconnected (function + `/api/integrations` card, no Disconnect action); connected row → connected + account surfaced; `pending`/`error` rows → disconnected; Composio-OFF → unconditional connected (legacy preserved, no DB touch); DB read throws → rejects (propagation).
- Focused suite (`integrations-status*`, provider-availability, public-mode, openai-safety): all green.
- `npm run verify`: passed. `npm run lint` (typegen + `tsc --noEmit` + banned patterns + repo-boundary + protocol-drift): clean. `npm run guardrails:agent`: passed.

## Residual risk
If `COMPOSIO_ENABLED=true` but `COMPOSIO_API_KEY` is unset, the gate throws `ComposioConfigError` (propagated) instead of the old false `connected` — only reachable in an already-broken deployment where every publish/analytics call throws identically, and preferable to a false "connected". Prod has the key set. The deprecated sync `oauthStatus` twin keeps its legacy behavior (documented; it has no remaining callers).