### PR TITLE
docs(compose): fix stale ANALYTICS_PROVIDER default comment (defaults to composio, not direct_meta)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -666,8 +666,9 @@ services:
       ARIES_INSIGHTS_SWEEP_GRACE_MINUTES: ${ARIES_INSIGHTS_SWEEP_GRACE_MINUTES:-60}
       # Composio analytics (#596/#597). ACTIVATION: the Facebook insights path
       # (account bridge + adapter) turns on ONLY when ANALYTICS_PROVIDER=composio.
-      # With the default (direct_meta) the bridge no-ops, the adapter never
-      # activates, and no Composio analytics tool runs. When enabled, the adapter
+      # ANALYTICS_PROVIDER defaults to composio (here and in code), so the only
+      # default-deploy blocker is COMPOSIO_ENABLED=false; setting
+      # ANALYTICS_PROVIDER=direct_meta explicitly disables the path. When enabled, the adapter
       # executes Composio tools, so this sidecar needs the same Composio
       # credentials as the app (COMPOSIO_API_KEY etc.); the *_ACTION slugs are
       # optional (verified code defaults).


### PR DESCRIPTION
## What
The `aries-insights-sync-worker` comment in `docker-compose.yml` claimed `ANALYTICS_PROVIDER`'s default is `direct_meta`. It isn't — both the compose default (`ANALYTICS_PROVIDER:-composio`) and the **code** default (`analyticsProviderSelector` → `parseSelector(env.ANALYTICS_PROVIDER, 'composio')`, `backend/integrations/providers/integration-config.ts`) are `composio`.

So the Facebook/Instagram insights gate `isComposioEnabled(env) && analyticsProviderSelector(env) === 'composio'` (`backend/insights/sync/adapter-factory.ts`) is blocked on a default deploy **only** by `COMPOSIO_ENABLED=false` — `ANALYTICS_PROVIDER=direct_meta` is an explicit off-switch, not the default. The old comment could mislead an operator into thinking they must flip `ANALYTICS_PROVIDER` to activate.

```diff
       # (account bridge + adapter) turns on ONLY when ANALYTICS_PROVIDER=composio.
-      # With the default (direct_meta) the bridge no-ops, the adapter never
-      # activates, and no Composio analytics tool runs. When enabled, the adapter
+      # ANALYTICS_PROVIDER defaults to composio (here and in code), so the only
+      # default-deploy blocker is COMPOSIO_ENABLED=false; setting
+      # ANALYTICS_PROVIDER=direct_meta explicitly disables the path. When enabled, the adapter
```

## Scope
**Comment-only — no behavior change.** No env value, default, or code touched; only the explanatory comment.

## Context
Found during **S1-12 (Gap B3 / AA-88 area)** DOCKER.md insights-activation recon. Not tied to an S-ticket itself. The DOCKER.md activation section is a separate, still-pending change (awaiting prod values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)