### PR TITLE
test(publishing): wire duplicate-posting incident wall into verify + resolveMediaUrls direction tests

### DIFF
--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -112,6 +112,21 @@ const steps = [
     args: ['--test', 'tests/insights-tz-boundary-agreement.test.ts'],
   },
   {
+    // 2026-07-13 duplicate-posting incident (AA-134 / PR #841) regression wall:
+    // scheduler day-mapping + same-instant de-collision, the reel-companion
+    // synthesis clamp, the publish-boundary duplicate/spacing guards, and the
+    // worker retry backoff (incl. the crash-safety tick harness that drives the
+    // backoff write site). Pure + in-memory fakes, no DB — a regression here
+    // means Aries can burst-post or retry-hammer a platform again.
+    name: 'duplicate-posting incident wall (scheduler, guards, backoff)',
+    args: [
+      '--test',
+      'tests/duplicate-posting-guards.test.ts',
+      'tests/scheduled-posts-worker-backoff.test.ts',
+      'tests/scheduled-posts-worker-crash-safety.test.ts',
+    ],
+  },
+  {
     // PRD §20 canonical behavioral invariants — codified as runtime checks so
     // future PRs get a green/red CI signal on spec conformance.  See
     // tests/prd-invariants/README.md and docs/product/aries-ai-prd.md §20.

--- a/tests/duplicate-posting-guards.test.ts
+++ b/tests/duplicate-posting-guards.test.ts
@@ -410,3 +410,51 @@ test('guard env parsing: defaults 14d / 30m; invalid values fall back', () => {
   assert.equal(duplicateCaptionWindowDays({ ARIES_DUPLICATE_CAPTION_WINDOW_DAYS: '0' } as unknown as NodeJS.ProcessEnv), 0);
   assert.equal(samePlatformSpacingMinutes({ ARIES_SAME_PLATFORM_MIN_SPACING_MINUTES: '45' } as unknown as NodeJS.ProcessEnv), 45);
 });
+
+// --- 5. Media-type-aware asset resolution -------------------------------------
+
+import { resolveMediaUrls } from '../app/api/internal/publishing/scheduled-dispatch/route';
+
+test('resolveMediaUrls: a VIDEO post only resolves video assets', async () => {
+  let capturedSql = '';
+  const db = fakeDb((sql) => {
+    capturedSql = sql;
+    return { rows: [] };
+  });
+  await resolveMediaUrls('415', '15', db, 'video');
+  assert.match(capturedSql, /AND ca\.media_type = 'video'/);
+  assert.doesNotMatch(capturedSql, /IS DISTINCT FROM/);
+});
+
+test('resolveMediaUrls: an IMAGE post excludes video assets (default direction)', async () => {
+  let capturedSql = '';
+  const db = fakeDb((sql) => {
+    capturedSql = sql;
+    return { rows: [] };
+  });
+  // Default mediaType is image — the legacy call shape must keep excluding videos.
+  await resolveMediaUrls('403', '15', db);
+  assert.match(capturedSql, /AND ca\.media_type IS DISTINCT FROM 'video'/);
+});
+
+test('resolveMediaUrls: served refs map to servable URLs regardless of the media filter', async () => {
+  const db = fakeDb(() => ({
+    rows: [
+      { storage_kind: 'runtime_asset', storage_key: '/host/path.png', served_asset_ref: '/api/internal/hermes/media/abc' },
+      { storage_kind: 'external_url', storage_key: 'https://cdn.example/x.mp4', served_asset_ref: null },
+      { storage_kind: 'runtime_asset', storage_key: '/host/other.png', served_asset_ref: null }, // no servable ref → dropped
+    ],
+  }));
+  const prev = process.env.APP_BASE_URL;
+  process.env.APP_BASE_URL = 'https://aries.example.com';
+  try {
+    const urls = await resolveMediaUrls('999', '15', db, 'video');
+    assert.deepEqual(urls, [
+      'https://aries.example.com/api/internal/hermes/media/abc',
+      'https://cdn.example/x.mp4',
+    ]);
+  } finally {
+    if (prev === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = prev;
+  }
+});


### PR DESCRIPTION
Follow-up to #841 (Jira AA-134) closing the three test-coverage findings from the adversarial review:

- The incident regression suites (`duplicate-posting-guards`, `scheduled-posts-worker-backoff`, `scheduled-posts-worker-crash-safety` — the latter carries the tick-level backoff write-site tests) now run in `npm run verify` on every PR, not only in the full-suite CI gate. A regression here means Aries can burst-post or retry-hammer a platform again, so it belongs in the fast wall.
- `resolveMediaUrls` direction tests: a video post only resolves `media_type='video'` assets, an image post excludes videos (default call shape), and served-ref → servable-URL mapping is pinned.

Test-only + verify-script change; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)