### PR TITLE
tests(settings): give the settings-screen mount queries a real wait budget

### DIFF
--- a/tests/settings-screen-dirty-drafts.component.test.ts
+++ b/tests/settings-screen-dirty-drafts.component.test.ts
@@ -162,8 +162,19 @@ test('approval-only save preserves dirty business drafts until a deliberate busi
   const screen = await mountSettings();
 
   try {
-    const businessName = await screen.findByDisplayValue('Stored Business') as HTMLInputElement;
-    const primaryGoal = await screen.findByDisplayValue('Increase social media presence') as HTMLInputElement;
+    // Mounting this screen is expensive: jsdom + React + the Next router context,
+    // then `useBusinessProfile`'s autoLoad round-trip and the effect that syncs the
+    // loaded profile into input state. That costs ~200ms on an idle box but 0.6-1.4s
+    // when the machine is oversubscribed, which straddles @testing-library's 1000ms
+    // default and makes these two queries flake under parallel suite load.
+    // Both conditions are monotonic — once an input holds its value it keeps it —
+    // so there is no earlier signal to await and a longer budget cannot mask a bug:
+    // it can only fail if the profile genuinely never reaches the inputs. Note this
+    // is deliberately scoped to the mount queries; the in-flight "Saving…" assertion
+    // below is a real transient and must keep the short default.
+    const mountWait = { timeout: 15_000 };
+    const businessName = await screen.findByDisplayValue('Stored Business', undefined, mountWait) as HTMLInputElement;
+    const primaryGoal = await screen.findByDisplayValue('Increase social media presence', undefined, mountWait) as HTMLInputElement;
     const launchApprover = screen.getByLabelText('Launch approver') as HTMLSelectElement;
 
     fireEvent.change(businessName, { target: { value: 'Unsaved Draft Business' } });


### PR DESCRIPTION
## Problem

`tests/settings-screen-dirty-drafts.component.test.ts` has a latent flake at the two mount queries, distinct from the `Saving…` race:

```
TestingLibraryElementError: Unable to find an element with the display value: Stored Business.
```

It does not reproduce in a normal full-suite run, but shows up readily once the box is oversubscribed.

## Root cause

The two `findByDisplayValue` calls that wait for the loaded business profile to reach the inputs were running on @testing-library's **1000ms default** `asyncUtilTimeout`. Mounting this screen is expensive — jsdom + React + the Next router context, then `useBusinessProfile`'s autoLoad round-trip and the effect that syncs the loaded profile into input state.

Measured on a 4-CPU box:

| Condition | Mount → first find |
|---|---|
| Idle | **199ms** |
| 8 concurrent processes | **561–1366ms** |

The loaded latency distribution straddles the 1000ms default, so the query becomes a coin flip under load and never fails idle.

This is **not** a race. Both conditions are monotonic — once an input holds its value it keeps it — and the fetch mock already resolves immediately, so there is no earlier deterministic signal to await. Re-running the same queries with a 120s budget resolved **24/24**, confirming the condition always arrives and merely misses the deadline.

## Fix

Scoped `{ timeout: 15_000 }` to the two mount queries only.

Deliberately **not** a suite-level `asyncUtilTimeout`: that would also lift the budget on the in-flight `Saving…` assertion, which is a genuine transient where a longer budget buys nothing and only makes a real failure slower to surface.

## Verification

8 concurrent processes × 3 rounds of this file alone:

| | This failure mode |
|---|---|
| Before | **9/24** |
| After | **0/24** |

- 0/24 confirmed on two independent runs, plus 0/24 at 12-way (3x oversubscription).
- Full suite: **3945 pass / 0 fail / 62 skipped**, run twice — once against exactly this commit.
- `tsc --noEmit` clean.

## Note

The separate `Saving…` race in this same file is fixed independently (test-controlled PATCH gate) and is **not** included here. On this branch that assertion still flakes under artificial oversubscription — and its rate rises from 9/24 to 19/24, purely because runs that previously died at the mount query now survive long enough to reach it. Previously masked, not a regression. The verification runs above that show 0/24 overall had both fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
