### PR TITLE
chore(funding): point custom sponsor link to aries.sugarandleather.com

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 github:
   - DeliciousHouse
 custom:
-  - https://sugarandleather.com
+  - https://aries.sugarandleather.com


### PR DESCRIPTION
## Summary

Update the `custom:` sponsor link in `.github/FUNDING.yml` from `https://sugarandleather.com` to `https://aries.sugarandleather.com` so the "Sponsor this project" button points at the Aries-specific donation page.

## Type

- [x] Docs