### PR TITLE
S2-4/AA-95: day-boundary tz agreement test (audience + attention; trends pinned deferred)

### DIFF
--- a/backend/insights/attention/attention-snapshot-builder.ts
+++ b/backend/insights/attention/attention-snapshot-builder.ts
@@ -64,7 +64,8 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
-const DOW_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+// Exported for the S2-4 day-boundary tz-agreement test (tests/insights-tz-boundary-agreement.test.ts).
+export const DOW_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const FOLLOWER_MILESTONES = [100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000];
 

--- a/backend/insights/audience/audience-builder.ts
+++ b/backend/insights/audience/audience-builder.ts
@@ -68,7 +68,8 @@ function captionToTitle(caption: string | null): string {
 }
 
 // Grid rows are Mon..Sun (matches the frontend day-axis order).
-const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+// Exported (with dowToRow/fmtHour) for the S2-4 day-boundary tz-agreement test.
+export const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 function periodDays(period: NarrativePeriod): number {
   if (period === 'week')  return 7;
@@ -80,11 +81,11 @@ function periodDays(period: NarrativePeriod): number {
 const MIN_HEATMAP_EVENTS = 8;
 
 // Postgres DOW: 0=Sun..6=Sat → grid row index where 0=Mon..6=Sun.
-function dowToRow(dow: number): number {
+export function dowToRow(dow: number): number {
   return (dow + 6) % 7;
 }
 
-function fmtHour(hour: number): string {
+export function fmtHour(hour: number): string {
   const h12 = hour % 12 === 0 ? 12 : hour % 12;
   return `${h12} ${hour < 12 ? 'AM' : 'PM'}`;
 }

--- a/lib/format-timestamp.ts
+++ b/lib/format-timestamp.ts
@@ -305,6 +305,20 @@ export function tenantZonePeriodStartDateKey(
   return `${year}-${pad(month)}-${pad(day)}`;
 }
 
+/**
+ * S2-3/S2-4 — the tenant-zone day-of-week (0=Sun … 6=Sat), the JS mirror of the
+ * SQL `EXTRACT(DOW FROM ts AT TIME ZONE $tz)` the insights builders bucket by.
+ * Same numbering as Postgres EXTRACT(DOW). Returns null on an unparseable value.
+ */
+export function tenantZoneDow(
+  value: string | number | Date,
+  timeZone: string = DEFAULT_TENANT_TIMEZONE,
+): number | null {
+  const parts = tenantZoneParts(value, timeZone);
+  if (!parts) return null;
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).getUTCDay();
+}
+
 /** True when a UTC instant falls on the current calendar day in the tenant zone. */
 export function isTenantZoneToday(
   value: string | number | Date,

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -105,6 +105,13 @@ const steps = [
     args: ['--test', 'tests/insights-sync-worker-stranded-runs.test.ts'],
   },
   {
+    // S2-4/AA-95: day-boundary timezone AGREEMENT guardrail. Pure + no DB, so it
+    // runs here on every PR (unlike the S2-3/S2-1 requires-infra tz tests that
+    // self-skip in CI). Fails if audience or attention reverts to UTC bucketing.
+    name: 'insights day-boundary tz agreement (audience + attention)',
+    args: ['--test', 'tests/insights-tz-boundary-agreement.test.ts'],
+  },
+  {
     // PRD §20 canonical behavioral invariants — codified as runtime checks so
     // future PRs get a green/red CI signal on spec conformance.  See
     // tests/prd-invariants/README.md and docs/product/aries-ai-prd.md §20.

--- a/tests/insights-tz-boundary-agreement.test.ts
+++ b/tests/insights-tz-boundary-agreement.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { tenantZoneDow, tenantZoneDateKey, tenantZoneParts } from '../lib/format-timestamp';
+import { DOW_NAMES } from '../backend/insights/attention/attention-snapshot-builder';
+import { DAY_LABELS, dowToRow, fmtHour } from '../backend/insights/audience/audience-builder';
+
+// S2-4 / AA-95 (Gap E5, tz portion) — day-boundary timezone AGREEMENT guardrail.
+//
+// Proves the S2-3 fix: an event at 23:30 local in a UTC-05:00 tenant timezone
+// (late-night local, but already the NEXT day in UTC) is attributed to the SAME
+// tenant calendar day by BOTH the audience peakWindow and the attention dayName.
+// If either section slipped back to UTC bucketing, its day flips to Friday and
+// the assertions (anchored to the EXPECTED tenant day, Thursday) fail.
+//
+// Runs in `npm run verify` — pure + no DB (the tz math is the JS mirror the SQL
+// `EXTRACT(DOW ... AT TIME ZONE $tz)` implements, driven through each section's
+// REAL labeling helpers; the source-guard below pins the builder SQL itself).
+// This is deliberately CI-enforced on every PR, unlike the S2-3/S2-1
+// requires-infra tests that self-skip without a database.
+//
+// trends is EXCLUDED BY DESIGN: S2-3 deferred all trends bucketing (backlog
+// item 2). Its account series is keyed on a bare DATE column that cannot be
+// re-bucketed read-side, and it shares one chart axis with the comments series,
+// so a partial tenant-tz fix would misalign the two. The source-guard below pins
+// trends' current UTC bucketing; WHEN ITEM 2 LANDS, flip that pin and ADD trends
+// to the agreement assertion here.
+
+const TZ = 'America/New_York';                     // January = EST = UTC-05:00 (not DST)
+const BOUNDARY = new Date('2026-01-16T04:30:00Z'); // = Thu 2026-01-15 23:30 EST ; Fri 2026-01-16 UTC
+
+const EXPECTED_DAY_KEY = '2026-01-15';
+const EXPECTED_DOW     = 4;            // Thursday (0=Sun..6=Sat), matches Postgres EXTRACT(DOW)
+const UTC_DOW          = 5;            // Friday — what UTC bucketing would give
+
+test('fixture sanity: the instant straddles the day boundary (tenant Thu vs UTC Fri)', () => {
+  assert.equal(tenantZoneDateKey(BOUNDARY, TZ), EXPECTED_DAY_KEY, 'tenant calendar day = 2026-01-15');
+  assert.equal(tenantZoneDow(BOUNDARY, TZ), EXPECTED_DOW, 'tenant DOW = Thursday (4)');
+  assert.equal(tenantZoneParts(BOUNDARY, TZ)?.hour, 23, 'tenant local hour = 23');
+  assert.equal(BOUNDARY.toISOString().slice(0, 10), '2026-01-16', 'UTC day = 2026-01-16');
+  assert.equal(BOUNDARY.getUTCDay(), UTC_DOW, 'UTC DOW = Friday (5)');
+  assert.notEqual(EXPECTED_DOW, UTC_DOW, 'tenant and UTC land on different days — the boundary case');
+});
+
+test('audience peakWindow and attention dayName agree on the tenant day (== Thursday, != UTC Friday)', () => {
+  const tenantDow  = tenantZoneDow(BOUNDARY, TZ)!;
+  const tenantHour = tenantZoneParts(BOUNDARY, TZ)!.hour;
+
+  // Each section's REAL labeling helper, fed the tenant-tz dow/hour.
+  const attentionDayName = DOW_NAMES[tenantDow];                 // attention section
+  const audienceDay      = DAY_LABELS[dowToRow(tenantDow)];      // audience section
+  const audienceHour     = fmtHour(tenantHour);                  // audience section
+
+  // Anchored to the EXPECTED tenant day — not just mutual agreement — so a revert
+  // to UTC in EITHER or BOTH sections (which would agree on Friday) still fails.
+  assert.equal(attentionDayName, 'Thursday', 'attention dayName = Thursday');
+  assert.equal(audienceDay,      'Thu',      'audience peakWindow.day = Thu');
+  assert.equal(audienceHour,     '11 PM',    'audience peakWindow.hour = 11 PM');
+
+  // Cross-section: both name the same weekday.
+  assert.equal(audienceDay, attentionDayName.slice(0, 3), 'audience + attention name the same day');
+
+  // And the UTC computation would disagree — the fails-before contrast.
+  assert.equal(DOW_NAMES[UTC_DOW],            'Friday', 'UTC DOW would be Friday');
+  assert.equal(DAY_LABELS[dowToRow(UTC_DOW)], 'Fri',    'UTC audience day would be Fri');
+  assert.notEqual(attentionDayName, DOW_NAMES[UTC_DOW],            'attention must not match the UTC day');
+  assert.notEqual(audienceDay,      DAY_LABELS[dowToRow(UTC_DOW)], 'audience must not match the UTC day');
+});
+
+test('source-guard: audience + attention bucket in tenant-tz ($tz); trends still UTC (deferred, item 2)', () => {
+  const read = (p: string) => fs.readFileSync(path.join(import.meta.dirname, '..', p), 'utf8');
+  const attention = read('backend/insights/attention/attention-snapshot-builder.ts');
+  const audience  = read('backend/insights/audience/audience-builder.ts');
+  const trends    = read('backend/insights/trends/trends-snapshot-builder.ts');
+
+  // Fixed sections: DOW/HOUR bucketed via the tenant tz param ($n), never 'UTC'.
+  assert.match(attention, /EXTRACT\(DOW FROM p\.published_at AT TIME ZONE \$\d\)/,
+    'attention best-day-of-week must bucket in the tenant tz ($n)');
+  assert.doesNotMatch(attention, /published_at AT TIME ZONE 'UTC'/,
+    'attention must not revert to UTC DOW bucketing');
+  assert.match(audience, /EXTRACT\(DOW\s+FROM \(received_at AT TIME ZONE \$\d\)\)/,
+    'audience heatmap DOW must bucket in the tenant tz ($n)');
+  assert.match(audience, /EXTRACT\(HOUR FROM \(received_at AT TIME ZONE \$\d\)\)/,
+    'audience heatmap HOUR must bucket in the tenant tz ($n)');
+  assert.doesNotMatch(audience, /received_at AT TIME ZONE 'UTC'/,
+    'audience must not revert to UTC bucketing');
+
+  // trends is DEFERRED (backlog item 2): its comments series shares one chart axis
+  // with the write-side-bound bare-DATE account series, so it stays UTC for now.
+  // WHEN ITEM 2 LANDS: delete this pin and add trends to the agreement test above.
+  assert.match(trends, /received_at AT TIME ZONE 'UTC'/,
+    'trends comments series is intentionally still UTC (item 2) — update S2-4 when fixed');
+});


### PR DESCRIPTION
**Closes S2-4 / AA-95** (Gap E5, tz portion, `docs/plans/2026-07-07-analytics-page-roadmap.md`, PR #789). A tests ticket.

## ⚠️ Sequencing — stacks on S2-3 (#837)
Branches off `hammad/s2-3-timezone-readside`; PR base is the S2-3 branch so this diff shows **only** S2-4 (GitHub auto-retargets to `master` when #837 merges). **Merge order: #823 → #825 → #837 → this.**

## What it proves
A CI-enforced guardrail for the S2-3 timezone fix: an event at **23:30 local in a UTC−05:00 tenant timezone** (late-night local, but already the **next day in UTC**) is attributed to the **same tenant calendar day** by both the **audience peakWindow** and the **attention dayName**.

- **Fixture:** `2026-01-16T04:30:00Z` = **Thu 2026-01-15 23:30 EST** (America/New_York in January = UTC−05:00) vs **Fri 2026-01-16 in UTC**.
- **Anchored to the expected tenant day** (Thursday), not mere mutual agreement — so a *both-sections-reverted-to-UTC* regression (which would still agree, on Friday) also fails.

## ✅ Runs in `npm run verify` — no DB (the hard constraint)
Added as an explicit step in `scripts/verify-regression-suite.mjs` (`[verify 9/25] insights day-boundary tz agreement`), so the property is a green/red signal on **every PR** — unlike the S2-3/S2-1 requires-infra tz tests that self-skip in CI.

**How it runs without a DB:** the sections bucket in SQL (`EXTRACT(DOW … AT TIME ZONE $tz)`), which can't execute in CI without Postgres. So the test:
1. proves the **tz-math property** via the JS mirror the SQL implements (`tenantZoneDow` / `tenantZoneParts` / `tenantZoneDateKey`), driven through each section's **real labeling helpers** (attention `DOW_NAMES`; audience `DAY_LABELS`/`dowToRow`/`fmtHour`); and
2. a **source-guard** asserts the builder SQL still passes `$tz` (not `'UTC'`) — the tripwire that catches a builder revert.

## Changes
- `lib/format-timestamp.ts` — add pure `tenantZoneDow` (JS mirror of the SQL DOW).
- attention + audience builders — **export-only** (`DOW_NAMES`; `DAY_LABELS`, `dowToRow`, `fmtHour`) so the test drives the real labeling code. **No runtime change.**
- `scripts/verify-regression-suite.mjs` — add the step to the curated verify list.
- `tests/insights-tz-boundary-agreement.test.ts` (new).

## 🔶 trends is EXCLUDED BY DESIGN (backlog item 2)
S2-3 deferred **all** trends bucketing. Its account series is keyed on a bare `DATE` column that cannot be re-bucketed read-side, and it shares **one chart axis** with the comments series, so a partial tenant-tz fix would misalign the two. The source-guard **pins trends' current `'UTC'` bucketing** with an explicit reminder: **when item 2 lands, delete the pin and add trends to the agreement assertion here.** (Note: the ticket's premise that "S2-3 fixed the trends comments series" was not what shipped — S2-3 left trends entirely UTC; this test reflects the actual base.)

## Verification
- `npm run verify` → **green**, including `[verify 9/25] insights day-boundary tz agreement (audience + attention)` (3/3). Typecheck clean.
- **Fails-before demo:** flipping attention's DOW SQL `$4 → 'UTC'` makes the source-guard sub-test fail (`# fail 1`), restored → green. (The pure agreement sub-test can't see the SQL — that's why the source-guard exists.)

## S2-5 boundary (no duplication)
S2-4 owns cross-section **day/DOW/hour agreement** at the tz boundary; S2-5 pins per-section **arithmetic**. No overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)