### PR TITLE
S3-1/AA-97: honesty pass on synthetic numbers (hoursSaved, Aries Score, whyItWorked + niche benchmark)

### DIFF
--- a/backend/insights/activity/activity-snapshot-builder.ts
+++ b/backend/insights/activity/activity-snapshot-builder.ts
@@ -9,7 +9,8 @@
  *   - commentsReceived — comments received on those posts
  *   - highPerformers   — posts that hit ≥2x the period average reach (same
  *                        baseline logic as the Section 3 opportunity card)
- *   - hoursSaved       — formula: postsPublished × HOURS_PER_POST
+ *   - hoursSaved       — shared estimateHoursSaved(postsPublished): a synthetic
+ *                        estimate (posts × 3h), NOT a measurement; see hours-saved.ts
  *   - platformCount    — distinct platforms for the footer line
  *
  * Content mix:
@@ -22,10 +23,8 @@ import pool from '@/lib/db';
 import { LATEST_POST_METRICS_LATERAL } from '../latest-post-metrics-sql';
 import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
 import { tenantZonePeriodStart } from '@/lib/format-timestamp';
+import { estimateHoursSaved } from '../hours-saved';
 import type { NarrativePeriod } from '../narrative/snapshot-builder';
-
-// Conservative estimate: research + writing + creative + scheduling per post.
-const HOURS_PER_POST = 3;
 
 export interface ContentMixSlice {
   contentType: string;   // 'uncategorized' when content_type IS NULL
@@ -184,7 +183,7 @@ export async function buildActivitySnapshot(
       commentsHandled,
       commentsNeedReply,
       highPerformers,
-      hoursSaved:   postsPublished * HOURS_PER_POST,
+      hoursSaved:   estimateHoursSaved(postsPublished),
       platformCount,
       platforms,
       contentMix,

--- a/backend/insights/hours-saved.ts
+++ b/backend/insights/hours-saved.ts
@@ -1,0 +1,23 @@
+/**
+ * backend/insights/hours-saved.ts
+ *
+ * S3-1 / AA-97 — single source of truth for the "hours saved" ESTIMATE shown in
+ * the Hero band and the Activity strip. Two builders previously computed it two
+ * different ways (0.35–0.9h/post + 0.05h/comment  vs  a flat 3h/post), so the
+ * same dashboard could show two disagreeing numbers.
+ *
+ * This is a SYNTHETIC ESTIMATE, not a measurement — always rendered with a "~"
+ * prefix and honest "estimate" framing. HOURS_PER_POST is an assumption (research
+ * + writing + creative + scheduling for one post) worth sanity-checking against
+ * real operator time; it is kept as one tunable constant rather than a per-surface
+ * guess so the two surfaces can never diverge again.
+ *
+ * Reconciled to posts-only: the previous per-comment credit (0.05h) is dropped —
+ * comment-handling time is more speculative than per-post time, so a smaller
+ * synthetic surface is the more honest estimate.
+ */
+export const HOURS_PER_POST = 3;
+
+export function estimateHoursSaved(posts: number): number {
+  return Math.round(posts * HOURS_PER_POST * 10) / 10;
+}

--- a/backend/insights/narrative/handler.ts
+++ b/backend/insights/narrative/handler.ts
@@ -29,7 +29,11 @@ import crypto from 'crypto';
 // (account-daily totals as tenant-tz calendar dates; post/comment windows as
 // tenant-tz-midnight instants), so which rows fall in the current vs prior window
 // (and thus reach/engagement/deltas/hero post) shift near the day boundary.
-const TEMPLATE_VERSION = 'template-v3';
+// v4: S3-1 (AA-97) honesty pass — hoursSaved reconciled to the shared synthetic
+// estimate (was 0.35–0.9h/post + 0.05h/comment), and the Aries Score no longer
+// floats at the ~50 base for a dead/near-dead account (zero-signal → 0; near-dead
+// now hits the empty state). Bump invalidates stale v3 bodies.
+const TEMPLATE_VERSION = 'template-v4';
 const CACHE_TTL_MS     = 60 * 60 * 1000; // 1 hour
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);
@@ -205,6 +209,7 @@ export async function handleGetInsightsNarrative(
       snapshot.engagementRate,
       snapshot.reachDelta,
       snapshot.engagementRatePrev,
+      snapshot.reach,
     );
     const inputHash = snapshotHash(tenantId, period, platform);
 

--- a/backend/insights/narrative/score-builder.ts
+++ b/backend/insights/narrative/score-builder.ts
@@ -11,6 +11,12 @@
  * reach deltas, so the baseline needs to compress to keep scores comparable:
  *   week=56, 30day=52, 90day=48
  *
+ * S3-1 (AA-97): the base is only granted to an account with MEASURED performance.
+ * A dead / near-dead account (no reach AND no engagement AND no positive reach
+ * delta) has nothing to score, so it returns 0 instead of floating at the base
+ * (~50) — which read as fabricated reassurance. Accounts with real reach or
+ * engagement are unaffected. (The Hero also renders an empty state for this case.)
+ *
  * scoreDelta = currentScore − prevScore, where prevScore uses the same formula
  * applied to the previous period's engagementRate (reachDelta assumed ~0 for
  * the prior period since we don't query 3 windows back).
@@ -53,7 +59,15 @@ export function computeAriesScore(
   engagementRate:      number,
   reachDelta:          number,
   engagementRatePrev:  number,
+  reach:               number = 0,
 ): AriesScore {
+  // S3-1: zero-signal guard. No measured performance (no reach, no engagement, no
+  // positive reach delta) → no earned base; the account scores 0, not the ~50 base.
+  const measured = reach > 0 || engagementRate > 0 || (reachDelta ?? 0) > 0;
+  if (!measured) {
+    return { score: 0, scoreDelta: 0, judgment: judgment(0, 0, period) };
+  }
+
   const base    = PERIOD_BASE[period];
   const score   = Math.round(rawScore(base, engagementRate, reachDelta));
   // Previous period: assume flat reach delta (no 3-window query)

--- a/backend/insights/narrative/snapshot-builder.ts
+++ b/backend/insights/narrative/snapshot-builder.ts
@@ -15,6 +15,7 @@ import pool from '@/lib/db';
 import { LATEST_POST_METRICS_LATERAL } from '../latest-post-metrics-sql';
 import { resolveTenantInsightsTimeZone } from '../tenant-timezone';
 import { tenantZonePeriodStart, tenantZonePeriodStartDateKey } from '@/lib/format-timestamp';
+import { estimateHoursSaved } from '../hours-saved';
 
 export type NarrativePeriod = 'week' | '30day' | '90day';
 
@@ -209,10 +210,10 @@ export async function buildNarrativeSnapshot(
       ? Math.round(((prevLikes + prevComments + prevShares) / reachPrev) * 10000) / 100
       : 0;
 
-    // Hours saved: writing + scheduling per post, plus handling replied comments
-    const hoursPerPost = platform === 'youtube' ? 0.9 : 0.35;
-    const handledComments = Math.max(0, commentsTotal - unreplied);
-    const hoursSaved = Math.round((posts * hoursPerPost + handledComments * 0.05) * 10) / 10;
+    // S3-1: hours saved is a synthetic ESTIMATE (rendered with "~"), reconciled to
+    // the shared estimateHoursSaved so the Hero band and the Activity strip can't
+    // show two different numbers (they previously used two different constants).
+    const hoursSaved = estimateHoursSaved(posts);
 
     let topPost: TopPost | null = null;
     if (topPostRes.rows.length > 0) {
@@ -241,7 +242,11 @@ export async function buildNarrativeSnapshot(
       hoursSaved,
       topPost,
       watchTimeMinutes:    includeWatchTime(platform) ? watchTime : null,
-      hasData:             posts > 0 || reach > 0,
+      // S3-1: "enough data" requires measurable reach or engagement — a post with
+      // zero reach and zero engagement is "not enough data yet" (near-dead), not a
+      // summarizable period. Previously `posts > 0` let a 0-reach post render a
+      // fabricated ~50 Aries Score instead of the empty state.
+      hasData:             reach > 0 || engagementRate > 0,
     };
   } finally {
     client.release();

--- a/backend/insights/top/handler.ts
+++ b/backend/insights/top/handler.ts
@@ -30,7 +30,11 @@ import crypto from 'crypto';
 // v5: S2-3 — the period window is computed in the tenant's business timezone, and
 // each post's date label + best-weekday now render in that zone (not UTC), so a
 // late-evening post's weekday/label and window membership change. Invalidates v4.
-const TEMPLATE_VERSION = 'top-v5';
+// v6: S3-1 (AA-97) honesty pass — whyItWorked + pattern-card notes no longer
+// claim a hardcoded "1.5x/1.7x your rate" (fabricated stat posing as measured);
+// replaced with qualitative content-type copy. Real derived claims (post
+// multiplier, save rate) are unchanged. Bump invalidates stale v5 bodies.
+const TEMPLATE_VERSION = 'top-v6';
 const CACHE_TTL_MS     = 60 * 60 * 1000;
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/top/top-template-builder.ts
+++ b/backend/insights/top/top-template-builder.ts
@@ -29,9 +29,9 @@ export interface PatternCard {
 const CONTENT_TYPE_NOTES: Record<string, string> = {
   educational:  'Educational content lifts shares and performs well across LinkedIn and Instagram.',
   promotional:  'Promotional posts perform best when paired with strong visual creative.',
-  testimonial:  'Testimonials build trust and drive saves at 1.5x your average rate.',
+  testimonial:  'Testimonials build trust and tend to earn saves.',
   announcement: 'Announcements spike reach quickly — best posted at the start of the week.',
-  lifestyle:    'Lifestyle content converts viewers to followers at 1.7x your average.',
+  lifestyle:    'Lifestyle content tends to convert viewers into followers.',
   engagement:   'Engagement posts drive comments and keep the algorithm active between launches.',
   uncategorized:'Aries is still learning your content formats — classification pending.',
 };
@@ -57,7 +57,7 @@ export function buildWhyItWorked(post: TopPost, avgReach: number): string {
     } else if (ct === 'educational') {
       parts.push(`${ctLabel} content performs disproportionately well on ${platformName(post.platform)} for your niche.`);
     } else if (ct === 'testimonial') {
-      parts.push(`${ctLabel} content builds trust and drives saves at 1.5x your typical rate.`);
+      parts.push(`${ctLabel} content builds trust and tends to earn saves.`);
     } else if (ct === 'announcement') {
       parts.push(`${ctLabel} posts tend to spike reach in the first 24 hours — timing the publish matters.`);
     } else if (ct === 'promotional') {

--- a/backend/insights/trends/handler.ts
+++ b/backend/insights/trends/handler.ts
@@ -29,7 +29,11 @@ import crypto from 'crypto';
 // post (not SUM across dated cumulative rows), so the chosen title can change.
 // (The headline trends numbers are account-level and unchanged.) Bump
 // invalidates stale v3 bodies.
-const TEMPLATE_VERSION = 'trends-v4';
+// v5: S3-1 (AA-97) honesty pass — the engagement + visit-to-follow interpretation
+// copy no longer cites a fabricated "1–3.5% range for design accounts" benchmark
+// or assumes a "design accounts" niche (the tenant is not a design account); the
+// copy is now niche-neutral with no invented statistic. Bump invalidates v4.
+const TEMPLATE_VERSION = 'trends-v5';
 const CACHE_TTL_MS     = 60 * 60 * 1000; // 1 hour
 
 const VALID_PERIODS = new Set<string>(['week', '30day', '90day']);

--- a/backend/insights/trends/trends-template-builder.ts
+++ b/backend/insights/trends/trends-template-builder.ts
@@ -113,7 +113,7 @@ function buildEngagementDisplay(snap: TrendsSnapshot): MetricDisplay {
 
   let interpretation: string;
   if (value >= 5) {
-    interpretation = `Engagement is strong — your audience is more active than the typical 1–3.5% range for design accounts.`;
+    interpretation = `Engagement is strong for this period — your audience is highly active.`;
   } else if (value >= 3.5) {
     interpretation = `Engagement is healthy — within the upper range for accounts your size.`;
   } else {
@@ -205,7 +205,7 @@ function buildVisitsDisplay(snap: TrendsSnapshot): MetricDisplay {
   if (convNum >= 7) {
     interpretation = `Strong visit-to-follow conversion — visitors are finding what they came for.`;
   } else if (convNum >= 4) {
-    interpretation = `Healthy visit-to-follow rate — typical for design accounts at your stage.`;
+    interpretation = `Healthy visit-to-follow rate — a good sign visitors find what they came for.`;
   } else {
     interpretation = `Conversion is on the lower side — a clear bio and strong pinned post tend to lift this.`;
   }

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -112,6 +112,14 @@ const steps = [
     args: ['--test', 'tests/insights-tz-boundary-agreement.test.ts'],
   },
   {
+    // S3-1/AA-97: honesty pass — no fabricated numbers posing as measured stats.
+    // Dead account scores 0 (not ~50); one shared hoursSaved estimate; whyItWorked
+    // uses the real multiplier not a hardcoded 1.5x/1.7x; and a copy tripwire
+    // against "design accounts" / "1-3.5%" / "N.Nx your ..." reintroduction. No DB.
+    name: 'insights honesty pass (no fabricated stats)',
+    args: ['--test', 'tests/insights-honesty-pass.test.ts'],
+  },
+  {
     // 2026-07-13 duplicate-posting incident (AA-134 / PR #841) regression wall:
     // scheduler day-mapping + same-instant de-collision, the reel-companion
     // synthesis clamp, the publish-boundary duplicate/spacing guards, and the

--- a/tests/insights-honesty-pass.test.ts
+++ b/tests/insights-honesty-pass.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { computeAriesScore } from '../backend/insights/narrative/score-builder';
+import { estimateHoursSaved, HOURS_PER_POST } from '../backend/insights/hours-saved';
+import { buildWhyItWorked } from '../backend/insights/top/top-template-builder';
+import type { TopPost } from '../backend/insights/top/top-snapshot-builder';
+
+// S3-1 / AA-97 — HONESTY PASS. These pins guard against the page rendering
+// fabricated/synthetic numbers as if they were measured stats. Pure + no DB;
+// runs in `npm run verify` on every PR.
+
+// ── Aries Score: a dead/zero-signal account scores 0, NOT the ~50 base ─────────
+test('computeAriesScore: zero-signal account scores 0 (not the fabricated ~50 base)', () => {
+  for (const period of ['week', '30day', '90day'] as const) {
+    const s = computeAriesScore(period, 0, 0, 0, 0);
+    assert.equal(s.score, 0, `${period}: dead account must score 0, not the base`);
+  }
+});
+
+test('computeAriesScore: an account with real signal still scores from the formula', () => {
+  // week base 56 + 2.5*4 + 0.42*10 = 70.2 → 70. Confirms the guard does NOT
+  // suppress a genuine account — only the no-signal case.
+  const s = computeAriesScore('week', 4, 10, 2, 5000);
+  assert.equal(s.score, 70);
+  // Any single real signal (engagement OR reach) is enough to earn the base.
+  assert.ok(computeAriesScore('week', 1, 0, 0, 0).score > 0, 'engagement alone earns a score');
+  assert.ok(computeAriesScore('week', 0, 0, 0, 1).score > 0, 'reach alone earns a score');
+});
+
+// ── hoursSaved: ONE shared estimate, no second divergent formula ───────────────
+test('estimateHoursSaved: single synthetic estimate (posts × 3h)', () => {
+  assert.equal(HOURS_PER_POST, 3);
+  assert.equal(estimateHoursSaved(0), 0);
+  assert.equal(estimateHoursSaved(7), 21);
+  assert.equal(estimateHoursSaved(10), 30);
+});
+
+test('source-guard: neither builder computes hoursSaved inline (no second formula)', () => {
+  const read = (p: string) => fs.readFileSync(path.join(import.meta.dirname, '..', p), 'utf8');
+  const narrative = read('backend/insights/narrative/snapshot-builder.ts');
+  const activity  = read('backend/insights/activity/activity-snapshot-builder.ts');
+  for (const [name, src] of [['narrative', narrative], ['activity', activity]] as const) {
+    assert.match(src, /estimateHoursSaved\(/, `${name} must call the shared estimateHoursSaved`);
+    // The old inline per-post/per-comment constants must not come back.
+    assert.doesNotMatch(src, /hoursPerPost|\* 0\.35|\* 0\.9|\* 0\.05/, `${name} must not compute hours inline`);
+    assert.doesNotMatch(src, /const HOURS_PER_POST\s*=/, `${name} must not redeclare a local HOURS_PER_POST`);
+  }
+});
+
+// ── whyItWorked: renders the REAL derived multiplier, never a hardcoded 1.5x/1.7x ─
+test('buildWhyItWorked: uses the real per-post multiplier and no fabricated "N.Nx your rate"', () => {
+  const post = {
+    contentType: 'testimonial',
+    multiplier: 2.3,      // real, S2-1-derived
+    saveRate: 0,
+    bestDow: 'Monday',
+    platform: 'instagram',
+  } as unknown as TopPost;
+
+  const copy = buildWhyItWorked(post, 1000);
+  assert.match(copy, /2\.3x/, 'renders the real derived multiplier');
+  assert.doesNotMatch(copy, /1\.5x|1\.7x/, 'no hardcoded fabricated multiplier');
+  assert.doesNotMatch(copy, /\d\.\dx your (typical|average) rate/, 'no fabricated "your rate" stat');
+});
+
+// ── Copy-audit tripwire: fabricated numbers/niche must not return ──────────────
+test('source-guard: no fabricated stats or wrong-niche copy in the top/trends builders', () => {
+  const read = (p: string) => fs.readFileSync(path.join(import.meta.dirname, '..', p), 'utf8');
+  const top    = read('backend/insights/top/top-template-builder.ts');
+  const trends = read('backend/insights/trends/trends-template-builder.ts');
+
+  for (const [name, src] of [['top', top], ['trends', trends]] as const) {
+    assert.doesNotMatch(src, /design account/i, `${name}: no "design accounts" niche assumption`);
+    assert.doesNotMatch(src, /1[–-]3\.5/, `${name}: no invented "1–3.5%" benchmark`);
+    // A hardcoded "N.Nx your average/typical/rate" posing as a measured stat.
+    assert.doesNotMatch(src, /\d\.\dx your (average|typical|rate)/, `${name}: no hardcoded "N.Nx your ..." stat`);
+  }
+});


### PR DESCRIPTION
**Closes S3-1 / AA-97** (Gap A7, `docs/plans/2026-07-07-analytics-page-roadmap.md`, PR #789). Branches off `master`.

Theme: the insights page rendered **fabricated/synthetic numbers as if they were measured stats**. This pass kills the fabricated NUMBERS (the three named issues + the two worst audit finds), keeps genuinely-derived numbers, and adds a CI tripwire against reintroduction.

## The three named issues
1. **hoursSaved — two disagreeing formulas → ONE.** Hero band used `0.35–0.9h/post + 0.05h/comment`; the Activity strip used a flat `3h/post` — the same dashboard could show two different "hours saved" (~8.5× apart). Both now call the shared `estimateHoursSaved` (`backend/insights/hours-saved.ts`): `posts × 3h`, still an **ESTIMATE** (rendered with `~`), not a measurement. ⚠️ The `3h/post` constant is a **deliberate assumption worth sanity-checking**; the per-comment term was dropped as more speculative (smaller synthetic surface). Activity's rendered value is unchanged (`posts × 3` before and after) → its cache is **not** bumped.
2. **Aries Score — dead/near-dead no longer floats at ~50.** `computeAriesScore` gets a **zero-signal guard**: no reach AND no engagement AND no positive reach delta → **score 0**, not the fabricated `56/55/48` base. Accounts with real reach/engagement are unaffected. The Hero "enough data" gate is widened (`reach>0 || engagementRate>0`, was `posts>0 || reach>0`) so the **near-dead case (1 post / 0 reach / 0 engagement)** shows the existing empty state instead of "56 / Slow". Nothing branches on the score crossing 50 (judgment uses 76/68/60); backward-compatible (new param defaulted).
3. **whyItWorked — hardcoded `1.5x`/`1.7x` "your rate" removed.** The real per-content-type multiplier isn't reliably derivable from a 5-post snapshot, so these become **qualitative** content-type copy (no fabricated statistic). Genuinely-derived claims untouched: `post.multiplier` ("Nx your average reach") and `post.saveRate`.

## Full copy-audit checklist (acceptance requirement)
| # | File:line | Text | Class | Disposition |
|---|-----------|------|-------|-------------|
| a | narrative:213 / activity:187 | two hoursSaved formulas | fabricated (conflict) | **FIXED** → shared estimate |
| b | score-builder:33-40 | `base 56/55/48` floor | fabricated | **FIXED** → zero-signal guard |
| c | top-template:32,60 | testimonial "1.5x your rate" | fabricated | **FIXED** → qualitative |
| d | top-template:34 | lifestyle "1.7x your average" | fabricated | **FIXED** → qualitative |
| e | trends-template:116 | "1–3.5% range for design accounts" | fabricated + wrong-niche | **FIXED** → niche-neutral, no number |
| f | trends-template:208 | "typical for design accounts" | fabricated niche | **FIXED** → niche-neutral |
| g | top-template:58 | "disproportionately well … for your niche" | borderline (unverified, no number) | **DEFERRED** → follow-up |
| h | top-template:56 | "above-average rates" | borderline (unverified, no number) | **DEFERRED** → follow-up |
| i | top-template:74 | "peak activity window" | borderline (bestDow real, claim asserted) | **DEFERRED** → follow-up |
| j | trends-template:316 | "ahead of your typical pace" | borderline (no baseline) | **DEFERRED** → follow-up |
| — | top:46,80 / trends:72,110-112,280-287 / attention-card:96 | multiplier, saveRate, ratio, engagementBaseline | **real (derived)** | left as-is |

**e/f** (the "design accounts" / "1–3.5%" fabrication on a leather-goods tenant) were the worst offenders and are fixed here. **g–j** are unverified qualitative claims with **no fabricated number** — split into their own small follow-up ticket (none is a one-word fix), to keep this PR coherently scoped to killing fabricated numbers.

## Version bumps (only where rendered output changes)
narrative `v3→v4` (hoursSaved + score), top `v5→v6` (whyItWorked copy), trends `v4→v5` (e/f copy). **Activity NOT bumped** — byte-identical output (`posts × 3` before and after), so nothing stale to flush.

## Tests (`tests/insights-honesty-pass.test.ts`, in `npm run verify`, pure/no DB)
`[verify 10/27] insights honesty pass` → **6/6**:
- dead/zero-signal account → **score 0** (not ~50); a real account still scores from the formula
- `estimateHoursSaved` single value + source-guard that neither builder computes hours inline
- `buildWhyItWorked` renders the real multiplier and **no** `1.5x`/`1.7x`
- copy tripwire: top/trends builders contain no `design accounts` / `1–3.5%` / `N.Nx your …`

**Fails-before demos** (perturb source → assertion fails → restore):
- remove the score guard → dead-account test fails
- reintroduce `1.5x your typical rate` → whyItWorked test fails
- reintroduce "design accounts" benchmark → copy-tripwire fails

## Verification
- `npm run verify` → green (incl. the new step 6/6). `npm run typecheck` → clean.

## Follow-up ticket (to file)
Audit items **g–j** — soften the borderline unverified qualitative claims (no fabricated number, own focused review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)