### PR TITLE
fix(insights): keep content clear of navigation rail (AA-145)

### DIFF
--- a/frontend/insights/InsightsDashboard.tsx
+++ b/frontend/insights/InsightsDashboard.tsx
@@ -31,8 +31,8 @@ export function InsightsDashboard() {
   return (
     <div style={{ background: C.bg, minHeight: "100%" }}>
       <div
+        className="insights-dashboard-content"
         style={{
-          padding:  "28px 48px 72px",
           maxWidth: 1600,
           width:    "100%",
           margin:   "0 auto",

--- a/frontend/insights/insights.css
+++ b/frontend/insights/insights.css
@@ -10,8 +10,6 @@
 *::before,
 *::after {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 body {
@@ -20,6 +18,16 @@ body {
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.insights-dashboard-content {
+  padding: 28px 48px 72px;
+}
+
+@media (max-width: 640px) {
+  .insights-dashboard-content {
+    padding: 20px 16px 40px;
+  }
 }
 
 /* Skeleton shimmer */

--- a/tests/insights-shell-layout.regression-aa145.test.ts
+++ b/tests/insights-shell-layout.regression-aa145.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import { resolveProjectRoot } from './helpers/project-root';
+
+const PROJECT_ROOT = resolveProjectRoot(import.meta.url);
+const insightsCss = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'insights', 'insights.css'),
+  'utf8',
+);
+const shell = readFileSync(
+  path.join(PROJECT_ROOT, 'components', 'redesign', 'layout', 'app-shell-client.tsx'),
+  'utf8',
+);
+const dashboard = readFileSync(
+  path.join(PROJECT_ROOT, 'frontend', 'insights', 'InsightsDashboard.tsx'),
+  'utf8',
+);
+
+test('/insights styles preserve the desktop shell rail clearance (AA-145)', () => {
+  const universalReset = insightsCss.match(
+    /\*,\s*\n\*::before,\s*\n\*::after\s*\{(?<declarations>[\s\S]*?)\}/,
+  );
+
+  assert.ok(universalReset?.groups?.declarations, 'expected the shared box-sizing rule');
+  assert.match(universalReset.groups.declarations, /box-sizing:\s*border-box/);
+  assert.doesNotMatch(
+    universalReset.groups.declarations,
+    /\b(?:margin|padding)\s*:/,
+    'route CSS must not zero AppShell padding that clears the fixed nav rail',
+  );
+
+  // Keep the route-level guard tied to the shell contract it protects: the
+  // collapsed and expanded desktop rail both reserve their full geometry.
+  assert.match(shell, /lg:pl-\[104px\]/);
+  assert.match(shell, /lg:peer-hover\/sidebar:pl-\[312px\]/);
+});
+
+test('/insights content padding remains usable on narrow mobile viewports (AA-145)', () => {
+  assert.match(dashboard, /className="insights-dashboard-content"/);
+  assert.match(
+    insightsCss,
+    /\.insights-dashboard-content\s*\{[^}]*padding:\s*28px 48px 72px/s,
+  );
+  assert.match(
+    insightsCss,
+    /@media\s*\(max-width:\s*640px\)\s*\{[^}]*\.insights-dashboard-content\s*\{[^}]*padding:\s*20px 16px 40px/s,
+  );
+});


### PR DESCRIPTION
## Summary

- stop the Insights page stylesheet from resetting spacing owned by the shared app shell
- preserve the existing 48px desktop content inset and reduce the Insights inset to 16px on narrow mobile viewports
- add AA-145 regression coverage for both the desktop rail-clearance contract and mobile padding

## Root cause

`frontend/insights/insights.css` applied `margin: 0` and `padding: 0` through a universal selector. Because the stylesheet is loaded globally for `/insights`, that reset also removed the shared app shell's desktop main-content offset, placing Insights content beneath the fixed navigation rail.

## Test evidence

- `APP_BASE_URL=https://aries.example.com ./node_modules/.bin/tsx --test tests/insights-shell-layout.regression-aa145.test.ts tests/app-shell-sidebar-push.regression-aa78.test.ts` — 8 passed, 0 failed
- `npm run lint` — passed in WSL Ubuntu
- `npm run typecheck` — passed in WSL Ubuntu
- `npm run build` — passed in WSL Ubuntu
- `npm run validate:repo-boundary` — passed in WSL Ubuntu
- `npm run validate:banned-patterns` — passed in WSL Ubuntu
- `node scripts/verify-canonical-workspace.mjs` — passed on Windows
- pre-landing review and staged-diff security scan — no issues found

Full-suite caveat: the canonical serial suite advanced through 2,494 tests in WSL but exceeded the one-hour local execution window before producing a final summary. The Windows `npm run test` wrapper is not directly portable because it uses POSIX inline environment assignment. CI remains the authoritative Linux full-suite run.

## Browser verification

Authenticated local QA at the required viewports:

- 1280x720 desktop: collapsed rail right edge and main left edge both at 80px; Insights content starts at 128px after its 48px inset. With the rail expanded, the main starts at 256px and content at 304px. No overlap.
- 1440x900 desktop: content remains separated from the fixed rail.
- 375x812 mobile: desktop rail is absent, responsive Insights horizontal padding is 16px, and `scrollWidth === innerWidth` (no horizontal clipping).

## Pre-Landing Review

No issues found.

## Scope drift

None. The change is limited to the Insights dashboard wrapper, its stylesheet, and the AA-145 regression test.

## Test plan

- [x] Reproduced the rail overlap on current `origin/master`
- [x] Added a regression test and observed it fail before the repair
- [x] Verified AA-145 and existing AA-78 shell tests pass together
- [x] Verified desktop collapsed/expanded rail geometry
- [x] Verified narrow mobile layout and horizontal overflow
- [x] Ran lint, typecheck, build, repository-boundary, and banned-pattern checks
