### PR TITLE
feat(insights): AA-103 / S3-7 attribution coverage-threshold helper

### DIFF
--- a/backend/insights/attribution-coverage.ts
+++ b/backend/insights/attribution-coverage.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure attribution-coverage math for insights period windows (S3-7 / AA-103).
+ *
+ * Callers should obtain the two counts from the same tenant/platform/time-window
+ * query. The result lets attribution-scoped readers fall back to all-channel
+ * metrics when too much history is missing `aries_post_id`.
+ */
+
+export interface AttributionCoverageCounts {
+  totalPosts: number;
+  attributedPosts: number;
+}
+
+export interface AttributionCoverageResult extends AttributionCoverageCounts {
+  /** Fraction from 0 to 1; zero when the window has no posts. */
+  coverage: number;
+  threshold: number;
+  /** Empty windows are never trustworthy, including when threshold is zero. */
+  isTrustworthy: boolean;
+}
+
+function assertNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`);
+  }
+}
+
+export function computeAttributionCoverage(
+  { totalPosts, attributedPosts }: AttributionCoverageCounts,
+  threshold: number,
+): AttributionCoverageResult {
+  assertNonNegativeInteger(totalPosts, 'totalPosts');
+  assertNonNegativeInteger(attributedPosts, 'attributedPosts');
+
+  if (attributedPosts > totalPosts) {
+    throw new RangeError('attributedPosts cannot exceed totalPosts');
+  }
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new RangeError('threshold must be a finite number between 0 and 1');
+  }
+
+  const coverage = totalPosts === 0 ? 0 : attributedPosts / totalPosts;
+
+  return {
+    totalPosts,
+    attributedPosts,
+    coverage,
+    threshold,
+    isTrustworthy: totalPosts > 0 && coverage >= threshold,
+  };
+}

--- a/scripts/verify-regression-suite.mjs
+++ b/scripts/verify-regression-suite.mjs
@@ -142,6 +142,13 @@ const steps = [
     ],
   },
   {
+    // S3-7/AA-103: attribution coverage gate for the S4-1 all-channel fallback.
+    // Pure count math, including empty-window and invalid-input fail-closed
+    // behavior; no DB or I/O.
+    name: 'insights attribution coverage threshold',
+    args: ['--test', 'tests/insights-attribution-coverage.test.ts'],
+  },
+  {
     // 2026-07-13 duplicate-posting incident (AA-134 / PR #841) regression wall:
     // scheduler day-mapping + same-instant de-collision, the reel-companion
     // synthesis clamp, the publish-boundary duplicate/spacing guards, and the

--- a/tests/insights-attribution-coverage.test.ts
+++ b/tests/insights-attribution-coverage.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { computeAttributionCoverage } from '../backend/insights/attribution-coverage';
+
+test('computeAttributionCoverage returns the attributed share and counts', () => {
+  assert.deepEqual(
+    computeAttributionCoverage({ totalPosts: 4, attributedPosts: 3 }, 0.8),
+    {
+      totalPosts: 4,
+      attributedPosts: 3,
+      coverage: 0.75,
+      threshold: 0.8,
+      isTrustworthy: false,
+    },
+  );
+});
+
+test('computeAttributionCoverage treats the threshold boundary as trustworthy', () => {
+  const result = computeAttributionCoverage({ totalPosts: 5, attributedPosts: 4 }, 0.8);
+
+  assert.equal(result.coverage, 0.8);
+  assert.equal(result.isTrustworthy, true);
+});
+
+test('computeAttributionCoverage does not trust an empty window', () => {
+  assert.deepEqual(
+    computeAttributionCoverage({ totalPosts: 0, attributedPosts: 0 }, 0),
+    {
+      totalPosts: 0,
+      attributedPosts: 0,
+      coverage: 0,
+      threshold: 0,
+      isTrustworthy: false,
+    },
+  );
+});
+
+test('computeAttributionCoverage rejects thresholds outside the inclusive 0–1 range', () => {
+  assert.throws(
+    () => computeAttributionCoverage({ totalPosts: 1, attributedPosts: 1 }, -0.01),
+    { name: 'RangeError' },
+  );
+  assert.throws(
+    () => computeAttributionCoverage({ totalPosts: 1, attributedPosts: 1 }, 1.01),
+    { name: 'RangeError' },
+  );
+  assert.throws(
+    () => computeAttributionCoverage({ totalPosts: 1, attributedPosts: 1 }, Number.NaN),
+    { name: 'RangeError' },
+  );
+});
+
+test('computeAttributionCoverage rejects impossible post counts', () => {
+  assert.throws(
+    () => computeAttributionCoverage({ totalPosts: 2, attributedPosts: 3 }, 0.8),
+    { name: 'RangeError' },
+  );
+  assert.throws(
+    () => computeAttributionCoverage({ totalPosts: -1, attributedPosts: 0 }, 0.8),
+    { name: 'RangeError' },
+  );
+  assert.throws(
+    () => computeAttributionCoverage({ totalPosts: 1.5, attributedPosts: 1 }, 0.8),
+    { name: 'RangeError' },
+  );
+});


### PR DESCRIPTION
## Summary

- Add the pure `computeAttributionCoverage` helper for S3-7 / AA-103.
- Compute attributed-post coverage as `attributedPosts / totalPosts` and mark non-empty windows trustworthy when coverage meets or exceeds the supplied threshold.
- Fail closed for empty windows and reject invalid thresholds, negative/fractional counts, or attributed counts greater than the total.
- Register the focused unit test in the canonical regression suite.

## Test evidence

- `APP_BASE_URL=https://aries.example.com ./node_modules/.bin/tsx --test tests/insights-attribution-coverage.test.ts`
- 5 tests passed; 0 failed.

## Review

- Prior adversarial self-review reported no correctness, boundary-semantics, hidden-edge-case, or test-gap findings.
