### PR TITLE
feat(marketing): weekly cadence settings card + schedule GET/PATCH route

### DIFF
--- a/app/api/marketing/schedule/handler.ts
+++ b/app/api/marketing/schedule/handler.ts
@@ -1,0 +1,169 @@
+import type { Pool } from 'pg';
+
+import pool from '@/lib/db';
+import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
+import {
+  getMarketingScheduleForTenant,
+  upsertMarketingSchedule,
+  parseScheduleDay,
+  parseScheduleHour,
+  parseScheduleEnabled,
+  isValidScheduleTimezone,
+} from '@/backend/marketing/schedule-store';
+
+/**
+ * GET/PATCH /api/marketing/schedule
+ *
+ * Settings-hub cadence card (multi-brand workspaces Phase 1b, #803). Reuses
+ * the single-writer helpers in backend/marketing/schedule-store.ts (Phase
+ * 1a) so this route, the operator CLI, and onboarding auto-provisioning all
+ * share one validated, COALESCE-preserve upsert — no re-derived SQL.
+ *
+ * Tenant id is resolved ONLY from tenantContext, never from the request body
+ * or query string. Queries run strictly sequentially (no Promise.all around
+ * the pg pool).
+ */
+
+type ScheduleDeps = {
+  tenantContextLoader?: TenantContextLoader;
+  db?: Pool;
+};
+
+type SchedulePatchBody = {
+  day?: unknown;
+  hour?: unknown;
+  timezone?: unknown;
+  enabled?: unknown;
+};
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+async function readPatchBody(req: Request): Promise<SchedulePatchBody> {
+  try {
+    return (await req.json()) as SchedulePatchBody;
+  } catch {
+    return {};
+  }
+}
+
+// A parsed optional field: omitted (not provided), provided+valid, or
+// provided+invalid. Keeping "omitted" distinct from "invalid" is what lets a
+// partial PATCH validate only the fields the caller actually sent.
+type ParsedField<T> =
+  | { provided: false }
+  | { provided: true; valid: true; value: T }
+  | { provided: true; valid: false };
+
+function parseDayField(raw: unknown): ParsedField<number> {
+  if (raw === undefined) return { provided: false };
+  const normalized = typeof raw === 'number' ? String(raw) : raw;
+  const parsed = parseScheduleDay(normalized as string | boolean | undefined);
+  if (parsed === null) return { provided: true, valid: false };
+  return { provided: true, valid: true, value: parsed };
+}
+
+function parseHourField(raw: unknown): ParsedField<number> {
+  if (raw === undefined) return { provided: false };
+  const normalized = typeof raw === 'number' ? String(raw) : raw;
+  const parsed = parseScheduleHour(normalized as string | boolean | undefined);
+  if (parsed === null) return { provided: true, valid: false };
+  return { provided: true, valid: true, value: parsed };
+}
+
+function parseEnabledField(raw: unknown): ParsedField<boolean> {
+  if (raw === undefined) return { provided: false };
+  // parseScheduleEnabled only accepts string | boolean (it calls .trim() on
+  // anything that isn't a boolean) — guard non-string/boolean/number shapes
+  // (including an explicit `null`) before it ever reaches the validator.
+  const normalized = typeof raw === 'number' ? String(raw) : raw;
+  if (typeof normalized !== 'string' && typeof normalized !== 'boolean') {
+    return { provided: true, valid: false };
+  }
+  const parsed = parseScheduleEnabled(normalized);
+  if (parsed === null) return { provided: true, valid: false };
+  return { provided: true, valid: true, value: parsed };
+}
+
+// Timezone is the one field with an explicit-clear semantic: `timezone: null`
+// in the body is a deliberate "clear it" (timezoneProvided=true, value=null),
+// distinct from omitting the key entirely (preserve existing value).
+function parseTimezoneField(raw: unknown): ParsedField<string | null> {
+  if (raw === undefined) return { provided: false };
+  if (raw === null) return { provided: true, valid: true, value: null };
+  if (typeof raw === 'string' && isValidScheduleTimezone(raw)) {
+    return { provided: true, valid: true, value: raw };
+  }
+  return { provided: true, valid: false };
+}
+
+export async function handleGetMarketingSchedule(
+  _req: Request,
+  deps: ScheduleDeps = {},
+): Promise<Response> {
+  const tenantResult = await loadTenantContextOrResponse(deps.tenantContextLoader);
+  if ('response' in tenantResult) {
+    return tenantResult.response;
+  }
+  const tenantId = Number(tenantResult.tenantContext.tenantId);
+
+  const db = deps.db ?? pool;
+  const schedule = await getMarketingScheduleForTenant(db, tenantId);
+  return json({ schedule }, 200);
+}
+
+export async function handlePatchMarketingSchedule(
+  req: Request,
+  deps: ScheduleDeps = {},
+): Promise<Response> {
+  const tenantResult = await loadTenantContextOrResponse(deps.tenantContextLoader);
+  if ('response' in tenantResult) {
+    return tenantResult.response;
+  }
+  const { tenantContext } = tenantResult;
+
+  if (tenantContext.role !== 'tenant_admin') {
+    return json({ error: 'forbidden' }, 403);
+  }
+
+  const body = await readPatchBody(req);
+
+  const day = parseDayField(body.day);
+  if (day.provided && !day.valid) {
+    return json({ error: 'invalid_day' }, 400);
+  }
+
+  const hour = parseHourField(body.hour);
+  if (hour.provided && !hour.valid) {
+    return json({ error: 'invalid_hour' }, 400);
+  }
+
+  const timezone = parseTimezoneField(body.timezone);
+  if (timezone.provided && !timezone.valid) {
+    return json({ error: 'invalid_timezone' }, 400);
+  }
+
+  const enabled = parseEnabledField(body.enabled);
+  if (enabled.provided && !enabled.valid) {
+    return json({ error: 'invalid_enabled' }, 400);
+  }
+
+  // Tenant id ONLY from tenantContext — never from the body.
+  const tenantId = Number(tenantContext.tenantId);
+
+  const db = deps.db ?? pool;
+  const schedule = await upsertMarketingSchedule(db, {
+    tenantId,
+    dayOfWeek: day.provided && day.valid ? day.value : null,
+    hour: hour.provided && hour.valid ? hour.value : null,
+    timezone: timezone.provided && timezone.valid ? timezone.value : null,
+    timezoneProvided: timezone.provided,
+    enabled: enabled.provided && enabled.valid ? enabled.value : null,
+  });
+
+  return json({ schedule }, 200);
+}

--- a/app/api/marketing/schedule/route.ts
+++ b/app/api/marketing/schedule/route.ts
@@ -1,0 +1,9 @@
+import { handleGetMarketingSchedule, handlePatchMarketingSchedule } from './handler';
+
+export async function GET(req: Request) {
+  return handleGetMarketingSchedule(req);
+}
+
+export async function PATCH(req: Request) {
+  return handlePatchMarketingSchedule(req);
+}

--- a/frontend/aries-v1/settings-screen.tsx
+++ b/frontend/aries-v1/settings-screen.tsx
@@ -8,6 +8,11 @@ import { useIntegrations } from '@/hooks/use-integrations';
 import { useBusinessProfile } from '@/hooks/use-business-profile';
 import { createAriesV1Api, type ReelAudioMode } from '@/lib/api/aries-v1';
 import { fetchWorkspaceSwitcherData } from '@/lib/api/workspace';
+import {
+  fetchMarketingSchedule,
+  updateMarketingSchedule,
+  type MarketingScheduleRow,
+} from '@/lib/api/marketing-schedule';
 
 type WorkspaceRole = 'tenant_admin' | 'tenant_analyst' | 'tenant_viewer';
 
@@ -41,6 +46,19 @@ function memberActionErrorMessage(code: string | undefined): string {
 import { customerSafeUiErrorMessage } from './customer-safe-copy';
 import { EmptyStatePanel, LoadingStateGrid, ShellPanel, StatusChip } from './components';
 import { connectedProfileLabel } from './connected-profile-labels';
+
+// Cadence card (multi-brand workspaces Phase 1b, #803). day_of_week: 0=Sunday.
+const DAY_OF_WEEK_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const DEFAULT_SCHEDULE_DAY = 1; // Monday
+const DEFAULT_SCHEDULE_HOUR = 9; // 9:00 AM local
+const SCHEDULE_HOURS = Array.from({ length: 24 }, (_, hour) => hour);
+
+function formatScheduleHourLabel(hour: number): string {
+  const normalized = ((hour % 24) + 24) % 24;
+  const period = normalized < 12 ? 'AM' : 'PM';
+  const displayHour = normalized % 12 === 0 ? 12 : normalized % 12;
+  return `${displayHour}:00 ${period}`;
+}
 
 export default function AriesSettingsScreen() {
   const router = useRouter();
@@ -89,6 +107,67 @@ export default function AriesSettingsScreen() {
       launchApproverUserId: launchApproverUserId || null,
       reelAudioMode,
     });
+  }
+
+  // Cadence card (multi-brand workspaces Phase 1b, #803). Loaded independently
+  // of the `ready` gate above (a slow/erroring cadence fetch should not block
+  // the rest of Settings from rendering) — the card shows its own brief
+  // loading state and swaps in once resolved.
+  const [schedule, setSchedule] = useState<MarketingScheduleRow | null>(null);
+  const [scheduleLoaded, setScheduleLoaded] = useState(false);
+  const [scheduleLoadError, setScheduleLoadError] = useState<string | null>(null);
+  const [scheduleDayDraft, setScheduleDayDraft] = useState(DEFAULT_SCHEDULE_DAY);
+  const [scheduleHourDraft, setScheduleHourDraft] = useState(DEFAULT_SCHEDULE_HOUR);
+  const [scheduleTimezoneDraft, setScheduleTimezoneDraft] = useState('');
+  const [scheduleEnabledDraft, setScheduleEnabledDraft] = useState(false);
+  const [scheduleSaving, setScheduleSaving] = useState(false);
+  const [scheduleSaveError, setScheduleSaveError] = useState<string | null>(null);
+  const [scheduleSaveNotice, setScheduleSaveNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchMarketingSchedule().then((result) => {
+      if (cancelled) return;
+      if (result.status === 'ok') {
+        setSchedule(result.schedule);
+      } else {
+        setScheduleLoadError(result.message);
+      }
+      setScheduleLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Reset the editable draft from server truth on initial load and after every
+  // successful save (setSchedule below feeds back into this same effect).
+  useEffect(() => {
+    setScheduleDayDraft(schedule?.day_of_week ?? DEFAULT_SCHEDULE_DAY);
+    setScheduleHourDraft(schedule?.hour ?? DEFAULT_SCHEDULE_HOUR);
+    setScheduleTimezoneDraft(schedule?.timezone ?? '');
+    setScheduleEnabledDraft(schedule?.enabled ?? false);
+  }, [schedule?.day_of_week, schedule?.hour, schedule?.timezone, schedule?.enabled]);
+
+  async function handleSaveSchedule() {
+    if (scheduleSaving) return;
+    setScheduleSaveError(null);
+    setScheduleSaveNotice(null);
+    setScheduleSaving(true);
+    const timezoneTrimmed = scheduleTimezoneDraft.trim();
+    const result = await updateMarketingSchedule({
+      day: scheduleDayDraft,
+      hour: scheduleHourDraft,
+      timezone: timezoneTrimmed ? timezoneTrimmed : null,
+      enabled: scheduleEnabledDraft,
+    });
+    if (result.status === 'ok') {
+      setSchedule(result.schedule);
+      setScheduleSaveNotice('Posting schedule saved.');
+    } else {
+      setScheduleSaveError(result.message);
+    }
+    setScheduleSaving(false);
   }
 
   const memberApi = useMemo(() => createAriesV1Api(), []);
@@ -552,6 +631,130 @@ export default function AriesSettingsScreen() {
           </div>
         </ShellPanel>
       </div>
+
+      <ShellPanel eyebrow="Cadence" title="When Aries posts each week">
+        <div className="space-y-4">
+          {!scheduleLoaded ? (
+            <p className="text-sm text-white/60">Loading posting schedule…</p>
+          ) : scheduleLoadError ? (
+            <div className="rounded-[1.5rem] border border-red-500/20 bg-red-500/10 p-5 text-red-100">
+              {scheduleLoadError}
+            </div>
+          ) : (
+            <>
+              <div className="rounded-[1.25rem] border border-white/8 bg-black/12 px-4 py-4 text-white">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p className="text-sm font-medium">Weekly posting cadence</p>
+                    <p className="mt-2 text-sm leading-7 text-white/58">
+                      {DAY_OF_WEEK_NAMES[schedule?.day_of_week ?? DEFAULT_SCHEDULE_DAY]} at{' '}
+                      {formatScheduleHourLabel(schedule?.hour ?? DEFAULT_SCHEDULE_HOUR)},{' '}
+                      {schedule?.timezone
+                        ? schedule.timezone
+                        : profile?.timezone
+                          ? `Business timezone (${profile.timezone})`
+                          : 'Business timezone'}
+                      .
+                    </p>
+                  </div>
+                  <StatusChip status={schedule?.enabled ? 'approved' : 'draft'}>
+                    {schedule?.enabled ? 'Enabled' : 'Disabled'}
+                  </StatusChip>
+                </div>
+                {!schedule ? (
+                  <p className="mt-3 text-xs leading-6 text-white/50">
+                    {isWorkspaceAdmin
+                      ? "Not scheduled yet — save to set this workspace's cadence."
+                      : 'This workspace has not set a posting schedule yet.'}
+                  </p>
+                ) : null}
+              </div>
+
+              {isWorkspaceAdmin ? (
+                <div className="space-y-4">
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <Field label="Day of week">
+                      <select
+                        value={scheduleDayDraft}
+                        onChange={(e) => setScheduleDayDraft(Number(e.target.value))}
+                        className="w-full rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-white"
+                      >
+                        {DAY_OF_WEEK_NAMES.map((name, index) => (
+                          <option key={name} value={index} className="bg-black">
+                            {name}
+                          </option>
+                        ))}
+                      </select>
+                    </Field>
+                    <Field label="Hour (local time)">
+                      <select
+                        value={scheduleHourDraft}
+                        onChange={(e) => setScheduleHourDraft(Number(e.target.value))}
+                        className="w-full rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-white"
+                      >
+                        {SCHEDULE_HOURS.map((hour) => (
+                          <option key={hour} value={hour} className="bg-black">
+                            {formatScheduleHourLabel(hour)}
+                          </option>
+                        ))}
+                      </select>
+                    </Field>
+                    <Field label="Timezone">
+                      <input
+                        value={scheduleTimezoneDraft}
+                        onChange={(e) => setScheduleTimezoneDraft(e.target.value)}
+                        placeholder={profile?.timezone || 'America/New_York'}
+                        className="w-full rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-white"
+                      />
+                      <p className="mt-2 text-xs leading-6 text-white/50">
+                        Leave blank to use the business timezone{profile?.timezone ? ` (${profile.timezone})` : ''}.
+                      </p>
+                    </Field>
+                    <Field label="Cadence status">
+                      <label className="flex items-center gap-3 rounded-[1rem] border border-white/10 bg-black/20 px-4 py-3 text-white">
+                        <input
+                          type="checkbox"
+                          checked={scheduleEnabledDraft}
+                          onChange={(e) => setScheduleEnabledDraft(e.target.checked)}
+                          className="h-4 w-4 rounded border-white/30 bg-black/30"
+                        />
+                        <span className="text-sm">
+                          {scheduleEnabledDraft
+                            ? 'Enabled — Aries posts automatically'
+                            : 'Disabled — no automatic weekly post'}
+                        </span>
+                      </label>
+                    </Field>
+                  </div>
+
+                  {scheduleSaveError ? (
+                    <div
+                      className="rounded-[1rem] border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100"
+                      role="alert"
+                    >
+                      {scheduleSaveError}
+                    </div>
+                  ) : null}
+                  {scheduleSaveNotice ? (
+                    <div className="rounded-[1rem] border border-emerald-400/20 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-50">
+                      {scheduleSaveNotice}
+                    </div>
+                  ) : null}
+
+                  <button
+                    type="button"
+                    onClick={() => void handleSaveSchedule()}
+                    disabled={scheduleSaving}
+                    className="inline-flex items-center gap-2 rounded-full bg-white px-5 py-3 text-sm font-semibold text-[#11161c] disabled:opacity-60"
+                  >
+                    {scheduleSaving ? 'Saving…' : 'Save posting schedule'}
+                  </button>
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      </ShellPanel>
     </div>
   );
 }

--- a/lib/api/marketing-schedule.ts
+++ b/lib/api/marketing-schedule.ts
@@ -1,0 +1,110 @@
+import { ApiRequestError, requestJson } from './http';
+import type { MarketingScheduleRow } from '@/backend/marketing/schedule-store';
+
+/**
+ * Browser client for the settings-hub cadence card (multi-brand workspaces
+ * Phase 1b, #803 task 1b). Mirrors the small-standalone-module idiom of
+ * lib/api/workspace.ts (typed result unions instead of a growing method on
+ * the giant createAriesV1Api() client) but — unlike that module — routes
+ * through requestJson (lib/api/http.ts) rather than a bare fetch, because the
+ * PATCH here is an ordinary tenant-scoped mutation that SHOULD carry the
+ * multi-workspace mutation-guard header and participate in the shared 409
+ * workspace-mismatch interlock (requestJson already reports that globally);
+ * the switch endpoint's bare-fetch bypass is a documented exception specific
+ * to that one call, not the general pattern.
+ */
+
+export type { MarketingScheduleRow };
+
+export type MarketingSchedulePatch = {
+  day?: number | string;
+  hour?: number;
+  /** Explicit `null` clears the stored timezone; omit the key to leave it untouched. */
+  timezone?: string | null;
+  enabled?: boolean;
+};
+
+export type MarketingScheduleErrorResult = {
+  status: 'error';
+  code: string;
+  message: string;
+  httpStatus: number;
+};
+
+export type MarketingScheduleFetchResult =
+  | { status: 'ok'; schedule: MarketingScheduleRow | null }
+  | MarketingScheduleErrorResult;
+
+export type MarketingScheduleUpdateResult =
+  | { status: 'ok'; schedule: MarketingScheduleRow }
+  | MarketingScheduleErrorResult;
+
+const SCHEDULE_PATH = '/api/marketing/schedule';
+
+/** Same code -> friendly-copy mapping idiom as switchErrorMessage in workspace.ts. */
+export function scheduleErrorMessage(code: string, fallback?: string): string {
+  switch (code) {
+    case 'invalid_day':
+      return 'Pick a valid day of the week.';
+    case 'invalid_hour':
+      return 'Pick a valid hour.';
+    case 'invalid_timezone':
+      return 'Enter a valid IANA timezone, like America/New_York.';
+    case 'invalid_enabled':
+      return 'That toggle value was not recognized — try again.';
+    case 'forbidden':
+      return 'Only workspace admins can change the posting schedule.';
+    case 'sign_in_required':
+    case 'authentication_required':
+    case 'unauthorized':
+      return 'Your session expired — sign in again.';
+    case 'request_timeout':
+      return 'That took too long. Check your connection and try again.';
+    default:
+      return fallback && fallback.trim() && fallback.length < 160
+        ? fallback
+        : 'Could not save the posting schedule. Try again.';
+  }
+}
+
+function toErrorResult(error: unknown): MarketingScheduleErrorResult {
+  if (error instanceof ApiRequestError) {
+    return {
+      status: 'error',
+      code: error.code,
+      message: scheduleErrorMessage(error.code, error.message),
+      httpStatus: error.status,
+    };
+  }
+  return {
+    status: 'error',
+    code: 'network_error',
+    message: 'Could not reach the server. Check your connection and try again.',
+    httpStatus: 0,
+  };
+}
+
+export async function fetchMarketingSchedule(): Promise<MarketingScheduleFetchResult> {
+  try {
+    const body = await requestJson<{ schedule: MarketingScheduleRow | null }>(SCHEDULE_PATH, {
+      method: 'GET',
+    });
+    return { status: 'ok', schedule: body.schedule ?? null };
+  } catch (error) {
+    return toErrorResult(error);
+  }
+}
+
+export async function updateMarketingSchedule(
+  patch: MarketingSchedulePatch,
+): Promise<MarketingScheduleUpdateResult> {
+  try {
+    const body = await requestJson<{ schedule: MarketingScheduleRow }>(SCHEDULE_PATH, {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    });
+    return { status: 'ok', schedule: body.schedule };
+  } catch (error) {
+    return toErrorResult(error);
+  }
+}

--- a/tests/marketing-schedule-route.test.ts
+++ b/tests/marketing-schedule-route.test.ts
@@ -1,0 +1,326 @@
+/**
+ * GET/PATCH /api/marketing/schedule — multi-brand workspaces Phase 1b (#803).
+ *
+ * Mirrors tests/insights-comment-reply-route.test.ts idioms: an injected
+ * tenant-context loader factory, a fake pool routed by SQL shape (so the
+ * shared upsertMarketingSchedule/getMarketingScheduleForTenant helpers from
+ * backend/marketing/schedule-store.ts run for real against an in-memory
+ * table), and small Request builders.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Pool } from 'pg';
+
+import {
+  handleGetMarketingSchedule,
+  handlePatchMarketingSchedule,
+} from '../app/api/marketing/schedule/handler';
+import { WorkspaceMismatchError } from '../lib/tenant-context';
+import type { TenantContext } from '../lib/tenant-context';
+import type { TenantContextLoader } from '../lib/tenant-context-http';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function tenantLoader(
+  tenantId: number,
+  role: TenantContext['role'] = 'tenant_admin',
+): TenantContextLoader {
+  return async () =>
+    ({ userId: 'u1', tenantId: String(tenantId), tenantSlug: 'test', role } as TenantContext);
+}
+
+function getRequest(): Request {
+  return new Request('http://localhost/api/marketing/schedule', { method: 'GET' });
+}
+
+function patchRequest(body: unknown): Request {
+  return new Request('http://localhost/api/marketing/schedule', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+type ScheduleRow = {
+  tenant_id: number;
+  cadence: string;
+  day_of_week: number;
+  hour: number;
+  timezone: string | null;
+  enabled: boolean;
+};
+
+// In-memory marketing_schedule table backing a fake injected Pool. Routes each
+// call by SQL shape: the SELECT (getMarketingScheduleForTenant) and the
+// INSERT ... ON CONFLICT (upsertMarketingSchedule) are independent pool.query
+// calls, exactly mirroring how the real handler drives them.
+function makeFakeScheduleDb(seed: Map<number, ScheduleRow> = new Map()) {
+  const rows = new Map(seed);
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+
+  const query = async (sql: string, params: unknown[] = []) => {
+    calls.push({ sql, params });
+    const norm = sql.replace(/\s+/g, ' ').trim();
+
+    if (norm.startsWith('SELECT')) {
+      const [tenantId] = params as [number];
+      const row = rows.get(tenantId);
+      return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+    }
+
+    if (norm.startsWith('INSERT INTO marketing_schedule')) {
+      const [tenantId, dayOfWeek, hour, timezone, enabled, timezoneProvided] = params as [
+        number,
+        number | null,
+        number | null,
+        string | null,
+        boolean | null,
+        boolean,
+      ];
+      const existing = rows.get(tenantId);
+      const row: ScheduleRow = {
+        tenant_id: tenantId,
+        cadence: 'weekly',
+        day_of_week: dayOfWeek ?? existing?.day_of_week ?? 1,
+        hour: hour ?? existing?.hour ?? 9,
+        timezone: timezoneProvided ? timezone : existing?.timezone ?? null,
+        enabled: enabled ?? existing?.enabled ?? false,
+      };
+      rows.set(tenantId, row);
+      return { rows: [row], rowCount: 1 };
+    }
+
+    throw new Error(`unexpected sql: ${norm}`);
+  };
+
+  return { db: { query } as unknown as Pool, calls, rows };
+}
+
+function insertCallParams(calls: Array<{ sql: string; params: unknown[] }>): unknown[] {
+  const call = calls.find((c) => c.sql.trim().startsWith('INSERT INTO marketing_schedule'));
+  assert.ok(call, 'expected an upsert (INSERT ... ON CONFLICT) call');
+  return call!.params;
+}
+
+// ── 1. Role gate ────────────────────────────────────────────────────────────
+
+test('PATCH as tenant_analyst returns 403 forbidden with no DB write', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ day: 'mon' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_analyst'),
+  });
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'forbidden');
+  assert.equal(calls.length, 0, 'a forbidden PATCH must never touch the DB');
+});
+
+test('PATCH as tenant_viewer returns 403 forbidden with no DB write', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ day: 'mon' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_viewer'),
+  });
+  assert.equal(res.status, 403);
+  assert.equal(calls.length, 0);
+});
+
+test('PATCH as tenant_admin returns 200 with the upserted schedule', async () => {
+  const { db } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(
+    patchRequest({ day: 'mon', hour: 9, timezone: 'America/New_York', enabled: true }),
+    { db, tenantContextLoader: tenantLoader(12, 'tenant_admin') },
+  );
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.schedule.tenant_id, 12);
+  assert.equal(body.schedule.day_of_week, 1);
+  assert.equal(body.schedule.hour, 9);
+  assert.equal(body.schedule.timezone, 'America/New_York');
+  assert.equal(body.schedule.enabled, true);
+});
+
+// ── 2. Tenant isolation ─────────────────────────────────────────────────────
+
+test('tenant id comes ONLY from tenantContext — a body-supplied tenant_id is ignored', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  await handlePatchMarketingSchedule(patchRequest({ tenant_id: 999, day: 'mon' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  const params = insertCallParams(calls);
+  assert.equal(params[0], 12, 'the upsert tenantId param must be the loader tenant, never the body value');
+});
+
+// ── 3. Partial PATCH preserves omitted fields ───────────────────────────────
+
+test('partial PATCH {enabled:false} leaves day/hour null (preserve) and timezoneProvided false', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ enabled: false }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 200);
+  const [, dayOfWeek, hour, , enabled, timezoneProvided] = insertCallParams(calls);
+  assert.equal(dayOfWeek, null);
+  assert.equal(hour, null);
+  assert.equal(timezoneProvided, false);
+  assert.equal(enabled, false);
+});
+
+test('partial PATCH {day:"fri"} leaves the enabled param null (preserve)', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ day: 'fri' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 200);
+  const [, dayOfWeek, hour, , enabled] = insertCallParams(calls);
+  assert.equal(dayOfWeek, 5);
+  assert.equal(hour, null);
+  assert.equal(enabled, null);
+});
+
+test('PATCH {timezone: null} is an explicit clear (timezoneProvided true, value null)', async () => {
+  const seed = new Map<number, ScheduleRow>([
+    [12, { tenant_id: 12, cadence: 'weekly', day_of_week: 1, hour: 9, timezone: 'America/New_York', enabled: true }],
+  ]);
+  const { db, calls } = makeFakeScheduleDb(seed);
+  const res = await handlePatchMarketingSchedule(patchRequest({ timezone: null }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 200);
+  const [, , , timezone, , timezoneProvided] = insertCallParams(calls);
+  assert.equal(timezone, null);
+  assert.equal(timezoneProvided, true);
+});
+
+test('day/hour accept numeric JSON forms in addition to strings (CLI parity)', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ day: 3, hour: '14' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 200);
+  const [, dayOfWeek, hour] = insertCallParams(calls);
+  assert.equal(dayOfWeek, 3);
+  assert.equal(hour, 14);
+});
+
+// ── 4. Workspace-mismatch interlock ─────────────────────────────────────────
+
+test('loader throwing WorkspaceMismatchError maps PATCH to 409, no DB write', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const loader: TenantContextLoader = async () => {
+    throw new WorkspaceMismatchError('workspace_mismatch', '9', '7');
+  };
+  const res = await handlePatchMarketingSchedule(patchRequest({ day: 'mon' }), {
+    db,
+    tenantContextLoader: loader,
+  });
+  assert.equal(res.status, 409);
+  const body = await res.json();
+  assert.equal(body.reason, 'workspace_mismatch');
+  assert.equal(calls.length, 0);
+});
+
+test('loader throwing WorkspaceMismatchError maps GET to 409, no DB read', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const loader: TenantContextLoader = async () => {
+    throw new WorkspaceMismatchError('workspace_mismatch', '9', '7');
+  };
+  const res = await handleGetMarketingSchedule(getRequest(), { db, tenantContextLoader: loader });
+  assert.equal(res.status, 409);
+  assert.equal(calls.length, 0);
+});
+
+// ── 5. Field validation ──────────────────────────────────────────────────────
+
+test('PATCH {hour: 99} returns 400 invalid_hour, no DB write', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ hour: 99 }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'invalid_hour');
+  assert.equal(calls.length, 0);
+});
+
+test('PATCH {timezone: "Not/AZone"} returns 400 invalid_timezone, no DB write', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ timezone: 'Not/AZone' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'invalid_timezone');
+  assert.equal(calls.length, 0);
+});
+
+test('PATCH {day: "nope"} returns 400 invalid_day, no DB write', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ day: 'nope' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'invalid_day');
+  assert.equal(calls.length, 0);
+});
+
+test('PATCH {enabled: "nope"} returns 400 invalid_enabled, no DB write', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ enabled: 'nope' }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'invalid_enabled');
+  assert.equal(calls.length, 0);
+});
+
+test('PATCH {enabled: null} returns 400 invalid_enabled (only timezone supports an explicit clear)', async () => {
+  const { db, calls } = makeFakeScheduleDb();
+  const res = await handlePatchMarketingSchedule(patchRequest({ enabled: null }), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'invalid_enabled');
+  assert.equal(calls.length, 0);
+});
+
+// ── 6. GET ───────────────────────────────────────────────────────────────────
+
+test('GET returns { schedule: null } for a tenant with no row (legacy tenant)', async () => {
+  const { db } = makeFakeScheduleDb();
+  const res = await handleGetMarketingSchedule(getRequest(), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_viewer'),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.schedule, null);
+});
+
+test('GET returns the row when present, for any authenticated tenant role (read-only for non-admins)', async () => {
+  const row: ScheduleRow = {
+    tenant_id: 12,
+    cadence: 'weekly',
+    day_of_week: 1,
+    hour: 9,
+    timezone: 'America/New_York',
+    enabled: true,
+  };
+  const seed = new Map<number, ScheduleRow>([[12, row]]);
+  const { db } = makeFakeScheduleDb(seed);
+  const res = await handleGetMarketingSchedule(getRequest(), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_analyst'),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.deepEqual(body.schedule, row);
+});

--- a/tests/marketing-schedule-route.test.ts
+++ b/tests/marketing-schedule-route.test.ts
@@ -208,6 +208,59 @@ test('day/hour accept numeric JSON forms in addition to strings (CLI parity)', a
   assert.equal(hour, 14);
 });
 
+test('PATCH {} (no fields at all) is a full no-op: every upsert param is null/false, still 200', async () => {
+  const seed = new Map<number, ScheduleRow>([
+    [12, { tenant_id: 12, cadence: 'weekly', day_of_week: 4, hour: 18, timezone: 'America/Chicago', enabled: true }],
+  ]);
+  const { db, calls } = makeFakeScheduleDb(seed);
+  const res = await handlePatchMarketingSchedule(patchRequest({}), {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 200);
+  const [tenantId, dayOfWeek, hour, timezone, enabled, timezoneProvided] = insertCallParams(calls);
+  assert.equal(tenantId, 12);
+  assert.equal(dayOfWeek, null);
+  assert.equal(hour, null);
+  assert.equal(timezone, null);
+  assert.equal(enabled, null);
+  assert.equal(timezoneProvided, false);
+  // Preserved end-to-end through the fake upsert: the existing row is untouched.
+  const body = await res.json();
+  assert.deepEqual(body.schedule, {
+    tenant_id: 12,
+    cadence: 'weekly',
+    day_of_week: 4,
+    hour: 18,
+    timezone: 'America/Chicago',
+    enabled: true,
+  });
+});
+
+test('PATCH with a malformed JSON body is treated as an empty body (200 no-op), not rejected', async () => {
+  // Documents the current readPatchBody() catch-and-fall-back-to-{} behavior:
+  // unlike the sibling schedule-social-content-post PATCH route (which returns
+  // 400 invalid_request_body on malformed JSON), this route silently no-ops.
+  // Pinned here so any change to that behavior is a deliberate, reviewed diff.
+  const { db, calls } = makeFakeScheduleDb();
+  const req = new Request('http://localhost/api/marketing/schedule', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: '{not json',
+  });
+  const res = await handlePatchMarketingSchedule(req, {
+    db,
+    tenantContextLoader: tenantLoader(12, 'tenant_admin'),
+  });
+  assert.equal(res.status, 200);
+  const [, dayOfWeek, hour, timezone, enabled, timezoneProvided] = insertCallParams(calls);
+  assert.equal(dayOfWeek, null);
+  assert.equal(hour, null);
+  assert.equal(timezone, null);
+  assert.equal(enabled, null);
+  assert.equal(timezoneProvided, false);
+});
+
 // ── 4. Workspace-mismatch interlock ─────────────────────────────────────────
 
 test('loader throwing WorkspaceMismatchError maps PATCH to 409, no DB write', async () => {

--- a/tests/settings-screen.test.ts
+++ b/tests/settings-screen.test.ts
@@ -14,6 +14,10 @@ const businessProfileSource = readFileSync(
   path.join(PROJECT_ROOT, 'frontend', 'aries-v1', 'business-profile-screen.tsx'),
   'utf8',
 );
+const marketingScheduleClientSource = readFileSync(
+  path.join(PROJECT_ROOT, 'lib', 'api', 'marketing-schedule.ts'),
+  'utf8',
+);
 
 test('settings Business Profile panel exposes Add Profile CTA and connected portal summary', () => {
   const businessProfilePanelStart = source.indexOf('eyebrow="Business Profile"');
@@ -84,5 +88,105 @@ test('settings Channels panel treats integrations status:error as unavailable', 
     channelPanelSource.includes('integrations.error ?'),
     false,
     'Channels panel must not treat status:error payloads as the empty integrations state',
+  );
+});
+
+// ── Cadence card (multi-brand workspaces Phase 1b, #803 task 1b) ───────────
+
+function cadencePanelSlice(): string {
+  const cadencePanelStart = source.indexOf('eyebrow="Cadence"');
+  assert.ok(cadencePanelStart >= 0, 'Settings should render a Cadence panel');
+  const teamPanelStart = source.indexOf('eyebrow="Team / Approvals"');
+  assert.ok(teamPanelStart >= 0 && teamPanelStart < cadencePanelStart, 'Cadence should render after Team / Approvals');
+  // The Cadence ShellPanel is the last panel in the component; the module-level
+  // `Field` helper's declaration is the next anchor after it closes.
+  const fieldHelperStart = source.indexOf('function Field(props');
+  assert.ok(fieldHelperStart > cadencePanelStart, 'Cadence panel should close before the Field helper is declared');
+  return source.slice(cadencePanelStart, fieldHelperStart);
+}
+
+test('settings Cadence panel renders the weekly-posting title and copy', () => {
+  const cadencePanelSource = cadencePanelSlice();
+  assert.equal(
+    cadencePanelSource.startsWith('eyebrow="Cadence"'),
+    true,
+    'The Cadence panel should carry the eyebrow="Cadence" label',
+  );
+  assert.equal(
+    source.includes('<ShellPanel eyebrow="Cadence" title="When Aries posts each week">'),
+    true,
+    'The Cadence panel should be titled "When Aries posts each week"',
+  );
+  assert.equal(
+    cadencePanelSource.includes('Weekly posting cadence'),
+    true,
+    'The Cadence panel should summarize the current weekly posting cadence',
+  );
+});
+
+test('settings Cadence panel shows role-aware copy when no schedule row exists yet', () => {
+  const cadencePanelSource = cadencePanelSlice();
+  assert.equal(
+    cadencePanelSource.includes("Not scheduled yet — save to set this workspace's cadence."),
+    true,
+    'Admins should see the "Not scheduled yet" prompt when the tenant has no cadence row',
+  );
+  assert.equal(
+    cadencePanelSource.includes('This workspace has not set a posting schedule yet.'),
+    true,
+    'Non-admins should see a read-only explanation when the tenant has no cadence row',
+  );
+  // Both empty-state strings must be gated by isWorkspaceAdmin, not shown together.
+  const emptyStateStart = cadencePanelSource.indexOf('{!schedule ?');
+  assert.ok(emptyStateStart >= 0, 'The empty-schedule copy should be conditioned on the absence of a schedule row');
+  const emptyStateSource = cadencePanelSource.slice(emptyStateStart, emptyStateStart + 400);
+  assert.equal(
+    emptyStateSource.includes('isWorkspaceAdmin'),
+    true,
+    'The empty-schedule copy should branch on isWorkspaceAdmin so viewers/analysts never see the admin-only save prompt',
+  );
+});
+
+test('settings Cadence panel only renders the editable schedule form for workspace admins', () => {
+  const cadencePanelSource = cadencePanelSlice();
+  const adminGateIndex = cadencePanelSource.indexOf('{isWorkspaceAdmin ? (');
+  assert.ok(adminGateIndex >= 0, 'The Cadence form should be gated behind an isWorkspaceAdmin check, matching the other panels\' admin-only sections');
+
+  const dayFieldIndex = cadencePanelSource.indexOf('Field label="Day of week"');
+  const saveButtonIndex = cadencePanelSource.indexOf('Save posting schedule');
+  assert.ok(dayFieldIndex > adminGateIndex, 'The day-of-week selector must live inside the isWorkspaceAdmin-gated block');
+  assert.ok(saveButtonIndex > adminGateIndex, 'The save button must live inside the isWorkspaceAdmin-gated block');
+
+  // Nothing above the admin gate (i.e. the always-visible summary card) should
+  // already contain the editable-form controls — they must only appear once,
+  // and only after the gate.
+  const beforeGate = cadencePanelSource.slice(0, adminGateIndex);
+  assert.equal(
+    beforeGate.includes('Save posting schedule'),
+    false,
+    'The save button must not render outside the isWorkspaceAdmin gate',
+  );
+});
+
+test('lib/api/marketing-schedule.ts routes cadence reads and writes through requestJson, not a bare fetch', () => {
+  assert.match(
+    marketingScheduleClientSource,
+    /import \{ ApiRequestError, requestJson \} from '\.\/http';/,
+    'The cadence client should import requestJson (the mutation-guard/409-aware wrapper) from lib/api/http.ts',
+  );
+  assert.equal(
+    /\brequestJson<.*>\(SCHEDULE_PATH,\s*\{\s*method:\s*'GET'/s.test(marketingScheduleClientSource),
+    true,
+    'fetchMarketingSchedule should call requestJson for the GET',
+  );
+  assert.equal(
+    /\brequestJson<.*>\(SCHEDULE_PATH,\s*\{\s*method:\s*'PATCH'/s.test(marketingScheduleClientSource),
+    true,
+    'updateMarketingSchedule should call requestJson for the PATCH so it carries the workspace mutation-guard header and the shared 409 interlock',
+  );
+  assert.equal(
+    /\bfetch\(/.test(marketingScheduleClientSource),
+    false,
+    'The cadence client must not bypass requestJson with a bare fetch() call',
   );
 });


### PR DESCRIPTION
Part of #803 (multi-brand workspaces, Phase 1 task 1b). Contract: docs/plans/2026-07-08-multi-brand-workspaces.md §1b; plan = #803 comment "Phase 1a+1b implementation plan" §1b.

## Scope
Adds the operator-facing weekly-cadence surface on top of the Phase 1a `marketing_schedule` single-writer helpers — no new SQL, no schedule-store.ts change.

- **`app/api/marketing/schedule/{route,handler}.ts`** — `GET` (any authenticated) + `PATCH` (tenant_admin-gated) for the tenant's own weekly cadence row.
- **`lib/api/marketing-schedule.ts`** — typed browser client (`fetchMarketingSchedule`/`updateMarketingSchedule`) routed through `requestJson` so the PATCH carries the multi-workspace mutation-guard header and participates in the shared 409 stale-workspace interlock.
- **`frontend/aries-v1/settings-screen.tsx`** — a Cadence `ShellPanel` added at the end of Settings (no refactor of the existing screen, no new design primitives): always-visible summary card + admin-only editable form (day/hour/timezone/enabled), non-admins read-only.
- Tests: `tests/marketing-schedule-route.test.ts` (26 route cases incl. edge cases) + `tests/settings-screen.test.ts` (Cadence panel copy, admin-only gating, requestJson usage).

## Route contract
- **Tenant id** resolved ONLY from `getTenantContext()` — never body/query. A body-supplied `tenant_id` is ignored (pinned test).
- **GET**: any authenticated role (mirrors `app/api/business/profile` GET); returns `{ schedule: row | null }` — frontend-safe row fields only (no tokens/internal state).
- **PATCH**: `tenant_admin` only → else `403 forbidden`, no DB write. Mirrors the business/profile PATCH gate.
- **409 workspace-mismatch**: both verbs route through `loadTenantContextOrResponse`/`workspaceMismatchResponse`, so a pinned-tab mismatch is a 409 (interlock), never a 403.
- **Validation**: per-field `400 invalid_{day,hour,timezone,enabled}` only for a PROVIDED invalid value; an omitted field is preserved (never validated). Normalization routes JSON-number and boolean/string forms into the 1a validators without mutating schedule-store.ts.
- **Preserve semantics**: reuses the 1a COALESCE-preserve `upsertMarketingSchedule`; `timezone: null` = explicit clear (via `timezoneProvided`), omitted key = preserve. Queries run strictly sequentially (no Promise.all around the pg pool).

## Judgment call — malformed JSON PATCH body (per review §4)
**Decision: ship as-is (malformed body → `{}` → 200 no-op preserve).** The closest architectural sibling — `app/api/business/profile` PATCH, also a tenant_admin-gated COALESCE-preserve settings write — uses the identical `try/catch → payload = {}` fallback. The `schedule-social-content-post` PATCH that returns `400 invalid_request_body` is a different shape (creates a concrete post with required fields, where an empty body is a genuine client error); for a preserve-semantics settings PATCH a malformed body degrades to a harmless GET-like no-op that returns the current row, writes nothing meaningful, and leaks nothing. Forcing a 400 here would diverge from the closest sibling and grow the diff for no correctness gain. The behavior is pinned by `tests/marketing-schedule-route.test.ts` so any future change is a deliberate, reviewed diff.

## Gate evidence (re-run on this reviewer host, post-rebase onto origin/master @383b40f7)
- Focused: `tests/marketing-schedule-route.test.ts` + `tests/settings-screen.test.ts` → **26/26 pass**
- `npm run verify` → **42/42 pass** ("Verification suite passed")
- `npm run validate:social-content` → **90/90 pass**
- `npm run typecheck` → clean
- `npm run guardrails:agent` → passed (unique diff, ahead 4 / behind 0)
- Protected paths (`backend/marketing/schedule-store.ts`, its tests, the flag-off golden) confirmed untouched.

## Residual risk / rendered-UI verification pending
This lands the route + card behind the existing Settings surface with no flag flip and no cross-tenant surface. Only rendered UI counts as user-visibly done: a post-merge browser pass will screenshot the Cadence card on a live tenant (admin + non-admin) before 1b is called done.