### PR TITLE
S2-2/AA-93 (part 2/2): per-post intraday upsert (DO NOTHING → DO UPDATE)

### DIFF
--- a/backend/insights/sync/dispatcher.ts
+++ b/backend/insights/sync/dispatcher.ts
@@ -287,7 +287,29 @@ export async function syncAccountForTenant(
                      $5, $6, $7, $8,
                      $9, $10, $11,
                      '{}', $12)
-             ON CONFLICT (tenant_id, post_id, date) DO NOTHING`,
+             -- S2-2 (AA-93) part 2/2: intraday upsert. Sync runs ~every 30 min;
+             -- the first run of a calendar day inserted the row and every later
+             -- same-day run was discarded by DO NOTHING, freezing the day's row at
+             -- its earliest value. DO UPDATE refreshes it to each later sync's
+             -- latest value. Only value columns this INSERT provides are updated
+             -- (via EXCLUDED); reach/saves are NOT written here so are omitted
+             -- (their EXCLUDED is NULL and would clobber any other writer); the
+             -- conflict key (tenant_id, post_id, date) is never touched.
+             -- SAFE ONLY WITH S2-1 LIVE: per-post rows are lifetime-cumulative
+             -- snapshots. Under S2-1's latest-snapshot readers (ORDER BY date DESC
+             -- LIMIT 1), DO UPDATE only freshens the single newest row a reader
+             -- reads — no sum-across-dates path exists to re-inflate. This PR must
+             -- merge AFTER S2-1 (#823); before it, the old SUM readers would
+             -- inflate worse.
+             ON CONFLICT (tenant_id, post_id, date) DO UPDATE SET
+               views                 = EXCLUDED.views,
+               watch_time_minutes    = EXCLUDED.watch_time_minutes,
+               avg_view_duration_sec = EXCLUDED.avg_view_duration_sec,
+               avg_view_percentage   = EXCLUDED.avg_view_percentage,
+               likes                 = EXCLUDED.likes,
+               comments_count        = EXCLUDED.comments_count,
+               shares                = EXCLUDED.shares,
+               raw_source            = EXCLUDED.raw_source`,
             [
               tenantId, post.id, platform, pm.date,
               pm.views, pm.watchTimeMinutes,

--- a/tests/insights-post-metrics-upsert.requires-infra.test.ts
+++ b/tests/insights-post-metrics-upsert.requires-infra.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import pg from 'pg';
+
+import { requireDbEnvOrSkip } from './helpers/requires-infra';
+
+// S2-2 / AA-93 (part 2/2) — live-schema proof that a later same-day sync REFRESHES
+// the per-post metrics row (DO UPDATE), instead of the old DO NOTHING that froze
+// the row at its earliest-morning value (Gap A10 "intraday freeze").
+//
+// insights_post_metrics_daily holds one lifetime-cumulative snapshot per post per
+// sync date, keyed by (tenant_id, post_id, date). The sync runs ~every 30 min;
+// without DO UPDATE the first run of a calendar day wins and every later same-day
+// run is discarded, so today's row never advances as the post's lifetime totals
+// grow through the day.
+//
+// SAFE ONLY WITH S2-1 LIVE: S2-1's latest-snapshot readers take ORDER BY date DESC
+// LIMIT 1, so DO UPDATE only freshens the single newest row a reader reads — no
+// sum-across-dates path exists to re-inflate. This test exercises the write path
+// in isolation (it proves the upsert, independent of any reader), so it passes
+// with or without S2-1; the S2-1 dependency is a prod merge-order constraint, not
+// a test dependency.
+//
+// The fix is pure SQL, so a mock proves nothing — this runs the EXACT
+// ON CONFLICT ... DO UPDATE clause shipped in
+// backend/insights/sync/dispatcher.ts against real Postgres inside a rolled-back
+// transaction. requires-infra: self-skips without DB env (as in CI), verified
+// locally.
+
+// Kept byte-identical to the dispatcher's Site B statement so this test exercises
+// the shipped SQL, not a paraphrase.
+const POST_METRICS_UPSERT = `
+  INSERT INTO insights_post_metrics_daily
+    (tenant_id, post_id, platform, date,
+     views, watch_time_minutes,
+     avg_view_duration_sec, avg_view_percentage,
+     likes, comments_count, shares,
+     platform_data, raw_source)
+  VALUES ($1, $2, $3, $4,
+          $5, $6, $7, $8,
+          $9, $10, $11,
+          '{}', $12)
+  ON CONFLICT (tenant_id, post_id, date) DO UPDATE SET
+    views                 = EXCLUDED.views,
+    watch_time_minutes    = EXCLUDED.watch_time_minutes,
+    avg_view_duration_sec = EXCLUDED.avg_view_duration_sec,
+    avg_view_percentage   = EXCLUDED.avg_view_percentage,
+    likes                 = EXCLUDED.likes,
+    comments_count        = EXCLUDED.comments_count,
+    shares                = EXCLUDED.shares,
+    raw_source            = EXCLUDED.raw_source`;
+
+test('later same-day per-post sync updates the row (DO UPDATE, not frozen DO NOTHING)', async (t) => {
+  if (!requireDbEnvOrSkip(t)) return;
+
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    max: 1,
+  });
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const org = (await client.query<{ id: number }>(
+      `INSERT INTO organizations (name) VALUES ('S2-2 per-post upsert test') RETURNING id`,
+    )).rows[0].id;
+
+    const account = (await client.query<{ id: number }>(
+      `INSERT INTO insights_accounts (tenant_id, platform, external_account_id)
+       VALUES ($1, 'facebook', 'fb-acct-1') RETURNING id`,
+      [org],
+    )).rows[0].id;
+
+    const post = (await client.query<{ id: number }>(
+      `INSERT INTO insights_posts (tenant_id, account_id, platform, external_post_id, published_at, media_type)
+       VALUES ($1, $2, 'facebook', 'fb-post-1', now() - interval '5 days', 'image') RETURNING id`,
+      [org, account],
+    )).rows[0].id;
+
+    // A single fixed calendar day (the conflict key), so both writes collide.
+    const day = '2026-07-01';
+    const writeSnapshot = async (views: number, likes: number, shares: number) => {
+      await client.query(POST_METRICS_UPSERT, [
+        org, post, 'facebook', day,
+        views, /* watch */ 0, /* avg_view_duration_sec */ 0, /* avg_view_percentage */ 0,
+        likes, /* comments */ 0, shares,
+        JSON.stringify({}),
+      ]);
+    };
+
+    // First sync of the day (earliest-morning lifetime total).
+    await writeSnapshot(100, 10, 2);
+    // A later same-day sync as the post's lifetime totals grow — same (tenant, post, date).
+    await writeSnapshot(200, 30, 5);
+
+    const row = (await client.query<{ views: string; likes: string; shares: string }>(
+      `SELECT views, likes, shares
+       FROM insights_post_metrics_daily
+       WHERE tenant_id = $1 AND post_id = $2`,
+      [org, post],
+    )).rows[0];
+
+    // DO UPDATE: the row reflects the LATER sync. Under the old DO NOTHING it would
+    // still read 100 / 10 / 2 (frozen at the first write).
+    assert.equal(Number(row.views), 200, 'views advance to the later same-day sync (not frozen at 100)');
+    assert.equal(Number(row.likes), 30, 'likes advance to the later same-day sync (not frozen at 10)');
+    assert.equal(Number(row.shares), 5, 'shares advance to the later same-day sync (not frozen at 2)');
+
+    // And exactly one row exists for the day — the upsert updated in place, it did
+    // not insert a duplicate.
+    const count = (await client.query<{ n: string }>(
+      `SELECT COUNT(*) AS n FROM insights_post_metrics_daily
+       WHERE tenant_id = $1 AND post_id = $2`,
+      [org, post],
+    )).rows[0];
+    assert.equal(Number(count.n), 1, 'one row per (tenant, post, date) — updated in place');
+  } finally {
+    await client.query('ROLLBACK').catch(() => {});
+    client.release();
+    await pool.end();
+  }
+});


### PR DESCRIPTION
**Closes S2-2 / AA-93** (Gap A10 "intraday freeze", `docs/plans/2026-07-07-analytics-page-roadmap.md`, PR #789). This is **PART 2 OF 2 — the per-post half** — and completes the ticket. Part 1 (#824, account-dailies half) is the other half of the split.

## ⚠️ MERGE ORDER: land AFTER S2-1 (#823) — do NOT merge before it
This PR is **safe by merge-order, not in isolation.** The per-post `DO UPDATE` is only correct once S2-1's latest-snapshot readers are live. **If merged to prod before #823, it makes the metric inflation worse** (see safety section). #823 (S2-1) must merge first.

## The bug
The insights sync runs ~every 30 min, but the per-post metrics insert used `ON CONFLICT (tenant_id, post_id, date) DO NOTHING`. The **first** sync of a calendar day inserts the row; every **later same-day** sync is discarded — so today's row freezes at its earliest value and never advances as the post's lifetime totals grow through the day.

## The fix (Site B — per-post metrics)
`ON CONFLICT ... DO NOTHING` → `DO UPDATE SET` at `backend/insights/sync/dispatcher.ts`, refreshing only the value columns this INSERT provides, from `EXCLUDED`:
`views, watch_time_minutes, avg_view_duration_sec, avg_view_percentage, likes, comments_count, shares, raw_source`.

- **Not updated:** `reach`, `saves` — this path never writes them, so their `EXCLUDED` is NULL and setting them would clobber any other writer.
- **Never touched:** the conflict key `(tenant_id, post_id, date)`.
- **No schema change.**

## Why it's safe — but only with S2-1 live
Per-post rows are **lifetime-cumulative** snapshots (one growing all-time total per post per sync date).
- **With S2-1 live (required):** readers take the newest row per post (`ORDER BY date DESC LIMIT 1`). `DO UPDATE` only freshens that **single newest row** a reader reads — there is no sum-across-dates path left, so nothing can re-inflate. It strictly improves freshness.
- **Without S2-1 (the hazard):** the old readers `SUM` across dated rows. Raising today's row to the latest, higher lifetime total would make that SUM **bigger** → worse inflation. That is why this must merge after #823.

This branch was built on a base **without** S2-1 (it was still an open PR at authoring time). The change is reader-independent and does **not overlap S2-1's files** (S2-1 touched readers + a new SQL module; this touches only the Site B insert), so it applies cleanly on top of S2-1. Before this lands, I'll re-confirm it still applies once #823 is merged.

## Other `DO NOTHING` sites — deliberately left alone (flagged again)
No metric freezes there, intentionally untouched:
- `insights_comments` `(tenant_id, platform, external_comment_id) DO NOTHING` — comment body/author/received_at are immutable; the row carries no mutating metric.
- `insights_comment_classifications` `(comment_id) DO NOTHING` — intentional: don't re-classify an already-labeled comment (avoids re-spending the Hermes call).

(`insights_posts` already uses `DO UPDATE` for title/caption/platform_data — not a freeze. Account dailies = part 1, #824.)

## Test
`tests/insights-post-metrics-upsert.requires-infra.test.ts` runs the **exact shipped `ON CONFLICT ... DO UPDATE` clause** against real Postgres in a rolled-back transaction: a later same-day write with higher values updates the row in place (one row, refreshed).
- **Fails-before:** against the old `DO NOTHING`, the row stays frozen at the first write (`actual 100 !== expected 200`).
- **Passes-after:** row advances to `200 / 30 / 5`; exactly one row per `(tenant, post, date)`.
- The test exercises the **write path in isolation**, so it passes with or without S2-1 on the base — the S2-1 dependency is prod merge-order only, not a test dependency.
- **requires-infra:** self-skips in CI without DB env; verified locally.

## Verification
- `npm run verify` → 42/42 green.
- `npm run typecheck` → clean.
- requires-infra test: fails-before / passes-after demonstrated locally against live Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)