### PR TITLE
fix(publishing): cast $4::text in child-status UPDATE (42P08 broke every post-publish write)

### DIFF
--- a/scripts/automations/scheduled-posts-worker.mjs
+++ b/scripts/automations/scheduled-posts-worker.mjs
@@ -1,7 +1,7 @@
 /**
  * Scheduled-posts worker — drains the scheduled_posts table and fires
  * publishToMetaGraph for each row whose scheduled_for <= NOW() and
- * dispatch_status = 'pending'. Runs every minute via the cron manifest.
+ * dispatch_status = 'pending'. Runs as the aries-scheduled-posts-worker compose sidecar (self-scheduling; the legacy host cron that double-dispatched alongside it was removed 2026-07-13).
  */
 import 'dotenv/config';
 
@@ -188,13 +188,20 @@ async function seedPlatformDispatches(client, rowId, platforms) {
  * still marks terminal failures only. */
 async function setPlatformDispatchStatus(client, rowId, platform, status, errorMessage) {
   const truncated = errorMessage ? String(errorMessage).slice(0, 1000) : null;
+  // $4 is cast to text everywhere it appears: with the bare parameter in both
+  // a CASE result and an IS NOT NULL predicate, Postgres cannot infer its type
+  // and rejects the statement with 42P08 "could not determine data type of
+  // parameter $4" — which failed EVERY post-publish write (the publish went
+  // live but was never recorded, re-opening the stale-reclaim duplicate
+  // window). Caught live 2026-07-13 20:05Z; the in-memory test fakes cannot
+  // see prepare-time type inference, hence the live-SQL prepare test.
   await client.query(
     `UPDATE scheduled_post_dispatches
      SET status = $3,
          dispatched_at = CASE WHEN $3 = 'dispatched' THEN now() ELSE dispatched_at END,
          error_at = CASE WHEN $3 = 'failed' THEN now() ELSE error_at END,
-         error_message = CASE WHEN $3 = 'failed' THEN $4
-                              WHEN $3 = 'pending' AND $4 IS NOT NULL THEN $4
+         error_message = CASE WHEN $3 = 'failed' THEN $4::text
+                              WHEN $3 = 'pending' AND $4::text IS NOT NULL THEN $4::text
                               ELSE error_message END,
          updated_at = now()
      WHERE scheduled_post_id = $1 AND platform = $2`,

--- a/tests/scheduled-posts-worker-backoff.test.ts
+++ b/tests/scheduled-posts-worker-backoff.test.ts
@@ -50,7 +50,7 @@ test('init-db.js ships the next_attempt_at column the worker SQL depends on', ()
 test('pending child rows now persist their error_message (silent-retry observability)', () => {
   assert.match(
     workerSource,
-    /WHEN \$3 = 'pending' AND \$4 IS NOT NULL THEN \$4/,
+    /WHEN \$3 = 'pending' AND \$4::text IS NOT NULL THEN \$4::text/,
     'setPlatformDispatchStatus must record the retryable error on pending children',
   );
 });
@@ -104,4 +104,19 @@ test('a (re)schedule upsert clears next_attempt_at — operator reschedules beat
   );
   const conflictClause = upsertSource.slice(upsertSource.indexOf('ON CONFLICT (post_id) DO UPDATE'));
   assert.match(conflictClause, /next_attempt_at = NULL/);
+});
+
+test('setPlatformDispatchStatus casts $4 to text — bare $4 fails Postgres prepare (42P08)', () => {
+  // Postgres cannot infer $4's type when the bare parameter appears in both a
+  // CASE result and an IS NOT NULL predicate; the statement then fails at
+  // prepare time and EVERY post-publish write dies — the publish goes live
+  // but is never recorded, re-opening the stale-reclaim duplicate window
+  // (caught live 2026-07-13 20:05Z). In-memory fakes cannot see prepare-time
+  // inference, so pin the casts at source level.
+  const stmt = workerSource.slice(
+    workerSource.indexOf('UPDATE scheduled_post_dispatches'),
+    workerSource.indexOf('WHERE scheduled_post_id = $1 AND platform = $2'),
+  );
+  const bare = stmt.match(/\$4(?!::text)/g) ?? [];
+  assert.equal(bare.length, 0, `every $4 in the child-status UPDATE must be cast ::text; found ${bare.length} bare`);
 });


### PR DESCRIPTION
Hotfix for a live defect introduced by #841 and caught on the first real dispatch (2026-07-13 20:05Z, Jira AA-134):

`setPlatformDispatchStatus`'s new pending-error persistence placed the bare `$4` in both a CASE result and an `IS NOT NULL` predicate — Postgres cannot infer the parameter type and rejects the statement at prepare time (`42P08`). **Every post-publish write threw**: the publish went live but was never recorded, re-opening the exact stale-reclaim duplicate window the incident fix closes. (The affected FB dispatch was completed manually in prod before the reclaim fired; no duplicate was posted.)

- Cast `$4::text` at every use; source-level regression test pins the casts (in-memory fakes cannot see prepare-time type inference).
- Proven against the live Postgres: old statement fails `42P08`, fixed statement + backoff + due/claim SQL all prepare clean.
- Also documents removal of the legacy host-cron double-dispatcher (a one-shot worker pass inside the app container every minute, racing the compose sidecar — removed from the host crontab, backup kept at `/home/node/aries-logs/crontab.backup-2026-07-13`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)