### PR TITLE
S2-3/AA-94: single tenant-tz read-side policy across builders

### DIFF
--- a/backend/insights/activity/activity-snapshot-builder.ts
+++ b/backend/insights/activity/activity-snapshot-builder.ts
@@ -20,6 +20,8 @@
 
 import pool from '@/lib/db';
 import { LATEST_POST_METRICS_LATERAL } from '../latest-post-metrics-sql';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart } from '@/lib/format-timestamp';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 
 // Conservative estimate: research + writing + creative + scheduling per post.
@@ -52,13 +54,6 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
-function daysAgo(days: number): Date {
-  const d = new Date();
-  d.setUTCHours(0, 0, 0, 0);
-  d.setUTCDate(d.getUTCDate() - days);
-  return d;
-}
-
 // ── Main builder ──────────────────────────────────────────────────────────────
 
 export async function buildActivitySnapshot(
@@ -67,11 +62,14 @@ export async function buildActivitySnapshot(
   platform:  string,
 ): Promise<ActivitySnapshot> {
   const days           = periodDays(period);
-  const fromDate       = daysAgo(days);
   const platformFilter = platform === 'all' ? null : platform;
 
   const client = await pool.connect();
   try {
+    // S2-3: all activity windows filter timestamptz columns (published_at /
+    // received_at), so the lower bound is the tenant-tz-midnight instant.
+    const tz       = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromDate = tenantZonePeriodStart(days, tz);
 
     // ── Posts published + platform count ─────────────────────────────────────
     const postsRes = await client.query<{

--- a/backend/insights/activity/handler.ts
+++ b/backend/insights/activity/handler.ts
@@ -24,7 +24,10 @@ import crypto from 'crypto';
 // latest lifetime snapshots per post, not SUM across dated cumulative rows.
 // Because per-post inflation varied by sync age, the threshold basis and the
 // resulting count shift. Bump invalidates stale v3 bodies.
-const TEMPLATE_VERSION = 'activity-v4';
+// v5: S2-3 — the period window is now computed in the tenant's business timezone,
+// so which posts/comments fall in-window (and thus the counts, high-performer set,
+// hours-saved, and content mix) shift near the day boundary. Bump invalidates v4.
+const TEMPLATE_VERSION = 'activity-v5';
 const CACHE_TTL_MS     = 60 * 60 * 1000; // 1 hour
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/aries/aries-builder.ts
+++ b/backend/insights/aries/aries-builder.ts
@@ -12,6 +12,8 @@
  */
 
 import pool from '@/lib/db';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart } from '@/lib/format-timestamp';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 
 // ── Public shapes ─────────────────────────────────────────────────────────────
@@ -51,12 +53,6 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
-function daysAgo(days: number): Date {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - days);
-  return d;
-}
-
 function formatWeekLabel(date: Date): string {
   return new Date(date).toLocaleDateString('en-US', {
     month:    'short',
@@ -94,11 +90,15 @@ export async function buildWorkingWithAriesSnapshot(
   period:   NarrativePeriod,
 ): Promise<WorkingWithAriesSnapshot> {
   const days          = periodDays(period);
-  const fromDate      = daysAgo(days);
-  const priorFromDate = daysAgo(days * 2);
 
   const client = await pool.connect();
   try {
+    // S2-3: windows + weekly bucketing in the tenant's business timezone.
+    // campaign_learning_labels.created_at is timestamptz → tenant-tz-midnight
+    // instant; the learning-curve week is trunc'd in tenant-tz ($tz), not UTC.
+    const tz            = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromDate      = tenantZonePeriodStart(days, tz);
+    const priorFromDate = tenantZonePeriodStart(days * 2, tz);
 
     // ── Query 1: current-period label counts ─────────────────────────────────
     const flowRes = await client.query<{
@@ -146,8 +146,10 @@ export async function buildWorkingWithAriesSnapshot(
       rejected:   string;
       edited:     string;
     }>(
+      // S2-3: bucket the week in the tenant's business timezone ($3), not UTC/
+      // session tz, so the learning-curve weeks align with the tenant's calendar.
       `SELECT
-         date_trunc('week', created_at)                            AS week_start,
+         date_trunc('week', created_at AT TIME ZONE $3)            AS week_start,
          COUNT(*) FILTER (WHERE label = 'approved')                AS approved,
          COUNT(*) FILTER (WHERE label = 'rejected')                AS rejected,
          COUNT(*) FILTER (WHERE label = 'needs_changes')           AS edited
@@ -157,7 +159,7 @@ export async function buildWorkingWithAriesSnapshot(
          AND label IN ('approved', 'rejected', 'needs_changes')
        GROUP BY week_start
        ORDER BY week_start ASC`,
-      [tenantId, daysAgo(84)],   // 12 weeks back
+      [tenantId, tenantZonePeriodStart(84, tz), tz],   // 12 weeks back
     );
 
     // ── Approval flow ─────────────────────────────────────────────────────────

--- a/backend/insights/aries/aries-builder.ts
+++ b/backend/insights/aries/aries-builder.ts
@@ -141,15 +141,20 @@ export async function buildWorkingWithAriesSnapshot(
 
     // ── Query 4: weekly label history for learning curve (last 12 weeks) ─────
     const curveRes = await client.query<{
-      week_start: Date;
+      week_start: string;
       approved:   string;
       rejected:   string;
       edited:     string;
     }>(
       // S2-3: bucket the week in the tenant's business timezone ($3), not UTC/
       // session tz, so the learning-curve weeks align with the tenant's calendar.
+      // week_start is emitted as a YYYY-MM-DD string: date_trunc(.. AT TIME ZONE)
+      // yields timestamp WITHOUT time zone, which node-pg would parse in the
+      // process's local TZ before formatWeekLabel re-reads it as UTC — shifting
+      // the label a day back on any TZ-ahead-of-UTC process. A plain date string
+      // parses as UTC and stays process-TZ-independent.
       `SELECT
-         date_trunc('week', created_at AT TIME ZONE $3)            AS week_start,
+         to_char(date_trunc('week', created_at AT TIME ZONE $3), 'YYYY-MM-DD') AS week_start,
          COUNT(*) FILTER (WHERE label = 'approved')                AS approved,
          COUNT(*) FILTER (WHERE label = 'rejected')                AS rejected,
          COUNT(*) FILTER (WHERE label = 'needs_changes')           AS edited
@@ -194,7 +199,7 @@ export async function buildWorkingWithAriesSnapshot(
       const weekApproved = Number(row.approved);
       if (weekApproved === 0) continue;   // skip weeks with no approved outcomes
       const weekTotal    = weekApproved + Number(row.rejected) + Number(row.edited);
-      curveLabels.push(formatWeekLabel(new Date(row.week_start)));
+      curveLabels.push(formatWeekLabel(new Date(`${row.week_start}T00:00:00Z`)));
       curveValues.push(parseFloat((weekTotal / weekApproved).toFixed(1)));
     }
 

--- a/backend/insights/attention/attention-snapshot-builder.ts
+++ b/backend/insights/attention/attention-snapshot-builder.ts
@@ -13,6 +13,8 @@
 
 import pool from '@/lib/db';
 import { LATEST_POST_METRICS_LATERAL } from '../latest-post-metrics-sql';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart, tenantZonePeriodStartDateKey } from '@/lib/format-timestamp';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 
 export interface HighPerformer {
@@ -62,13 +64,6 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
-function daysAgo(days: number): Date {
-  const d = new Date();
-  d.setUTCHours(0, 0, 0, 0);
-  d.setUTCDate(d.getUTCDate() - days);
-  return d;
-}
-
 const DOW_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const FOLLOWER_MILESTONES = [100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000];
@@ -93,11 +88,17 @@ export async function buildAttentionSnapshot(
   platform:  string,
 ): Promise<AttentionSnapshot> {
   const days           = periodDays(period);
-  const fromDate       = daysAgo(days);
   const platformFilter = platform === 'all' ? null : platform;
 
   const client = await pool.connect();
   try {
+    // S2-3: windows + day-of-week bucketing in the tenant's business timezone.
+    // timestamptz columns (received_at / published_at) use the tenant-tz-midnight
+    // instant; the two account-daily (bare DATE) sub-queries use a tenant-tz
+    // calendar date ($n::date).
+    const tz       = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromDate = tenantZonePeriodStart(days, tz);
+    const fromKey  = tenantZonePeriodStartDateKey(days, tz);
 
     // ── A: Unreplied comments + classification hints ──────────────────────────
     const unrepliedRes = await client.query<{
@@ -196,10 +197,12 @@ export async function buildAttentionSnapshot(
         // S2-1: average each post's LATEST lifetime reach per weekday (and count
         // posts, not dated rows). The old direct join fanned out per date row, so
         // AVG/COUNT were over cumulative snapshots, not posts.
+        // S2-3: weekday derived in the tenant's business timezone ($4), not UTC —
+        // this is the flagship "best day to post" coherence fix.
         `SELECT dow, AVG(reach) AS avg_reach, COUNT(*) AS cnt
          FROM (
-           SELECT EXTRACT(DOW FROM p.published_at AT TIME ZONE 'UTC')::int AS dow,
-                  COALESCE(m.reach, m.views, 0)                            AS reach
+           SELECT EXTRACT(DOW FROM p.published_at AT TIME ZONE $4)::int AS dow,
+                  COALESCE(m.reach, m.views, 0)                          AS reach
            FROM insights_posts p
            ${LATEST_POST_METRICS_LATERAL}
            WHERE p.tenant_id    = $1
@@ -209,7 +212,7 @@ export async function buildAttentionSnapshot(
          GROUP BY dow
          HAVING COUNT(*) >= 2
          ORDER BY avg_reach DESC`,
-        [tenantId, fromDate, platformFilter],
+        [tenantId, fromDate, platformFilter, tz],
       );
 
       if (dowRes.rows.length >= 2) {
@@ -232,16 +235,17 @@ export async function buildAttentionSnapshot(
           platform:  string;
           avg_reach: string;
         }>(
+          // S2-3: bare DATE column bounded by a tenant-tz calendar date ($2::date).
           `SELECT
              platform,
              AVG(COALESCE(reach, views, 0)) AS avg_reach
            FROM insights_account_metrics_daily
            WHERE tenant_id = $1
-             AND date >= $2
+             AND date >= $2::date
            GROUP BY platform
            HAVING COUNT(DISTINCT date) >= 3
            ORDER BY avg_reach DESC`,
-          [tenantId, fromDate],
+          [tenantId, fromKey],
         );
 
         if (platRes.rows.length >= 2) {
@@ -268,17 +272,18 @@ export async function buildAttentionSnapshot(
       start_followers:  string | null;
       end_followers:    string | null;
     }>(
+      // S2-3: bare DATE column bounded by a tenant-tz calendar date ($2::date).
       `SELECT
          platform,
          MIN(followers) AS start_followers,
          MAX(followers) AS end_followers
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND followers IS NOT NULL
          AND ($3::text IS NULL OR platform = $3)
        GROUP BY platform`,
-      [tenantId, fromDate, platformFilter],
+      [tenantId, fromKey, platformFilter],
     );
 
     for (const row of milestoneRes.rows) {

--- a/backend/insights/attention/handler.ts
+++ b/backend/insights/attention/handler.ts
@@ -24,7 +24,11 @@ import crypto from 'crypto';
 // use the latest lifetime snapshot per post (not SUM across dated cumulative
 // rows); since per-post inflation varied by sync age, the multiplier and DOW
 // ranking change. Bump invalidates stale v3 bodies.
-const TEMPLATE_VERSION = 'attention-v4';
+// v5: S2-3 — the period window and the best-day-of-week bucketing are now
+// computed in the tenant's business timezone (weekday via AT TIME ZONE $tz, not
+// UTC), so a post near midnight can move to a different weekday and the DOW
+// ranking / window membership change. Bump invalidates stale v4 bodies.
+const TEMPLATE_VERSION = 'attention-v5';
 const CACHE_TTL_MS     = 15 * 60 * 1000; // 15 minutes
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/audience/audience-builder.ts
+++ b/backend/insights/audience/audience-builder.ts
@@ -17,6 +17,8 @@
  */
 
 import pool from '@/lib/db';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart } from '@/lib/format-timestamp';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 
 // ── Public shapes ─────────────────────────────────────────────────────────────
@@ -64,10 +66,6 @@ function captionToTitle(caption: string | null): string {
     ? `${firstLine.slice(0, 57).trimEnd()}…`
     : firstLine;
 }
-
-// Default bucket timezone when the tenant has no business_profiles.timezone set.
-// The current prod tenant is US-Central; per-tenant tz should be populated there.
-const DEFAULT_TZ = 'America/Chicago';
 
 // Grid rows are Mon..Sun (matches the frontend day-axis order).
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
@@ -150,16 +148,14 @@ export async function buildAudienceSnapshot(
     // bucketed by day-of-week × hour in the tenant's local timezone. This is
     // engagement timing, NOT the platform "followers online" metric — that
     // still needs the Phase 3 audience-analytics adapters (see demographics).
-    const tzRes = await client.query<{ timezone: string | null }>(
-      `SELECT timezone FROM business_profiles WHERE tenant_id = $1 LIMIT 1`,
-      [tenantId],
-    );
-    const timezone = tzRes.rows[0]?.timezone || DEFAULT_TZ;
-
+    // S2-3: the tenant's own business timezone (single source of truth; the
+    // America/New_York default applies only to a tenant with no zone set). This
+    // heatmap already bucketed comments in tenant-tz — now the period window is
+    // tenant-tz too (received_at is timestamptz → tenant-tz-midnight instant), so
+    // window and buckets no longer disagree.
+    const timezone = await resolveTenantInsightsTimeZone(client, tenantId);
     const days     = periodDays(period);
-    const fromDate = new Date();
-    fromDate.setUTCHours(0, 0, 0, 0);
-    fromDate.setUTCDate(fromDate.getUTCDate() - days);
+    const fromDate = tenantZonePeriodStart(days, timezone);
 
     const heatRes = await client.query<{ dow: number; hour: number; n: string }>(
       `SELECT

--- a/backend/insights/conversations/conversations-builder.ts
+++ b/backend/insights/conversations/conversations-builder.ts
@@ -13,6 +13,8 @@
  */
 
 import pool from '@/lib/db';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart } from '@/lib/format-timestamp';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 
 // ── Public shapes ─────────────────────────────────────────────────────────────
@@ -58,12 +60,6 @@ function periodDays(period: NarrativePeriod): number {
   if (period === 'week')  return 7;
   if (period === '30day') return 30;
   return 90;
-}
-
-function daysAgo(days: number): Date {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - days);
-  return d;
 }
 
 /** Derive a 2-character avatar from an @handle or plain username. */
@@ -116,12 +112,15 @@ export async function buildConversationsSnapshot(
   period:   NarrativePeriod,
   platform: string,
 ): Promise<ConversationsSnapshot> {
-  const fromDate       = daysAgo(periodDays(period));
   const platformFilter = platform === 'all' ? null : platform;
   const now            = new Date();
 
   const client = await pool.connect();
   try {
+    // S2-3: comment window filters received_at (timestamptz) → tenant-tz-midnight
+    // instant, in the tenant's own business timezone.
+    const tz       = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromDate = tenantZonePeriodStart(periodDays(period), tz);
 
     // ── Aggregate: totals for meta + lead-quality counts ─────────────────────
     const aggRes = await client.query<{

--- a/backend/insights/goal/goal-snapshot-builder.ts
+++ b/backend/insights/goal/goal-snapshot-builder.ts
@@ -16,6 +16,8 @@
 import pool, { type PoolClient } from '@/lib/db';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 import { LATEST_POST_METRICS_LATERAL } from '../latest-post-metrics-sql';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart, tenantZonePeriodStartDateKey } from '@/lib/format-timestamp';
 
 export type GoalType = 'lead_generation' | 'content_growth' | 'product_sales' | 'brand_awareness';
 
@@ -135,13 +137,6 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
-function daysAgo(days: number): Date {
-  const d = new Date();
-  d.setUTCHours(0, 0, 0, 0);
-  d.setUTCDate(d.getUTCDate() - days);
-  return d;
-}
-
 function pctDelta(current: number, prev: number): number {
   if (prev === 0) return current > 0 ? 100 : 0;
   return Math.round(((current - prev) / prev) * 1000) / 10;
@@ -189,27 +184,29 @@ async function queryLeadGeneration(
 async function queryContentGrowth(
   client: PoolClient,
   tenantId: number,
-  fromDate: Date,
-  prevFrom: Date,
+  fromKey: string,
+  prevKey: string,
   platformFilter: string | null,
 ): Promise<{ current: number; prev: number; secondary: null }> {
+  // S2-3: the bare DATE column is bounded by a tenant-tz calendar date ($n::date),
+  // never a timestamptz instant (session-tz-dependent, off-by-one at the boundary).
   const [curr, prev] = await Promise.all([
     client.query<{ total: string }>(
       `SELECT COALESCE(SUM(followers_delta), 0) AS total
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND ($3::text IS NULL OR platform = $3)`,
-      [tenantId, fromDate, platformFilter],
+      [tenantId, fromKey, platformFilter],
     ),
     client.query<{ total: string }>(
       `SELECT COALESCE(SUM(followers_delta), 0) AS total
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
-         AND date < $3
+         AND date >= $2::date
+         AND date < $3::date
          AND ($4::text IS NULL OR platform = $4)`,
-      [tenantId, prevFrom, fromDate, platformFilter],
+      [tenantId, prevKey, fromKey, platformFilter],
     ),
   ]);
   return {
@@ -222,35 +219,36 @@ async function queryContentGrowth(
 async function queryProductSales(
   client: PoolClient,
   tenantId: number,
-  fromDate: Date,
-  prevFrom: Date,
+  fromKey: string,
+  prevKey: string,
   platformFilter: string | null,
 ): Promise<{ current: number; prev: number; secondary: number }> {
+  // S2-3: bare DATE column bounded by a tenant-tz calendar date ($n::date).
   const [curr, prev, visits] = await Promise.all([
     client.query<{ saves: string }>(
       `SELECT COALESCE(SUM(saves), 0) AS saves
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND ($3::text IS NULL OR platform = $3)`,
-      [tenantId, fromDate, platformFilter],
+      [tenantId, fromKey, platformFilter],
     ),
     client.query<{ saves: string }>(
       `SELECT COALESCE(SUM(saves), 0) AS saves
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
-         AND date < $3
+         AND date >= $2::date
+         AND date < $3::date
          AND ($4::text IS NULL OR platform = $4)`,
-      [tenantId, prevFrom, fromDate, platformFilter],
+      [tenantId, prevKey, fromKey, platformFilter],
     ),
     client.query<{ visits: string }>(
       `SELECT COALESCE(SUM(profile_visits), 0) AS visits
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND ($3::text IS NULL OR platform = $3)`,
-      [tenantId, fromDate, platformFilter],
+      [tenantId, fromKey, platformFilter],
     ),
   ]);
   return {
@@ -263,27 +261,28 @@ async function queryProductSales(
 async function queryBrandAwareness(
   client: PoolClient,
   tenantId: number,
-  fromDate: Date,
-  prevFrom: Date,
+  fromKey: string,
+  prevKey: string,
   platformFilter: string | null,
 ): Promise<{ current: number; prev: number; secondary: null }> {
+  // S2-3: bare DATE column bounded by a tenant-tz calendar date ($n::date).
   const [curr, prev] = await Promise.all([
     client.query<{ reach: string }>(
       `SELECT COALESCE(SUM(COALESCE(reach, views, 0)), 0) AS reach
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND ($3::text IS NULL OR platform = $3)`,
-      [tenantId, fromDate, platformFilter],
+      [tenantId, fromKey, platformFilter],
     ),
     client.query<{ reach: string }>(
       `SELECT COALESCE(SUM(COALESCE(reach, views, 0)), 0) AS reach
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
-         AND date < $3
+         AND date >= $2::date
+         AND date < $3::date
          AND ($4::text IS NULL OR platform = $4)`,
-      [tenantId, prevFrom, fromDate, platformFilter],
+      [tenantId, prevKey, fromKey, platformFilter],
     ),
   ]);
   return {
@@ -424,12 +423,20 @@ export async function buildGoalSnapshot(
   platform: string,
 ): Promise<GoalSnapshot | null> {
   const days          = periodDays(period);
-  const fromDate      = daysAgo(days);
-  const prevFrom      = daysAgo(days * 2);
   const platformFilter = platform === 'all' ? null : platform;
 
   const client = await pool.connect();
   try {
+    // S2-3: every window is computed in the tenant's own business timezone.
+    // timestamptz columns (received_at / published_at) use the UTC instant of
+    // tenant-tz midnight; the bare DATE metric column uses the tenant-tz calendar
+    // date ($n::date). The fallback default applies only to a tenant with no zone.
+    const tz       = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromDate = tenantZonePeriodStart(days, tz);          // timestamptz windows
+    const prevFrom = tenantZonePeriodStart(days * 2, tz);
+    const fromKey  = tenantZonePeriodStartDateKey(days, tz);   // DATE-column windows
+    const prevKey  = tenantZonePeriodStartDateKey(days * 2, tz);
+
     // Fetch primary_goal from business profile
     const profileRes = await client.query<{ primary_goal: string | null }>(
       `SELECT primary_goal FROM business_profiles WHERE tenant_id = $1 LIMIT 1`,
@@ -446,13 +453,15 @@ export async function buildGoalSnapshot(
     let secondary: number | null;
 
     if (goal === 'lead_generation') {
+      // received_at (timestamptz) → instant window.
       ({ current, prev, secondary } = await queryLeadGeneration(client, tenantId, fromDate, prevFrom, platformFilter));
     } else if (goal === 'content_growth') {
-      ({ current, prev, secondary } = await queryContentGrowth(client, tenantId, fromDate, prevFrom, platformFilter));
+      // account_metrics_daily.date (DATE) → date-key window.
+      ({ current, prev, secondary } = await queryContentGrowth(client, tenantId, fromKey, prevKey, platformFilter));
     } else if (goal === 'product_sales') {
-      ({ current, prev, secondary } = await queryProductSales(client, tenantId, fromDate, prevFrom, platformFilter));
+      ({ current, prev, secondary } = await queryProductSales(client, tenantId, fromKey, prevKey, platformFilter));
     } else {
-      ({ current, prev, secondary } = await queryBrandAwareness(client, tenantId, fromDate, prevFrom, platformFilter));
+      ({ current, prev, secondary } = await queryBrandAwareness(client, tenantId, fromKey, prevKey, platformFilter));
     }
 
     const contributors = await queryContributors(client, tenantId, goal, fromDate, platformFilter);

--- a/backend/insights/goal/handler.ts
+++ b/backend/insights/goal/handler.ts
@@ -28,7 +28,11 @@ import crypto from 'crypto';
 // v5: S2-1 — goal contributor/category values now use the latest lifetime
 // snapshot per post (not SUM across dated cumulative rows), so the "what
 // contributed" numbers change. Bump invalidates stale v4 bodies.
-const TEMPLATE_VERSION = 'goal-template-v5';
+// v6: S2-3 — period windows now computed in the tenant's business timezone
+// (lead-gen received_at instant; content_growth/product_sales/brand_awareness
+// account-daily windows as tenant-tz calendar dates), so which rows fall in the
+// current vs prior window shifts near the day boundary. Bump invalidates v5.
+const TEMPLATE_VERSION = 'goal-template-v6';
 const CACHE_TTL_MS     = 60 * 60 * 1000;
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/narrative/handler.ts
+++ b/backend/insights/narrative/handler.ts
@@ -25,7 +25,11 @@ import crypto from 'crypto';
 // v2: S2-1 — hero top-post reach now uses the latest lifetime snapshot per post
 // (not SUM across dated cumulative rows), so the displayed reach number (and
 // which post ranks top) changes. Bump invalidates stale v1 bodies.
-const TEMPLATE_VERSION = 'template-v2';
+// v3: S2-3 — period windows now computed in the tenant's business timezone
+// (account-daily totals as tenant-tz calendar dates; post/comment windows as
+// tenant-tz-midnight instants), so which rows fall in the current vs prior window
+// (and thus reach/engagement/deltas/hero post) shift near the day boundary.
+const TEMPLATE_VERSION = 'template-v3';
 const CACHE_TTL_MS     = 60 * 60 * 1000; // 1 hour
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/narrative/snapshot-builder.ts
+++ b/backend/insights/narrative/snapshot-builder.ts
@@ -13,6 +13,8 @@
 
 import pool from '@/lib/db';
 import { LATEST_POST_METRICS_LATERAL } from '../latest-post-metrics-sql';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart, tenantZonePeriodStartDateKey } from '@/lib/format-timestamp';
 
 export type NarrativePeriod = 'week' | '30day' | '90day';
 
@@ -68,13 +70,6 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
-function daysAgo(days: number): Date {
-  const d = new Date();
-  d.setUTCHours(0, 0, 0, 0);
-  d.setUTCDate(d.getUTCDate() - days);
-  return d;
-}
-
 function pctDelta(current: number, prev: number): number {
   if (prev === 0) return current > 0 ? 100 : 0;
   return Math.round(((current - prev) / prev) * 1000) / 10; // 1 decimal
@@ -88,12 +83,19 @@ export async function buildNarrativeSnapshot(
   platform: string,
 ): Promise<NarrativeSnapshot> {
   const days          = periodDays(period);
-  const fromDate      = daysAgo(days);
-  const prevFrom      = daysAgo(days * 2);
   const platformFilter = platform === 'all' ? null : platform;
 
   const client = await pool.connect();
   try {
+    // S2-3: windows in the tenant's business timezone. Account-daily (bare DATE)
+    // totals use the tenant-tz calendar date ($n::date); post/comment windows on
+    // published_at / received_at (timestamptz) use the tenant-tz-midnight instant.
+    const tz       = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromDate = tenantZonePeriodStart(days, tz);
+    const prevFrom = tenantZonePeriodStart(days * 2, tz);
+    const fromKey  = tenantZonePeriodStartDateKey(days, tz);
+    const prevKey  = tenantZonePeriodStartDateKey(days * 2, tz);
+
     // Current period account-level totals
     const metricsRes = await client.query<{
       reach:              string;
@@ -110,9 +112,9 @@ export async function buildNarrativeSnapshot(
          COALESCE(SUM(watch_time_minutes), 0)        AS watch_time_minutes
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND ($3::text IS NULL OR platform = $3)`,
-      [tenantId, fromDate, platformFilter],
+      [tenantId, fromKey, platformFilter],
     );
 
     // Previous period totals (for delta + scoreDelta)
@@ -129,10 +131,10 @@ export async function buildNarrativeSnapshot(
          COALESCE(SUM(shares), 0)                    AS shares
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
-         AND date < $3
+         AND date >= $2::date
+         AND date < $3::date
          AND ($4::text IS NULL OR platform = $4)`,
-      [tenantId, prevFrom, fromDate, platformFilter],
+      [tenantId, prevKey, fromKey, platformFilter],
     );
 
     // Post count published in period

--- a/backend/insights/read-api.ts
+++ b/backend/insights/read-api.ts
@@ -14,15 +14,11 @@
 import { NextResponse } from 'next/server';
 import pool from '@/lib/db';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
+import { resolveTenantInsightsTimeZone } from './tenant-timezone';
+import { tenantZonePeriodStartDateKey } from '@/lib/format-timestamp';
 import { LATEST_POST_METRICS_LATERAL } from './latest-post-metrics-sql';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function daysAgoDate(days: number): Date {
-  const d = new Date();
-  d.setDate(d.getDate() - days);
-  return d;
-}
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -76,12 +72,15 @@ export async function handleGetInsightsSummary(
   const { searchParams } = new URL(req.url);
   const platform = searchParams.get('platform') || null;
   const days     = clamp(parseIntParam(searchParams.get('days'), 30), 1, 90);
-  const fromDate = daysAgoDate(days);
 
   const tenantId = Number(tenantResult.tenantContext.tenantId);
   const client = await pool.connect();
 
   try {
+    // S2-3: summary aggregates the bare-DATE account-metrics table, so the window
+    // is a tenant-tz calendar date ($2::date) in the tenant's business timezone.
+    const tz      = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromKey = tenantZonePeriodStartDateKey(days, tz);
     const res = await client.query<{
       total_views:              string;
       current_followers:        string;
@@ -110,14 +109,14 @@ export async function handleGetInsightsSummary(
          ), 0)                                AS total_engagement
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND ($3::text IS NULL OR platform = $3)`,
-      [tenantId, fromDate, platform],
+      [tenantId, fromKey, platform],
     );
 
     const row = res.rows[0];
     return NextResponse.json({
-      period: { days, from: fromDate.toISOString().split('T')[0] },
+      period: { days, from: fromKey },
       platform,
       totalViews:            Number(row.total_views),
       currentFollowers:      Number(row.current_followers),
@@ -252,12 +251,15 @@ export async function handleGetInsightsAccountMetrics(
   const { searchParams } = new URL(req.url);
   const platform = searchParams.get('platform') || null;
   const days     = clamp(parseIntParam(searchParams.get('days'), 30), 1, 90);
-  const fromDate = daysAgoDate(days);
 
   const tenantId = Number(tenantResult.tenantContext.tenantId);
   const client = await pool.connect();
 
   try {
+    // S2-3: bare-DATE account-metrics time-series windowed by a tenant-tz calendar
+    // date ($2::date) in the tenant's business timezone.
+    const tz      = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromKey = tenantZonePeriodStartDateKey(days, tz);
     const res = await client.query<{
       date:                 string;
       platform:             string;
@@ -281,11 +283,11 @@ export async function handleGetInsightsAccountMetrics(
          COALESCE(SUM(shares), 0)             AS shares
        FROM insights_account_metrics_daily
        WHERE tenant_id = $1
-         AND date >= $2
+         AND date >= $2::date
          AND ($3::text IS NULL OR platform = $3)
        GROUP BY date, platform
        ORDER BY date ASC`,
-      [tenantId, fromDate, platform],
+      [tenantId, fromKey, platform],
     );
 
     const series = res.rows.map((row) => ({
@@ -301,7 +303,7 @@ export async function handleGetInsightsAccountMetrics(
     }));
 
     return NextResponse.json({
-      period: { days, from: fromDate.toISOString().split('T')[0] },
+      period: { days, from: fromKey },
       platform,
       series,
     });

--- a/backend/insights/tenant-timezone.ts
+++ b/backend/insights/tenant-timezone.ts
@@ -1,0 +1,41 @@
+/**
+ * backend/insights/tenant-timezone.ts
+ *
+ * S2-3 / AA-94 — single source of truth for "what timezone does THIS tenant see
+ * their analytics in?". Every insights builder resolves the tenant's own business
+ * timezone through this helper and threads it into period-window math and SQL
+ * day/hour/week bucketing, so all sections agree on which day/hour an event fell
+ * on (the timezone-incoherence bug: heatmap in tenant-tz, DOW/windows in UTC).
+ *
+ * Resolution order: `business_profiles.timezone` for the tenant → coerced through
+ * `resolveTenantTimeZone` (validates against the Intl database) → the single
+ * `DEFAULT_TENANT_TIMEZONE` fallback ONLY when unset/invalid. The fallback is a
+ * safety net for a tenant who never configured a zone; a configured tenant always
+ * gets their own. Fail-open: any DB/query error resolves to the default rather
+ * than throwing, so a metadata read can never break a dashboard section.
+ */
+
+import { resolveTenantTimeZone } from '@/lib/format-timestamp';
+
+interface QueryableClient {
+  query<T = Record<string, unknown>>(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: T[] }>;
+}
+
+export async function resolveTenantInsightsTimeZone(
+  client: QueryableClient,
+  tenantId: number,
+): Promise<string> {
+  try {
+    const res = await client.query<{ timezone: string | null }>(
+      `SELECT timezone FROM business_profiles WHERE tenant_id = $1 LIMIT 1`,
+      [tenantId],
+    );
+    return resolveTenantTimeZone(res.rows[0]?.timezone ?? null);
+  } catch {
+    // Never let a timezone lookup fail a section — fall back to the single default.
+    return resolveTenantTimeZone(null);
+  }
+}

--- a/backend/insights/top/handler.ts
+++ b/backend/insights/top/handler.ts
@@ -27,7 +27,10 @@ import crypto from 'crypto';
 // v4: S2-1 — per-post reach/saves/shares/comments, avg reach, and multipliers
 // now use the latest lifetime snapshot per post (not SUM across dated cumulative
 // rows), so displayed numbers and ranking change. Bump invalidates stale v3.
-const TEMPLATE_VERSION = 'top-v4';
+// v5: S2-3 — the period window is computed in the tenant's business timezone, and
+// each post's date label + best-weekday now render in that zone (not UTC), so a
+// late-evening post's weekday/label and window membership change. Invalidates v4.
+const TEMPLATE_VERSION = 'top-v5';
 const CACHE_TTL_MS     = 60 * 60 * 1000;
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/top/top-snapshot-builder.ts
+++ b/backend/insights/top/top-snapshot-builder.ts
@@ -16,6 +16,8 @@
 import pool from '@/lib/db';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
 import { LATEST_POST_METRICS_LATERAL } from '../latest-post-metrics-sql';
+import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
+import { tenantZonePeriodStart } from '@/lib/format-timestamp';
 
 export type TopSortKey = 'reach' | 'engagement' | 'saves' | 'shares' | 'comments';
 
@@ -71,19 +73,15 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
-function utcDayStart(daysAgo: number): Date {
-  const d = new Date();
-  d.setUTCHours(0, 0, 0, 0);
-  d.setUTCDate(d.getUTCDate() - daysAgo);
-  return d;
+// S2-3: a post's date label and best-weekday render in the tenant's business
+// timezone, not UTC — so a post published late-evening tenant-time is not labelled
+// with the next UTC day / weekday (which contradicted the tenant-tz DOW analysis).
+function fmtDate(iso: string, tz: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: tz });
 }
 
-function fmtDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
-}
-
-function fmtDow(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', { weekday: 'long', timeZone: 'UTC' });
+function fmtDow(iso: string, tz: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { weekday: 'long', timeZone: tz });
 }
 
 // ORDER BY column for each sort key (engagement is computed, handled in JS).
@@ -118,11 +116,13 @@ export async function buildTopSnapshot(
   sortBy:    TopSortKey,
 ): Promise<TopSnapshot> {
   const days           = periodDays(period);
-  const fromDate       = utcDayStart(days);
   const platformFilter = platform === 'all' ? null : platform;
 
   const client = await pool.connect();
   try {
+    // S2-3: window filters published_at (timestamptz) → tenant-tz-midnight instant.
+    const tz       = await resolveTenantInsightsTimeZone(client, tenantId);
+    const fromDate = tenantZonePeriodStart(days, tz);
 
     // ── 1. Period average reach (for the multiplier) ─────────────────────────
     const avgRes = await client.query<{ avg_reach: string | null; post_count: string }>(
@@ -249,7 +249,7 @@ export async function buildTopSnapshot(
         caption:       row.caption,
         permalink:     row.permalink,
         publishedAt:   new Date(row.published_at).toISOString(),
-        dateLabel:     fmtDate(row.published_at),
+        dateLabel:     fmtDate(row.published_at, tz),
         contentType:   row.content_type,
         mediaType:     row.media_type,
         reach,
@@ -259,7 +259,7 @@ export async function buildTopSnapshot(
         comments,
         saveRate,
         multiplier,
-        bestDow:       fmtDow(row.published_at),
+        bestDow:       fmtDow(row.published_at, tz),
         sentiment:     sentimentByPost.get(Number(row.id)) ?? null,
         followerSplit: extractFollowerSplit(row.platform_data),
       };

--- a/lib/format-timestamp.ts
+++ b/lib/format-timestamp.ts
@@ -245,6 +245,66 @@ export function tenantZoneDateKey(
   return `${year}-${month}-${day}`;
 }
 
+/**
+ * The tenant-zone civil (year, month, day) that is `days` calendar days before
+ * `now`'s tenant-zone civil date. Shared by the two period-window helpers below.
+ * Subtracting on a UTC-anchored civil date keeps the arithmetic DST-agnostic
+ * (we only ever manipulate the calendar fields, never an instant).
+ */
+function tenantZoneCivilDateNDaysAgo(
+  days: number,
+  zone: string,
+  now: Date,
+): { year: number; month: number; day: number } {
+  const parts = tenantZoneParts(now, zone);
+  const base = parts
+    ? new Date(Date.UTC(parts.year, parts.month - 1, parts.day))
+    : new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  base.setUTCDate(base.getUTCDate() - days);
+  return { year: base.getUTCFullYear(), month: base.getUTCMonth() + 1, day: base.getUTCDate() };
+}
+
+/**
+ * S2-3 / AA-94 — the UTC instant of tenant-zone midnight, `days` tenant-days
+ * before `now`. This is the period-window lower bound for a `timestamptz` column
+ * (e.g. `received_at`, `published_at`, `created_at`): `col >= $1` then means
+ * "on or after midnight, `days` days ago, in the tenant's own timezone" for every
+ * section consistently — replacing the old per-builder `setUTCHours(0,0,0,0)` UTC
+ * window that made sections disagree about which day an event fell on.
+ */
+export function tenantZonePeriodStart(
+  days: number,
+  timeZone: string = DEFAULT_TENANT_TIMEZONE,
+  now: Date = new Date(),
+): Date {
+  const zone = resolveTenantTimeZone(timeZone);
+  const { year, month, day } = tenantZoneCivilDateNDaysAgo(days, zone, now);
+  const pad = (input: number) => String(input).padStart(2, '0');
+  const wall = `${year}-${pad(month)}-${pad(day)}T00:00:00`;
+  const utc = fromZonedTime(wall, zone);
+  return Number.isFinite(utc.getTime()) ? utc : now;
+}
+
+/**
+ * S2-3 / AA-94 — the `YYYY-MM-DD` tenant-zone calendar date, `days` tenant-days
+ * before `now`. This is the period-window lower bound for the bare `DATE` columns
+ * on the daily metric tables (`insights_account_metrics_daily.date`), compared as
+ * `date >= $1::date`. A bare DATE has no time-of-day, so it must be bounded by a
+ * calendar date, NOT the instant from `tenantZonePeriodStart` (comparing a DATE to
+ * a timestamptz instant is session-timezone-dependent and off-by-one at the
+ * boundary). The per-row day attribution on those tables remains write-side-bound.
+ */
+export function tenantZonePeriodStartDateKey(
+  days: number,
+  timeZone: string = DEFAULT_TENANT_TIMEZONE,
+  now: Date = new Date(),
+): string {
+  const zone = resolveTenantTimeZone(timeZone);
+  const { year, month, day } = tenantZoneCivilDateNDaysAgo(days, zone, now);
+  const pad = (input: number) => String(input).padStart(2, '0');
+  return `${year}-${pad(month)}-${pad(day)}`;
+}
+
 /** True when a UTC instant falls on the current calendar day in the tenant zone. */
 export function isTenantZoneToday(
   value: string | number | Date,

--- a/tests/insights-tenant-timezone.test.ts
+++ b/tests/insights-tenant-timezone.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  tenantZonePeriodStart,
+  tenantZonePeriodStartDateKey,
+} from '../lib/format-timestamp';
+
+// S2-3 / AA-94 — the read-side timezone helpers attribute a boundary instant to
+// the TENANT's calendar day, not UTC. This is the arithmetic every insights
+// builder now shares so all sections agree on which day/hour an event fell on.
+//
+// Anchor instant: 2026-07-08T03:30:00Z. In America/New_York (UTC-4 in July DST)
+// that is 2026-07-07 23:30 — i.e. still "yesterday" for the tenant while UTC has
+// already ticked over to the 8th. The classic 23:30-local boundary case.
+const NOW = new Date('2026-07-08T03:30:00Z');
+const NY = 'America/New_York';
+
+test('tenantZonePeriodStartDateKey attributes a boundary instant to the tenant day, not UTC', () => {
+  // days=0 → the tenant's current calendar day. NY sees 2026-07-07; UTC sees 07-08.
+  assert.equal(tenantZonePeriodStartDateKey(0, NY, NOW), '2026-07-07');
+
+  // days=7 → 7 tenant-days back from 07-07 = 06-30. A UTC computation from 07-08
+  // would land on 07-01, so the tenant-tz window boundary genuinely differs.
+  assert.equal(tenantZonePeriodStartDateKey(7, NY, NOW), '2026-06-30');
+});
+
+test('tenantZonePeriodStart returns the UTC instant of tenant-zone midnight', () => {
+  // Midnight 2026-07-07 in America/New_York (EDT, UTC-4) = 2026-07-07T04:00:00Z.
+  assert.equal(tenantZonePeriodStart(0, NY, NOW).toISOString(), '2026-07-07T04:00:00.000Z');
+});
+
+test('an event in the window-boundary gap is IN-window under tenant-tz but excluded under the old UTC window', () => {
+  // The two 7-day lower bounds differ:
+  //   tenant-tz:  midnight 06-30 NY   = 2026-06-30T04:00:00Z
+  //   old UTC:    setUTCHours(0,0,0,0) on NOW(07-08) minus 7 days = 2026-07-01T00:00:00Z
+  const tenantWindowStart = tenantZonePeriodStart(7, NY, NOW);
+  assert.equal(tenantWindowStart.toISOString(), '2026-06-30T04:00:00.000Z');
+  const oldUtcWindowStart = new Date('2026-07-01T00:00:00Z'); // what the pre-S2-3 code produced
+
+  // An event at 2026-06-30 08:00 NY (= 2026-06-30T12:00:00Z) falls in the gap:
+  // included by the tenant-tz window, excluded by the old UTC window.
+  const event = new Date('2026-06-30T12:00:00Z');
+  assert.ok(event.getTime() >= tenantWindowStart.getTime(), 'included by tenant-tz window');
+  assert.ok(event.getTime() <  oldUtcWindowStart.getTime(), 'excluded by the old UTC window');
+});
+
+test('a different tenant zone shifts the boundary independently', () => {
+  // Same instant, Chicago (CDT, UTC-5) = 2026-07-07 22:30 → still the 7th, and
+  // midnight is 2026-07-07T05:00:00Z. Confirms the helper is per-tenant, not fixed.
+  assert.equal(tenantZonePeriodStartDateKey(0, 'America/Chicago', NOW), '2026-07-07');
+  assert.equal(tenantZonePeriodStart(0, 'America/Chicago', NOW).toISOString(), '2026-07-07T05:00:00.000Z');
+});
+
+test('DST-safe: a period boundary landing on a spring-forward / fall-back day resolves at midnight', () => {
+  // The helper always anchors at 00:00 wall-time, which is NEVER inside a DST gap
+  // (spring gap is 02:00–03:00) or ambiguous window (fall 01:00–02:00), so
+  // fromZonedTime resolves it to exactly one instant. This is independent of the
+  // known wallTimeToUtc fall-back bug (a different function, at 01:30, not touched).
+
+  // US spring-forward is 2026-03-08 (02:00→03:00). Midnight 03-08 is still EST
+  // (UTC-5) → 2026-03-08T05:00:00Z.
+  const springNow = new Date('2026-03-08T12:00:00Z'); // NY civil date = 03-08
+  assert.equal(tenantZonePeriodStartDateKey(0, NY, springNow), '2026-03-08');
+  assert.equal(tenantZonePeriodStart(0, NY, springNow).toISOString(), '2026-03-08T05:00:00.000Z');
+
+  // US fall-back is 2026-11-01 (02:00→01:00). Midnight 11-01 is still EDT (UTC-4)
+  // → 2026-11-01T04:00:00Z.
+  const fallNow = new Date('2026-11-01T12:00:00Z'); // NY civil date = 11-01
+  assert.equal(tenantZonePeriodStartDateKey(0, NY, fallNow), '2026-11-01');
+  assert.equal(tenantZonePeriodStart(0, NY, fallNow).toISOString(), '2026-11-01T04:00:00.000Z');
+});
+
+test('invalid/unset zone falls back to the single default (America/New_York)', () => {
+  // Fallback path: an unset tenant zone resolves to the default, never throws.
+  assert.equal(
+    tenantZonePeriodStartDateKey(0, undefined, NOW),
+    tenantZonePeriodStartDateKey(0, NY, NOW),
+  );
+  assert.equal(
+    tenantZonePeriodStartDateKey(0, 'Not/AZone', NOW),
+    tenantZonePeriodStartDateKey(0, NY, NOW),
+  );
+});

--- a/tests/insights-timezone-bucketing.requires-infra.test.ts
+++ b/tests/insights-timezone-bucketing.requires-infra.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import pg from 'pg';
+
+import { requireDbEnvOrSkip } from './helpers/requires-infra';
+
+// S2-3 / AA-94 — live-schema proof that the SQL day-of-week bucketing derives the
+// weekday in the TENANT's business timezone ($tz), not UTC. This is the exact
+// expression the attention best-day-of-week query now runs (and the shape the
+// aries week-bucket + audience heatmap share):
+//   EXTRACT(DOW FROM published_at AT TIME ZONE $tz)
+//
+// Boundary post: published 2026-07-08T03:30:00Z. In America/New_York (UTC-4 in
+// July DST) that is 2026-07-07 23:30 — a TUESDAY. In UTC it is 2026-07-08 — a
+// WEDNESDAY. So the tenant-tz DOW (2 = Tue) must differ from the UTC DOW (3 = Wed);
+// the pre-S2-3 `AT TIME ZONE 'UTC'` expression returned the Wednesday.
+//
+// requires-infra: self-skips without DB env (as in CI), verified locally.
+test('SQL DOW bucketing uses the tenant timezone, not UTC (boundary post)', async (t) => {
+  if (!requireDbEnvOrSkip(t)) return;
+
+  const pool = new pg.Pool({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    max: 1,
+  });
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const org = (await client.query<{ id: number }>(
+      `INSERT INTO organizations (name) VALUES ('S2-3 tz-bucketing test') RETURNING id`,
+    )).rows[0].id;
+
+    const account = (await client.query<{ id: number }>(
+      `INSERT INTO insights_accounts (tenant_id, platform, external_account_id)
+       VALUES ($1, 'facebook', 'fb-acct-1') RETURNING id`,
+      [org],
+    )).rows[0].id;
+
+    // 2026-07-07 23:30 America/New_York = 2026-07-08 03:30 UTC.
+    await client.query(
+      `INSERT INTO insights_posts (tenant_id, account_id, platform, external_post_id, published_at, media_type)
+       VALUES ($1, $2, 'facebook', 'fb-post-1', '2026-07-08T03:30:00Z', 'image')`,
+      [org, account],
+    );
+
+    const row = (await client.query<{ tenant_dow: number; utc_dow: number }>(
+      `SELECT
+         EXTRACT(DOW FROM published_at AT TIME ZONE $2)::int AS tenant_dow,
+         EXTRACT(DOW FROM published_at AT TIME ZONE 'UTC')::int AS utc_dow
+       FROM insights_posts
+       WHERE tenant_id = $1`,
+      [org, 'America/New_York'],
+    )).rows[0];
+
+    // Passes-after: the shipped $tz expression buckets the post on Tuesday (2).
+    assert.equal(Number(row.tenant_dow), 2, 'tenant-tz weekday = Tuesday (post was 23:30 NY on the 7th)');
+    // Fails-before contrast: the old AT TIME ZONE \'UTC\' expression bucketed it on
+    // Wednesday (3) — a different day. Proves the swap actually changes the result.
+    assert.equal(Number(row.utc_dow), 3, 'UTC weekday = Wednesday (the pre-S2-3 answer)');
+    assert.notEqual(Number(row.tenant_dow), Number(row.utc_dow), 'tenant-tz and UTC disagree at the boundary');
+  } finally {
+    await client.query('ROLLBACK').catch(() => {});
+    client.release();
+    await pool.end();
+  }
+});


### PR DESCRIPTION
**Closes S2-3 / AA-94** (Gap A5 "timezone incoherence", `docs/plans/2026-07-07-analytics-page-roadmap.md`, PR #789).

## ⚠️ Sequencing — stacks on S2-1 (#823)
This branches off `hammad/s2-1-latest-snapshot` and is authored against S2-1's final reader SQL (versions bumped **from** their post-S2-1 values). The PR base is the S2-1 branch, so this diff shows **only** S2-3; GitHub will auto-retarget the base to `master` once #823 merges. **Merge order: #823 (S2-1) → #825 (S2-2 pt2) → this.** Merged sequentially per the repo owner's workflow.

## The bug
The audience heatmap bucketed activity in the **tenant's** business timezone, but Attention day-of-week and **every builder's period-window boundaries** were computed in **UTC** (some read-api paths in server-local). So the same event could land on a different day/hour in different sections — the page could contradict its own best-time-to-post advice. Two different default-tz constants also existed (`America/New_York` vs `America/Chicago`).

## The fix (read-side only, shipped atomically)
- **Shared helpers** (`lib/format-timestamp.ts`, pure, DST-safe, no DB): `tenantZonePeriodStart(days,tz)` → UTC instant of tenant-tz midnight (for **timestamptz** columns); `tenantZonePeriodStartDateKey(days,tz)` → `YYYY-MM-DD` tenant-tz calendar date (for the **bare DATE** metric columns, compared `date >= $1::date`).
- **`backend/insights/tenant-timezone.ts`**: `resolveTenantInsightsTimeZone` reads `business_profiles.timezone` per tenant → `resolveTenantTimeZone` → single `DEFAULT_TENANT_TIMEZONE` fallback **only** when unset/invalid. Fail-open. **Every tenant sees analytics in their own timezone; the default is a fallback, not a global.**
- **All builders threaded on:** goal, attention, activity, top, narrative, audience, conversations, aries, read-api. `AT TIME ZONE 'UTC' → $tz` swaps for the attention **best-day-of-week** (flagship) and the aries learning-curve week; top's per-post date label + best-weekday render in tenant-tz; audience's `America/Chicago` `DEFAULT_TZ` deleted and folded onto the single default (its window is now tenant-tz too).
- **Reconciled to ONE default** (`America/New_York`); deleted the Chicago outlier.

## Why the DATE/timestamptz split matters
Comparing a bare `DATE` column to a timestamptz instant is session-tz-dependent and off-by-one at the boundary, so DATE-column windows use a tenant-tz **calendar date** (`$n::date`) while timestamptz windows use the **instant**. Two helpers, applied by column type.

## 🔶 Why trends is deliberately NOT changed (and stays `trends-v4`)
The trends **daily-account series** is keyed on the **bare `DATE`** column of `insights_account_metrics_daily`. A bare DATE has no time-of-day, so **it cannot be re-bucketed to a different timezone read-side** — the day is fixed at write time. trends also plots that account series and the `received_at` comments series on **one shared bucket axis**; re-bucketing only the timestamptz (comments) half would misalign the two series on the chart. So trends' timezone coherence is **write-side-bound (backlog item 2)** and is intentionally left untouched and unbumped. All other sections only aggregate over a window or bucket a single timestamptz column, so they are fully fixable read-side.

**Write-side stamping (backlog item 2) is a decision recorded here, not implemented** — no write path is touched in this PR.

## Version bumps (5, each because rendered output actually changes)
| Section | Bump | Reason |
|---|---|---|
| narrative | `template-v2 → v3` | period windows now tenant-tz (account-daily as calendar dates; post/comment as instants) |
| goal | `goal-template-v5 → v6` | lead-gen received_at instant + account-daily calendar-date windows |
| attention | `attention-v4 → v5` | window + **best-day-of-week re-bucketed in tenant-tz** (`AT TIME ZONE $tz`) |
| activity | `activity-v4 → v5` | period window tenant-tz → counts / high-performers / mix shift at boundary |
| top | `top-v4 → v5` | window tenant-tz + per-post date/weekday labels render in tenant-tz |
| ~~trends~~ | **unchanged (v4)** | write-side-bound bare-DATE series (see above) |

Uncached, fixed, no bump: audience, conversations, aries, read-api.

## ⚠️ Pre-existing test failure — NOT introduced by this PR
`tests/format-timestamp-dst.test.ts` test 5 (`wallTimeToUtc DST fall-back duplicate: 01:30 on 2026-11-01`) fails. **This is pre-existing and unrelated to S2-3:**
- **Proof:** it fails **identically on pristine `master`** with this PR's `lib/format-timestamp.ts` changes stashed (`git stash push -- lib/format-timestamp.ts` → same failure, 7 pass / 1 fail).
- It is in **`wallTimeToUtc`**, a function **S2-3 does not touch** (this PR only *adds* new functions to that file).
- It is **not** in the `npm run verify` gate (which is 42/42 green here).
- **Recommend a SEPARATE ticket** for the `wallTimeToUtc` fall-back-duplicate bug. Please do not attribute it to S2-3.

S2-3's own timezone code is DST-safe (see tests below): it anchors period boundaries at **midnight**, which is never inside the spring gap (02:00–03:00) or the fall ambiguous window (01:00–02:00), so `fromZonedTime` resolves to exactly one instant.

## Tests
- `tests/insights-tenant-timezone.test.ts` (unit, in the full suite, **6/6**): boundary instant → tenant day ≠ UTC day; window-gap event included under tenant-tz but excluded under the old UTC window; per-tenant zones differ; fallback; **DST-safety on spring-forward (`2026-03-08` → `05:00Z`) and fall-back (`2026-11-01` → `04:00Z`) boundary days**.
- `tests/insights-timezone-bucketing.requires-infra.test.ts`: proves the shipped `EXTRACT(DOW … AT TIME ZONE $tz)` buckets a 23:30-NY boundary post on **Tuesday** where `'UTC'` gives **Wednesday** (fails-before/passes-after demonstrated locally). Self-skips in CI without DB env.

## Verification
- `npm run verify` → **42/42**. `npm run typecheck` → clean.
- New unit + requires-infra tests green locally against live Postgres.

## prod-tenant tz (ops note)
Dev DB shows the single tenant's `business_profiles.timezone = 'America/Chicago'` (explicitly set) → the per-tenant read handles it and the New_York default never applies. **Verify prod's `business_profiles.timezone` is populated separately**; if NULL, set the tenant's real zone (ops) rather than let the fallback guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)