### PR TITLE
fix(marketing): highlight the failing form field on create errors (AA-131)

### DIFF
--- a/app/api/marketing/jobs/handler.ts
+++ b/app/api/marketing/jobs/handler.ts
@@ -24,6 +24,7 @@ import {
   normalizeMetaPageId,
   validateCanonicalCompetitorUrl,
 } from '@/lib/marketing-competitor';
+import { mapMarketingCreateFailure } from '@/lib/marketing-create-errors';
 import { loadTenantContextOrResponse, type TenantContextLoader } from '@/lib/tenant-context-http';
 
 const MARKETING_ONBOARDING_REQUIRED = {
@@ -496,7 +497,11 @@ export async function handlePostMarketingJobs(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message === COMPETITOR_URL_SOCIAL_ERROR || message === COMPETITOR_URL_INVALID_ERROR) {
-      return NextResponse.json({ error: message }, { status: 400 });
+      // fieldErrors keys the inline red highlight on the competitor input.
+      return NextResponse.json(
+        { error: message, message, fieldErrors: { competitorUrl: message } },
+        { status: 400 },
+      );
     }
     throw error;
   }
@@ -579,16 +584,36 @@ export async function handlePostMarketingJobs(
     if (message.startsWith('workflow_missing_for_route:')) {
       return NextResponse.json({ error: message, reason: 'workflow_missing_for_route' }, { status: 501 });
     }
-    if (message.startsWith('brand_kit_')) {
-      return NextResponse.json({ error: message }, { status: 422 });
+    // Operator-actionable failures (brand-kit fetch/extraction, missing
+    // required fields) return structured fieldErrors keyed by the create
+    // form's field names, so the form highlights the exact input to fix
+    // (AA-131). The raw message — which can carry an inner fetch/DNS cause —
+    // stays server-side in this log line and never reaches the browser.
+    const createFailure = mapMarketingCreateFailure(message);
+    if (createFailure) {
+      console.warn('[marketing-job-create] rejected', { error: message });
+      return NextResponse.json(
+        {
+          error: createFailure.error,
+          message: createFailure.message,
+          ...(createFailure.fieldErrors ? { fieldErrors: createFailure.fieldErrors } : {}),
+        },
+        { status: createFailure.status },
+      );
     }
     if (
-      message.startsWith('missing_required_fields:') ||
       message.startsWith('unsupported_job_type:') ||
       message === COMPETITOR_URL_SOCIAL_ERROR ||
       message === COMPETITOR_URL_INVALID_ERROR
     ) {
-      return NextResponse.json({ error: message }, { status: 400 });
+      const fieldErrors =
+        message === COMPETITOR_URL_SOCIAL_ERROR || message === COMPETITOR_URL_INVALID_ERROR
+          ? { competitorUrl: message }
+          : undefined;
+      return NextResponse.json(
+        { error: message, ...(fieldErrors ? { message, fieldErrors } : {}) },
+        { status: 400 },
+      );
     }
 
     console.error('[marketing-job-create] unhandled error', {

--- a/frontend/aries-v1/generate-this-week.ts
+++ b/frontend/aries-v1/generate-this-week.ts
@@ -206,7 +206,10 @@ export async function submitGenerateThisWeek(
 
   const jobId = readString(parsed, 'jobId');
   const jobStatusUrl = readString(parsed, 'jobStatusUrl');
-  const rawError = readString(parsed, 'error') ?? readString(parsed, 'message');
+  // Prefer the operator-facing sentence (`message`) the jobs handler now sends
+  // alongside the machine-readable `error` code; fall back to the code for
+  // older/unmapped response shapes.
+  const rawError = readString(parsed, 'message') ?? readString(parsed, 'error');
 
   return {
     ok: response.ok,

--- a/frontend/marketing/month-day-picker.tsx
+++ b/frontend/marketing/month-day-picker.tsx
@@ -51,7 +51,7 @@ const optionClassName = '[&>option]:bg-[#050505] [&>option]:text-white';
 const selectClassName =
   `rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-primary/50 ${optionClassName}`;
 const selectInvalidClassName =
-  `rounded-2xl border border-red-500/50 bg-white/5 px-4 py-3 text-white focus:outline-none focus:border-red-500/70 ${optionClassName}`;
+  `rounded-2xl border border-red-500/60 bg-red-500/10 px-4 py-3 text-white focus:outline-none focus:border-red-400 ${optionClassName}`;
 
 export function MonthDayPicker({ value, onChange, ariaLabel, invalid, _today }: MonthDayPickerProps) {
   const today = _today ?? new Date();

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import React, { useEffect, useState, type FormEvent } from 'react';
+import React, { useEffect, useRef, useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowRight, FileUp, LoaderCircle, Rocket, Sparkles } from 'lucide-react';
 
 import type { MarketingApiError } from '@/lib/api/marketing';
 import { isValidWebsiteUrl } from '@/lib/api/marketing';
 import { validateCanonicalCompetitorUrl } from '@/lib/marketing-competitor';
+import { humanizeMarketingCreateMessage } from '@/lib/marketing-create-errors';
 import { useMarketingJobCreate, type UseMarketingJobCreateOptions } from '@/hooks/use-marketing-job-create';
 import StatusBadge from '../components/status-badge';
 import { MonthDayPicker } from './month-day-picker';
@@ -55,6 +56,32 @@ const SUBMIT_PROGRESS_MESSAGES = [
 
 const FINAL_SUBMIT_PROGRESS_INDEX = SUBMIT_PROGRESS_MESSAGES.length - 1;
 
+/**
+ * Field-error keys this form renders inline (red box + one-line message under
+ * the input). A server fieldError for any OTHER key (e.g. businessType, which
+ * has no input here) falls back to the top-level alert so it is never
+ * silently dropped.
+ */
+const RENDERED_FIELD_KEYS = new Set([
+  'websiteUrl',
+  'competitorUrl',
+  'oneOff.name',
+  'oneOff.campaignEndDate',
+  'oneOff.cta',
+  'oneOff.milestoneDate',
+  'oneOff.milestoneLabel',
+]);
+
+const INPUT_BASE_CLASSNAME =
+  'w-full rounded-2xl border px-4 py-3 text-white placeholder:text-white/30 focus:outline-none';
+
+/** Red box treatment for an input that needs the operator's attention. */
+function inputClassName(hasError: boolean): string {
+  return hasError
+    ? `${INPUT_BASE_CLASSNAME} border-red-500/60 bg-red-500/10 focus:border-red-400`
+    : `${INPUT_BASE_CLASSNAME} border-white/10 bg-white/5 focus:border-primary/50`;
+}
+
 export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContentProps) {
   const router = props.router;
   const marketingCreate = useMarketingJobCreate(props.clientOptions);
@@ -88,6 +115,13 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
   const [oneOffCta, setOneOffCta] = useState('');
   const [milestoneDate, setMilestoneDate] = useState('');
   const [milestoneLabel, setMilestoneLabel] = useState('');
+  // Bumped on every submit attempt so the scroll-to-first-error effect re-runs
+  // even when the same field fails twice in a row.
+  const [submitAttempt, setSubmitAttempt] = useState(0);
+  // Field keys whose error the operator has started fixing (edited since the
+  // last submit); their red box is hidden until the next submit re-validates.
+  const [dismissedFields, setDismissedFields] = useState<ReadonlySet<string>>(new Set());
+  const formRef = useRef<HTMLFormElement | null>(null);
 
   useEffect(() => {
     if (!submitting) {
@@ -112,40 +146,101 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
   }, [submitting]);
 
   useEffect(() => {
-    if (marketingCreate.error?.message) {
-      setErrorText(marketingCreate.error.message);
+    if (!marketingCreate.error) {
+      return;
     }
-  }, [marketingCreate.error]);
+    // A fresh server failure must never be hidden by an earlier
+    // dismiss-on-edit: clear dismissals so its field errors render.
+    setDismissedFields(new Set());
+    // When the server pinned the failure to specific fields, the inline red
+    // boxes carry the message — the top-level alert only shows copy for
+    // fields this form does not render, so nothing is ever silently dropped.
+    // "Rendered" means actually MOUNTED: oneOff.* inputs only exist in
+    // one-off mode, so their errors fall back to the alert if the operator
+    // toggled back to Weekly while the request was in flight (jobMode is a
+    // dependency so a later toggle re-evaluates this split).
+    const serverFieldErrors = marketingCreate.fieldErrors ?? {};
+    const isMounted = (key: string) =>
+      RENDERED_FIELD_KEYS.has(key) && (jobMode === 'oneOff' || !key.startsWith('oneOff.'));
+    const unrendered = Object.entries(serverFieldErrors).filter(([key]) => !isMounted(key));
+    const hasRendered = Object.keys(serverFieldErrors).some(isMounted);
+    if (unrendered.length > 0) {
+      setErrorText([...new Set(unrendered.map(([, copy]) => copy))].join(' '));
+    } else if (hasRendered) {
+      setErrorText(null);
+    } else if (marketingCreate.error.message) {
+      setErrorText(humanizeMarketingCreateMessage(marketingCreate.error.message));
+    }
+  }, [marketingCreate.error, marketingCreate.fieldErrors, jobMode]);
+
+  // Field errors from either side (client pre-submit validation or a server
+  // 4xx) scroll the first offending input into view and focus it, so the
+  // operator lands on the exact red box that explains what is missing. The
+  // attempt guard fires this at most once per submit — when the errors first
+  // appear — never again while the operator is editing fields (a re-fire
+  // would steal focus mid-typing).
+  const clientErrorCount = Object.keys(clientFieldErrors).length;
+  const serverErrorCount = Object.keys(marketingCreate.fieldErrors ?? {}).length;
+  const lastScrolledAttempt = useRef(0);
+  useEffect(() => {
+    if (clientErrorCount === 0 && serverErrorCount === 0) {
+      return;
+    }
+    if (lastScrolledAttempt.current === submitAttempt) {
+      return;
+    }
+    const firstInvalid = formRef.current?.querySelector<HTMLElement>(
+      '[aria-invalid="true"], [data-field-invalid="true"]',
+    );
+    if (!firstInvalid) {
+      return;
+    }
+    lastScrolledAttempt.current = submitAttempt;
+    firstInvalid.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    firstInvalid.focus({ preventScroll: true });
+    // dismissedFields is a dependency because a server-error arrival clears
+    // dismissals one render later — the red box only becomes queryable then.
+  }, [submitAttempt, clientErrorCount, serverErrorCount, dismissedFields]);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setErrorText(null);
+    setSubmitAttempt((current) => current + 1);
+    setDismissedFields(new Set());
+
+    // Aggregate every failing field into the same keyed shape the server
+    // returns from a 4xx so each missing input gets its own inline red box +
+    // one-line message -- not a single top-level alert that hides which
+    // fields the operator needs to fill in. The server re-checks shape and
+    // ordering so a malicious or scripted POST cannot bypass these rules.
+    const errors: Record<string, string> = {};
 
     const trimmedWebsiteUrl = normalizeWebsiteUrlInput(websiteUrl);
     if (!trimmedWebsiteUrl) {
-      setErrorText('website URL is required');
-      return;
+      errors.websiteUrl = 'Website URL is required.';
+    } else if (!isValidWebsiteUrl(trimmedWebsiteUrl)) {
+      errors.websiteUrl = 'Website URL must look like https://example.com.';
     }
-    if (!isValidWebsiteUrl(trimmedWebsiteUrl)) {
-      setErrorText('Website URL must look like https://example.com');
-      return;
+
+    const trimmedCompetitorUrl = competitorUrl.trim();
+    let normalizedCompetitorUrl: string | null = null;
+    if (trimmedCompetitorUrl) {
+      const validation = validateCanonicalCompetitorUrl(trimmedCompetitorUrl);
+      if (validation.error) {
+        errors.competitorUrl = validation.error;
+      } else {
+        normalizedCompetitorUrl = validation.normalized ?? trimmedCompetitorUrl;
+      }
     }
 
     // One-off mode: name + campaign end date + CTA are required; milestone
-    // date + label are optional but paired. Aggregate every failing field
-    // into the same `oneOff.*` keyed shape the server returns from a 422 so
-    // every missing field gets an inline red error -- not a single top-level
-    // alert that hides which fields the operator needs to fill in. The
-    // server re-checks shape and ordering so a malicious or scripted POST
-    // cannot bypass these rules.
-    setClientFieldErrors({});
+    // date + label are optional but paired.
     if (jobMode === 'oneOff') {
       const trimmedOneOffName = oneOffName.trim();
       const trimmedCampaignEndDate = campaignEndDate.trim();
       const trimmedOneOffCta = oneOffCta.trim();
       const trimmedMilestoneDate = milestoneDate.trim();
       const trimmedMilestoneLabel = milestoneLabel.trim();
-      const errors: Record<string, string> = {};
       if (!trimmedOneOffName) errors['oneOff.name'] = 'Name is required.';
       if (!trimmedCampaignEndDate) errors['oneOff.campaignEndDate'] = 'End date is required.';
       if (!trimmedOneOffCta) errors['oneOff.cta'] = 'CTA is required.';
@@ -158,10 +253,11 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
       if (trimmedMilestoneDate && trimmedMilestoneDate > trimmedCampaignEndDate) {
         errors['oneOff.milestoneDate'] = 'Milestone date must be on or before the end date.';
       }
-      if (Object.keys(errors).length > 0) {
-        setClientFieldErrors(errors);
-        return;
-      }
+    }
+
+    setClientFieldErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      return;
     }
 
     const formData = new FormData();
@@ -183,14 +279,8 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
         formData.set('oneOff.milestoneLabel', milestoneLabel.trim());
       }
     }
-    const trimmedCompetitorUrl = competitorUrl.trim();
-    if (trimmedCompetitorUrl) {
-      const validation = validateCanonicalCompetitorUrl(trimmedCompetitorUrl);
-      if (validation.error) {
-        setErrorText(validation.error);
-        return;
-      }
-      formData.set('competitorUrl', validation.normalized ?? trimmedCompetitorUrl);
+    if (normalizedCompetitorUrl) {
+      formData.set('competitorUrl', normalizedCompetitorUrl);
     }
     if (brandVoice.trim()) {
       formData.set('brandVoice', brandVoice.trim());
@@ -219,14 +309,14 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
     try {
       const response = await marketingCreate.createJob(formData);
       if (!response) {
-        setErrorText(
-          marketingCreate.error?.message || 'Failed to create marketing job'
-        );
+        // The error effect above renders the failure from fresh hook state
+        // (inline red boxes when the server pinned fields, alert otherwise);
+        // reading marketingCreate.error here would see a stale closure.
         return;
       }
 
       if (isErrorResult(response)) {
-        setErrorText(response.message || response.error);
+        setErrorText(humanizeMarketingCreateMessage(response.message || response.error));
         return;
       }
 
@@ -259,11 +349,21 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
   const websiteUrlIsValid = isValidWebsiteUrl(normalizedWebsiteUrl);
   // Unified field-error lookup. Client-side errors (set synchronously on
   // submit) take precedence so the operator sees inline feedback before any
-  // network round trip; server-side errors (from 422) fill in the same shape
-  // after a POST. Both keyspaces are 'oneOff.<fieldName>' to match what the
-  // server returns.
-  const oneOffFieldError = (key: string): string | undefined =>
-    clientFieldErrors[key] ?? marketingCreate.fieldErrors?.[key];
+  // network round trip; server-side errors (from a 4xx) fill in the same
+  // shape after a POST. Editing a field dismisses its error until the next
+  // submit so the red box does not linger while the operator is fixing it.
+  const fieldErrorFor = (key: string): string | undefined =>
+    dismissedFields.has(key)
+      ? undefined
+      : clientFieldErrors[key] ?? marketingCreate.fieldErrors?.[key];
+  const dismissFieldError = (key: string) => {
+    setDismissedFields((current) => {
+      if (current.has(key)) return current;
+      const next = new Set(current);
+      next.add(key);
+      return next;
+    });
+  };
 
   return (
     <div className={wrapperClassName}>
@@ -278,7 +378,7 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
 
         <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
           <div className="glass rounded-[2.5rem] p-8">
-            <form onSubmit={onSubmit} className="space-y-6">
+            <form ref={formRef} onSubmit={onSubmit} className="space-y-6">
               <div>
                 <div className="mb-4 flex items-center gap-3">
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10">
@@ -297,17 +397,20 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
               <Field label="Website URL" required>
                 <input
                   value={websiteUrl}
-                  onChange={(event) => setWebsiteUrl(event.target.value)}
+                  onChange={(event) => {
+                    setWebsiteUrl(event.target.value);
+                    dismissFieldError('websiteUrl');
+                  }}
                   onBlur={() => setWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl))}
                   placeholder="https://yourbrand.com"
                   required
-                  aria-invalid={marketingCreate.fieldErrors?.websiteUrl ? true : undefined}
-                  aria-describedby={marketingCreate.fieldErrors?.websiteUrl ? 'website-url-error' : undefined}
-                  className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                  aria-invalid={fieldErrorFor('websiteUrl') ? true : undefined}
+                  aria-describedby={fieldErrorFor('websiteUrl') ? 'website-url-error' : undefined}
+                  className={inputClassName(!!fieldErrorFor('websiteUrl'))}
                 />
-                {marketingCreate.fieldErrors?.websiteUrl ? (
+                {fieldErrorFor('websiteUrl') ? (
                   <p id="website-url-error" className="mt-2 text-sm text-red-300">
-                    {marketingCreate.fieldErrors.websiteUrl}
+                    {fieldErrorFor('websiteUrl')}
                   </p>
                 ) : null}
               </Field>
@@ -400,15 +503,18 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
               <Field label="Competitor website URL">
                 <input
                   value={competitorUrl}
-                  onChange={(event) => setCompetitorUrl(event.target.value)}
+                  onChange={(event) => {
+                    setCompetitorUrl(event.target.value);
+                    dismissFieldError('competitorUrl');
+                  }}
                   placeholder="Optional competitor website, e.g. https://competitor.com"
-                  aria-invalid={marketingCreate.fieldErrors?.competitorUrl ? true : undefined}
-                  aria-describedby={marketingCreate.fieldErrors?.competitorUrl ? 'competitor-url-error' : undefined}
-                  className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                  aria-invalid={fieldErrorFor('competitorUrl') ? true : undefined}
+                  aria-describedby={fieldErrorFor('competitorUrl') ? 'competitor-url-error' : undefined}
+                  className={inputClassName(!!fieldErrorFor('competitorUrl'))}
                 />
-                {marketingCreate.fieldErrors?.competitorUrl ? (
+                {fieldErrorFor('competitorUrl') ? (
                   <p id="competitor-url-error" className="mt-2 text-sm text-red-300">
-                    {marketingCreate.fieldErrors.competitorUrl}
+                    {fieldErrorFor('competitorUrl')}
                   </p>
                 ) : null}
                 <p className="mt-2 text-sm text-white/70">
@@ -457,37 +563,53 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                   <Field label="Post name" required>
                     <input
                       value={oneOffName}
-                      onChange={(e) => setOneOffName(e.target.value)}
+                      onChange={(e) => {
+                        setOneOffName(e.target.value);
+                        dismissFieldError('oneOff.name');
+                      }}
                       placeholder='e.g. "Summer flash sale" or "Aries AI Hackathon"'
-                      aria-invalid={oneOffFieldError('oneOff.name') ? true : undefined}
-                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                      aria-invalid={fieldErrorFor('oneOff.name') ? true : undefined}
+                      aria-describedby={fieldErrorFor('oneOff.name') ? 'one-off-name-error' : undefined}
+                      className={inputClassName(!!fieldErrorFor('oneOff.name'))}
                     />
-                    {oneOffFieldError('oneOff.name') ? (
-                      <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.name')}</p>
+                    {fieldErrorFor('oneOff.name') ? (
+                      <p id="one-off-name-error" className="mt-2 text-sm text-red-300">{fieldErrorFor('oneOff.name')}</p>
                     ) : null}
                   </Field>
                   <Field label="Post end date" required>
-                    <MonthDayPicker
-                      value={campaignEndDate}
-                      onChange={setCampaignEndDate}
-                      ariaLabel="Post end date"
-                      invalid={!!oneOffFieldError('oneOff.campaignEndDate')}
-                    />
+                    <div
+                      data-field-invalid={fieldErrorFor('oneOff.campaignEndDate') ? 'true' : undefined}
+                      tabIndex={-1}
+                    >
+                      <MonthDayPicker
+                        value={campaignEndDate}
+                        onChange={(next) => {
+                          setCampaignEndDate(next);
+                          dismissFieldError('oneOff.campaignEndDate');
+                        }}
+                        ariaLabel="Post end date"
+                        invalid={!!fieldErrorFor('oneOff.campaignEndDate')}
+                      />
+                    </div>
                     <p className="mt-2 text-xs text-white/70">Aries stops publishing past end-of-day in your timezone.</p>
-                    {oneOffFieldError('oneOff.campaignEndDate') ? (
-                      <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.campaignEndDate')}</p>
+                    {fieldErrorFor('oneOff.campaignEndDate') ? (
+                      <p id="one-off-end-date-error" className="mt-2 text-sm text-red-300">{fieldErrorFor('oneOff.campaignEndDate')}</p>
                     ) : null}
                   </Field>
                   <Field label="Call to action" required>
                     <input
                       value={oneOffCta}
-                      onChange={(e) => setOneOffCta(e.target.value)}
+                      onChange={(e) => {
+                        setOneOffCta(e.target.value);
+                        dismissFieldError('oneOff.cta');
+                      }}
                       placeholder='e.g. "Shop the sale" or "Register at example.com/event"'
-                      aria-invalid={oneOffFieldError('oneOff.cta') ? true : undefined}
-                      className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                      aria-invalid={fieldErrorFor('oneOff.cta') ? true : undefined}
+                      aria-describedby={fieldErrorFor('oneOff.cta') ? 'one-off-cta-error' : undefined}
+                      className={inputClassName(!!fieldErrorFor('oneOff.cta'))}
                     />
-                    {oneOffFieldError('oneOff.cta') ? (
-                      <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.cta')}</p>
+                    {fieldErrorFor('oneOff.cta') ? (
+                      <p id="one-off-cta-error" className="mt-2 text-sm text-red-300">{fieldErrorFor('oneOff.cta')}</p>
                     ) : null}
                   </Field>
 
@@ -499,24 +621,36 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                       <Field label="Milestone label">
                         <input
                           value={milestoneLabel}
-                          onChange={(e) => setMilestoneLabel(e.target.value)}
+                          onChange={(e) => {
+                            setMilestoneLabel(e.target.value);
+                            dismissFieldError('oneOff.milestoneLabel');
+                          }}
                           placeholder='e.g. "Sale ends"'
-                          aria-invalid={oneOffFieldError('oneOff.milestoneLabel') ? true : undefined}
-                          className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                          aria-invalid={fieldErrorFor('oneOff.milestoneLabel') ? true : undefined}
+                          aria-describedby={fieldErrorFor('oneOff.milestoneLabel') ? 'one-off-milestone-label-error' : undefined}
+                          className={inputClassName(!!fieldErrorFor('oneOff.milestoneLabel'))}
                         />
-                        {oneOffFieldError('oneOff.milestoneLabel') ? (
-                          <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.milestoneLabel')}</p>
+                        {fieldErrorFor('oneOff.milestoneLabel') ? (
+                          <p id="one-off-milestone-label-error" className="mt-2 text-sm text-red-300">{fieldErrorFor('oneOff.milestoneLabel')}</p>
                         ) : null}
                       </Field>
                       <Field label="Milestone date">
-                        <MonthDayPicker
-                          value={milestoneDate}
-                          onChange={setMilestoneDate}
-                          ariaLabel="Milestone date"
-                          invalid={!!oneOffFieldError('oneOff.milestoneDate')}
-                        />
-                        {oneOffFieldError('oneOff.milestoneDate') ? (
-                          <p className="mt-2 text-sm text-red-300">{oneOffFieldError('oneOff.milestoneDate')}</p>
+                        <div
+                          data-field-invalid={fieldErrorFor('oneOff.milestoneDate') ? 'true' : undefined}
+                          tabIndex={-1}
+                        >
+                          <MonthDayPicker
+                            value={milestoneDate}
+                            onChange={(next) => {
+                              setMilestoneDate(next);
+                              dismissFieldError('oneOff.milestoneDate');
+                            }}
+                            ariaLabel="Milestone date"
+                            invalid={!!fieldErrorFor('oneOff.milestoneDate')}
+                          />
+                        </div>
+                        {fieldErrorFor('oneOff.milestoneDate') ? (
+                          <p id="one-off-milestone-date-error" className="mt-2 text-sm text-red-300">{fieldErrorFor('oneOff.milestoneDate')}</p>
                         ) : null}
                       </Field>
                     </div>

--- a/frontend/marketing/new-job.tsx
+++ b/frontend/marketing/new-job.tsx
@@ -578,6 +578,9 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                   </Field>
                   <Field label="Post end date" required>
                     <div
+                      role="group"
+                      aria-label="Post end date"
+                      aria-describedby={fieldErrorFor('oneOff.campaignEndDate') ? 'one-off-end-date-error' : undefined}
                       data-field-invalid={fieldErrorFor('oneOff.campaignEndDate') ? 'true' : undefined}
                       tabIndex={-1}
                     >
@@ -636,6 +639,9 @@ export function MarketingNewJobScreenContent(props: MarketingNewJobScreenContent
                       </Field>
                       <Field label="Milestone date">
                         <div
+                          role="group"
+                          aria-label="Milestone date"
+                          aria-describedby={fieldErrorFor('oneOff.milestoneDate') ? 'one-off-milestone-date-error' : undefined}
                           data-field-invalid={fieldErrorFor('oneOff.milestoneDate') ? 'true' : undefined}
                           tabIndex={-1}
                         >

--- a/frontend/social-content/new-job.tsx
+++ b/frontend/social-content/new-job.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState, type FormEvent } from "react";
+import React, { useEffect, useRef, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 
 import { isValidWebsiteUrl } from "@/lib/api/marketing";
+import { humanizeMarketingCreateMessage } from "@/lib/marketing-create-errors";
 import { normalizeWebsiteUrlInput } from "@/frontend/marketing/new-job";
 
 const DEFAULT_FORBIDDEN_VISUAL_PATTERNS = [
@@ -20,11 +21,42 @@ const DEFAULT_FORBIDDEN_VISUAL_PATTERNS = [
 
 const DEFAULT_PLATFORMS = ["meta", "instagram"] as const;
 
+/**
+ * Field-error keys this form renders inline (red box + one-line message under
+ * the input). A server fieldError for any other key falls back to the
+ * top-level alert so it is never silently dropped (AA-131).
+ */
+const RENDERED_FIELD_KEYS = new Set(["websiteUrl", "businessType", "weeklyGoal", "competitorUrl"]);
+
+const INPUT_BASE_CLASSNAME =
+  "w-full rounded-2xl border px-4 py-3 text-white placeholder:text-white/30 focus:outline-none";
+
+/** Red box treatment for an input that needs the operator's attention. */
+function inputClassName(hasError: boolean): string {
+  return hasError
+    ? `${INPUT_BASE_CLASSNAME} border-red-500/60 bg-red-500/10 focus:border-red-400`
+    : `${INPUT_BASE_CLASSNAME} border-white/10 bg-white/5 focus:border-primary/50`;
+}
+
 function splitLines(value: string): string[] {
   return value
     .split("\n")
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function readServerFieldErrors(body: unknown): Record<string, string> {
+  const fieldErrors = (body as { fieldErrors?: unknown })?.fieldErrors;
+  if (!fieldErrors || typeof fieldErrors !== "object" || Array.isArray(fieldErrors)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(fieldErrors as Record<string, unknown>)) {
+    if (typeof value === "string" && value.trim()) {
+      out[key] = value;
+    }
+  }
+  return out;
 }
 
 type SocialContentCreateResponse = {
@@ -81,6 +113,42 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
 
   const [submitting, setSubmitting] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
+  // Per-field errors (client validation or server fieldErrors) rendered as a
+  // red box + one-line message under the input that needs attention (AA-131).
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  // Bumped per submit attempt so the scroll-to-first-error effect re-runs even
+  // when the same field fails twice in a row.
+  const [submitAttempt, setSubmitAttempt] = useState(0);
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  // Scroll+focus the first errored field at most ONCE per submit attempt —
+  // when its errors first appear (synchronously for client validation, after
+  // the response for server fieldErrors). Without the attempt guard,
+  // dismiss-on-edit would shrink fieldErrorCount and re-fire this effect,
+  // stealing focus to the next errored field while the operator is typing.
+  const fieldErrorCount = Object.keys(fieldErrors).length;
+  const lastScrolledAttempt = useRef(0);
+  useEffect(() => {
+    if (fieldErrorCount === 0 || lastScrolledAttempt.current === submitAttempt) {
+      return;
+    }
+    const firstInvalid = formRef.current?.querySelector<HTMLElement>('[aria-invalid="true"]');
+    if (!firstInvalid) {
+      return;
+    }
+    lastScrolledAttempt.current = submitAttempt;
+    firstInvalid.scrollIntoView({ behavior: "smooth", block: "center" });
+    firstInvalid.focus({ preventScroll: true });
+  }, [submitAttempt, fieldErrorCount]);
+
+  const dismissFieldError = (key: string) => {
+    setFieldErrors((current) => {
+      if (!(key in current)) return current;
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+  };
 
   const wrapperClassName = props.embedded
     ? "space-y-6"
@@ -99,22 +167,25 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setErrorText(null);
+    setSubmitAttempt((current) => current + 1);
 
+    // Aggregate every failing field so each missing input gets its own inline
+    // red box + one-line message instead of one top-level alert at a time.
+    const errors: Record<string, string> = {};
     const normalizedWebsiteUrl = normalizeWebsiteUrlInput(websiteUrl);
     if (!normalizedWebsiteUrl) {
-      setErrorText("Website URL is required.");
-      return;
-    }
-    if (!isValidWebsiteUrl(normalizedWebsiteUrl)) {
-      setErrorText("Website URL must look like https://example.com");
-      return;
+      errors.websiteUrl = "Website URL is required.";
+    } else if (!isValidWebsiteUrl(normalizedWebsiteUrl)) {
+      errors.websiteUrl = "Website URL must look like https://example.com.";
     }
     if (!businessType.trim()) {
-      setErrorText("Business type is required.");
-      return;
+      errors.businessType = "Business type is required.";
     }
     if (!weeklyGoal.trim()) {
-      setErrorText("Weekly goal is required.");
+      errors.weeklyGoal = "Weekly goal is required.";
+    }
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) {
       return;
     }
 
@@ -178,13 +249,27 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
       } catch {}
 
       if (!response.ok) {
-        const message =
-          typeof (body as { message?: unknown })?.message === "string"
-            ? (body as { message: string }).message
-            : typeof (body as { error?: unknown })?.error === "string"
-              ? (body as { error: string }).error
-              : "Failed to create weekly social posts.";
-        throw new Error(message);
+        // Structured fieldErrors from the jobs handler pin the failure to the
+        // exact input (red box + one-line message); the alert only carries
+        // copy for fields this form does not render, or unmapped failures.
+        const serverFieldErrors = readServerFieldErrors(body);
+        const rendered = Object.entries(serverFieldErrors).filter(([key]) => RENDERED_FIELD_KEYS.has(key));
+        const unrendered = Object.entries(serverFieldErrors).filter(([key]) => !RENDERED_FIELD_KEYS.has(key));
+        if (rendered.length > 0) {
+          setFieldErrors(Object.fromEntries(rendered));
+        }
+        if (unrendered.length > 0) {
+          setErrorText([...new Set(unrendered.map(([, copy]) => copy))].join(" "));
+        } else if (rendered.length === 0) {
+          const message =
+            typeof (body as { message?: unknown })?.message === "string"
+              ? (body as { message: string }).message
+              : typeof (body as { error?: unknown })?.error === "string"
+                ? (body as { error: string }).error
+                : "Failed to create weekly social posts.";
+          setErrorText(humanizeMarketingCreateMessage(message));
+        }
+        return;
       }
 
       const data = body as SocialContentCreateResponse | null;
@@ -213,16 +298,24 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
         </div>
 
         <div className="glass rounded-[2.5rem] p-8">
-          <form onSubmit={onSubmit} className="space-y-8">
+          <form ref={formRef} onSubmit={onSubmit} className="space-y-8">
             <Section title="Brand">
               <Field label="Website URL" required>
                 <input
                   value={websiteUrl}
-                  onChange={(event) => setWebsiteUrl(event.target.value)}
+                  onChange={(event) => {
+                    setWebsiteUrl(event.target.value);
+                    dismissFieldError("websiteUrl");
+                  }}
                   onBlur={() => setWebsiteUrl(normalizeWebsiteUrlInput(websiteUrl))}
                   placeholder="https://yourbusiness.com"
-                  className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                  aria-invalid={fieldErrors.websiteUrl ? true : undefined}
+                  aria-describedby={fieldErrors.websiteUrl ? "website-url-error" : undefined}
+                  className={inputClassName(!!fieldErrors.websiteUrl)}
                 />
+                {fieldErrors.websiteUrl ? (
+                  <p id="website-url-error" className="mt-2 text-sm text-red-300">{fieldErrors.websiteUrl}</p>
+                ) : null}
               </Field>
               <Field label="Business name">
                 <input
@@ -235,10 +328,18 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
               <Field label="Business type" required>
                 <input
                   value={businessType}
-                  onChange={(event) => setBusinessType(event.target.value)}
+                  onChange={(event) => {
+                    setBusinessType(event.target.value);
+                    dismissFieldError("businessType");
+                  }}
                   placeholder="Fitness studio, SaaS, local service..."
-                  className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                  aria-invalid={fieldErrors.businessType ? true : undefined}
+                  aria-describedby={fieldErrors.businessType ? "business-type-error" : undefined}
+                  className={inputClassName(!!fieldErrors.businessType)}
                 />
+                {fieldErrors.businessType ? (
+                  <p id="business-type-error" className="mt-2 text-sm text-red-300">{fieldErrors.businessType}</p>
+                ) : null}
               </Field>
             </Section>
 
@@ -246,11 +347,19 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
               <Field label="What should this week’s posts help with?" required>
                 <textarea
                   value={weeklyGoal}
-                  onChange={(event) => setWeeklyGoal(event.target.value)}
+                  onChange={(event) => {
+                    setWeeklyGoal(event.target.value);
+                    dismissFieldError("weeklyGoal");
+                  }}
                   rows={3}
                   placeholder="Get more consultation calls, promote a launch, book demos..."
-                  className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                  aria-invalid={fieldErrors.weeklyGoal ? true : undefined}
+                  aria-describedby={fieldErrors.weeklyGoal ? "weekly-goal-error" : undefined}
+                  className={inputClassName(!!fieldErrors.weeklyGoal)}
                 />
+                {fieldErrors.weeklyGoal ? (
+                  <p id="weekly-goal-error" className="mt-2 text-sm text-red-300">{fieldErrors.weeklyGoal}</p>
+                ) : null}
               </Field>
               <Field label="Offer or CTA">
                 <input
@@ -312,10 +421,18 @@ export function SocialContentNewJobScreenContent(props: SocialContentNewJobScree
               <Field label="Competitor URL">
                 <input
                   value={competitorUrl}
-                  onChange={(event) => setCompetitorUrl(event.target.value)}
+                  onChange={(event) => {
+                    setCompetitorUrl(event.target.value);
+                    dismissFieldError("competitorUrl");
+                  }}
                   placeholder="https://competitor.com"
-                  className="w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/30 focus:outline-none focus:border-primary/50"
+                  aria-invalid={fieldErrors.competitorUrl ? true : undefined}
+                  aria-describedby={fieldErrors.competitorUrl ? "competitor-url-error" : undefined}
+                  className={inputClassName(!!fieldErrors.competitorUrl)}
                 />
+                {fieldErrors.competitorUrl ? (
+                  <p id="competitor-url-error" className="mt-2 text-sm text-red-300">{fieldErrors.competitorUrl}</p>
+                ) : null}
               </Field>
               <Field label="Facebook page URL">
                 <input

--- a/hooks/use-marketing-job-create.ts
+++ b/hooks/use-marketing-job-create.ts
@@ -20,11 +20,13 @@ export function useMarketingJobCreate(options: UseMarketingJobCreateOptions = {}
   const api = useMemo(() => createMarketingApi(options), [options.baseUrl]);
   const state = useAsyncAction<MarketingResult<StartJobAccepted>>();
 
-  // Prefer structured field errors from a 422 response body over the generic
-  // top-level error message. Both the thrown ApiRequestError (via state.error.details)
-  // and an inline MarketingApiError result carry the same shape.
+  // Prefer structured field errors from a 4xx response body over the generic
+  // top-level error message (422 for brand-kit/one-off validation, 400 for
+  // missing_required_fields). Both the thrown ApiRequestError (via
+  // state.error.details) and an inline MarketingApiError result carry the
+  // same shape.
   const fieldErrors = useMemo<Record<string, string>>(() => {
-    if (state.error?.status === 422) {
+    if (state.error && state.error.status >= 400 && state.error.status < 500) {
       const parsed = parseMarketingFieldErrors(state.error.details);
       if (Object.keys(parsed).length > 0) return parsed;
     }

--- a/lib/marketing-create-errors.ts
+++ b/lib/marketing-create-errors.ts
@@ -1,0 +1,151 @@
+/**
+ * Frontend-safe mapping for marketing job-create failures (AA-131).
+ *
+ * startSocialContentJob surfaces operator-actionable failures as coded Error
+ * messages (`brand_kit_fetch_failed:<inner>`, `missing_required_fields:<list>`,
+ * `needs_brand_kit:<inner>`). Before this module the jobs handler echoed those
+ * raw codes to the browser and the create form printed them verbatim — the
+ * operator saw `brand_kit_fetch_failed:fetch failed` with no hint which input
+ * to fix. Each mapping below pins the failure to the form field that needs
+ * attention (fieldErrors keyed by the form's field names) plus a one-line
+ * sentence the operator can act on.
+ *
+ * The inner detail after the first colon (an undici cause, a DNS error, a
+ * stack fragment) is deliberately collapsed out of the response body — same
+ * rationale as classifyClientError in app/api/business/profile/route.ts
+ * (CodeQL js/stack-trace-exposure). Callers keep the raw message server-side
+ * in logs.
+ *
+ * Lives in lib/ (not backend/ or app/api/) because both the route handler and
+ * the browser form import it: the handler to build the response, the form to
+ * humanize legacy/raw codes that reach it from older response shapes.
+ */
+
+export interface MarketingCreateFailureMapping {
+  status: number;
+  /** Stable machine-readable code (no dynamic inner detail). */
+  error: string;
+  /** One-line operator-actionable sentence. */
+  message: string;
+  /** Per-field copy keyed by the create form's field names. */
+  fieldErrors?: Record<string, string>;
+}
+
+export const WEBSITE_URL_REQUIRED_COPY = 'Website URL is required.';
+export const WEBSITE_UNREACHABLE_COPY =
+  "We couldn't reach this website. Check the address is correct and the site is online, then try again.";
+export const WEBSITE_LOW_SIGNAL_COPY =
+  "We couldn't find enough brand detail (logo, colors, copy) at this address. Point Aries at your main marketing site.";
+export const WEBSITE_BRAND_KIT_GENERIC_COPY =
+  "We couldn't build a brand kit from this website. Double-check the address and try again.";
+export const BUSINESS_TYPE_MISSING_COPY =
+  'Your business type is missing. Add it in Settings → Business profile, then try again.';
+
+/**
+ * missing_required_fields:<list> entries → the form field that carries the
+ * inline error. Both the payload.* spelling (thrown by the orchestrator) and
+ * the bare spelling (thrown by older validators) are accepted.
+ */
+const MISSING_FIELD_MAPPINGS: Record<string, { field: string; copy: string }> = {
+  'payload.brandUrl': { field: 'websiteUrl', copy: WEBSITE_URL_REQUIRED_COPY },
+  brandUrl: { field: 'websiteUrl', copy: WEBSITE_URL_REQUIRED_COPY },
+  websiteUrl: { field: 'websiteUrl', copy: WEBSITE_URL_REQUIRED_COPY },
+  'payload.businessType': { field: 'businessType', copy: BUSINESS_TYPE_MISSING_COPY },
+  businessType: { field: 'businessType', copy: BUSINESS_TYPE_MISSING_COPY },
+};
+
+/**
+ * Map a job-create failure message to a frontend-safe response shape, or null
+ * when the message is not a known operator-actionable failure (the caller
+ * falls through to its existing handling).
+ */
+export function mapMarketingCreateFailure(rawMessage: string): MarketingCreateFailureMapping | null {
+  if (typeof rawMessage !== 'string' || rawMessage.length === 0) {
+    return null;
+  }
+
+  // The weekly brand-kit refresh path wraps the same failures as
+  // needs_brand_kit:<inner>; classify the inner message.
+  const message = rawMessage.startsWith('needs_brand_kit:')
+    ? rawMessage.slice('needs_brand_kit:'.length)
+    : rawMessage;
+
+  if (message === 'brand_url_missing') {
+    return {
+      status: 422,
+      error: 'missing_required_fields:websiteUrl',
+      message: WEBSITE_URL_REQUIRED_COPY,
+      fieldErrors: { websiteUrl: WEBSITE_URL_REQUIRED_COPY },
+    };
+  }
+
+  if (message.startsWith('brand_kit_fetch_failed')) {
+    return {
+      status: 422,
+      error: 'brand_kit_fetch_failed',
+      message: WEBSITE_UNREACHABLE_COPY,
+      fieldErrors: { websiteUrl: WEBSITE_UNREACHABLE_COPY },
+    };
+  }
+
+  if (message.startsWith('brand_kit_insufficient_source_data')) {
+    return {
+      status: 422,
+      error: 'brand_kit_insufficient_source_data',
+      message: WEBSITE_LOW_SIGNAL_COPY,
+      fieldErrors: { websiteUrl: WEBSITE_LOW_SIGNAL_COPY },
+    };
+  }
+
+  if (message.startsWith('brand_kit_') || message.startsWith('invalid_tenant_brand_kit')) {
+    return {
+      status: 422,
+      error: 'brand_kit_error',
+      message: WEBSITE_BRAND_KIT_GENERIC_COPY,
+      fieldErrors: { websiteUrl: WEBSITE_BRAND_KIT_GENERIC_COPY },
+    };
+  }
+
+  if (message.startsWith('missing_required_fields:')) {
+    const fields = message
+      .slice('missing_required_fields:'.length)
+      .split(',')
+      .map((field) => field.trim())
+      .filter(Boolean);
+    const fieldErrors: Record<string, string> = {};
+    const unmappedFields: string[] = [];
+    for (const field of fields) {
+      const known = MISSING_FIELD_MAPPINGS[field];
+      if (known) {
+        fieldErrors[known.field] = known.copy;
+      } else {
+        unmappedFields.push(field);
+      }
+    }
+
+    const sentences = [...new Set(Object.values(fieldErrors))];
+    if (unmappedFields.length > 0) {
+      sentences.push(`Required information is missing: ${unmappedFields.join(', ')}.`);
+    }
+
+    return {
+      status: 400,
+      // The field list is server-derived (never echoes operator input), so the
+      // raw code stays useful for API consumers and log correlation.
+      error: message,
+      message: sentences.join(' ') || 'Required information is missing.',
+      ...(Object.keys(fieldErrors).length > 0 ? { fieldErrors } : {}),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Best-effort humanizer for the create form: returns the mapped one-line
+ * sentence for a known failure code, or the input unchanged. Used as a
+ * fallback for error strings that arrive without the structured shape.
+ */
+export function humanizeMarketingCreateMessage(raw: string): string {
+  return mapMarketingCreateFailure(raw)?.message ?? raw;
+}

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -216,6 +216,8 @@ const steps = [
       'tests/integrations-openai-safety.test.ts',
       'tests/social-content-new-job-screen.test.ts',
       'tests/marketing-job-route.smoke.test.ts',
+      'tests/marketing-create-error-mapping.test.ts',
+      'tests/marketing-new-job-field-errors.test.ts',
       'tests/runtime-pages.test.ts',
       'tests/docs-social-content-guidance.test.ts',
       'tests/social-content-public-copy.test.ts',

--- a/tests/marketing-create-error-mapping.test.ts
+++ b/tests/marketing-create-error-mapping.test.ts
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  BUSINESS_TYPE_MISSING_COPY,
+  WEBSITE_UNREACHABLE_COPY,
+  WEBSITE_URL_REQUIRED_COPY,
+  humanizeMarketingCreateMessage,
+  mapMarketingCreateFailure,
+} from '../lib/marketing-create-errors';
+import { COMPETITOR_URL_SOCIAL_ERROR } from '../lib/marketing-competitor';
+import { submitGenerateThisWeek } from '../frontend/aries-v1/generate-this-week';
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+
+// AA-131: a create-post submission that failed on brand-kit extraction
+// surfaced the raw `brand_kit_fetch_failed:fetch failed` code in the form's
+// top-level alert, with no hint which input to fix. The mapping pins each
+// operator-actionable failure to the create form's field names and collapses
+// the inner error detail out of the response body.
+
+test('mapMarketingCreateFailure collapses brand_kit_fetch_failed inner detail and pins websiteUrl', () => {
+  const mapped = mapMarketingCreateFailure('brand_kit_fetch_failed:fetch failed');
+  assert.ok(mapped);
+  assert.equal(mapped.status, 422);
+  assert.equal(mapped.error, 'brand_kit_fetch_failed');
+  assert.equal(mapped.fieldErrors?.websiteUrl, WEBSITE_UNREACHABLE_COPY);
+  // The undici cause must never reach the response body.
+  assert.ok(!JSON.stringify(mapped).includes('fetch failed'));
+});
+
+test('mapMarketingCreateFailure unwraps the needs_brand_kit weekly-refresh prefix', () => {
+  const mapped = mapMarketingCreateFailure('needs_brand_kit:brand_kit_fetch_failed:getaddrinfo ENOTFOUND example.test');
+  assert.ok(mapped);
+  assert.equal(mapped.status, 422);
+  assert.equal(mapped.error, 'brand_kit_fetch_failed');
+  assert.equal(mapped.fieldErrors?.websiteUrl, WEBSITE_UNREACHABLE_COPY);
+  assert.ok(!JSON.stringify(mapped).includes('ENOTFOUND'));
+});
+
+test('mapMarketingCreateFailure maps brand_url_missing to a required websiteUrl field error', () => {
+  const mapped = mapMarketingCreateFailure('needs_brand_kit:brand_url_missing');
+  assert.ok(mapped);
+  assert.equal(mapped.status, 422);
+  assert.equal(mapped.fieldErrors?.websiteUrl, WEBSITE_URL_REQUIRED_COPY);
+});
+
+test('mapMarketingCreateFailure maps missing_required_fields entries to form field errors', () => {
+  const mapped = mapMarketingCreateFailure('missing_required_fields:payload.brandUrl,payload.businessType');
+  assert.ok(mapped);
+  assert.equal(mapped.status, 400);
+  assert.equal(mapped.error, 'missing_required_fields:payload.brandUrl,payload.businessType');
+  assert.equal(mapped.fieldErrors?.websiteUrl, WEBSITE_URL_REQUIRED_COPY);
+  assert.equal(mapped.fieldErrors?.businessType, BUSINESS_TYPE_MISSING_COPY);
+  assert.ok(mapped.message.includes(WEBSITE_URL_REQUIRED_COPY));
+  assert.ok(mapped.message.includes(BUSINESS_TYPE_MISSING_COPY));
+});
+
+test('mapMarketingCreateFailure surfaces unmapped missing fields in the message', () => {
+  const mapped = mapMarketingCreateFailure('missing_required_fields:tenantId');
+  assert.ok(mapped);
+  assert.equal(mapped.status, 400);
+  assert.equal(mapped.fieldErrors, undefined);
+  assert.ok(mapped.message.includes('tenantId'));
+});
+
+test('mapMarketingCreateFailure returns null for unknown failures', () => {
+  assert.equal(mapMarketingCreateFailure('some_totally_unknown_error'), null);
+  assert.equal(mapMarketingCreateFailure(''), null);
+});
+
+test('humanizeMarketingCreateMessage falls back to the input for unknown codes', () => {
+  assert.equal(humanizeMarketingCreateMessage('brand_kit_fetch_failed:fetch failed'), WEBSITE_UNREACHABLE_COPY);
+  assert.equal(humanizeMarketingCreateMessage('anything else'), 'anything else');
+});
+
+// Handler-level regression: the POST /api/marketing/jobs response for a
+// brand-kit fetch failure must carry structured fieldErrors and must NOT echo
+// the raw inner error. Uses a private-IP brand URL so ssrfSafeFetch rejects
+// deterministically with no network dependency (any fetch/DNS failure takes
+// the same brand_kit_fetch_failed wrap).
+async function withHandlerRuntimeEnv<T>(run: (dataRoot: string) => Promise<T>): Promise<T> {
+  const previousCodeRoot = process.env.CODE_ROOT;
+  const previousDataRoot = process.env.DATA_ROOT;
+  const dataRoot = await mkdtemp(path.join(tmpdir(), 'aries-create-error-'));
+  process.env.CODE_ROOT = PROJECT_ROOT;
+  process.env.DATA_ROOT = dataRoot;
+  try {
+    return await run(dataRoot);
+  } finally {
+    if (previousCodeRoot === undefined) delete process.env.CODE_ROOT;
+    else process.env.CODE_ROOT = previousCodeRoot;
+    if (previousDataRoot === undefined) delete process.env.DATA_ROOT;
+    else process.env.DATA_ROOT = previousDataRoot;
+    await rm(dataRoot, { recursive: true, force: true });
+  }
+}
+
+function tenantLoaderStub(tenantId: string) {
+  return async () => ({
+    userId: `user-${tenantId}`,
+    tenantId,
+    tenantSlug: tenantId.replace(/_/g, '-'),
+    role: 'tenant_admin' as const,
+  });
+}
+
+test('POST /api/marketing/jobs returns 422 + websiteUrl fieldError when the brand-kit fetch fails', async () => {
+  await withHandlerRuntimeEnv(async () => {
+    const { handlePostMarketingJobs } = await import('../app/api/marketing/jobs/handler');
+    const response = await handlePostMarketingJobs(
+      new Request('http://aries.example.test/api/marketing/jobs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jobType: 'weekly_social_content',
+          payload: {
+            brandUrl: 'https://127.0.0.1/',
+            businessType: 'Test vertical',
+          },
+        }),
+      }),
+      tenantLoaderStub('tenant_create_error_fetch'),
+    );
+
+    assert.equal(response.status, 422);
+    const body = (await response.json()) as Record<string, unknown>;
+    assert.equal(body.error, 'brand_kit_fetch_failed');
+    assert.equal(typeof body.message, 'string');
+    const fieldErrors = body.fieldErrors as Record<string, string>;
+    assert.equal(fieldErrors.websiteUrl, WEBSITE_UNREACHABLE_COPY);
+    // No inner fetch/DNS/SSRF detail may leak into the response body.
+    const serialized = JSON.stringify(body);
+    assert.ok(!serialized.includes('ssrf_blocked'));
+    assert.ok(!serialized.includes('fetch failed'));
+    assert.ok(!serialized.includes('127.0.0.1'));
+  });
+});
+
+test('POST /api/marketing/jobs returns 400 + competitorUrl fieldError for a social competitor URL', async () => {
+  await withHandlerRuntimeEnv(async () => {
+    const { handlePostMarketingJobs } = await import('../app/api/marketing/jobs/handler');
+    const response = await handlePostMarketingJobs(
+      new Request('http://aries.example.test/api/marketing/jobs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jobType: 'weekly_social_content',
+          payload: {
+            brandUrl: 'https://brand.example/',
+            businessType: 'Test vertical',
+            competitorUrl: 'https://www.facebook.com/somecompetitor',
+          },
+        }),
+      }),
+      tenantLoaderStub('tenant_create_error_competitor'),
+    );
+
+    assert.equal(response.status, 400);
+    const body = (await response.json()) as Record<string, unknown>;
+    assert.equal(body.error, COMPETITOR_URL_SOCIAL_ERROR);
+    const fieldErrors = body.fieldErrors as Record<string, string>;
+    assert.equal(fieldErrors.competitorUrl, COMPETITOR_URL_SOCIAL_ERROR);
+  });
+});
+
+test('submitGenerateThisWeek prefers the operator-facing message over the machine error code', async () => {
+  const fetchStub = (async () =>
+    new Response(
+      JSON.stringify({
+        error: 'brand_kit_fetch_failed',
+        message: WEBSITE_UNREACHABLE_COPY,
+        fieldErrors: { websiteUrl: WEBSITE_UNREACHABLE_COPY },
+      }),
+      { status: 422, headers: { 'content-type': 'application/json' } },
+    )) as typeof fetch;
+
+  const result = await submitGenerateThisWeek(fetchStub);
+  assert.equal(result.ok, false);
+  assert.equal(result.errorMessage, WEBSITE_UNREACHABLE_COPY);
+});
+
+test('POST /api/marketing/jobs returns 400 + businessType fieldError when the profile has no business type', async () => {
+  await withHandlerRuntimeEnv(async () => {
+    const { handlePostMarketingJobs } = await import('../app/api/marketing/jobs/handler');
+    const response = await handlePostMarketingJobs(
+      new Request('http://aries.example.test/api/marketing/jobs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          jobType: 'weekly_social_content',
+          payload: {
+            brandUrl: 'https://brand.example/',
+          },
+        }),
+      }),
+      tenantLoaderStub('tenant_create_error_biztype'),
+    );
+
+    assert.equal(response.status, 400);
+    const body = (await response.json()) as Record<string, unknown>;
+    assert.equal(body.error, 'missing_required_fields:payload.businessType');
+    const fieldErrors = body.fieldErrors as Record<string, string>;
+    assert.equal(fieldErrors.businessType, BUSINESS_TYPE_MISSING_COPY);
+  });
+});

--- a/tests/marketing-new-job-field-errors.test.ts
+++ b/tests/marketing-new-job-field-errors.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import React from "react";
+
+import { MarketingNewJobScreenContent } from "../frontend/marketing/new-job";
+import { BUSINESS_TYPE_MISSING_COPY, WEBSITE_UNREACHABLE_COPY } from "../lib/marketing-create-errors";
+
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// AA-131 regression: a create failure must highlight the exact field that
+// needs attention (inline red box + one-line message) instead of dumping a
+// raw error code into the bottom alert.
+
+test("marketing new-job form renders inline field errors for missing one-off inputs", async () => {
+  const previousFetch = globalThis.fetch;
+  const pushCalls: string[] = [];
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ jobId: "job_ignored" }), {
+      status: 202,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+  try {
+    const { act, create } = await import("react-test-renderer");
+    let root!: import("react-test-renderer").ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(MarketingNewJobScreenContent, {
+          embedded: true,
+          router: {
+            push(href: string) {
+              pushCalls.push(href);
+            },
+          },
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    // Switch to one-off mode (submit is not disabled there) and submit the
+    // empty form: every missing required field reports at once. The one-off
+    // toggle is the initially-unchecked radio in the Content type group.
+    const oneOffToggle = root.root
+      .findAll((node) => node.type === "button" && node.props.role === "radio")
+      .find((node) => node.props["aria-checked"] === false);
+    assert.ok(oneOffToggle);
+    await act(async () => {
+      oneOffToggle.props.onClick();
+      await flushMicrotasks();
+    });
+
+    const form = root.root.findByType("form");
+    await act(async () => {
+      await form.props.onSubmit({ preventDefault() {} });
+      await flushMicrotasks();
+    });
+
+    const rendered = JSON.stringify(root.toJSON());
+    assert.match(rendered, /Website URL is required\./);
+    assert.match(rendered, /Name is required\./);
+    assert.match(rendered, /End date is required\./);
+    assert.match(rendered, /CTA is required\./);
+    assert.deepEqual(pushCalls, []);
+
+    // Editing the field dismisses its error until the next submit.
+    const websiteInput = root.root.findByProps({ placeholder: "https://yourbrand.com" });
+    await act(async () => {
+      websiteInput.props.onChange({ target: { value: "https://example.com" } });
+      await flushMicrotasks();
+    });
+    assert.doesNotMatch(JSON.stringify(root.toJSON()), /Website URL is required\./);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("marketing new-job form renders a server brand-kit failure inline on the website field", async () => {
+  const previousFetch = globalThis.fetch;
+  const pushCalls: string[] = [];
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        error: "brand_kit_fetch_failed",
+        message: WEBSITE_UNREACHABLE_COPY,
+        fieldErrors: { websiteUrl: WEBSITE_UNREACHABLE_COPY },
+      }),
+      { status: 422, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+
+  try {
+    const { act, create } = await import("react-test-renderer");
+    let root!: import("react-test-renderer").ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(MarketingNewJobScreenContent, {
+          embedded: true,
+          router: {
+            push(href: string) {
+              pushCalls.push(href);
+            },
+          },
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    const websiteInput = root.root.findByProps({ placeholder: "https://yourbrand.com" });
+    await act(async () => {
+      websiteInput.props.onChange({ target: { value: "https://unreachable.example" } });
+      await flushMicrotasks();
+    });
+
+    const form = root.root.findByType("form");
+    await act(async () => {
+      await form.props.onSubmit({ preventDefault() {} });
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    const rendered = JSON.stringify(root.toJSON());
+    // The one-line sentence renders inline at the website field...
+    assert.match(rendered, new RegExp(WEBSITE_UNREACHABLE_COPY.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    // ...and the raw machine code never reaches the operator.
+    assert.doesNotMatch(rendered, /brand_kit_fetch_failed/);
+    assert.deepEqual(pushCalls, []);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("marketing new-job form surfaces a fieldError for an unrendered field in the top alert", async () => {
+  // businessType has no input on this form — its server fieldError must fall
+  // back to the alert instead of being silently dropped.
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        error: "missing_required_fields:payload.businessType",
+        message: BUSINESS_TYPE_MISSING_COPY,
+        fieldErrors: { businessType: BUSINESS_TYPE_MISSING_COPY },
+      }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+
+  try {
+    const { act, create } = await import("react-test-renderer");
+    let root!: import("react-test-renderer").ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(MarketingNewJobScreenContent, {
+          embedded: true,
+          router: { push() {} },
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    const websiteInput = root.root.findByProps({ placeholder: "https://yourbrand.com" });
+    await act(async () => {
+      websiteInput.props.onChange({ target: { value: "https://example.com" } });
+      await flushMicrotasks();
+    });
+
+    const form = root.root.findByType("form");
+    await act(async () => {
+      await form.props.onSubmit({ preventDefault() {} });
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    const rendered = JSON.stringify(root.toJSON());
+    assert.match(rendered, new RegExp(BUSINESS_TYPE_MISSING_COPY.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.doesNotMatch(rendered, /missing_required_fields/);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("marketing new-job form still shows a server field error dismissed mid-flight", async () => {
+  // Editing a field while the request is in flight adds it to dismissedFields;
+  // the arriving server failure must clear dismissals so its red box renders —
+  // otherwise the submit fails with zero visible feedback.
+  const previousFetch = globalThis.fetch;
+  let resolveResponse!: (response: Response) => void;
+  globalThis.fetch = (async () =>
+    new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    })) as typeof fetch;
+  // The submit-progress effect calls window.setInterval while the request is
+  // in flight; give the node test env a minimal window.
+  const previousWindow = (globalThis as Record<string, unknown>).window;
+  (globalThis as Record<string, unknown>).window = {
+    setInterval: setInterval.bind(globalThis),
+    clearInterval: clearInterval.bind(globalThis),
+  };
+
+  try {
+    const { act, create } = await import("react-test-renderer");
+    let root!: import("react-test-renderer").ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(MarketingNewJobScreenContent, {
+          embedded: true,
+          router: { push() {} },
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    const websiteInput = root.root.findByProps({ placeholder: "https://yourbrand.com" });
+    await act(async () => {
+      websiteInput.props.onChange({ target: { value: "https://unreachable.example" } });
+      await flushMicrotasks();
+    });
+
+    const form = root.root.findByType("form");
+    await act(async () => {
+      form.props.onSubmit({ preventDefault() {} });
+      await flushMicrotasks();
+    });
+
+    // Mid-flight edit dismisses the (not-yet-existing) websiteUrl error.
+    await act(async () => {
+      websiteInput.props.onChange({ target: { value: "https://unreachable2.example" } });
+      await flushMicrotasks();
+    });
+
+    await act(async () => {
+      resolveResponse(
+        new Response(
+          JSON.stringify({
+            error: "brand_kit_fetch_failed",
+            message: WEBSITE_UNREACHABLE_COPY,
+            fieldErrors: { websiteUrl: WEBSITE_UNREACHABLE_COPY },
+          }),
+          { status: 422, headers: { "content-type": "application/json" } },
+        ),
+      );
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    const rendered = JSON.stringify(root.toJSON());
+    assert.match(rendered, new RegExp(WEBSITE_UNREACHABLE_COPY.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousWindow === undefined) {
+      delete (globalThis as Record<string, unknown>).window;
+    } else {
+      (globalThis as Record<string, unknown>).window = previousWindow;
+    }
+  }
+});

--- a/tests/social-content-new-job-screen.test.ts
+++ b/tests/social-content-new-job-screen.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import React from "react";
 
 import { SocialContentNewJobScreenContent } from "../frontend/social-content/new-job";
+import { WEBSITE_UNREACHABLE_COPY } from "../lib/marketing-create-errors";
 
 function flushMicrotasks() {
   return new Promise((resolve) => setTimeout(resolve, 0));
@@ -152,6 +153,68 @@ test("social content form submits defaults and navigates to social-content statu
       "extra logos",
     ]);
     assert.equal(pushCalls[0], "/social-content/status?jobId=job_123");
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("social content form renders server fieldErrors inline and hides raw codes (AA-131)", async () => {
+  const previousFetch = globalThis.fetch;
+  const pushCalls: string[] = [];
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        error: "brand_kit_fetch_failed",
+        message: WEBSITE_UNREACHABLE_COPY,
+        fieldErrors: { websiteUrl: WEBSITE_UNREACHABLE_COPY },
+      }),
+      { status: 422, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+
+  try {
+    const { act, create } = await import("react-test-renderer");
+    let root!: import("react-test-renderer").ReactTestRenderer;
+
+    await act(async () => {
+      root = create(
+        React.createElement(SocialContentNewJobScreenContent, {
+          embedded: true,
+          router: {
+            push(href: string) {
+              pushCalls.push(href);
+            },
+          },
+        }),
+      );
+      await flushMicrotasks();
+    });
+
+    const websiteInput = root.root.findByProps({ placeholder: "https://yourbusiness.com" });
+    const businessTypeInput = root.root.findByProps({
+      placeholder: "Fitness studio, SaaS, local service...",
+    });
+    const goalInput = root.root.findByProps({
+      placeholder: "Get more consultation calls, promote a launch, book demos...",
+    });
+    await act(async () => {
+      websiteInput.props.onChange({ target: { value: "https://unreachable.example" } });
+      businessTypeInput.props.onChange({ target: { value: "SaaS" } });
+      goalInput.props.onChange({ target: { value: "Book demos" } });
+      await flushMicrotasks();
+    });
+
+    const form = root.root.findByType("form");
+    await act(async () => {
+      await form.props.onSubmit({ preventDefault() {} });
+      await flushMicrotasks();
+      await flushMicrotasks();
+    });
+
+    const rendered = JSON.stringify(root.toJSON());
+    const copyPattern = new RegExp(WEBSITE_UNREACHABLE_COPY.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    assert.match(rendered, copyPattern);
+    assert.doesNotMatch(rendered, /brand_kit_fetch_failed/);
+    assert.deepEqual(pushCalls, []);
   } finally {
     globalThis.fetch = previousFetch;
   }

--- a/tests/use-marketing-job-create.test.ts
+++ b/tests/use-marketing-job-create.test.ts
@@ -97,6 +97,54 @@ test('useMarketingJobCreate surfaces 422 field errors from FastAPI detail[] body
   }
 });
 
+test('useMarketingJobCreate surfaces fieldErrors from a 400 body (missing_required_fields shape)', async () => {
+  // AA-131: the jobs handler returns missing_required_fields as 400 with
+  // structured fieldErrors. The hook must parse fieldErrors from any 4xx,
+  // not just 422 — reverting the boundary silently reproduces the raw-code
+  // alert for these responses.
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        error: 'missing_required_fields:payload.businessType',
+        message: 'Your business type is missing.',
+        fieldErrors: { businessType: 'Your business type is missing.' },
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } }
+    )) as typeof fetch;
+
+  let captured: ReturnType<typeof useMarketingJobCreate> | null = null;
+
+  function Harness() {
+    captured = useMarketingJobCreate();
+    return React.createElement('div', null, 'harness');
+  }
+
+  try {
+    const { act, create } = await import('react-test-renderer');
+    await act(async () => {
+      create(React.createElement(Harness));
+      await flushMicrotasks();
+    });
+
+    await act(async () => {
+      const fd = new FormData();
+      fd.set('jobType', 'weekly_social_content');
+      fd.set('brandUrl', 'https://example.com');
+      await captured!.createJob(fd);
+      await flushMicrotasks();
+    });
+
+    const result = captured as ReturnType<typeof useMarketingJobCreate> | null;
+    assert.ok(result, 'hook should be captured');
+    assert.equal(result.isError, true);
+    assert.equal(result.error?.status, 400);
+    assert.deepEqual(result.fieldErrors, { businessType: 'Your business type is missing.' });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
 test('useMarketingJobCreate keeps fieldErrors empty for non-422 errors', async () => {
   const previousFetch = globalThis.fetch;
   globalThis.fetch = (async () =>


### PR DESCRIPTION
## Summary

Fixes the customer incident behind Jira **AA-131** ("can't create social media post — `error: brand_kit_fetch_failed:fetch failed` — please fix the forms and provide an actionable error message").

Root cause: `startSocialContentJob` fetches the tenant's website synchronously during job creation to build the brand kit (`extractAndSaveTenantBrandKit` → `extractBrandKitFromWebsite`). When that fetch fails (unreachable site, DNS failure, SSRF-blocked address), the raw coded error propagated through the jobs handler's `brand_kit_` catch straight into the browser, and both create forms printed it verbatim in the bottom alert — no hint which input to fix.

This PR makes every operator-actionable create failure point at the exact form field:

- **New `lib/marketing-create-errors.ts`** — maps `brand_kit_fetch_failed:*`, `brand_kit_insufficient_source_data`, other `brand_kit_*`/`invalid_tenant_brand_kit`, `needs_brand_kit:*`, and `missing_required_fields:*` to structured `{status, error, message, fieldErrors}` responses. The inner fetch/DNS/SSRF detail is collapsed out of the response body (same rationale as `classifyClientError` in the business-profile route) and kept server-side in a log line.
- **`app/api/marketing/jobs/handler.ts`** — returns the structured body; competitor-URL rejections now carry `fieldErrors.competitorUrl` in both branches.
- **`frontend/marketing/new-job.tsx` + `frontend/social-content/new-job.tsx`** — red box + inline one-line message on the failing field (client validation and server fieldErrors), scroll+focus the first errored field once per submit attempt, dismiss-on-edit (a fresh server failure clears dismissals so it can never be hidden), and alert fallback for fields the form doesn't render (e.g. `businessType`) so nothing is silently dropped. `MonthDayPicker`'s invalid style is aligned with the new input treatment.
- **`hooks/use-marketing-job-create.ts`** — parses `fieldErrors` from any 4xx (`missing_required_fields` is a 400).
- **`frontend/aries-v1/generate-this-week.ts`** — the dashboard banner prefers the friendly `message` over the machine `error` code.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Security
- [ ] Refactor
- [x] Tests

## Validation

- [x] npm run typecheck
- [x] npm run lint
- [ ] npm run test
- [x] npm run verify
- [ ] Manual UI check, if applicable (component tests cover both forms' rendered error output; live screenshot pending)

New coverage, wired into `npm run verify`:
- `tests/marketing-create-error-mapping.test.ts` — mapping unit tests plus hermetic handler-level tests (an SSRF-blocked `https://127.0.0.1/` brand URL exercises the real fetch-failure wrap with zero network dependency): 422 + `fieldErrors.websiteUrl` with no inner-detail leak, 400 + `fieldErrors.businessType`, 400 + `fieldErrors.competitorUrl`, and the Generate-this-week message preference.
- `tests/marketing-new-job-field-errors.test.ts` — component tests: aggregated one-off inline errors, server brand-kit failure rendering inline (raw code never shown), unrendered-field fallback to the alert, and the mid-flight dismissal race (edit during flight must not hide the arriving server error).
- `tests/social-content-new-job-screen.test.ts` — server fieldErrors render inline, raw codes hidden.
- `tests/use-marketing-job-create.test.ts` — the 422→any-4xx fieldErrors boundary.

An adversarial multi-agent review of the diff confirmed and I fixed two UX holes before submitting: (1) a server error arriving after a mid-flight field edit could render nowhere (alert suppressed + red box dismissed); (2) `oneOff.*` server errors arriving after a mode toggle counted as "rendered" while unmounted. Both now have regression tests.

## Security-sensitive areas touched

- [ ] Auth/session
- [ ] OAuth
- [ ] Tenant isolation
- [ ] Internal callback routes
- [ ] Publishing
- [ ] Database
- [ ] GitHub Actions/deployment
- [x] None

(Note: the change *removes* an information leak — raw fetch/DNS/SSRF error detail no longer reaches the browser from the jobs handler.)

## Screenshots

Rendered-UI states are asserted by the component tests; a live screenshot pass on the dashboard form is a good follow-up before closing AA-131.

## Secret/data check

- [x] No secrets committed
- [x] No customer data committed
- [x] No production URLs/tokens/cookies exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmUMS2tNY7g1vRqJu7C5gA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmUMS2tNY7g1vRqJu7C5gA)_