### PR TITLE
fix(marketing): terminally mark scheduled posts dead past campaign_end_date

### DIFF
--- a/scripts/automations/scheduled-posts-worker.mjs
+++ b/scripts/automations/scheduled-posts-worker.mjs
@@ -2,6 +2,12 @@
  * Scheduled-posts worker — drains the scheduled_posts table and fires
  * publishToMetaGraph for each row whose scheduled_for <= NOW() and
  * dispatch_status = 'pending'. Runs as the aries-scheduled-posts-worker compose sidecar (self-scheduling; the legacy host cron that double-dispatched alongside it was removed 2026-07-13).
+ *
+ * Each tick also runs the dead-campaign sweep (SWEEP_DEAD_CAMPAIGN_SQL):
+ * rows whose campaign_end_date has passed are permanently excluded by the
+ * claim filter, so without the sweep they rot as invisible forever-'pending'
+ * while their posts still read 'approved' (the 2026-07-21 stuck-queue
+ * incident). The sweep marks them terminally failed and expires the posts.
  */
 import 'dotenv/config';
 
@@ -14,6 +20,10 @@ const REPO_ROOT = path.resolve(__dirname, '../..');
 
 const INTERVAL_MS = 60 * 1000; // 1 minute
 const BATCH_SIZE = 50;
+// Dead-campaign sweep batch. The population is bounded by scheduling volume
+// (a handful of rows per tenant-week), so one batch per tick converges fast;
+// a full batch is logged loudly so a larger backlog is never silently capped.
+const SWEEP_BATCH_SIZE = 200;
 const FETCH_TIMEOUT_MS = 30_000;
 // VIDEO publish is a long async two-step (create container -> poll up to ~300s
 // -> publish), run synchronously by the dispatch route. The worker MUST wait
@@ -114,6 +124,122 @@ export const DUE_ROWS_SQL = `SELECT id FROM scheduled_posts
 export const MARK_IN_FLIGHT_SQL = `UPDATE scheduled_posts
      SET dispatch_status = 'in_flight', updated_at = now()
      WHERE id = $1`;
+
+// Dead-campaign sweep: terminally mark rows the campaign_end_date filter above
+// has made permanently unclaimable. Without this, a row that misses its window
+// (retry backoff, guard deferral, worker outage) stays dispatch_status='pending'
+// FOREVER while its posts row still reads 'approved' — a full week of content
+// silently undelivered with nothing in any UI saying so (12 such rows found in
+// prod 2026-07-21, scheduled 7/07-7/18 with campaign_end 7/13 and 7/20).
+//
+// Semantics (deliberate):
+//   - Delivery still STOPS at campaign_end_date — this sweep never publishes
+//     late. For a one_off event campaign, posting after the event ends is
+//     wrong (promoting an ended sale); weekly jobs share the same column, so a
+//     grace-delivery window cannot be added here without splitting the two
+//     populations. Considered and rejected for now; the fix is visibility.
+//   - Parent -> dispatch_status='failed' (the EXISTING terminal vocabulary —
+//     labels.ts, calendar.ts, and the child-table CHECK constraint all already
+//     handle 'failed'; a new enum value would need every consumer audited for
+//     ===/!== literal checks, the widening-union trap this repo shipped 3x).
+//     The canonical 'campaign_window_passed:' error_message prefix is what
+//     distinguishes it, with the per-row end date interpolated for diagnosis.
+//   - Posts mirror -> published_status='expired' (+ legacy status mirror +
+//     expired_at), the draft-expiry-sweep vocabulary for "aged out, never went
+//     live", so the row leaves the approval/backlog trays honestly. Guarded by
+//     published_at IS NULL AND platform_post_id IS NULL AND a pre-publish
+//     published_status, so a post that is live anywhere is NEVER expired.
+//   - Non-terminal children -> 'failed' too, but COALESCE keeps an existing
+//     retryable error_message (e.g. the FB-368 rate-limit text that caused the
+//     miss) — that is the diagnosis, the parent carries the classification.
+//   - pending rows sweep immediately once the deadline passes (they are already
+//     unclaimable); in_flight rows only once STALE past the reclaim window
+//     ($2, same cutoff as CLAIM_ROW_SQL), so a live publish that crossed the
+//     deadline mid-flight still writes its own real outcome.
+//   - Every mutating arm re-checks the full predicate (draft-expiry-sweep
+//     pattern) and the dead CTE takes FOR UPDATE SKIP LOCKED, so a row being
+//     claimed/finished concurrently is skipped, never clobbered. Idempotent:
+//     a swept row no longer matches.
+// $1 = batch limit, $2 = stale-in_flight cutoff timestamp.
+export const SWEEP_DEAD_CAMPAIGN_SQL = `WITH dead AS (
+     SELECT id, post_id FROM scheduled_posts
+      WHERE campaign_end_date IS NOT NULL AND campaign_end_date < NOW()
+        AND (dispatch_status = 'pending'
+             OR (dispatch_status = 'in_flight' AND updated_at < $2))
+      ORDER BY scheduled_for
+      LIMIT $1
+      FOR UPDATE SKIP LOCKED
+   ),
+   marked AS (
+     UPDATE scheduled_posts sp
+        SET dispatch_status = 'failed',
+            error_at = now(),
+            -- The message must be TRUE for partial-success rows: a cross-post
+            -- row with one platform already live rolls up 'pending' and is
+            -- swept too — claiming "never published" there invites a manual
+            -- re-publish of the live platform (a duplicate-post hazard).
+            error_message = 'campaign_window_passed: campaign_end_date '
+              || to_char(sp.campaign_end_date AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+              || CASE WHEN EXISTS (SELECT 1 FROM scheduled_post_dispatches spd0
+                                    WHERE spd0.scheduled_post_id = sp.id
+                                      AND spd0.status = 'dispatched')
+                 THEN ' elapsed before full dispatch; at least one platform already published (see per-platform rows) — the remaining platform(s) were never sent (swept terminal by scheduled-posts-worker)'
+                 ELSE ' elapsed before dispatch; post was never published (swept terminal by scheduled-posts-worker)'
+                 END,
+            updated_at = now()
+       FROM dead d
+      WHERE sp.id = d.id
+        AND sp.campaign_end_date IS NOT NULL AND sp.campaign_end_date < NOW()
+        AND (sp.dispatch_status = 'pending'
+             OR (sp.dispatch_status = 'in_flight' AND sp.updated_at < $2))
+      RETURNING sp.id, sp.post_id
+   ),
+   swept_children AS (
+     UPDATE scheduled_post_dispatches spd
+        SET status = 'failed',
+            error_at = now(),
+            error_message = COALESCE(spd.error_message,
+              'campaign_window_passed: never dispatched before campaign end'),
+            updated_at = now()
+       FROM marked m
+      WHERE spd.scheduled_post_id = m.id
+        AND spd.status IN ('pending','in_flight')
+      RETURNING spd.id
+   ),
+   expired_posts AS (
+     UPDATE posts p
+        SET published_status = 'expired',
+            status = 'expired',
+            expired_at = now(),
+            updated_at = now()
+       FROM marked m
+      WHERE p.id = m.post_id
+        AND p.published_at IS NULL
+        AND p.platform_post_id IS NULL
+        AND p.published_status IN ('draft','in_review','approved')
+      RETURNING p.id
+   )
+   SELECT (SELECT count(*) FROM marked)::int AS swept,
+          (SELECT count(*) FROM expired_posts)::int AS posts_expired`;
+
+/**
+ * One dead-campaign sweep pass (single batched statement). Returns counts.
+ * Exported for the regression test; called once per tick, failure-isolated so
+ * a sweep error can never stall dispatch.
+ */
+export async function sweepDeadCampaignRows(pool) {
+  const staleCutoff = new Date(Date.now() - IN_FLIGHT_RECLAIM_MS).toISOString();
+  const result = await pool.query(SWEEP_DEAD_CAMPAIGN_SQL, [SWEEP_BATCH_SIZE, staleCutoff]);
+  const row = result.rows?.[0] ?? {};
+  const swept = Number(row.swept) || 0;
+  const postsExpired = Number(row.posts_expired) || 0;
+  if (swept > 0) {
+    console.warn(
+      `[scheduled-posts-worker] dead-campaign sweep: ${swept} row(s) past campaign_end_date marked failed (${postsExpired} post(s) expired)${swept >= SWEEP_BATCH_SIZE ? ' — full batch, more may remain; continuing next tick' : ''}`,
+    );
+  }
+  return { swept, postsExpired };
+}
 
 /**
  * Atomically claim a row (SELECT ... FOR UPDATE SKIP LOCKED). Picks pending
@@ -430,7 +556,18 @@ export async function tick(pool) {
 
   if (!baseUrl) {
     console.error('[scheduled-posts-worker] APP_BASE_URL not set; skipping tick');
-    return { processed: 0, dispatched: 0, failed: 0, skipped: 0 };
+    return { processed: 0, dispatched: 0, failed: 0, skipped: 0, expired: 0 };
+  }
+
+  // Terminally mark rows whose campaign window has passed BEFORE scanning for
+  // due work — they are permanently unclaimable, and leaving them 'pending'
+  // hides a delivery failure from every surface. Isolated: a sweep error must
+  // never stall dispatch of live rows.
+  let sweep = { swept: 0, postsExpired: 0 };
+  try {
+    sweep = await sweepDeadCampaignRows(pool);
+  } catch (sweepError) {
+    console.error('[scheduled-posts-worker] dead-campaign sweep error (isolated; dispatch continues)', sweepError);
   }
 
   // Fetch due rows: pending rows, plus 'in_flight' rows whose worker pass
@@ -440,7 +577,7 @@ export async function tick(pool) {
   const dueResult = await pool.query(DUE_ROWS_SQL, [BATCH_SIZE, staleCutoff]);
 
   const ids = dueResult.rows.map((r) => r.id);
-  const report = { processed: ids.length, dispatched: 0, failed: 0, skipped: 0 };
+  const report = { processed: ids.length, dispatched: 0, failed: 0, skipped: 0, expired: sweep.swept };
 
   for (const rowId of ids) {
     // The claim transaction and the post-publish write each need a pooled
@@ -553,7 +690,7 @@ async function tickSafe(pool) {
   running = true;
   try {
     const report = await tick(pool);
-    if (report.processed > 0 || report.failed > 0) {
+    if (report.processed > 0 || report.failed > 0 || report.expired > 0) {
       console.log(
         `[scheduled-posts-worker] summary ${JSON.stringify(report)}`,
       );

--- a/tests/REQUIRES_INFRA.md
+++ b/tests/REQUIRES_INFRA.md
@@ -38,6 +38,7 @@ All files below gate on the **superset** `DB_HOST` + `DB_PORT` + `DB_USER` + `DB
 | `tests/insights-sync-runs-sweep.requires-infra.test.ts` | the stranded-run sweep predicate flips only stale `'running'` rows, and the dispatcher's terminal-ok UPDATE overrides a mid-flight sweep + clears the abort message (rolled back) | — |
 | `tests/insights-summary-current-followers.requires-infra.test.ts` | `summary.currentFollowers` is the SUM of each platform's LATEST follower count (`CURRENT_FOLLOWERS_SUM_SQL`), not MAX across platforms and not SUM across dated snapshots — seeds older+latest FB/IG rows and asserts 16k, not 10k/29k (rolled back) | — |
 | `tests/publish-creative-asset-ids.test.ts` | `creative_asset_ids` round-trips through the real `posts` schema + `resolveMediaUrls` SQL (rolled back) | — |
+| `tests/scheduled-posts-worker-campaign-sweep.test.ts` | the dead-campaign sweep terminally fails past-`campaign_end_date` rows, expires the never-live posts mirror, and skips live/fresh-in_flight rows (rolled back) | — |
 | `tests/scheduled-posts-worker-end-date.test.ts` | the `campaign_end_date` column exists and the claim filter plans correctly | — |
 | `tests/scheduled-posts-worker-live-db.test.ts` | the scheduled-posts worker drains/claims rows through the live schema (rolled back) | — |
 | `tests/hackathon-register.test.ts` | `hackathon_registrations` accepts insert + upsert against the live schema (rolled back) | — |

--- a/tests/scheduled-posts-worker-backoff.test.ts
+++ b/tests/scheduled-posts-worker-backoff.test.ts
@@ -112,10 +112,15 @@ test('setPlatformDispatchStatus casts $4 to text — bare $4 fails Postgres prep
   // prepare time and EVERY post-publish write dies — the publish goes live
   // but is never recorded, re-opening the stale-reclaim duplicate window
   // (caught live 2026-07-13 20:05Z). In-memory fakes cannot see prepare-time
-  // inference, so pin the casts at source level.
+  // inference, so pin the casts at source level. Anchored to the
+  // setPlatformDispatchStatus function — the dead-campaign sweep CTE contains
+  // an earlier `UPDATE scheduled_post_dispatches` that must not shift this
+  // slice onto unrelated text.
+  const fnStart = workerSource.indexOf('async function setPlatformDispatchStatus');
+  assert.notEqual(fnStart, -1, 'setPlatformDispatchStatus must exist in the worker');
   const stmt = workerSource.slice(
-    workerSource.indexOf('UPDATE scheduled_post_dispatches'),
-    workerSource.indexOf('WHERE scheduled_post_id = $1 AND platform = $2'),
+    workerSource.indexOf('UPDATE scheduled_post_dispatches', fnStart),
+    workerSource.indexOf('WHERE scheduled_post_id = $1 AND platform = $2', fnStart),
   );
   const bare = stmt.match(/\$4(?!::text)/g) ?? [];
   assert.equal(bare.length, 0, `every $4 in the child-status UPDATE must be cast ::text; found ${bare.length} bare`);

--- a/tests/scheduled-posts-worker-campaign-sweep.test.ts
+++ b/tests/scheduled-posts-worker-campaign-sweep.test.ts
@@ -1,0 +1,393 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+import { requireDbEnvOrSkip } from './helpers/requires-infra';
+
+// Regression: the dead-campaign sweep (2026-07-21 stuck-queue incident).
+//
+// The claim filter (campaign_end_date >= NOW()) permanently excludes rows whose
+// campaign window passed — correct for delivery (stale campaign content must
+// not go out late), but before the sweep those rows rotted as invisible
+// forever-'pending' while their posts still read 'approved': 12 rows in prod
+// (scheduled 7/07–7/18, campaign_end 7/13 and 7/20), a week of content
+// silently undelivered with no surface saying so.
+//
+// The sweep terminally marks them (dispatch_status='failed', canonical
+// 'campaign_window_passed:' error_message) and expires the posts row
+// (published_status='expired', the draft-expiry vocabulary), guarded so a
+// post that is live anywhere is never touched.
+//
+// Three layers, matching scheduled-posts-worker-end-date.test.ts:
+//   1. Source-level assertions on the exported SQL (always run).
+//   2. tick() integration via a fake pool: report wiring + failure isolation.
+//   3. Live-DB behavioural exercise in a rolled-back transaction (skips when
+//      DB env absent; requires-infra).
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const WORKER_PATH = path.join(REPO_ROOT, 'scripts/automations/scheduled-posts-worker.mjs');
+const WORKER_SRC = readFileSync(WORKER_PATH, 'utf8');
+
+type WorkerModule = {
+  SWEEP_DEAD_CAMPAIGN_SQL: string;
+  sweepDeadCampaignRows: (pool: {
+    query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number }>;
+  }) => Promise<{ swept: number; postsExpired: number }>;
+  tick: (pool: {
+    query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number }>;
+    connect: () => Promise<unknown>;
+  }) => Promise<{ processed: number; dispatched: number; failed: number; skipped: number; expired: number }>;
+};
+
+async function loadWorker(): Promise<WorkerModule> {
+  return (await import(WORKER_PATH)) as unknown as WorkerModule;
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: source-level assertions
+// ---------------------------------------------------------------------------
+
+function extractExportedSql(name: string): string {
+  const match = WORKER_SRC.match(new RegExp(`export const ${name} = \`([\\s\\S]*?)\`;`));
+  assert.ok(match, `${name} must be defined and exported in the worker`);
+  return match[1];
+}
+
+const SWEEP_SQL = extractExportedSql('SWEEP_DEAD_CAMPAIGN_SQL');
+
+test('sweep selects only permanently-unclaimable rows: past-end pending, or past-end STALE in_flight', () => {
+  assert.match(
+    SWEEP_SQL,
+    /campaign_end_date IS NOT NULL AND campaign_end_date < NOW\(\)/,
+    'the dead CTE must require a PASSED campaign_end_date (NULL = weekly legacy, never swept)',
+  );
+  assert.match(
+    SWEEP_SQL,
+    /dispatch_status = 'pending'\s+OR \(dispatch_status = 'in_flight' AND updated_at < \$2\)/,
+    'pending rows sweep immediately; in_flight rows only past the stale-reclaim cutoff ($2) so a live publish crossing the deadline still writes its own outcome',
+  );
+  assert.match(SWEEP_SQL, /FOR UPDATE SKIP LOCKED/, 'the dead CTE must skip rows locked by a concurrent claim');
+});
+
+test('sweep mutating arm re-checks the FULL predicate (draft-expiry pattern) and writes the existing terminal vocabulary', () => {
+  // The UPDATE must re-assert the predicate — a row that gets claimed or
+  // finished between the CTE SELECT and the UPDATE is skipped, not clobbered.
+  assert.match(
+    SWEEP_SQL,
+    /WHERE sp\.id = d\.id\s+AND sp\.campaign_end_date IS NOT NULL AND sp\.campaign_end_date < NOW\(\)\s+AND \(sp\.dispatch_status = 'pending'\s+OR \(sp\.dispatch_status = 'in_flight' AND sp\.updated_at < \$2\)\)/,
+    'the parent UPDATE must re-check the full dead predicate in its own WHERE',
+  );
+  assert.match(
+    SWEEP_SQL,
+    /SET dispatch_status = 'failed'/,
+    "the terminal parent state must be the EXISTING 'failed' value (labels.ts / calendar.ts / the child CHECK all handle it)",
+  );
+  // Widening-union guard: this fix must NOT introduce a new dispatch_status
+  // enum value — every ===/'!==' literal check site-wide would need auditing.
+  assert.doesNotMatch(SWEEP_SQL, /expired_campaign/, 'no new dispatch_status enum value');
+  assert.match(
+    SWEEP_SQL,
+    /campaign_window_passed: campaign_end_date/,
+    'the canonical campaign_window_passed: error_message prefix is what distinguishes a swept row',
+  );
+  // A partial-success cross-post row (one platform live, one still retrying)
+  // rolls up 'pending' and is swept too — the message must not claim "never
+  // published" for it (misdiagnosis -> manual re-publish -> duplicate post).
+  assert.match(
+    SWEEP_SQL,
+    /CASE WHEN EXISTS \(SELECT 1 FROM scheduled_post_dispatches spd0\s+WHERE spd0\.scheduled_post_id = sp\.id\s+AND spd0\.status = 'dispatched'\)/,
+    'the parent message must be conditional on whether ANY platform already dispatched',
+  );
+});
+
+test('sweep expires the posts mirror ONLY when the post is provably not live anywhere', () => {
+  assert.match(
+    SWEEP_SQL,
+    /p\.published_at IS NULL\s+AND p\.platform_post_id IS NULL\s+AND p\.published_status IN \('draft','in_review','approved'\)/,
+    'posts guard: never expire a published / Meta-native-scheduled / already-terminal post',
+  );
+  assert.match(
+    SWEEP_SQL,
+    /SET published_status = 'expired',\s+status = 'expired',\s+expired_at = now\(\)/,
+    "posts mirror must write BOTH status columns to 'expired' + expired_at (draft-expiry lockstep rule)",
+  );
+});
+
+test('sweep terminally fails non-terminal children but PRESERVES their diagnostic error_message', () => {
+  assert.match(
+    SWEEP_SQL,
+    /spd\.status IN \('pending','in_flight'\)/,
+    'only non-terminal children are touched; a dispatched child (already live) is never rewritten',
+  );
+  assert.match(
+    SWEEP_SQL,
+    /error_message = COALESCE\(spd\.error_message,/,
+    'an existing retryable error (e.g. the FB-368 text that caused the miss) is the diagnosis — COALESCE must keep it',
+  );
+});
+
+test('tick() runs the sweep failure-isolated (a sweep error never stalls dispatch)', () => {
+  const tickBody = WORKER_SRC.slice(WORKER_SRC.indexOf('export async function tick'));
+  assert.match(
+    tickBody,
+    /try \{\s*sweep = await sweepDeadCampaignRows\(pool\);\s*\} catch/,
+    'the sweep call inside tick() must be wrapped so its failure is isolated',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Layer 2: tick() integration via a fake pool
+// ---------------------------------------------------------------------------
+
+test('tick() reports sweep counts and continues dispatch when the sweep errors', async () => {
+  const { tick } = await loadWorker();
+  process.env.APP_BASE_URL = 'https://aries.example.test';
+  process.env.INTERNAL_API_SECRET = 'test-secret';
+
+  // Case A: sweep returns counts, no due rows -> report.expired wired through.
+  const poolA = {
+    query: async (sql: string) => {
+      if (sql.trimStart().startsWith('WITH dead AS')) {
+        return { rows: [{ swept: 3, posts_expired: 2 }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 }; // DUE_ROWS_SQL: nothing due
+    },
+    connect: async () => {
+      throw new Error('no claim expected in this case');
+    },
+  };
+  const reportA = await tick(poolA);
+  assert.equal(reportA.expired, 3, 'tick report must surface the swept-row count');
+  assert.equal(reportA.processed, 0);
+
+  // Case B: the sweep statement throws -> dispatch scan still runs.
+  let dueScanned = false;
+  const poolB = {
+    query: async (sql: string) => {
+      if (sql.trimStart().startsWith('WITH dead AS')) {
+        throw new Error('sweep exploded');
+      }
+      dueScanned = true;
+      return { rows: [], rowCount: 0 };
+    },
+    connect: async () => {
+      throw new Error('no claim expected in this case');
+    },
+  };
+  const reportB = await tick(poolB);
+  assert.equal(dueScanned, true, 'the due-rows scan must still run after a sweep failure');
+  assert.equal(reportB.expired, 0, 'a failed sweep reports zero, never a stale count');
+});
+
+// ---------------------------------------------------------------------------
+// Layer 3: live-DB behavioural exercise (rolled back; requires-infra)
+// ---------------------------------------------------------------------------
+
+function dbConfigFromEnv(): pg.PoolConfig | null {
+  const { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } = process.env;
+  if (!DB_HOST || !DB_PORT || !DB_USER || !DB_PASSWORD || !DB_NAME) return null;
+  return {
+    host: DB_HOST,
+    port: Number(DB_PORT),
+    user: DB_USER,
+    password: DB_PASSWORD,
+    database: DB_NAME,
+    max: 2,
+  };
+}
+
+test('dead-campaign sweep semantics against real Postgres (rolled back)', async (t) => {
+  const dbConfig = dbConfigFromEnv();
+  if (!dbConfig) {
+    requireDbEnvOrSkip(t);
+    return;
+  }
+  const { SWEEP_DEAD_CAMPAIGN_SQL } = await loadWorker();
+
+  const pool = new pg.Pool(dbConfig);
+  try {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const org = await client.query(
+        `INSERT INTO organizations (name) VALUES ('campaign-sweep-test') RETURNING id`,
+      );
+      const tenantId = (org.rows[0] as { id: number }).id;
+
+      // Seed one posts+scheduled_posts pair per case. Helper returns ids.
+      async function seedPair(opts: {
+        publishedStatus: string;
+        dispatchStatus: string;
+        campaignEnd: string | null;
+        updatedAt?: string;
+        platformPostId?: string | null;
+      }): Promise<{ postId: number; spId: number }> {
+        const post = await client.query(
+          `INSERT INTO posts (tenant_id, caption, published_status, platform_post_id)
+           VALUES ($1, 'sweep-test caption', $2, $3) RETURNING id`,
+          [tenantId, opts.publishedStatus, opts.platformPostId ?? null],
+        );
+        const postId = (post.rows[0] as { id: number }).id;
+        const sp = await client.query(
+          `INSERT INTO scheduled_posts
+             (post_id, tenant_id, scheduled_for, target_platforms, campaign_end_date, dispatch_status, updated_at)
+           VALUES ($1, $2, now() - interval '3 days', '{facebook}', $3, $4, $5)
+           RETURNING id`,
+          [
+            postId,
+            tenantId,
+            opts.campaignEnd,
+            opts.dispatchStatus,
+            opts.updatedAt ?? new Date().toISOString(),
+          ],
+        );
+        return { postId, spId: (sp.rows[0] as { id: number }).id };
+      }
+
+      const past = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
+      const future = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+      const staleUpdated = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h > 15min reclaim
+
+      // 1. pending + past end -> swept, post expired.
+      const dead = await seedPair({ publishedStatus: 'approved', dispatchStatus: 'pending', campaignEnd: past });
+      // 2. pending + future end -> untouched (still deliverable).
+      const alive = await seedPair({ publishedStatus: 'approved', dispatchStatus: 'pending', campaignEnd: future });
+      // 3. pending + NULL end (legacy weekly) -> untouched.
+      const legacy = await seedPair({ publishedStatus: 'approved', dispatchStatus: 'pending', campaignEnd: null });
+      // 4. FRESH in_flight + past end (live publish crossing the deadline) -> untouched.
+      const inFlight = await seedPair({ publishedStatus: 'approved', dispatchStatus: 'in_flight', campaignEnd: past });
+      // 5. STALE in_flight + past end (crashed pass) -> swept.
+      const staleFlight = await seedPair({
+        publishedStatus: 'approved',
+        dispatchStatus: 'in_flight',
+        campaignEnd: past,
+        updatedAt: staleUpdated,
+      });
+      // 6. pending + past end but the post already reached Meta -> row swept,
+      //    post NOT expired (the platform_post_id guard).
+      const livePost = await seedPair({
+        publishedStatus: 'approved',
+        dispatchStatus: 'pending',
+        campaignEnd: past,
+        platformPostId: 'ig_media_123',
+      });
+      // 7. Partial success: fb child already dispatched (live), ig child still
+      //    retryable when the campaign ended. Parent rollup is 'pending' so it
+      //    IS swept — but the message must say a platform already published,
+      //    and the 'published' post + dispatched child must be untouched.
+      const partial = await seedPair({
+        publishedStatus: 'published',
+        dispatchStatus: 'pending',
+        campaignEnd: past,
+        platformPostId: 'fb_media_456',
+      });
+      await client.query(
+        `INSERT INTO scheduled_post_dispatches (scheduled_post_id, platform, status)
+         VALUES ($1, 'facebook', 'dispatched'), ($1, 'instagram', 'pending')`,
+        [partial.spId],
+      );
+      // Seed a non-terminal child with a diagnostic error for case 1.
+      await client.query(
+        `INSERT INTO scheduled_post_dispatches (scheduled_post_id, platform, status, error_message)
+         VALUES ($1, 'facebook', 'pending', 'rate limit (code 368)')`,
+        [dead.spId],
+      );
+
+      // NOTE on counts: this transaction sees the REAL database, which may
+      // hold genuinely-dead prod rows (the incident population) — the sweep
+      // marks those too inside this rolled-back txn. So counts are asserted as
+      // lower bounds and the per-case semantics are asserted per-row below.
+      // The generous batch limit guarantees the whole population (prod rows +
+      // seeds) drains in one pass so the idempotency check is exact.
+      const staleCutoff = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+      const sweep = await client.query(SWEEP_DEAD_CAMPAIGN_SQL, [100000, staleCutoff]);
+      const counts = sweep.rows[0] as { swept: number; posts_expired: number };
+      assert.ok(counts.swept >= 4, `dead pending, stale in_flight, live-post, and partial rows must be swept (got ${counts.swept})`);
+      assert.ok(counts.posts_expired >= 2, `the two never-live posts must be expired (got ${counts.posts_expired})`);
+
+      const spState = async (id: number) => {
+        const r = await client.query(
+          `SELECT dispatch_status, error_message FROM scheduled_posts WHERE id = $1`,
+          [id],
+        );
+        return r.rows[0] as { dispatch_status: string; error_message: string | null };
+      };
+      const postState = async (id: number) => {
+        const r = await client.query(
+          `SELECT published_status, status, expired_at FROM posts WHERE id = $1`,
+          [id],
+        );
+        return r.rows[0] as { published_status: string; status: string; expired_at: string | null };
+      };
+
+      const deadSp = await spState(dead.spId);
+      assert.equal(deadSp.dispatch_status, 'failed');
+      assert.match(String(deadSp.error_message), /^campaign_window_passed: campaign_end_date /);
+      const deadPost = await postState(dead.postId);
+      assert.equal(deadPost.published_status, 'expired');
+      assert.equal(deadPost.status, 'expired');
+      assert.ok(deadPost.expired_at, 'expired_at is stamped');
+
+      const deadChild = await client.query(
+        `SELECT status, error_message FROM scheduled_post_dispatches WHERE scheduled_post_id = $1`,
+        [dead.spId],
+      );
+      assert.equal((deadChild.rows[0] as { status: string }).status, 'failed');
+      assert.equal(
+        (deadChild.rows[0] as { error_message: string }).error_message,
+        'rate limit (code 368)',
+        'the diagnostic child error that caused the miss is preserved, not overwritten',
+      );
+
+      const partialSp = await spState(partial.spId);
+      assert.equal(partialSp.dispatch_status, 'failed', 'partial-success row is swept (rollup was pending)');
+      assert.match(
+        String(partialSp.error_message),
+        /elapsed before full dispatch; at least one platform already published/,
+        'partial-success rows must NOT claim "never published"',
+      );
+      const partialChildren = await client.query(
+        `SELECT platform, status FROM scheduled_post_dispatches WHERE scheduled_post_id = $1 ORDER BY platform`,
+        [partial.spId],
+      );
+      assert.deepEqual(
+        partialChildren.rows,
+        [
+          { platform: 'facebook', status: 'dispatched' },
+          { platform: 'instagram', status: 'failed' },
+        ],
+        'the live fb child is untouched; only the never-sent ig child is terminally failed',
+      );
+      assert.equal(
+        (await postState(partial.postId)).published_status,
+        'published',
+        'a published post is never expired by the sweep',
+      );
+
+      assert.equal((await spState(alive.spId)).dispatch_status, 'pending', 'future-end row untouched');
+      assert.equal((await spState(legacy.spId)).dispatch_status, 'pending', 'NULL-end row untouched');
+      assert.equal((await spState(inFlight.spId)).dispatch_status, 'in_flight', 'fresh in_flight row untouched');
+      assert.equal((await spState(staleFlight.spId)).dispatch_status, 'failed', 'stale in_flight row swept');
+      assert.equal(
+        (await postState(livePost.postId)).published_status,
+        'approved',
+        'a post that reached Meta keeps its status even though its schedule row is swept',
+      );
+
+      // Idempotency: a second pass matches nothing (the first drained the
+      // whole population within this transaction).
+      const again = await client.query(SWEEP_DEAD_CAMPAIGN_SQL, [100000, staleCutoff]);
+      assert.equal((again.rows[0] as { swept: number }).swept, 0, 'sweep is idempotent');
+
+      await client.query('ROLLBACK');
+    } finally {
+      client.release();
+    }
+  } finally {
+    await pool.end();
+  }
+});

--- a/tests/scheduled-posts-worker-crash-safety.test.ts
+++ b/tests/scheduled-posts-worker-crash-safety.test.ts
@@ -210,6 +210,13 @@ class FakeClient {
       return { rows: [], rowCount: 0 };
     }
 
+    if (s.startsWith('WITH dead AS')) {
+      // Dead-campaign sweep. No row in this fake carries a campaign_end_date,
+      // so the sweep is always a structural no-op here; its real semantics are
+      // covered by scheduled-posts-worker-campaign-sweep.test.ts.
+      return { rows: [{ swept: 0, posts_expired: 0 }], rowCount: 1 };
+    }
+
     throw new Error(`FakeClient: unhandled SQL: ${s.slice(0, 80)}`);
   }
 


### PR DESCRIPTION
## Problem

The scheduled-posts worker's claim SQL excludes rows with `campaign_end_date < NOW()` — correct for delivery (stale campaign content must not go out late), but a row that misses its window (retry backoff, guard deferral, worker outage) then rots as `dispatch_status='pending'` **forever**, invisible, while its `posts` row still reads `approved`. As of 2026-07-21 prod has 12 such rows (tenant 15, scheduled 7/07–7/18, campaign_end 7/13 and 7/20) — a full week of approved content silently undelivered with nothing in any UI saying so. The tail of every weekly window sits ~2 days from its end date, i.e. one long backoff away from silent death.

## Fix

Each worker tick now runs a **dead-campaign sweep**: one batched CTE statement, failure-isolated so a sweep error can never stall dispatch.

- **Parent** → `dispatch_status='failed'` + `error_at` + a canonical `campaign_window_passed:` `error_message` carrying the row's end date. Reuses the **existing** terminal vocabulary (labels.ts, calendar.ts, and the child-table CHECK all already handle `'failed'`) — no new enum value, no widening-union audit. The message is conditional: a partial-success cross-post row (one platform live, one still retrying at campaign end) says "at least one platform already published" instead of falsely claiming nothing went out (adversarial-review finding: the false message invited a duplicate manual re-publish).
- **Children** → non-terminal (`pending`/`in_flight`) rows go `'failed'`, with `COALESCE` preserving an existing retryable error (e.g. the FB-368 rate-limit text that caused the miss) as the diagnosis; already-`dispatched` children are never rewritten.
- **Posts mirror** → `published_status='expired'` + legacy `status` + `expired_at` (the draft-expiry vocabulary), guarded by `published_at IS NULL AND platform_post_id IS NULL AND published_status IN ('draft','in_review','approved')` so a post that is live anywhere is **never** expired. This is the complement of the draft-expiry sweep, which by design never touches posts that have a `scheduled_posts` row.
- **Race safety**: `pending` rows sweep immediately once dead (they are already unclaimable); `in_flight` rows only past the same stale-reclaim cutoff the claim SQL uses, so a live publish crossing the deadline still writes its own real outcome. Every mutating arm re-checks the full predicate (draft-expiry pattern) and the dead CTE takes `FOR UPDATE SKIP LOCKED`. Idempotent: a swept row leaves the predicate.

**Delivery semantics are unchanged** — nothing publishes late, and the 12 existing prod rows are made visible/terminal on first tick after deploy, never published. A grace window that delivers late instead of killing was considered and rejected: `one_off` event campaigns share the column and must not post after the event ends; splitting the two populations is a follow-up.

## Tests

`tests/scheduled-posts-worker-campaign-sweep.test.ts` (added to `tests/REQUIRES_INFRA.md`):
1. **SQL-shape** assertions: full-predicate re-check in every mutating arm, stale-in_flight guard, `FOR UPDATE SKIP LOCKED`, posts guards, conditional message, and an explicit no-new-enum-value guard.
2. **tick() integration** via fake pool: report wiring + sweep-failure isolation.
3. **Live-DB behavioural** (rolled back, requires-infra): 7 seeded cases — dead pending swept with message + post expired + child diagnosis preserved; future-end / NULL-end / fresh-in_flight untouched; stale-in_flight swept; Meta-live post's row swept but post untouched; partial-success row swept with the "already published" message, `dispatched` child untouched, `published` post untouched; idempotency. **Run for real against the prod schema** (rolled back), passing.

Also: the backoff test's `$4::text` incident pin is re-anchored to `setPlatformDispatchStatus` (the sweep's earlier `UPDATE scheduled_post_dispatches` shifted its source slice onto comment text); the crash-safety fake handles the new statement.

`npm run verify` ✅ · `npm run lint` ✅ · adversarial multi-lens review (9 agents) ✅ — 1 confirmed finding, fixed in-PR (the conditional message above).

## Follow-ups (chips filed, out of scope)

- Manual reschedule of a terminally-failed row never revives it (`upsertScheduledPost` deliberately doesn't touch `dispatch_status`; needs a manual-route-only reset that never touches `dispatched`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)