### PR TITLE
S2-5/AA-96: pin S2-1/S2-3 math (trends pctDelta, goal windows, top ranking)

### DIFF
--- a/backend/insights/top/top-snapshot-builder.ts
+++ b/backend/insights/top/top-snapshot-builder.ts
@@ -94,6 +94,42 @@ function orderColumn(sortBy: TopSortKey): string {
   }
 }
 
+/**
+ * Per-post derived metrics from the LATEST-snapshot raw counts (S2-1) and the
+ * period average reach. Pinned by tests/insights-math-pinning.test.ts (S2-5).
+ *   engagement = (likes+comments+saves+shares)/reach, as a % to 1 decimal
+ *   saveRate   = saves/reach, as a % to 2 decimals
+ *   multiplier = reach / period-average-reach, to 1 decimal ("Nx average")
+ * Each guards its divisor: reach<=0 → engagement/saveRate 0; avgReach<=0 → multiplier 0.
+ */
+export interface TopPostMetrics { engagement: number; saveRate: number; multiplier: number }
+export function deriveTopPostMetrics(
+  raw: { reach: number; likes: number; comments: number; saves: number; shares: number },
+  avgReach: number,
+): TopPostMetrics {
+  const interactions = raw.likes + raw.comments + raw.saves + raw.shares;
+  return {
+    engagement: raw.reach > 0 ? Math.round((interactions / raw.reach) * 1000) / 10 : 0,
+    saveRate:   raw.reach > 0 ? Math.round((raw.saves / raw.reach) * 10000) / 100 : 0,
+    multiplier: avgReach > 0 ? Math.round((raw.reach / avgReach) * 10) / 10 : 0,
+  };
+}
+
+/**
+ * Final top-N ordering. Behavior-identical to the pre-S2-5 inline logic (pinned
+ * by S2-5): engagement is a JS-computed column so it is re-sorted here (desc);
+ * every other sort key trusts the incoming DB `ORDER BY <col> DESC` order. Then
+ * the top 5 are returned. NO tie-breaker — exact-metric ties keep the input
+ * (DB/insertion) order, which is NOT deterministic; a follow-up ticket should add
+ * an id-asc tie-breaker (and only then pin exact tie order).
+ */
+export function rankTopPosts<T extends { engagement: number }>(posts: T[], sortBy: TopSortKey): T[] {
+  const ranked = sortBy === 'engagement'
+    ? [...posts].sort((a, b) => b.engagement - a.engagement)
+    : [...posts];
+  return ranked.slice(0, 5);
+}
+
 // Read a follower-split string out of platform_data JSONB if the platform
 // reported follower vs non-follower reach (Instagram). Returns null otherwise.
 function extractFollowerSplit(platformData: Record<string, unknown> | null): string | null {
@@ -237,10 +273,10 @@ export async function buildTopSnapshot(
       const comments = Number(row.comments);
       const saves    = Number(row.saves);
       const shares   = Number(row.shares);
-      const interactions = likes + comments + saves + shares;
-      const engagement   = reach > 0 ? Math.round((interactions / reach) * 1000) / 10 : 0;
-      const saveRate     = reach > 0 ? Math.round((saves / reach) * 10000) / 100 : 0;
-      const multiplier   = avgReach > 0 ? Math.round((reach / avgReach) * 10) / 10 : 0;
+      const { engagement, saveRate, multiplier } = deriveTopPostMetrics(
+        { reach, likes, comments, saves, shares },
+        avgReach,
+      );
 
       return {
         id:            Number(row.id),
@@ -265,12 +301,10 @@ export async function buildTopSnapshot(
       };
     });
 
-    // Engagement sort is computed in JS (not a DB column); re-sort when requested.
-    if (sortBy === 'engagement') {
-      posts.sort((a, b) => b.engagement - a.engagement);
-    }
-
-    posts = posts.slice(0, 5);
+    // Final ordering + top-5 trim (extracted to rankTopPosts, pinned by S2-5).
+    // Engagement is a JS-computed column so it is re-sorted here; other keys trust
+    // the DB ORDER BY. Behavior-identical to the previous inline logic.
+    posts = rankTopPosts(posts, sortBy);
 
     return { posts, avgReach, postCount, sortBy };
 

--- a/backend/insights/trends/trends-snapshot-builder.ts
+++ b/backend/insights/trends/trends-snapshot-builder.ts
@@ -80,6 +80,25 @@ function periodDays(period: NarrativePeriod): number {
   return 90;
 }
 
+/**
+ * Percent change of `cur` vs the prior-period `pri`, or null when no meaningful
+ * comparison exists. Pinned by tests/insights-math-pinning.test.ts (S2-5).
+ *
+ * - `pri <= 0` → null: a freshly connected account has ~no prior-window data, and
+ *   dividing by zero/negative is meaningless (also covers both-zero).
+ * - `|delta| > 999` (or non-finite) → null: suppress the absurd magnitudes a
+ *   near-zero baseline produces (e.g. 1 → 33 = +3200%), which read as broken; the
+ *   template then falls back to the absolute value. The cutoff is strictly `> 999`,
+ *   so exactly ±999% is kept.
+ * - otherwise → Math.round(delta).
+ */
+export function trendsPctDelta(cur: number, pri: number): number | null {
+  if (pri <= 0) return null;
+  const d = ((cur - pri) / pri) * 100;
+  if (!Number.isFinite(d) || Math.abs(d) > 999) return null;
+  return Math.round(d);
+}
+
 function utcDayStart(daysAgo: number): Date {
   const d = new Date();
   d.setUTCHours(0, 0, 0, 0);
@@ -287,16 +306,8 @@ export async function buildTrendsSnapshot(
     const curEngRate  = curReach > 0 ? Math.round((curIntTotal / curReach) * 1000) / 10 : 0;
     const priEngRate  = priReach > 0 ? Math.round((priIntTotal / priReach) * 1000) / 10 : 0;
 
-    const pctDelta = (cur: number, pri: number): number | null => {
-      // No meaningful comparison without a real prior baseline — a freshly
-      // connected account has ~no data in the prior window. Also suppress the
-      // absurd magnitudes a near-zero baseline produces (e.g. 1 → 33 = +3200%),
-      // which read as broken; the template then falls back to the absolute value.
-      if (pri <= 0) return null;
-      const d = ((cur - pri) / pri) * 100;
-      if (!Number.isFinite(d) || Math.abs(d) > 999) return null;
-      return Math.round(d);
-    };
+    // pctDelta extracted to the module-level `trendsPctDelta` (pinned by S2-5).
+    const pctDelta = trendsPctDelta;
 
     // Visits available if any profile_visits data exists for this selection
     const visitsAvailable = curVisits > 0 || priVisits > 0;

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -112,6 +112,14 @@ const steps = [
     args: ['--test', 'tests/insights-tz-boundary-agreement.test.ts'],
   },
   {
+    // S2-5/AA-96: deterministic pins for the S2-1 (latest-snapshot metric) and
+    // S2-3 (tenant-tz window) math — trends pctDelta edges, goal window
+    // boundaries incl. DST, top derive+rank. Pure + no DB; a regression here
+    // means a refactor silently changed a displayed number or window boundary.
+    name: 'insights metric/window math pinning (S2-1 + S2-3)',
+    args: ['--test', 'tests/insights-math-pinning.test.ts'],
+  },
+  {
     // 2026-07-13 duplicate-posting incident (AA-134 / PR #841) regression wall:
     // scheduler day-mapping + same-instant de-collision, the reel-companion
     // synthesis clamp, the publish-boundary duplicate/spacing guards, and the

--- a/tests/insights-math-pinning.test.ts
+++ b/tests/insights-math-pinning.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { tenantZonePeriodStart, tenantZonePeriodStartDateKey } from '../lib/format-timestamp';
+import { trendsPctDelta } from '../backend/insights/trends/trends-snapshot-builder';
+import { deriveTopPostMetrics, rankTopPosts } from '../backend/insights/top/top-snapshot-builder';
+
+// S2-5 / AA-96 (Gap E5) — deterministic unit tests PINNING the math introduced by
+// S2-1 (latest-snapshot metric calcs) and S2-3 (tenant-tz windows), so a future
+// refactor can't silently change the numbers. Pure fixtures, no DB — runs in
+// `npm run verify` on every PR (added to the curated regression suite).
+//
+// Seam vs the other tz/metric tests:
+//   - S2-4 (insights-tz-boundary-agreement) = cross-section DAY agreement.
+//   - requires-infra (S2-1/S2-3) = live SQL (LATERAL, AT TIME ZONE $tz) — self-skip in CI.
+//   - S2-5 (this) = per-piece deterministic ARITHMETIC in verify. No overlap.
+
+// ── 1. trends pctDelta — percent-change arithmetic + edge cases ────────────────
+// Edge inputs are where this breaks, so they are pinned as first-class cases.
+test('trendsPctDelta: divide-by-zero / both-zero / negative-prior all return null', () => {
+  assert.equal(trendsPctDelta(100, 0), null, 'prior=0 → null (no divide-by-zero)');
+  assert.equal(trendsPctDelta(0, 0), null, 'both-zero → null');
+  assert.equal(trendsPctDelta(50, -5), null, 'negative prior → null');
+});
+
+test('trendsPctDelta: ordinary deltas round to the nearest integer percent', () => {
+  assert.equal(trendsPctDelta(50, 100), -50, 'halving → -50%');
+  assert.equal(trendsPctDelta(110, 99), 11, '11.11% → 11 (rounds down)');
+  assert.equal(trendsPctDelta(3, 2), 50, '+50%');
+});
+
+test('trendsPctDelta: absurd-magnitude cap is strictly > 999 (±999% kept, beyond → null)', () => {
+  assert.equal(trendsPctDelta(1000, 1), null, '99900% → null (near-zero baseline blowup)');
+  assert.equal(trendsPctDelta(999, 100), 899, '899% is under the cap → kept');
+  assert.equal(trendsPctDelta(1099, 100), 999, 'exactly +999% is kept (cutoff is > 999, not >= 999)');
+});
+
+// ── 2. goal windows — tenant-tz period-window boundaries (S2-3) ────────────────
+// Fixed "now" whose America/New_York (EST, UTC-5) civil day is 2026-01-15. goal
+// maps week/30day/90day → 7/30/90 days, and the prior period doubles that.
+const NOW = new Date('2026-01-16T04:30:00Z');
+const NY = 'America/New_York';
+
+test('goal windows: week/30day/90day current + prior boundaries are pinned per tenant tz', () => {
+  // week (7) + prior (14)
+  assert.equal(tenantZonePeriodStartDateKey(7, NY, NOW), '2026-01-08');
+  assert.equal(tenantZonePeriodStartDateKey(14, NY, NOW), '2026-01-01');
+  assert.equal(tenantZonePeriodStart(7, NY, NOW).toISOString(), '2026-01-08T05:00:00.000Z');
+  // 30day (30) + prior (60)
+  assert.equal(tenantZonePeriodStartDateKey(30, NY, NOW), '2025-12-16');
+  assert.equal(tenantZonePeriodStartDateKey(60, NY, NOW), '2025-11-16');
+  // 90day (90) + prior (180)
+  assert.equal(tenantZonePeriodStartDateKey(90, NY, NOW), '2025-10-17');
+  assert.equal(tenantZonePeriodStartDateKey(180, NY, NOW), '2025-07-19');
+});
+
+test('goal windows: DST correctness — historical windows anchor at THAT date’s offset (EDT vs EST)', () => {
+  // 7/30/60 days back land in winter → EST (UTC-5) → midnight is 05:00Z.
+  assert.equal(tenantZonePeriodStart(30, NY, NOW).toISOString(), '2025-12-16T05:00:00.000Z');
+  assert.equal(tenantZonePeriodStart(60, NY, NOW).toISOString(), '2025-11-16T05:00:00.000Z');
+  // 90/180 days back land BEFORE the Nov 1 fall-back → EDT (UTC-4) → midnight is
+  // 04:00Z. Freezing the offset difference guards the per-date DST resolution.
+  assert.equal(tenantZonePeriodStart(90, NY, NOW).toISOString(), '2025-10-17T04:00:00.000Z');
+  assert.equal(tenantZonePeriodStart(180, NY, NOW).toISOString(), '2025-07-19T04:00:00.000Z');
+});
+
+test('goal windows: a "now" ON the spring-forward day resolves at tenant midnight', () => {
+  // US spring-forward 2026-03-08 (02:00→03:00). Midnight 03-08 is still EST → 05:00Z.
+  const dstNow = new Date('2026-03-08T12:00:00Z'); // NY civil day = 2026-03-08
+  assert.equal(tenantZonePeriodStartDateKey(0, NY, dstNow), '2026-03-08');
+  assert.equal(tenantZonePeriodStart(0, NY, dstNow).toISOString(), '2026-03-08T05:00:00.000Z');
+  assert.equal(tenantZonePeriodStart(7, NY, dstNow).toISOString(), '2026-03-01T05:00:00.000Z');
+});
+
+// ── 3. top ranking — latest-snapshot derived metrics + ordering (S2-1) ─────────
+test('deriveTopPostMetrics: engagement / saveRate / multiplier arithmetic + rounding', () => {
+  assert.deepEqual(
+    deriveTopPostMetrics({ reach: 100, likes: 10, comments: 5, saves: 3, shares: 2 }, 50),
+    { engagement: 20, saveRate: 3, multiplier: 2 },
+  );
+  // engagement rounds to 1 decimal: 5/80 = 6.25% → 6.3 ; multiplier 80/50 = 1.6
+  assert.deepEqual(
+    deriveTopPostMetrics({ reach: 80, likes: 5, comments: 0, saves: 0, shares: 0 }, 50),
+    { engagement: 6.3, saveRate: 0, multiplier: 1.6 },
+  );
+});
+
+test('deriveTopPostMetrics: divisor guards (reach=0 and avgReach=0 never divide)', () => {
+  assert.deepEqual(
+    deriveTopPostMetrics({ reach: 0, likes: 5, comments: 1, saves: 1, shares: 1 }, 50),
+    { engagement: 0, saveRate: 0, multiplier: 0 },
+  );
+  assert.equal(
+    deriveTopPostMetrics({ reach: 100, likes: 1, comments: 0, saves: 0, shares: 0 }, 0).multiplier,
+    0,
+    'avgReach=0 → multiplier 0 (no divide)',
+  );
+});
+
+test('rankTopPosts: engagement re-sorts desc and trims to top 5', () => {
+  const posts = [
+    { id: 1, engagement: 20 }, { id: 2, engagement: 35 }, { id: 3, engagement: 35 },
+    { id: 4, engagement: 10 }, { id: 5, engagement: 50 }, { id: 6, engagement: 5 },
+    { id: 7, engagement: 40 },
+  ];
+  const ranked = rankTopPosts(posts, 'engagement');
+  assert.equal(ranked.length, 5, 'trimmed to top 5');
+  // Deterministic (non-tied) positions:
+  assert.equal(ranked[0].id, 5, 'highest engagement (50) first');
+  assert.equal(ranked[1].id, 7, 'next (40)');
+  assert.equal(ranked[4].id, 1, 'fifth is engagement 20');
+  // The two engagement=35 posts (ids 2,3) TIE. Ordering among exact-metric ties is
+  // NOT deterministic today (no tie-breaker), so assert only MEMBERSHIP — pinning
+  // an exact tie order would pin luck. (Follow-up: add an id-asc tie-breaker.)
+  assert.deepEqual(
+    new Set(ranked.slice(2, 4).map((p) => p.id)),
+    new Set([2, 3]),
+    'both tied (35) posts occupy the middle two slots, order unspecified',
+  );
+});
+
+test('rankTopPosts: non-engagement keys trust incoming DB order and trim to 5', () => {
+  // For non-engagement sort keys the DB ORDER BY is authoritative; rankTopPosts
+  // preserves the incoming order and trims. (Behavior-identical to pre-S2-5.)
+  const posts = [1, 2, 3, 4, 5, 6, 7].map((id) => ({ id, engagement: 0 }));
+  const ranked = rankTopPosts(posts, 'reach');
+  assert.deepEqual(ranked.map((p) => p.id), [1, 2, 3, 4, 5], 'input order preserved, first 5 kept');
+});


### PR DESCRIPTION
**Closes S2-5 / AA-96** (Gap E5, `docs/plans/2026-07-07-analytics-page-roadmap.md`, PR #789). A tests ticket; closes the #782/#783 no-unit-test debt. Branches cleanly off `master` (all of S2-1/S2-2/S2-3/S2-4 merged).

## What it pins
Deterministic unit tests freezing the math from **S2-1** (latest-snapshot metric calcs) and **S2-3** (tenant-tz windows), so a future refactor can't silently change a displayed number or a window boundary.

**Runs in `npm run verify`** — pure fixtures, no DB (added as `[verify 10/27] insights metric/window math pinning`), so it's CI-enforced on every PR (unlike the S2-1/S2-3 requires-infra tests that self-skip in CI).

## Minimal, behavior-preserving extractions (export-style, like S2-4)
- **trends**: the inner `pctDelta` closure → module-level `trendsPctDelta`. Builder keeps a local alias; the two call sites are unchanged.
- **top**: per-post derivation + final ordering → `deriveTopPostMetrics` and `rankTopPosts`; the builder calls them. `rankTopPosts` is **byte-identical** to the previous inline logic (engagement is a JS-computed column → re-sorted desc; every other key trusts the DB `ORDER BY`; then top-5). **No prod behavior change.**

## Pinned cases (all verified against the real code)
**trends `pctDelta`** — edges are first-class:
- `prior<=0` / both-zero / negative-prior → **null** (divide-by-zero guard)
- ordinary deltas round to nearest % (`110,99 → 11`; `50,100 → -50`)
- absurd-magnitude cap is **strictly `> 999`**: `999,100 → 899` kept, `1099,100 → 999` kept (exact boundary), `1000,1 → null`

**goal windows** (`tenantZonePeriodStart` / `…DateKey`, fixed `now` whose NY civil day is 2026-01-15):
- week/30day/90day current + prior (7/14/30/60/90/180-day) boundaries
- **DST correctness**: 7/30/60-day-back resolve at **EST 05:00Z**, but 90/180-day-back resolve at **EDT 04:00Z** — each window anchors at *that historical date's* offset — plus a "now on the 2026-03-08 spring-forward day" case

**top ranking**:
- `deriveTopPostMetrics` engagement/saveRate/multiplier arithmetic + rounding (`6.25% → 6.3`; `80/50 → 1.6x`) + divisor guards (`reach=0`, `avgReach=0` → 0)
- `rankTopPosts` engagement re-sort desc + top-5 trim; non-engagement keys preserve DB order + trim

## ⚠️ Follow-up: non-deterministic tie ordering (real latent issue, deliberately not fixed here)
`rankTopPosts` has **no tie-breaker**, so exact-metric ties keep whatever order the input (DB/insertion) gives — **non-deterministic**. To avoid pinning luck, the tie fixture asserts only **membership** (both tied posts occupy the two middle slots), not an exact order.

This is a genuine improvement worth making — **but it's a prod-behavior change and deserves its own focused review**, not a footnote in a tests PR (especially right after the #824 scope miss). **Recommend a small follow-up ticket:** add a deterministic `id`-asc tie-breaker in `rankTopPosts`, then that ticket adds the exact-order tie assertion.

## Verification
- `npm run verify` → green, incl. `[verify 10/27] insights metric/window math pinning (S2-1 + S2-3)` (10/10). Typecheck clean.
- **Fails-before demos** (perturb source → pinned assertion fails → restore):
  - trends cap `999→800` → `999,100` expected 899 got null ❌
  - goal window off-by-one → `2026-01-08` got `2026-01-09` ❌
  - top engagement scale `*1000→*100` → engagement 20 got 2 ❌

## Seam (no duplication)
S2-4 pins cross-section **day agreement**; the requires-infra tests exercise **live SQL**; S2-5 pins per-piece deterministic **arithmetic**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)